### PR TITLE
feat(intake): add automated UGC preflight gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-update-subnet-interface.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-subnet-interface.yml
@@ -3,12 +3,12 @@ description: Submit a public subnet API, docs, dashboard, OpenAPI, SSE, reposito
 title: "interface: "
 labels:
   - interface-submission
-  - maintainer-review
+  - metagraphed-under-review
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve Metagraphed. Schema-valid submissions are not auto-published; a maintainer still reviews source facts, auth requirements, and probe safety before promotion into the curated registry. Approved imports require the `metagraphed-import-approved` label and open a pull request.
+        Thanks for helping improve Metagraphed. Schema-valid submissions are not auto-published; public validation is followed by the private Metagraphed submission gate. Clean submissions can be imported automatically after approval; edge cases get routed to manual review. Approved imports require the `metagraphed-import-approved` label and open a pull request.
   - type: input
     id: netuid
     attributes:

--- a/.github/ISSUE_TEMPLATE/report-endpoint-status-issue.yml
+++ b/.github/ISSUE_TEMPLATE/report-endpoint-status-issue.yml
@@ -3,7 +3,7 @@ description: Report a stale, down, misclassified, or unsafe public subnet interf
 title: "status: "
 labels:
   - status-report
-  - maintainer-review
+  - metagraphed-under-review
 body:
   - type: input
     id: netuid

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,8 @@
 
 - [ ] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
 - [ ] Generated artifacts came from repo scripts, not hand-edited public JSON.
-- [ ] Community-submitted interfaces remain maintainer-reviewed before promotion.
+- [ ] Direct community submissions change exactly one `registry/candidates/community/*.json` file and no generated artifacts.
+- [ ] Community-submitted interfaces pass public preflight before private gate review.
 
 ## Validation
 
@@ -23,6 +24,7 @@
 - [ ] `npm run validate:docs`
 - [ ] `npm run validate:intake`
 - [ ] `npm run validate:workflows`
+- [ ] `npm run submission:pr -- --changed-files <changed-files.txt>` for direct UGC submissions
 - [ ] `npm run worker:test`
 - [ ] `npm run test:coverage`
 - [ ] `npm run scan:public-safety`

--- a/.github/workflows/intake-import-pr.yml
+++ b/.github/workflows/intake-import-pr.yml
@@ -66,7 +66,7 @@ jobs:
           title: "feat(intake): import subnet interface submission"
           body: |
             ## Summary
-            - Imports a maintainer-approved subnet interface candidate from issue #${{ github.event.issue.number }}.
+            - Imports a gate-approved subnet interface candidate from issue #${{ github.event.issue.number }}.
             - Rebuilds public registry artifacts from the reviewed candidate source.
 
             ## Validation
@@ -82,4 +82,4 @@ jobs:
             - npm test
           labels: |
             interface-submission
-            maintainer-review
+            metagraphed-under-review

--- a/.github/workflows/intake-validation.yml
+++ b/.github/workflows/intake-validation.yml
@@ -57,7 +57,7 @@ jobs:
               '',
               report.errors.length > 0
                 ? `Errors:\n${report.errors.map((error) => `- ${error}`).join('\n')}`
-                : 'Candidate parsed successfully. Maintainer review is still required before promotion.'
+                : 'Candidate parsed successfully. Private gate review is still required before promotion.'
             ].join('\n');
             await github.rest.issues.createComment({
               owner: context.repo.owner,

--- a/.github/workflows/submission-gate.yml
+++ b/.github/workflows/submission-gate.yml
@@ -1,0 +1,51 @@
+name: Submission Gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: submission-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  metagraphed-submission-gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install
+        run: npm ci
+
+      - name: Capture changed files
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
+
+      - name: Run public submission preflight
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json
+
+      - name: Show public preflight report
+        run: node -e "const fs=require('fs'); const report=JSON.parse(fs.readFileSync('submission-report.json','utf8')); console.log(JSON.stringify({public_state:report.public_state,next_action:report.next_action,blocking:report.blocking,error_categories:report.error_categories,manual_reasons:report.manual_reasons},null,2));"

--- a/.gitignore
+++ b/.gitignore
@@ -116,6 +116,10 @@ tmp/
 # Local-only internal research notes
 docs/research/
 
+# Local/private automation implementation details
+private/
+ops/private/
+
 # FuseBox cache
 .fusebox/
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,16 +41,43 @@ npm run scan:public-safety
 
 ## Community Intake
 
-Issue submissions can become candidates, not direct registry truth.
+Community submissions can become candidates, not direct registry truth. There are
+two supported paths:
 
-The import flow is:
+- PR-first: add exactly one `registry/candidates/community/*.json` candidate
+  document and no other files.
+- Issue-first: submit an `interface-submission` issue and let the import
+  workflow create the candidate PR after approval.
+
+Do not include generated `public/metagraph/**` artifacts, native snapshots,
+workflow/script changes, secrets, wallet/PAT material, private URLs, or
+validator-local data in UGC submissions.
+
+The public submission gate performs deterministic checks first:
+
+- active Finney netuid;
+- supported surface kind;
+- registered provider;
+- public-safe interface and source URLs;
+- one candidate per submission;
+- no duplicate curated surface or candidate;
+- submitter provenance for direct PRs;
+- no generated artifact edits.
+
+Passing public preflight routes the submission into private gate review. The
+private reviewer may merge/import clean submissions, close hard failures, or
+route rare edge cases to manual review. Public comments expose broad reason
+categories only; private scoring prompts, thresholds, and corpus weights are not
+part of the public repo.
+
+The issue import flow is:
 
 1. Submit an `interface-submission` issue.
 2. `intake:dry-run` parses and validates the issue.
-3. A maintainer reviews source facts and safety.
-4. A maintainer applies `metagraphed-import-approved`.
+3. The submission gate reviews source facts and safety.
+4. The gate or a maintainer applies `metagraphed-import-approved`.
 5. The import workflow opens a PR.
-6. Normal validation and review decide whether it merges.
+6. Normal validation plus gate review decide whether it merges.
 
 Schema-valid does not mean accepted.
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ npm run validate:api
 npm run validate:docs
 npm run validate:intake
 npm run validate:workflows
+npm run submission:pr -- --changed-files changed-files.txt
 npm run r2:manifest:dry-run
 npm run r2:download:dry-run
 npm run kv:publish:dry-run
@@ -189,6 +190,12 @@ npm run probes:smoke
 `probes:smoke` performs read-only checks against public surfaces. It does not submit transactions, mutate subnet state, send wallet data, or use credentials.
 
 `r2:manifest` generates the Cloudflare R2 upload manifest for the current artifact tree. `r2:upload`, `r2:download`, and `kv:publish` require explicit write flags so local validation cannot accidentally publish or restore.
+
+## Community Submissions
+
+Metagraphed supports PR-first and issue-first UGC for public subnet interface corrections. Direct UGC PRs must change exactly one `registry/candidates/community/*.json` file and no generated artifacts. Public preflight returns broad states (`submit_pr`, `fix_required`, `route_away`, `manual_review`); private gate scoring and merge heuristics are intentionally not committed.
+
+See `docs/submission-gate.md` and `CONTRIBUTING.md` for the submission contract.
 
 ## Repository Layout
 

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -1,0 +1,91 @@
+# Metagraphed Submission Gate
+
+Metagraphed accepts community registry improvements through a public preflight
+contract and a private review gate.
+
+The public repo intentionally contains only deterministic validation, issue/PR
+templates, broad labels, and safe reason categories. Private scoring prompts,
+thresholds, corpus weights, and merge heuristics stay outside the public repo so
+the gate is harder to game.
+
+## Public States
+
+- `submit_pr`: the submission shape is valid and ready for private review.
+- `fix_required`: the submission is malformed, unsafe, duplicate, or out of
+  scope.
+- `route_away`: the PR is not a direct UGC submission and should use normal
+  backend review.
+- `manual_review`: the submission may be useful but needs human judgment.
+
+## Labels
+
+- `metagraphed-under-review`: the gate accepted the item for review.
+- `metagraphed-manual-review`: the item needs human judgment.
+- `metagraphed-closed-by-gate`: the gate closed a hard failure.
+- `metagraphed-merged-by-gate`: the gate merged or imported a passing item.
+- `metagraphed-import-approved`: an issue submission can open an import PR.
+
+The stable marker comment is:
+
+```html
+<!-- metagraphed-submission-gate -->
+```
+
+## Direct PR Shape
+
+Direct UGC PRs must change exactly one file:
+
+```text
+registry/candidates/community/<slug>.json
+```
+
+The file must contain exactly one candidate:
+
+```json
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "github-login",
+    "submitted_by_url": "https://github.com/github-login"
+  },
+  "candidates": [
+    {
+      "schema_version": 1,
+      "id": "community-sn-7-docs-example",
+      "netuid": 7,
+      "state": "schema-valid",
+      "name": "Allways community docs example",
+      "kind": "docs",
+      "url": "https://docs.example.com",
+      "source_url": "https://github.com/example/project",
+      "source_urls": ["https://github.com/example/project"],
+      "source_type": "community-pr-intake",
+      "source_tier": "community-docs",
+      "confidence": "medium",
+      "provider": "community",
+      "auth_required": false,
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate."
+    }
+  ]
+}
+```
+
+Generated artifacts, scripts, workflows, package metadata, native snapshots,
+private URLs, secrets, wallet/PAT data, and validator-local data are rejected.
+
+## Private Gate Runtime
+
+The private `metagraphed-submission-gate` should run on Cloudflare:
+
+- Worker for GitHub App webhooks and protected queue/status routes.
+- D1 for PR/issue state, verdicts, retry state, idempotency keys, and audit
+  rows.
+- R2 for redacted webhook payloads, probe evidence, and private review reports.
+- Queues plus a dead-letter queue for async review jobs.
+- Scheduled sweeper for stuck `validation_pending`, `merge_pending`, and
+  retryable rows.
+
+The public workflow job `metagraphed-submission-gate` only runs deterministic
+preflight. It must not publish, merge, or expose private review details.

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "types:generate": "node scripts/generate-types.mjs",
     "intake:dry-run": "node scripts/intake-dry-run.mjs",
     "intake:import": "node scripts/intake-dry-run.mjs --write",
+    "submission:pr": "node scripts/submission-pr.mjs",
     "r2:manifest": "node scripts/r2-manifest.mjs --write",
     "r2:manifest:dry-run": "node scripts/r2-manifest.mjs",
     "build-summary:refresh": "node scripts/refresh-build-summary.mjs",

--- a/registry/candidates/README.md
+++ b/registry/candidates/README.md
@@ -11,6 +11,15 @@ Candidate entries are not published as verified registry surfaces. They must sta
 - no secrets, private dashboards, credentialed flows, or validator-sensitive data are included.
 
 Generated public-source candidates live in `generated/public-sources.json`.
+Community-submitted direct PR candidates live in `community/*.json`.
+
+Direct PR submissions must:
+
+- change exactly one `registry/candidates/community/*.json` file;
+- include one `candidates[0]` entry only;
+- include `submission.submitted_by` and `submission.submitted_by_url` matching the PR author;
+- use public-safe `url` and `source_url` values;
+- avoid generated artifacts, secrets, private URLs, wallet data, and validator-local data.
 
 The generated bundle is allowed to contain:
 

--- a/scripts/intake-dry-run.mjs
+++ b/scripts/intake-dry-run.mjs
@@ -3,12 +3,14 @@ import path from "node:path";
 import {
   loadNativeSnapshot,
   loadProviders,
-  normalizePublicUrl,
   repoRoot,
-  slugify,
   stableStringify,
   writeJson,
 } from "./lib.mjs";
+import {
+  SUBMISSION_LABELS,
+  buildIssueIntakeReport,
+} from "./submission-policy.mjs";
 
 const args = process.argv.slice(2);
 const issueJsonPath = valueAfter("--issue-json");
@@ -16,11 +18,13 @@ const outPath = valueAfter("--out");
 const write = args.includes("--write");
 const native = await loadNativeSnapshot();
 const providers = await loadProviders();
-const providerIds = new Set(providers.map((provider) => provider.id));
-const importApprovalLabel = "metagraphed-import-approved";
-const report = await buildReport(
-  issueJsonPath ? JSON.parse(await fs.readFile(issueJsonPath, "utf8")) : null,
-);
+const report = buildIssueIntakeReport({
+  issue: issueJsonPath
+    ? JSON.parse(await fs.readFile(issueJsonPath, "utf8"))
+    : null,
+  native,
+  providers,
+});
 
 if (outPath) {
   await writeJson(path.resolve(outPath), report);
@@ -29,7 +33,7 @@ if (outPath) {
 if (write) {
   if (!report.import_allowed) {
     console.error(
-      `Refusing to import without schema-valid intake and ${importApprovalLabel} maintainer approval label.`,
+      `Refusing to import without schema-valid intake and ${SUBMISSION_LABELS.importApproved} approval label.`,
     );
     process.exit(1);
   }
@@ -43,164 +47,20 @@ if (write) {
       schema_version: 1,
       generated_by: "metagraphed-intake-import",
       generated_at: report.generated_at,
+      submission: {
+        issue_number: report.issue?.number || null,
+        submitted_by: report.issue?.author || null,
+        submitted_by_url: report.issue?.author
+          ? `https://github.com/${report.issue.author}`
+          : null,
+        review_marker: report.review_marker,
+      },
       candidates: [report.candidate],
     },
   );
 }
 
 console.log(stableStringify(report));
-
-async function buildReport(issue) {
-  const generatedAt = new Date().toISOString();
-  const fields = parseIssueFields(issue?.body || "");
-  const labels = issueLabels(issue);
-  const importApproved = labels.includes(importApprovalLabel);
-  const errors = [];
-
-  const netuid = Number(fields.netuid);
-  if (
-    !Number.isInteger(netuid) ||
-    !native.subnets.some((subnet) => subnet.netuid === netuid)
-  ) {
-    errors.push("netuid must be an active Finney netuid");
-  }
-
-  const kind = normalizeKind(fields["interface kind"] || fields.kind);
-  if (!kind) {
-    errors.push("interface kind is missing or unsupported");
-  }
-
-  const url = normalizePublicUrl(fields["public url"] || fields.url);
-  if (!url) {
-    errors.push("public URL is missing, invalid, or unsafe");
-  }
-
-  const sourceUrl = normalizePublicUrl(
-    fields["source url"] || fields.source_url,
-  );
-  if (!sourceUrl) {
-    errors.push("source URL is missing, invalid, or unsafe");
-  }
-
-  const provider = slugify(
-    fields["provider or team"] || fields.provider || "community",
-  );
-  if (provider && !providerIds.has(provider)) {
-    errors.push(`provider ${provider} is not registered in registry/providers`);
-  }
-
-  const authRequired = normalizeAuth(
-    fields["does this interface require authentication?"] ||
-      fields.auth_required,
-  );
-  if (authRequired === null) {
-    errors.push("auth_required must be no, yes, or unknown");
-  }
-
-  const subnet = native.subnets.find(
-    (candidate) => candidate.netuid === netuid,
-  );
-  const id = `community-sn-${netuid}-${kind || "surface"}-${slugify(new URL(url || "https://invalid.example").hostname)}`;
-  const candidate =
-    errors.length === 0
-      ? {
-          schema_version: 1,
-          id,
-          netuid,
-          state: "schema-valid",
-          name: `${subnet.name} community ${kind}`,
-          kind,
-          url,
-          source_url: sourceUrl,
-          source_urls: [sourceUrl],
-          source_type: "github-issue-intake",
-          source_tier: "community-docs",
-          confidence: "low",
-          provider,
-          auth_required: authRequired,
-          public_safe: true,
-          rate_limit_notes: fields["rate limits or access notes"] || "",
-          review_notes: `Community-submitted candidate from issue ${issue?.number || "unknown"}. Maintainer review is required before promotion.`,
-        }
-      : null;
-  const schemaValid = errors.length === 0;
-
-  return {
-    schema_version: 1,
-    generated_at: generatedAt,
-    issue: issue
-      ? {
-          number: issue.number || null,
-          title: issue.title || null,
-          author: issue.user?.login || null,
-        }
-      : null,
-    state: errors.length === 0 ? "schema-valid" : "schema-invalid",
-    labels,
-    errors,
-    candidate,
-    publish_allowed: false,
-    import_allowed: schemaValid && importApproved,
-    approval_required_label: importApprovalLabel,
-    next_action: !schemaValid
-      ? "resubmission-needed"
-      : importApproved
-        ? "open-import-pr"
-        : "maintainer-review",
-  };
-}
-
-function parseIssueFields(body) {
-  const fields = {};
-  const sections = String(body || "")
-    .split(/^###\s+/m)
-    .slice(1);
-  for (const section of sections) {
-    const [heading, ...rest] = section.split(/\r?\n/);
-    const key = heading.trim().toLowerCase();
-    const value = rest
-      .join("\n")
-      .trim()
-      .replace(/^_No response_$/i, "");
-    fields[key] = value;
-  }
-  return fields;
-}
-
-function normalizeKind(value) {
-  const allowed = new Set([
-    "website",
-    "source-repo",
-    "subnet-api",
-    "openapi",
-    "sse",
-    "dashboard",
-    "repo-registry",
-    "docs",
-    "data-artifact",
-    "subtensor-rpc",
-    "subtensor-wss",
-  ]);
-  const normalized = String(value || "").trim();
-  return allowed.has(normalized) ? normalized : null;
-}
-
-function normalizeAuth(value) {
-  const normalized = String(value || "")
-    .trim()
-    .toLowerCase();
-  if (normalized === "no") return false;
-  if (normalized === "yes") return true;
-  if (normalized === "unknown") return false;
-  return null;
-}
-
-function issueLabels(issue) {
-  return (issue?.labels || [])
-    .map((label) => (typeof label === "string" ? label : label?.name))
-    .filter(Boolean)
-    .sort();
-}
 
 function valueAfter(flag) {
   const index = args.indexOf(flag);

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -1,0 +1,659 @@
+import {
+  flattenSurfaces,
+  normalizePublicUrl,
+  registrySurfaceKey,
+  slugify,
+} from "./lib.mjs";
+
+export const SUBMISSION_REVIEW_MARKER = "<!-- metagraphed-submission-gate -->";
+
+export const SUBMISSION_LABELS = {
+  underReview: "metagraphed-under-review",
+  manualReview: "metagraphed-manual-review",
+  closedByGate: "metagraphed-closed-by-gate",
+  mergedByGate: "metagraphed-merged-by-gate",
+  importApproved: "metagraphed-import-approved",
+  interfaceSubmission: "interface-submission",
+  statusReport: "status-report",
+};
+
+export const PUBLIC_PREFLIGHT_STATES = new Set([
+  "submit_pr",
+  "fix_required",
+  "route_away",
+  "manual_review",
+]);
+
+export const DIRECT_CANDIDATE_PATTERN =
+  /^registry\/candidates\/community\/[a-z0-9][a-z0-9-]*\.json$/;
+
+export const SUPPORTED_INTERFACE_KINDS = new Set([
+  "website",
+  "source-repo",
+  "subnet-api",
+  "openapi",
+  "sse",
+  "dashboard",
+  "repo-registry",
+  "docs",
+  "data-artifact",
+  "subtensor-rpc",
+  "subtensor-wss",
+]);
+
+const TERMINAL_FIX_CATEGORIES = new Set([
+  "duplicate",
+  "generated-artifact-tampering",
+  "private-or-unsafe-url",
+  "secret-or-credential",
+  "unsupported-shape",
+]);
+
+const SECRET_PATTERNS = [
+  /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/,
+  /\bgithub_pat_[A-Za-z0-9_]{20,}\b/,
+  /\b[A-Za-z0-9+/]{32,}={0,2}\b.*\b(secret|token|pat|wallet|private key)\b/i,
+  /\b(private[_-]?key|seed phrase|mnemonic|wallet path|hotkey|coldkey)\b/i,
+];
+
+export function buildIssueIntakeReport({
+  issue,
+  native,
+  providers,
+  generatedAt = new Date().toISOString(),
+}) {
+  const fields = parseIssueFields(issue?.body || "");
+  const labels = issueLabels(issue);
+  const providerIds = new Set(providers.map((provider) => provider.id));
+  const importApproved = labels.includes(SUBMISSION_LABELS.importApproved);
+  const errors = [];
+  const manual_reasons = [];
+
+  const netuid = Number(fields.netuid);
+  if (
+    !Number.isInteger(netuid) ||
+    !native.subnets.some((subnet) => subnet.netuid === netuid)
+  ) {
+    errors.push("netuid must be an active Finney netuid");
+  }
+
+  const kind = normalizeKind(fields["interface kind"] || fields.kind);
+  if (!kind) {
+    errors.push("interface kind is missing or unsupported");
+  }
+
+  const url = normalizePublicUrl(fields["public url"] || fields.url);
+  if (!url) {
+    errors.push("public URL is missing, invalid, or unsafe");
+  }
+
+  const sourceUrl = normalizePublicUrl(
+    fields["source url"] || fields.source_url,
+  );
+  if (!sourceUrl) {
+    errors.push("source URL is missing, invalid, or unsafe");
+  }
+
+  const provider = slugify(
+    fields["provider or team"] || fields.provider || "community",
+  );
+  if (provider && !providerIds.has(provider)) {
+    errors.push(`provider ${provider} is not registered in registry/providers`);
+  }
+
+  const auth = normalizeAuth(
+    fields["does this interface require authentication?"] ||
+      fields.auth_required,
+  );
+  if (auth.value === null) {
+    errors.push("auth_required must be no, yes, or unknown");
+  }
+  if (auth.manualReason) {
+    manual_reasons.push(auth.manualReason);
+  }
+  if (kind && ["subtensor-rpc", "subtensor-wss"].includes(kind)) {
+    manual_reasons.push("base-layer RPC/WSS endpoint claims require review");
+  }
+
+  const unsafeText = unsafeTextReasons(
+    [
+      fields["rate limits or access notes"],
+      fields.evidence,
+      fields["public url"],
+      fields["source url"],
+    ].join("\n"),
+  );
+  errors.push(...unsafeText);
+
+  const subnet = native.subnets.find(
+    (candidate) => candidate.netuid === netuid,
+  );
+  const id =
+    errors.length === 0
+      ? `community-sn-${netuid}-${kind}-${slugify(new URL(url).hostname)}`
+      : null;
+  const candidate =
+    errors.length === 0
+      ? {
+          schema_version: 1,
+          id,
+          netuid,
+          state:
+            manual_reasons.length > 0 ? "maintainer-review" : "schema-valid",
+          name: `${subnet.name} community ${kind}`,
+          kind,
+          url,
+          source_url: sourceUrl,
+          source_urls: [sourceUrl],
+          source_type: "github-issue-intake",
+          source_tier: "community-docs",
+          confidence: manual_reasons.length > 0 ? "low" : "medium",
+          provider,
+          auth_required: auth.value === true,
+          public_safe: true,
+          rate_limit_notes: fields["rate limits or access notes"] || "",
+          review_notes: [
+            `Community-submitted candidate from issue ${issue?.number || "unknown"}.`,
+            manual_reasons.length > 0
+              ? `Manual review reasons: ${manual_reasons.join("; ")}.`
+              : "Ready for private review.",
+          ].join(" "),
+        }
+      : null;
+
+  const schemaValid = errors.length === 0;
+  return {
+    schema_version: 1,
+    generated_at: generatedAt,
+    source: "github-issue-intake",
+    issue: issue
+      ? {
+          number: issue.number || null,
+          title: issue.title || null,
+          author: issue.user?.login || null,
+        }
+      : null,
+    state: schemaValid ? "schema-valid" : "schema-invalid",
+    public_state: !schemaValid
+      ? "fix_required"
+      : manual_reasons.length > 0
+        ? "manual_review"
+        : "submit_pr",
+    labels,
+    errors,
+    manual_reasons,
+    candidate,
+    publish_allowed: false,
+    import_allowed: schemaValid && importApproved,
+    approval_required_label: SUBMISSION_LABELS.importApproved,
+    review_marker: SUBMISSION_REVIEW_MARKER,
+    next_action: !schemaValid
+      ? "resubmission-needed"
+      : importApproved
+        ? "open-import-pr"
+        : manual_reasons.length > 0
+          ? "manual-review"
+          : "private-review",
+  };
+}
+
+export function buildPrSubmissionReport({
+  changedFiles,
+  candidateDocument = null,
+  submitter = null,
+  native,
+  providers,
+  existingCandidates = [],
+  existingSubnets = [],
+  generatedAt = new Date().toISOString(),
+}) {
+  const normalizedFiles = normalizeChangedFiles(changedFiles);
+  const scope = classifyPrScope(normalizedFiles);
+  const errors = [...scope.errors];
+  const manual_reasons = [];
+  const warnings = [];
+  let candidate = null;
+
+  if (scope.scope === "normal-pr") {
+    return {
+      schema_version: 1,
+      generated_at: generatedAt,
+      source: "github-pr-intake",
+      state: "not-routed",
+      public_state: "route_away",
+      changed_files: normalizedFiles,
+      errors: [],
+      warnings: [],
+      manual_reasons: [],
+      candidate: null,
+      publish_allowed: false,
+      auto_merge_eligible: false,
+      blocking: false,
+      review_marker: SUBMISSION_REVIEW_MARKER,
+      next_action: "normal-review",
+    };
+  }
+
+  if (errors.length === 0) {
+    const extracted = extractSingleCandidate(candidateDocument);
+    errors.push(...extracted.errors);
+    candidate = extracted.candidate;
+  }
+
+  if (candidate) {
+    const deterministic = validateCandidateForSubmission({
+      candidate,
+      document: candidateDocument,
+      submitter,
+      native,
+      providers,
+      existingCandidates,
+      existingSubnets,
+    });
+    errors.push(...deterministic.errors);
+    manual_reasons.push(...deterministic.manual_reasons);
+    warnings.push(...deterministic.warnings);
+  }
+
+  const publicState =
+    errors.length > 0
+      ? "fix_required"
+      : manual_reasons.length > 0
+        ? "manual_review"
+        : "submit_pr";
+  const terminalRecommendation = errors.some((error) =>
+    TERMINAL_FIX_CATEGORIES.has(error.category),
+  )
+    ? "close"
+    : null;
+
+  return {
+    schema_version: 1,
+    generated_at: generatedAt,
+    source: "github-pr-intake",
+    state: errors.length === 0 ? "schema-valid" : "schema-invalid",
+    public_state: publicState,
+    changed_files: normalizedFiles,
+    direct_candidate_file: scope.candidateFiles[0] || null,
+    errors: errors.map((error) => error.message),
+    error_categories: errors.map((error) => error.category),
+    warnings,
+    manual_reasons,
+    candidate,
+    publish_allowed: false,
+    auto_merge_eligible: false,
+    private_review_required:
+      publicState === "submit_pr" || publicState === "manual_review",
+    blocking: publicState === "fix_required",
+    terminal_recommendation: terminalRecommendation,
+    review_marker: SUBMISSION_REVIEW_MARKER,
+    labels: {
+      under_review: SUBMISSION_LABELS.underReview,
+      manual_review: SUBMISSION_LABELS.manualReview,
+      closed_by_gate: SUBMISSION_LABELS.closedByGate,
+      merged_by_gate: SUBMISSION_LABELS.mergedByGate,
+    },
+    next_action:
+      publicState === "submit_pr"
+        ? "private-review"
+        : publicState === "manual_review"
+          ? "manual-review"
+          : terminalRecommendation || "resubmission-needed",
+  };
+}
+
+export function classifyPrScope(changedFiles) {
+  const files = normalizeChangedFiles(changedFiles);
+  const candidateFiles = files.filter((file) =>
+    DIRECT_CANDIDATE_PATTERN.test(file),
+  );
+  const touchedCommunityCandidate = files.filter((file) =>
+    file.startsWith("registry/candidates/community/"),
+  );
+  const errors = [];
+
+  if (candidateFiles.length === 0 && touchedCommunityCandidate.length === 0) {
+    return {
+      scope: "normal-pr",
+      candidateFiles,
+      errors,
+    };
+  }
+
+  if (candidateFiles.length !== 1) {
+    errors.push({
+      category: "unsupported-shape",
+      message:
+        "direct submissions must change exactly one registry/candidates/community/*.json file",
+    });
+  }
+
+  const unrelated = files.filter(
+    (file) => !DIRECT_CANDIDATE_PATTERN.test(file),
+  );
+  if (unrelated.length > 0) {
+    errors.push({
+      category: "generated-artifact-tampering",
+      message: `direct submissions cannot change other files: ${unrelated.join(", ")}`,
+    });
+  }
+
+  return {
+    scope: "direct-candidate",
+    candidateFiles,
+    errors,
+  };
+}
+
+export function extractSingleCandidate(document) {
+  const errors = [];
+  if (!document || typeof document !== "object") {
+    return {
+      candidate: null,
+      errors: [
+        {
+          category: "unsupported-shape",
+          message: "candidate document must be a JSON object",
+        },
+      ],
+    };
+  }
+
+  if (document.schema_version !== 1) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate document schema_version must be 1",
+    });
+  }
+  if (!Array.isArray(document.candidates) || document.candidates.length !== 1) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate document must contain exactly one candidate",
+    });
+  }
+
+  return {
+    candidate: document.candidates?.[0] || null,
+    errors,
+  };
+}
+
+export function validateCandidateForSubmission({
+  candidate,
+  document = {},
+  submitter = null,
+  native,
+  providers,
+  existingCandidates = [],
+  existingSubnets = [],
+}) {
+  const errors = [];
+  const warnings = [];
+  const manual_reasons = [];
+  const nativeNetuids = new Set(native.subnets.map((subnet) => subnet.netuid));
+  const providerIds = new Set(providers.map((provider) => provider.id));
+  const normalizedUrl = normalizePublicUrl(candidate?.url);
+  const normalizedSourceUrl = normalizePublicUrl(candidate?.source_url);
+
+  if (!candidate || typeof candidate !== "object") {
+    return {
+      errors: [
+        {
+          category: "unsupported-shape",
+          message: "candidate is required",
+        },
+      ],
+      warnings,
+      manual_reasons,
+    };
+  }
+
+  if (candidate.schema_version !== 1) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate schema_version must be 1",
+    });
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(candidate.id || "")) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate id must be a lowercase slug",
+    });
+  }
+  if (
+    !Number.isInteger(candidate.netuid) ||
+    !nativeNetuids.has(candidate.netuid)
+  ) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate netuid must be an active Finney netuid",
+    });
+  }
+  if (!SUPPORTED_INTERFACE_KINDS.has(candidate.kind)) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate kind is unsupported",
+    });
+  }
+  if (!normalizedUrl) {
+    errors.push({
+      category: "private-or-unsafe-url",
+      message: "candidate url is missing, invalid, or unsafe",
+    });
+  }
+  if (!normalizedSourceUrl) {
+    errors.push({
+      category: "private-or-unsafe-url",
+      message: "candidate source_url is missing, invalid, or unsafe",
+    });
+  }
+  if (candidate.url && normalizedUrl && candidate.url !== normalizedUrl) {
+    warnings.push("candidate url will be normalized by registry tooling");
+  }
+  if (
+    candidate.source_url &&
+    normalizedSourceUrl &&
+    candidate.source_url !== normalizedSourceUrl
+  ) {
+    warnings.push(
+      "candidate source_url will be normalized by registry tooling",
+    );
+  }
+  if (!providerIds.has(candidate.provider)) {
+    errors.push({
+      category: "unsupported-shape",
+      message: `candidate provider ${candidate.provider || "<missing>"} is not registered`,
+    });
+  }
+  if (candidate.public_safe !== true) {
+    errors.push({
+      category: "private-or-unsafe-url",
+      message: "candidate public_safe must be true for community submissions",
+    });
+  }
+  if (candidate.state && candidate.state !== "schema-valid") {
+    manual_reasons.push(`candidate state ${candidate.state} requires review`);
+  }
+  if (candidate.auth_required === true) {
+    manual_reasons.push("authenticated interfaces require review");
+  }
+  if (["subtensor-rpc", "subtensor-wss"].includes(candidate.kind)) {
+    manual_reasons.push("base-layer RPC/WSS endpoint claims require review");
+  }
+  if (candidate.source_tier === "native-chain") {
+    errors.push({
+      category: "unsupported-shape",
+      message: "community candidates cannot claim native-chain source tier",
+    });
+  }
+  if (
+    candidate.source_type &&
+    !["community-pr-intake", "github-issue-intake"].includes(
+      candidate.source_type,
+    )
+  ) {
+    warnings.push(
+      "candidate source_type is not a standard community intake type",
+    );
+  }
+
+  errors.push(...unsafeTextReasons(JSON.stringify(candidate)));
+  errors.push(
+    ...validateSubmissionProvenance({
+      document,
+      submitter,
+    }),
+  );
+
+  if (normalizedUrl && candidate.kind && Number.isInteger(candidate.netuid)) {
+    const locator = registrySurfaceKey({
+      netuid: candidate.netuid,
+      kind: candidate.kind,
+      url: normalizedUrl,
+    });
+    const surfaces = flattenSurfaces(existingSubnets || []);
+    const surfaceDuplicate = surfaces.find(
+      (surface) => registrySurfaceKey(surface) === locator,
+    );
+    if (surfaceDuplicate) {
+      errors.push({
+        category: "duplicate",
+        message: `candidate duplicates curated surface ${surfaceDuplicate.id}`,
+      });
+    }
+
+    const candidateDuplicate = existingCandidates.find(
+      (existing) =>
+        existing.id !== candidate.id &&
+        registrySurfaceKey(existing) === locator,
+    );
+    if (candidateDuplicate) {
+      errors.push({
+        category: "duplicate",
+        message: `candidate duplicates existing candidate ${candidateDuplicate.id}`,
+      });
+    }
+  }
+
+  return { errors, warnings, manual_reasons };
+}
+
+export function normalizeChangedFiles(files) {
+  if (typeof files === "string") {
+    return files
+      .split(/\r?\n/)
+      .map((file) => file.trim())
+      .filter(Boolean)
+      .sort();
+  }
+  return [...new Set((files || []).map((file) => String(file).trim()))]
+    .filter(Boolean)
+    .map((file) => file.replace(/\\/g, "/").replace(/^\.\/+/, ""))
+    .sort();
+}
+
+export function parseIssueFields(body) {
+  const fields = {};
+  const sections = String(body || "")
+    .split(/^###\s+/m)
+    .slice(1);
+  for (const section of sections) {
+    const [heading, ...rest] = section.split(/\r?\n/);
+    const key = heading.trim().toLowerCase();
+    const value = rest
+      .join("\n")
+      .trim()
+      .replace(/^_No response_$/i, "");
+    fields[key] = value;
+  }
+  return fields;
+}
+
+export function normalizeKind(value) {
+  const normalized = String(value || "").trim();
+  return SUPPORTED_INTERFACE_KINDS.has(normalized) ? normalized : null;
+}
+
+export function normalizeAuth(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (normalized === "no") return { value: false, manualReason: null };
+  if (normalized === "yes") {
+    return {
+      value: true,
+      manualReason: "authenticated interfaces require review",
+    };
+  }
+  if (normalized === "unknown") {
+    return {
+      value: false,
+      manualReason: "unknown auth requirements require review",
+    };
+  }
+  return { value: null, manualReason: null };
+}
+
+export function issueLabels(issue) {
+  return (issue?.labels || [])
+    .map((label) => (typeof label === "string" ? label : label?.name))
+    .filter(Boolean)
+    .sort();
+}
+
+export function validateSubmissionProvenance({ document, submitter }) {
+  const errors = [];
+  const provenance = document?.submission || {};
+  const normalizedSubmitter = normalizeGitHubLogin(submitter);
+  const submittedBy = normalizeGitHubLogin(provenance.submitted_by);
+  const submittedByUrl = String(provenance.submitted_by_url || "").trim();
+
+  if (!normalizedSubmitter) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "submitter is required for direct candidate PR validation",
+    });
+  }
+  if (!submittedBy) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate document must include submission.submitted_by",
+    });
+  }
+  if (
+    normalizedSubmitter &&
+    submittedBy &&
+    normalizedSubmitter !== submittedBy
+  ) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "submission.submitted_by must match the PR author",
+    });
+  }
+  if (submittedBy && submittedByUrl !== `https://github.com/${submittedBy}`) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "submission.submitted_by_url must match submitted_by",
+    });
+  }
+
+  return errors;
+}
+
+export function normalizeGitHubLogin(value) {
+  return String(value || "")
+    .trim()
+    .replace(/^@/, "")
+    .replace(/^https:\/\/github\.com\//i, "")
+    .replace(/\/+$/, "")
+    .toLowerCase();
+}
+
+export function unsafeTextReasons(text) {
+  const value = String(text || "");
+  return SECRET_PATTERNS.filter((pattern) => pattern.test(value)).map(() => ({
+    category: "secret-or-credential",
+    message:
+      "submission appears to include wallet, PAT, token, or private credential material",
+  }));
+}

--- a/scripts/submission-pr.mjs
+++ b/scripts/submission-pr.mjs
@@ -1,0 +1,71 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  loadCandidates,
+  loadNativeSnapshot,
+  loadProviders,
+  loadSubnets,
+  readJson,
+  stableStringify,
+  writeJson,
+} from "./lib.mjs";
+import {
+  DIRECT_CANDIDATE_PATTERN,
+  buildPrSubmissionReport,
+  normalizeChangedFiles,
+} from "./submission-policy.mjs";
+
+const args = process.argv.slice(2);
+const changedFilesPath = valueAfter("--changed-files");
+const outPath = valueAfter("--out");
+const submitter =
+  valueAfter("--submitter") || process.env.GITHUB_ACTOR || process.env.USER;
+const failOnBlocking = !args.includes("--no-fail");
+
+if (!changedFilesPath) {
+  console.error("--changed-files is required");
+  process.exit(1);
+}
+
+const changedFiles = normalizeChangedFiles(
+  await fs.readFile(changedFilesPath, "utf8"),
+);
+const directCandidateFile = changedFiles.find((file) =>
+  DIRECT_CANDIDATE_PATTERN.test(file),
+);
+const candidateDocument = directCandidateFile
+  ? await readJson(path.resolve(directCandidateFile))
+  : null;
+const existingCandidates = directCandidateFile
+  ? (await loadCandidates()).filter(
+      (candidate) =>
+        !candidateDocument?.candidates?.some(
+          (submitted) => submitted.id === candidate.id,
+        ),
+    )
+  : await loadCandidates();
+
+const report = buildPrSubmissionReport({
+  changedFiles,
+  candidateDocument,
+  submitter,
+  native: await loadNativeSnapshot(),
+  providers: await loadProviders(),
+  existingCandidates,
+  existingSubnets: await loadSubnets(),
+});
+
+if (outPath) {
+  await writeJson(path.resolve(outPath), report);
+}
+
+console.log(stableStringify(report));
+
+if (failOnBlocking && report.blocking) {
+  process.exit(1);
+}
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1] || null;
+}

--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -11,11 +11,19 @@ const statusTemplate = await fs.readFile(
   path.join(templateRoot, "report-endpoint-status-issue.yml"),
   "utf8",
 );
+const pullRequestTemplate = await fs.readFile(
+  path.join(repoRoot, ".github/pull_request_template.md"),
+  "utf8",
+);
+const submissionGateDocs = await fs.readFile(
+  path.join(repoRoot, "docs/submission-gate.md"),
+  "utf8",
+);
 const errors = [];
 
 checkIncludes(interfaceTemplate.toLowerCase(), "interface template", [
   "interface-submission",
-  "maintainer-review",
+  "metagraphed-under-review",
   "id: netuid",
   "id: kind",
   "id: url",
@@ -44,12 +52,30 @@ for (const kind of [
 
 checkIncludes(statusTemplate, "status template", [
   "status-report",
-  "maintainer-review",
+  "metagraphed-under-review",
   "id: netuid",
   "id: surface_id",
   "id: issue_type",
   "unsafe-or-private",
   "This report does not include secrets",
+]);
+
+checkIncludes(pullRequestTemplate, "pull request template", [
+  "registry/candidates/community/*.json",
+  "npm run submission:pr",
+]);
+
+checkIncludes(submissionGateDocs, "submission gate docs", [
+  "submit_pr",
+  "fix_required",
+  "route_away",
+  "manual_review",
+  "metagraphed-under-review",
+  "metagraphed-manual-review",
+  "metagraphed-closed-by-gate",
+  "metagraphed-merged-by-gate",
+  "metagraphed-import-approved",
+  "<!-- metagraphed-submission-gate -->",
 ]);
 
 if (errors.length > 0) {

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -88,6 +88,24 @@ for (const workflow of workflows) {
       "intake import must use the checked-in import script",
     );
   }
+  if (workflow === "submission-gate.yml") {
+    check(
+      content.includes("metagraphed-submission-gate:"),
+      workflow,
+      "submission gate workflow must expose the metagraphed-submission-gate job",
+    );
+    check(
+      content.includes("npm run submission:pr"),
+      workflow,
+      "submission gate workflow must use the checked-in PR classifier",
+    );
+    check(
+      !content.includes("contents: write") &&
+        !content.includes("pull-requests: write"),
+      workflow,
+      "public submission gate workflow must not publish or merge",
+    );
+  }
   if (
     ["validate.yml", "sync-subnets.yml", "publish-cloudflare.yml"].includes(
       workflow,

--- a/tests/fixtures/submissions/valid-direct-candidate.json
+++ b/tests/fixtures/submissions/valid-direct-candidate.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  },
+  "candidates": [
+    {
+      "schema_version": 1,
+      "id": "community-sn-7-docs-example",
+      "netuid": 7,
+      "state": "schema-valid",
+      "name": "Allways community docs example",
+      "kind": "docs",
+      "url": "https://docs.all-ways.io/community-submission-example",
+      "source_url": "https://docs.all-ways.io/how-it-works.html",
+      "source_urls": ["https://docs.all-ways.io/how-it-works.html"],
+      "source_type": "community-pr-intake",
+      "source_tier": "community-docs",
+      "confidence": "medium",
+      "provider": "allways",
+      "auth_required": false,
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate."
+    }
+  ]
+}

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, test } from "vitest";
+import {
+  loadNativeSnapshot,
+  loadProviders,
+  loadSubnets,
+} from "../scripts/lib.mjs";
+import {
+  SUBMISSION_LABELS,
+  buildIssueIntakeReport,
+  buildPrSubmissionReport,
+  classifyPrScope,
+} from "../scripts/submission-policy.mjs";
+
+const validCandidateDocument = JSON.parse(
+  readFileSync(
+    "tests/fixtures/submissions/valid-direct-candidate.json",
+    "utf8",
+  ),
+);
+const native = await loadNativeSnapshot();
+const providers = await loadProviders();
+const subnets = await loadSubnets();
+
+describe("Metagraphed submission gate policy", () => {
+  test("routes normal backend PRs away from the UGC gate", () => {
+    const report = buildPrSubmissionReport({
+      changedFiles: ["scripts/build-artifacts.mjs", "tests/artifacts.test.mjs"],
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+
+    assert.equal(report.public_state, "route_away");
+    assert.equal(report.next_action, "normal-review");
+    assert.equal(report.blocking, false);
+  });
+
+  test("accepts a one-file direct candidate for private review", () => {
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/allways-docs-example.json"],
+      candidateDocument: validCandidateDocument,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "JSONbored",
+    });
+
+    assert.equal(report.public_state, "submit_pr");
+    assert.equal(report.next_action, "private-review");
+    assert.equal(report.private_review_required, true);
+    assert.equal(report.blocking, false);
+    assert.equal(report.candidate.id, "community-sn-7-docs-example");
+  });
+
+  test("blocks direct candidates that edit unrelated files", () => {
+    const scope = classifyPrScope([
+      "registry/candidates/community/allways-docs-example.json",
+      "public/metagraph/subnets.json",
+    ]);
+
+    assert.equal(scope.scope, "direct-candidate");
+    assert.equal(scope.errors.length, 1);
+    assert.equal(scope.errors[0].category, "generated-artifact-tampering");
+  });
+
+  test("blocks unsafe candidate URLs", () => {
+    const document = structuredClone(validCandidateDocument);
+    document.candidates[0].url = "http://127.0.0.1:9944";
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/bad-localhost.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.blocking, true);
+    assert.equal(
+      report.error_categories.includes("private-or-unsafe-url"),
+      true,
+    );
+  });
+
+  test("routes auth-required and base-layer endpoint claims to manual review", () => {
+    const authDocument = structuredClone(validCandidateDocument);
+    authDocument.candidates[0].auth_required = true;
+    const authReport = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/auth-api.json"],
+      candidateDocument: authDocument,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(authReport.public_state, "manual_review");
+
+    const rpcDocument = structuredClone(validCandidateDocument);
+    rpcDocument.candidates[0].kind = "subtensor-rpc";
+    rpcDocument.candidates[0].url = "https://rpc.example.com";
+    const rpcReport = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/rpc.json"],
+      candidateDocument: rpcDocument,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(rpcReport.public_state, "manual_review");
+  });
+
+  test("blocks duplicate curated surfaces", () => {
+    const allways = subnets.find((subnet) => subnet.netuid === 7);
+    const duplicateSurface = allways.surfaces[0];
+    const document = structuredClone(validCandidateDocument);
+    Object.assign(document.candidates[0], {
+      kind: duplicateSurface.kind,
+      url: duplicateSurface.url,
+    });
+
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/duplicate.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.terminal_recommendation, "close");
+    assert.equal(report.error_categories.includes("duplicate"), true);
+  });
+
+  test("requires direct PR provenance to match the submitter", () => {
+    const document = structuredClone(validCandidateDocument);
+    document.submission.submitted_by = "someone-else";
+    document.submission.submitted_by_url = "https://github.com/someone-else";
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/provenance.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(
+      report.errors.includes(
+        "submission.submitted_by must match the PR author",
+      ),
+      true,
+    );
+  });
+
+  test("keeps issue approval explicit", () => {
+    const body = [
+      "### Netuid",
+      "7",
+      "### Subnet name",
+      "Allways",
+      "### Interface kind",
+      "docs",
+      "### Public URL",
+      "https://docs.all-ways.io/community-submission-example",
+      "### Source URL",
+      "https://docs.all-ways.io/how-it-works.html",
+      "### Provider or team",
+      "allways",
+      "### Does this interface require authentication?",
+      "no",
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 42,
+        title: "interface: allways docs",
+        user: { login: "jsonbored" },
+        labels: [
+          { name: SUBMISSION_LABELS.interfaceSubmission },
+          { name: SUBMISSION_LABELS.importApproved },
+        ],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.state, "schema-valid");
+    assert.equal(report.public_state, "submit_pr");
+    assert.equal(report.import_allowed, true);
+    assert.equal(report.next_action, "open-import-pr");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a public deterministic UGC preflight layer for Metagraphed submissions.
- Supports PR-first one-candidate submissions while keeping private reviewer scoring out of the public repo.
- Updates issue intake labels/docs/workflow checks around the Metagraphed submission gate.

## What changed
- Added a shared submission policy module for issue and PR intake.
- Added `npm run submission:pr` for direct PR preflight over changed files.
- Added a `metagraphed-submission-gate` workflow job for public deterministic checks.
- Added submission-gate docs, PR template guidance, candidate README guidance, and regression fixtures/tests.
- Added ignored `private/` and `ops/private/` paths for non-public gate implementation material.

## Why
- Clean community interface submissions should be able to move through automation without exposing private review prompts, thresholds, or scoring internals.
- The public repo needs a stable contract for contributors and future GitHub App/Cloudflare automation.

## Validation
- `npm run validate`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:intake`
- `npm run validate:workflows`
- `npm run validate:docs`
- `npm run validate:artifact-budgets`
- `npm run worker:test`
- `npm run test:coverage` - 4 files, 26 tests passed; 97.06% statement coverage
- `npm run lint`
- `npm run format:check`
- `npm run scan:public-safety`
- `npm run cloudflare:verify:dry-run` - passed with expected local-only Cloudflare binding warnings
- `git diff --check`

## Notes
- The private Cloudflare reviewer implementation is intentionally not committed here. This PR adds the public validation and integration contract only.
- Generated `public/metagraph/**` artifacts were left unchanged.