### PR TITLE
feat(api): type query contracts for list routes

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -528,6 +528,8 @@ export interface components {
             path: string;
             /** @constant */
             public: true;
+            query_collection?: string | null;
+            query_filter_names?: string[];
             query_parameters: components["schemas"]["ApiQueryParameter"][];
         };
         ArtifactBase: {
@@ -1633,12 +1635,12 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                state?: string;
+                state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -1914,10 +1916,10 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                coverage_level?: string;
+                coverage_level?: "native-only" | "manifested" | "probed";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "coverage_level" | "curation_level" | "name" | "netuid";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -1991,7 +1993,7 @@ export interface operations {
                 q?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "claim" | "source_url" | "subject" | "verified_at";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2131,11 +2133,11 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                coverage_level?: string;
-                curation_level?: string;
+                coverage_level?: "native-only" | "manifested" | "probed";
+                curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "coverage_level" | "curation_level" | "gap_count" | "name" | "netuid";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2207,10 +2209,10 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                status?: string;
+                status?: "ok" | "degraded" | "failed" | "unknown";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "avg_latency_ms" | "degraded_count" | "failed_count" | "last_checked" | "last_ok" | "name" | "netuid" | "ok_count" | "status" | "surface_count" | "unknown_count";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2282,11 +2284,13 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                status?: string;
-                classification?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                provider?: string;
+                status?: "ok" | "degraded" | "failed" | "unknown";
+                classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2428,11 +2432,11 @@ export interface operations {
         parameters: {
             query?: {
                 id?: string;
-                kind?: string;
-                authority?: string;
+                kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
+                authority?: "community" | "official" | "provider-claimed" | "registry-observed";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "authority" | "id" | "kind" | "name";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2573,12 +2577,12 @@ export interface operations {
     rpcEndpoints: {
         parameters: {
             query?: {
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                status?: string;
+                status?: "ok" | "degraded" | "failed" | "unknown";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "kind" | "latency_ms" | "provider" | "status";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2788,7 +2792,7 @@ export interface operations {
                 q?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "kind" | "netuid" | "slug" | "title";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2930,7 +2934,7 @@ export interface operations {
                 q?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "id" | "kind" | "path" | "record_count";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3002,13 +3006,13 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                coverage_level?: string;
-                curation_level?: string;
-                status?: string;
-                subnet_type?: string;
+                coverage_level?: "native-only" | "manifested" | "probed";
+                curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                status?: "active" | "inactive";
+                subnet_type?: "root" | "application";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3149,12 +3153,12 @@ export interface operations {
     subnetCandidates: {
         parameters: {
             query?: {
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                state?: string;
+                state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3227,13 +3231,13 @@ export interface operations {
     subnetHealth: {
         parameters: {
             query?: {
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                status?: string;
-                classification?: string;
+                status?: "ok" | "degraded" | "failed" | "unknown";
+                classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3306,13 +3310,11 @@ export interface operations {
     subnetSurfaces: {
         parameters: {
             query?: {
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                status?: string;
-                classification?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "id" | "kind" | "name" | "netuid" | "provider";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3386,13 +3388,11 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                status?: string;
-                classification?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "id" | "kind" | "name" | "netuid" | "provider";
                 order?: "asc" | "desc";
             };
             header?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -267,6 +267,8 @@
       "method": "GET",
       "path": "/api/v1",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -277,6 +279,14 @@
       "method": "GET",
       "path": "/api/v1/subnets",
       "public": true,
+      "query_collection": "subnets",
+      "query_filter_names": [
+        "netuid",
+        "coverage_level",
+        "curation_level",
+        "status",
+        "subnet_type"
+      ],
       "query_parameters": [
         {
           "name": "netuid",
@@ -288,24 +298,44 @@
         {
           "name": "coverage_level",
           "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
             "type": "string"
           }
         },
         {
           "name": "curation_level",
           "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
             "type": "string"
           }
         },
         {
           "name": "status",
           "schema": {
+            "enum": [
+              "active",
+              "inactive"
+            ],
             "type": "string"
           }
         },
         {
           "name": "subnet_type",
           "schema": {
+            "enum": [
+              "root",
+              "application"
+            ],
             "type": "string"
           }
         },
@@ -327,6 +357,21 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "block",
+              "candidate_count",
+              "coverage_level",
+              "curation_level",
+              "mechanism_count",
+              "name",
+              "netuid",
+              "participant_count",
+              "probed_surface_count",
+              "status",
+              "subnet_type",
+              "surface_count",
+              "tempo"
+            ],
             "type": "string"
           }
         },
@@ -349,6 +394,8 @@
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -359,6 +406,12 @@
       "method": "GET",
       "path": "/api/v1/surfaces",
       "public": true,
+      "query_collection": "curated-surfaces",
+      "query_filter_names": [
+        "netuid",
+        "kind",
+        "provider"
+      ],
       "query_parameters": [
         {
           "name": "netuid",
@@ -370,23 +423,24 @@
         {
           "name": "kind",
           "schema": {
+            "enum": [
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "openapi",
+              "repo-registry",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
             "type": "string"
           }
         },
         {
           "name": "provider",
-          "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "status",
-          "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "classification",
           "schema": {
             "type": "string"
           }
@@ -409,6 +463,13 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "id",
+              "kind",
+              "name",
+              "netuid",
+              "provider"
+            ],
             "type": "string"
           }
         },
@@ -431,27 +492,33 @@
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/surfaces",
       "public": true,
+      "query_collection": "curated-surfaces",
+      "query_filter_names": [
+        "kind",
+        "provider"
+      ],
       "query_parameters": [
         {
           "name": "kind",
           "schema": {
+            "enum": [
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "openapi",
+              "repo-registry",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
             "type": "string"
           }
         },
         {
           "name": "provider",
-          "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "status",
-          "schema": {
-            "type": "string"
-          }
-        },
-        {
-          "name": "classification",
           "schema": {
             "type": "string"
           }
@@ -474,6 +541,13 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "id",
+              "kind",
+              "name",
+              "netuid",
+              "provider"
+            ],
             "type": "string"
           }
         },
@@ -496,6 +570,13 @@
       "method": "GET",
       "path": "/api/v1/candidates",
       "public": true,
+      "query_collection": "candidates",
+      "query_filter_names": [
+        "netuid",
+        "kind",
+        "provider",
+        "state"
+      ],
       "query_parameters": [
         {
           "name": "netuid",
@@ -507,6 +588,19 @@
         {
           "name": "kind",
           "schema": {
+            "enum": [
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "openapi",
+              "repo-registry",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
             "type": "string"
           }
         },
@@ -519,6 +613,14 @@
         {
           "name": "state",
           "schema": {
+            "enum": [
+              "schema-invalid",
+              "schema-valid",
+              "maintainer-review",
+              "verified",
+              "stale",
+              "rejected"
+            ],
             "type": "string"
           }
         },
@@ -540,6 +642,15 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "confidence",
+              "id",
+              "kind",
+              "name",
+              "netuid",
+              "provider",
+              "state"
+            ],
             "type": "string"
           }
         },
@@ -562,10 +673,29 @@
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/candidates",
       "public": true,
+      "query_collection": "candidates",
+      "query_filter_names": [
+        "kind",
+        "provider",
+        "state"
+      ],
       "query_parameters": [
         {
           "name": "kind",
           "schema": {
+            "enum": [
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "openapi",
+              "repo-registry",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
             "type": "string"
           }
         },
@@ -578,6 +708,14 @@
         {
           "name": "state",
           "schema": {
+            "enum": [
+              "schema-invalid",
+              "schema-valid",
+              "maintainer-review",
+              "verified",
+              "stale",
+              "rejected"
+            ],
             "type": "string"
           }
         },
@@ -599,6 +737,15 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "confidence",
+              "id",
+              "kind",
+              "name",
+              "netuid",
+              "provider",
+              "state"
+            ],
             "type": "string"
           }
         },
@@ -621,6 +768,12 @@
       "method": "GET",
       "path": "/api/v1/providers",
       "public": true,
+      "query_collection": "providers",
+      "query_filter_names": [
+        "id",
+        "kind",
+        "authority"
+      ],
       "query_parameters": [
         {
           "name": "id",
@@ -631,12 +784,25 @@
         {
           "name": "kind",
           "schema": {
+            "enum": [
+              "data-provider",
+              "docs-provider",
+              "infrastructure-provider",
+              "registry",
+              "subnet-team"
+            ],
             "type": "string"
           }
         },
         {
           "name": "authority",
           "schema": {
+            "enum": [
+              "community",
+              "official",
+              "provider-claimed",
+              "registry-observed"
+            ],
             "type": "string"
           }
         },
@@ -658,6 +824,12 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "authority",
+              "id",
+              "kind",
+              "name"
+            ],
             "type": "string"
           }
         },
@@ -680,6 +852,8 @@
       "method": "GET",
       "path": "/api/v1/providers/{slug}",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -690,6 +864,8 @@
       "method": "GET",
       "path": "/api/v1/coverage",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -700,6 +876,11 @@
       "method": "GET",
       "path": "/api/v1/curation",
       "public": true,
+      "query_collection": "curation",
+      "query_filter_names": [
+        "netuid",
+        "coverage_level"
+      ],
       "query_parameters": [
         {
           "name": "netuid",
@@ -711,6 +892,11 @@
         {
           "name": "coverage_level",
           "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
             "type": "string"
           }
         },
@@ -732,6 +918,12 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "coverage_level",
+              "curation_level",
+              "name",
+              "netuid"
+            ],
             "type": "string"
           }
         },
@@ -754,6 +946,12 @@
       "method": "GET",
       "path": "/api/v1/gaps",
       "public": true,
+      "query_collection": "gaps",
+      "query_filter_names": [
+        "netuid",
+        "coverage_level",
+        "curation_level"
+      ],
       "query_parameters": [
         {
           "name": "netuid",
@@ -765,12 +963,24 @@
         {
           "name": "coverage_level",
           "schema": {
+            "enum": [
+              "native-only",
+              "manifested",
+              "probed"
+            ],
             "type": "string"
           }
         },
         {
           "name": "curation_level",
           "schema": {
+            "enum": [
+              "native",
+              "candidate-discovered",
+              "machine-verified",
+              "maintainer-reviewed",
+              "adapter-backed"
+            ],
             "type": "string"
           }
         },
@@ -792,6 +1002,13 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "coverage_level",
+              "curation_level",
+              "gap_count",
+              "name",
+              "netuid"
+            ],
             "type": "string"
           }
         },
@@ -814,6 +1031,11 @@
       "method": "GET",
       "path": "/api/v1/health",
       "public": true,
+      "query_collection": "health-subnets",
+      "query_filter_names": [
+        "netuid",
+        "status"
+      ],
       "query_parameters": [
         {
           "name": "netuid",
@@ -825,6 +1047,12 @@
         {
           "name": "status",
           "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
             "type": "string"
           }
         },
@@ -846,6 +1074,19 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "avg_latency_ms",
+              "degraded_count",
+              "failed_count",
+              "last_checked",
+              "last_ok",
+              "name",
+              "netuid",
+              "ok_count",
+              "status",
+              "surface_count",
+              "unknown_count"
+            ],
             "type": "string"
           }
         },
@@ -868,6 +1109,14 @@
       "method": "GET",
       "path": "/api/v1/health/history/{date}",
       "public": true,
+      "query_collection": "health-surfaces",
+      "query_filter_names": [
+        "netuid",
+        "kind",
+        "provider",
+        "status",
+        "classification"
+      ],
       "query_parameters": [
         {
           "name": "netuid",
@@ -877,14 +1126,57 @@
           }
         },
         {
+          "name": "kind",
+          "schema": {
+            "enum": [
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "openapi",
+              "repo-registry",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "provider",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
           "name": "status",
           "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
             "type": "string"
           }
         },
         {
           "name": "classification",
           "schema": {
+            "enum": [
+              "auth-required",
+              "content-mismatch",
+              "dead",
+              "live",
+              "rate-limited",
+              "redirected",
+              "timeout",
+              "transient",
+              "unsupported",
+              "unsafe"
+            ],
             "type": "string"
           }
         },
@@ -906,6 +1198,19 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "classification",
+              "kind",
+              "last_checked",
+              "last_ok",
+              "latency_ms",
+              "netuid",
+              "provider",
+              "status",
+              "status_code",
+              "surface_id",
+              "verified_at"
+            ],
             "type": "string"
           }
         },
@@ -928,10 +1233,30 @@
       "method": "GET",
       "path": "/api/v1/subnets/{netuid}/health",
       "public": true,
+      "query_collection": "health-surfaces",
+      "query_filter_names": [
+        "kind",
+        "provider",
+        "status",
+        "classification"
+      ],
       "query_parameters": [
         {
           "name": "kind",
           "schema": {
+            "enum": [
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "openapi",
+              "repo-registry",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
             "type": "string"
           }
         },
@@ -944,12 +1269,30 @@
         {
           "name": "status",
           "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
             "type": "string"
           }
         },
         {
           "name": "classification",
           "schema": {
+            "enum": [
+              "auth-required",
+              "content-mismatch",
+              "dead",
+              "live",
+              "rate-limited",
+              "redirected",
+              "timeout",
+              "transient",
+              "unsupported",
+              "unsafe"
+            ],
             "type": "string"
           }
         },
@@ -971,6 +1314,19 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "classification",
+              "kind",
+              "last_checked",
+              "last_ok",
+              "latency_ms",
+              "netuid",
+              "provider",
+              "status",
+              "status_code",
+              "surface_id",
+              "verified_at"
+            ],
             "type": "string"
           }
         },
@@ -993,6 +1349,8 @@
       "method": "GET",
       "path": "/api/v1/freshness",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -1003,6 +1361,8 @@
       "method": "GET",
       "path": "/api/v1/source-health",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -1013,6 +1373,8 @@
       "method": "GET",
       "path": "/api/v1/evidence",
       "public": true,
+      "query_collection": "claims",
+      "query_filter_names": [],
       "query_parameters": [
         {
           "name": "q",
@@ -1038,6 +1400,12 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "claim",
+              "source_url",
+              "subject",
+              "verified_at"
+            ],
             "type": "string"
           }
         },
@@ -1060,6 +1428,8 @@
       "method": "GET",
       "path": "/api/v1/changelog",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -1070,6 +1440,8 @@
       "method": "GET",
       "path": "/api/v1/source-snapshots",
       "public": true,
+      "query_collection": "sources",
+      "query_filter_names": [],
       "query_parameters": [
         {
           "name": "q",
@@ -1095,6 +1467,12 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "id",
+              "kind",
+              "path",
+              "record_count"
+            ],
             "type": "string"
           }
         },
@@ -1117,10 +1495,29 @@
       "method": "GET",
       "path": "/api/v1/rpc/endpoints",
       "public": true,
+      "query_collection": "endpoints",
+      "query_filter_names": [
+        "kind",
+        "provider",
+        "status"
+      ],
       "query_parameters": [
         {
           "name": "kind",
           "schema": {
+            "enum": [
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "openapi",
+              "repo-registry",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
             "type": "string"
           }
         },
@@ -1133,6 +1530,12 @@
         {
           "name": "status",
           "schema": {
+            "enum": [
+              "ok",
+              "degraded",
+              "failed",
+              "unknown"
+            ],
             "type": "string"
           }
         },
@@ -1154,6 +1557,12 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "kind",
+              "latency_ms",
+              "provider",
+              "status"
+            ],
             "type": "string"
           }
         },
@@ -1176,6 +1585,8 @@
       "method": "GET",
       "path": "/api/v1/rpc/pools",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -1186,6 +1597,8 @@
       "method": "GET",
       "path": "/api/v1/schemas",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -1196,6 +1609,8 @@
       "method": "GET",
       "path": "/api/v1/adapters/{slug}",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -1206,6 +1621,8 @@
       "method": "GET",
       "path": "/api/v1/search",
       "public": true,
+      "query_collection": "documents",
+      "query_filter_names": [],
       "query_parameters": [
         {
           "name": "q",
@@ -1231,6 +1648,12 @@
         {
           "name": "sort",
           "schema": {
+            "enum": [
+              "kind",
+              "netuid",
+              "slug",
+              "title"
+            ],
             "type": "string"
           }
         },
@@ -1253,6 +1676,8 @@
       "method": "GET",
       "path": "/api/v1/contracts",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -1263,6 +1688,8 @@
       "method": "GET",
       "path": "/api/v1/openapi.json",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     },
     {
@@ -1273,6 +1700,8 @@
       "method": "GET",
       "path": "/api/v1/build",
       "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
       "query_parameters": []
     }
   ],

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 827,
-  "artifact_size_bytes": 24955142,
+  "artifact_size_bytes": 24974805,
   "artifacts": [
     {
       "path": "adapters/allways.json",
@@ -21,8 +21,8 @@
     },
     {
       "path": "api-index.json",
-      "sha256": "3fa792cc9906ccbd061eeea005d0339a034092c57bfb73926d172572d622ccfe",
-      "size_bytes": 30390
+      "sha256": "ce81b09287f75a7b60e99e9098c883e9c846925deb963df73ec189ea1a59f34d",
+      "size_bytes": 41196
     },
     {
       "path": "candidates.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -152,6 +152,18 @@
           "public": {
             "const": true
           },
+          "query_collection": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "query_filter_names": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "query_parameters": {
             "items": {
               "$ref": "#/components/schemas/ApiQueryParameter"
@@ -3928,6 +3940,19 @@
             "name": "kind",
             "required": false,
             "schema": {
+              "enum": [
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "openapi",
+                "repo-registry",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
               "type": "string"
             }
           },
@@ -3944,6 +3969,14 @@
             "name": "state",
             "required": false,
             "schema": {
+              "enum": [
+                "schema-invalid",
+                "schema-valid",
+                "maintainer-review",
+                "verified",
+                "stale",
+                "rejected"
+              ],
               "type": "string"
             }
           },
@@ -3971,6 +4004,15 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "confidence",
+                "id",
+                "kind",
+                "name",
+                "netuid",
+                "provider",
+                "state"
+              ],
               "type": "string"
             }
           },
@@ -4352,6 +4394,11 @@
             "name": "coverage_level",
             "required": false,
             "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
               "type": "string"
             }
           },
@@ -4379,6 +4426,12 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "coverage_level",
+                "curation_level",
+                "name",
+                "netuid"
+              ],
               "type": "string"
             }
           },
@@ -4514,6 +4567,12 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "claim",
+                "source_url",
+                "subject",
+                "verified_at"
+              ],
               "type": "string"
             }
           },
@@ -4719,6 +4778,11 @@
             "name": "coverage_level",
             "required": false,
             "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
               "type": "string"
             }
           },
@@ -4727,6 +4791,13 @@
             "name": "curation_level",
             "required": false,
             "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
               "type": "string"
             }
           },
@@ -4754,6 +4825,13 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "coverage_level",
+                "curation_level",
+                "gap_count",
+                "name",
+                "netuid"
+              ],
               "type": "string"
             }
           },
@@ -4871,6 +4949,12 @@
             "name": "status",
             "required": false,
             "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
               "type": "string"
             }
           },
@@ -4898,6 +4982,19 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "avg_latency_ms",
+                "degraded_count",
+                "failed_count",
+                "last_checked",
+                "last_ok",
+                "name",
+                "netuid",
+                "ok_count",
+                "status",
+                "surface_count",
+                "unknown_count"
+              ],
               "type": "string"
             }
           },
@@ -5021,9 +5118,44 @@
           },
           {
             "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "openapi",
+                "repo-registry",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "provider",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "status",
             "required": false,
             "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
               "type": "string"
             }
           },
@@ -5032,6 +5164,18 @@
             "name": "classification",
             "required": false,
             "schema": {
+              "enum": [
+                "auth-required",
+                "content-mismatch",
+                "dead",
+                "live",
+                "rate-limited",
+                "redirected",
+                "timeout",
+                "transient",
+                "unsupported",
+                "unsafe"
+              ],
               "type": "string"
             }
           },
@@ -5059,6 +5203,19 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "classification",
+                "kind",
+                "last_checked",
+                "last_ok",
+                "latency_ms",
+                "netuid",
+                "provider",
+                "status",
+                "status_code",
+                "surface_id",
+                "verified_at"
+              ],
               "type": "string"
             }
           },
@@ -5263,6 +5420,13 @@
             "name": "kind",
             "required": false,
             "schema": {
+              "enum": [
+                "data-provider",
+                "docs-provider",
+                "infrastructure-provider",
+                "registry",
+                "subnet-team"
+              ],
               "type": "string"
             }
           },
@@ -5271,6 +5435,12 @@
             "name": "authority",
             "required": false,
             "schema": {
+              "enum": [
+                "community",
+                "official",
+                "provider-claimed",
+                "registry-observed"
+              ],
               "type": "string"
             }
           },
@@ -5298,6 +5468,12 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "authority",
+                "id",
+                "kind",
+                "name"
+              ],
               "type": "string"
             }
           },
@@ -5504,6 +5680,19 @@
             "name": "kind",
             "required": false,
             "schema": {
+              "enum": [
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "openapi",
+                "repo-registry",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
               "type": "string"
             }
           },
@@ -5520,6 +5709,12 @@
             "name": "status",
             "required": false,
             "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
               "type": "string"
             }
           },
@@ -5547,6 +5742,12 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "kind",
+                "latency_ms",
+                "provider",
+                "status"
+              ],
               "type": "string"
             }
           },
@@ -5858,6 +6059,12 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "kind",
+                "netuid",
+                "slug",
+                "title"
+              ],
               "type": "string"
             }
           },
@@ -6081,6 +6288,12 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "id",
+                "kind",
+                "path",
+                "record_count"
+              ],
               "type": "string"
             }
           },
@@ -6198,6 +6411,11 @@
             "name": "coverage_level",
             "required": false,
             "schema": {
+              "enum": [
+                "native-only",
+                "manifested",
+                "probed"
+              ],
               "type": "string"
             }
           },
@@ -6206,6 +6424,13 @@
             "name": "curation_level",
             "required": false,
             "schema": {
+              "enum": [
+                "native",
+                "candidate-discovered",
+                "machine-verified",
+                "maintainer-reviewed",
+                "adapter-backed"
+              ],
               "type": "string"
             }
           },
@@ -6214,6 +6439,10 @@
             "name": "status",
             "required": false,
             "schema": {
+              "enum": [
+                "active",
+                "inactive"
+              ],
               "type": "string"
             }
           },
@@ -6222,6 +6451,10 @@
             "name": "subnet_type",
             "required": false,
             "schema": {
+              "enum": [
+                "root",
+                "application"
+              ],
               "type": "string"
             }
           },
@@ -6249,6 +6482,21 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "block",
+                "candidate_count",
+                "coverage_level",
+                "curation_level",
+                "mechanism_count",
+                "name",
+                "netuid",
+                "participant_count",
+                "probed_surface_count",
+                "status",
+                "subnet_type",
+                "surface_count",
+                "tempo"
+              ],
               "type": "string"
             }
           },
@@ -6464,6 +6712,19 @@
             "name": "kind",
             "required": false,
             "schema": {
+              "enum": [
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "openapi",
+                "repo-registry",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
               "type": "string"
             }
           },
@@ -6480,6 +6741,14 @@
             "name": "state",
             "required": false,
             "schema": {
+              "enum": [
+                "schema-invalid",
+                "schema-valid",
+                "maintainer-review",
+                "verified",
+                "stale",
+                "rejected"
+              ],
               "type": "string"
             }
           },
@@ -6507,6 +6776,15 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "confidence",
+                "id",
+                "kind",
+                "name",
+                "netuid",
+                "provider",
+                "state"
+              ],
               "type": "string"
             }
           },
@@ -6625,6 +6903,19 @@
             "name": "kind",
             "required": false,
             "schema": {
+              "enum": [
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "openapi",
+                "repo-registry",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
               "type": "string"
             }
           },
@@ -6641,6 +6932,12 @@
             "name": "status",
             "required": false,
             "schema": {
+              "enum": [
+                "ok",
+                "degraded",
+                "failed",
+                "unknown"
+              ],
               "type": "string"
             }
           },
@@ -6649,6 +6946,18 @@
             "name": "classification",
             "required": false,
             "schema": {
+              "enum": [
+                "auth-required",
+                "content-mismatch",
+                "dead",
+                "live",
+                "rate-limited",
+                "redirected",
+                "timeout",
+                "transient",
+                "unsupported",
+                "unsafe"
+              ],
               "type": "string"
             }
           },
@@ -6676,6 +6985,19 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "classification",
+                "kind",
+                "last_checked",
+                "last_ok",
+                "latency_ms",
+                "netuid",
+                "provider",
+                "status",
+                "status_code",
+                "surface_id",
+                "verified_at"
+              ],
               "type": "string"
             }
           },
@@ -6794,28 +7116,25 @@
             "name": "kind",
             "required": false,
             "schema": {
+              "enum": [
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "openapi",
+                "repo-registry",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
               "type": "string"
             }
           },
           {
             "in": "query",
             "name": "provider",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "classification",
             "required": false,
             "schema": {
               "type": "string"
@@ -6845,6 +7164,13 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "id",
+                "kind",
+                "name",
+                "netuid",
+                "provider"
+              ],
               "type": "string"
             }
           },
@@ -6963,28 +7289,25 @@
             "name": "kind",
             "required": false,
             "schema": {
+              "enum": [
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "openapi",
+                "repo-registry",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
               "type": "string"
             }
           },
           {
             "in": "query",
             "name": "provider",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "status",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "in": "query",
-            "name": "classification",
             "required": false,
             "schema": {
               "type": "string"
@@ -7014,6 +7337,13 @@
             "name": "sort",
             "required": false,
             "schema": {
+              "enum": [
+                "id",
+                "kind",
+                "name",
+                "netuid",
+                "provider"
+              ],
               "type": "string"
             }
           },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 828,
-  "artifact_size_bytes": 25073436,
+  "artifact_size_bytes": 25096322,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -23,8 +23,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "3fa792cc9906ccbd061eeea005d0339a034092c57bfb73926d172572d622ccfe",
-      "size_bytes": 30390
+      "sha256": "ce81b09287f75a7b60e99e9098c883e9c846925deb963df73ec189ea1a59f34d",
+      "size_bytes": 41196
     },
     {
       "content_type": "application/json",
@@ -3223,8 +3223,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "b6bc0f5c3fc6be29c601a1ef22ae9c01a56f128c125284ae402be1340604994c",
-      "size_bytes": 186805
+      "sha256": "3e5e1a38f47d654383733ccf1a61efc8c80f11a4a610069eeaa43ed73eeff869",
+      "size_bytes": 195662
     },
     {
       "content_type": "application/json",
@@ -5583,8 +5583,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "0ac1f01daaebee75cdb236663509298053f5cc1837725d8def48ba215cffe96d",
-      "size_bytes": 118294
+      "sha256": "27fc2d79343cf6a7b89752540e43041763e4a82bca9d43f83ba804533e75a27c",
+      "size_bytes": 121517
     },
     {
       "content_type": "application/json",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -528,6 +528,8 @@ export interface components {
             path: string;
             /** @constant */
             public: true;
+            query_collection?: string | null;
+            query_filter_names?: string[];
             query_parameters: components["schemas"]["ApiQueryParameter"][];
         };
         ArtifactBase: {
@@ -1633,12 +1635,12 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                state?: string;
+                state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -1914,10 +1916,10 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                coverage_level?: string;
+                coverage_level?: "native-only" | "manifested" | "probed";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "coverage_level" | "curation_level" | "name" | "netuid";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -1991,7 +1993,7 @@ export interface operations {
                 q?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "claim" | "source_url" | "subject" | "verified_at";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2131,11 +2133,11 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                coverage_level?: string;
-                curation_level?: string;
+                coverage_level?: "native-only" | "manifested" | "probed";
+                curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "coverage_level" | "curation_level" | "gap_count" | "name" | "netuid";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2207,10 +2209,10 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                status?: string;
+                status?: "ok" | "degraded" | "failed" | "unknown";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "avg_latency_ms" | "degraded_count" | "failed_count" | "last_checked" | "last_ok" | "name" | "netuid" | "ok_count" | "status" | "surface_count" | "unknown_count";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2282,11 +2284,13 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                status?: string;
-                classification?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                provider?: string;
+                status?: "ok" | "degraded" | "failed" | "unknown";
+                classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2428,11 +2432,11 @@ export interface operations {
         parameters: {
             query?: {
                 id?: string;
-                kind?: string;
-                authority?: string;
+                kind?: "data-provider" | "docs-provider" | "infrastructure-provider" | "registry" | "subnet-team";
+                authority?: "community" | "official" | "provider-claimed" | "registry-observed";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "authority" | "id" | "kind" | "name";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2573,12 +2577,12 @@ export interface operations {
     rpcEndpoints: {
         parameters: {
             query?: {
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                status?: string;
+                status?: "ok" | "degraded" | "failed" | "unknown";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "kind" | "latency_ms" | "provider" | "status";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2788,7 +2792,7 @@ export interface operations {
                 q?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "kind" | "netuid" | "slug" | "title";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -2930,7 +2934,7 @@ export interface operations {
                 q?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "id" | "kind" | "path" | "record_count";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3002,13 +3006,13 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                coverage_level?: string;
-                curation_level?: string;
-                status?: string;
-                subnet_type?: string;
+                coverage_level?: "native-only" | "manifested" | "probed";
+                curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                status?: "active" | "inactive";
+                subnet_type?: "root" | "application";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "block" | "candidate_count" | "coverage_level" | "curation_level" | "mechanism_count" | "name" | "netuid" | "participant_count" | "probed_surface_count" | "status" | "subnet_type" | "surface_count" | "tempo";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3149,12 +3153,12 @@ export interface operations {
     subnetCandidates: {
         parameters: {
             query?: {
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                state?: string;
+                state?: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "confidence" | "id" | "kind" | "name" | "netuid" | "provider" | "state";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3227,13 +3231,13 @@ export interface operations {
     subnetHealth: {
         parameters: {
             query?: {
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                status?: string;
-                classification?: string;
+                status?: "ok" | "degraded" | "failed" | "unknown";
+                classification?: "auth-required" | "content-mismatch" | "dead" | "live" | "rate-limited" | "redirected" | "timeout" | "transient" | "unsupported" | "unsafe";
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "classification" | "kind" | "last_checked" | "last_ok" | "latency_ms" | "netuid" | "provider" | "status" | "status_code" | "surface_id" | "verified_at";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3306,13 +3310,11 @@ export interface operations {
     subnetSurfaces: {
         parameters: {
             query?: {
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                status?: string;
-                classification?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "id" | "kind" | "name" | "netuid" | "provider";
                 order?: "asc" | "desc";
             };
             header?: never;
@@ -3386,13 +3388,11 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
-                kind?: string;
+                kind?: "dashboard" | "data-artifact" | "docs" | "openapi" | "repo-registry" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
                 provider?: string;
-                status?: string;
-                classification?: string;
                 limit?: number;
                 cursor?: number;
-                sort?: string;
+                sort?: "id" | "kind" | "name" | "netuid" | "provider";
                 order?: "asc" | "desc";
             };
             header?: never;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -735,6 +735,11 @@
           "method": { "enum": ["GET"] },
           "path": { "type": "string", "pattern": "^/api/v1" },
           "public": { "const": true },
+          "query_collection": { "type": ["string", "null"] },
+          "query_filter_names": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
           "query_parameters": {
             "type": "array",
             "items": { "$ref": "#/components/schemas/ApiQueryParameter" }

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -11,6 +11,204 @@ export const CACHE_SECONDS = {
   static: 600,
 };
 
+const QUERY_ENUMS = {
+  candidateState: [
+    "schema-invalid",
+    "schema-valid",
+    "maintainer-review",
+    "verified",
+    "stale",
+    "rejected",
+  ],
+  coverageLevel: ["native-only", "manifested", "probed"],
+  curationLevel: [
+    "native",
+    "candidate-discovered",
+    "machine-verified",
+    "maintainer-reviewed",
+    "adapter-backed",
+  ],
+  healthClassification: [
+    "auth-required",
+    "content-mismatch",
+    "dead",
+    "live",
+    "rate-limited",
+    "redirected",
+    "timeout",
+    "transient",
+    "unsupported",
+    "unsafe",
+  ],
+  healthStatus: ["ok", "degraded", "failed", "unknown"],
+  providerAuthority: [
+    "community",
+    "official",
+    "provider-claimed",
+    "registry-observed",
+  ],
+  providerKind: [
+    "data-provider",
+    "docs-provider",
+    "infrastructure-provider",
+    "registry",
+    "subnet-team",
+  ],
+  subnetStatus: ["active", "inactive"],
+  subnetType: ["root", "application"],
+  surfaceKind: [
+    "dashboard",
+    "data-artifact",
+    "docs",
+    "openapi",
+    "repo-registry",
+    "source-repo",
+    "sse",
+    "subnet-api",
+    "subtensor-rpc",
+    "subtensor-wss",
+    "website",
+  ],
+};
+
+const integerSchema = { type: "integer", minimum: 0 };
+const textSchema = { type: "string" };
+
+export const API_QUERY_COLLECTIONS = {
+  candidates: queryCollection("candidates", {
+    filters: {
+      netuid: integerSchema,
+      kind: enumSchema(QUERY_ENUMS.surfaceKind),
+      provider: textSchema,
+      state: enumSchema(QUERY_ENUMS.candidateState),
+    },
+    sort: ["confidence", "id", "kind", "name", "netuid", "provider", "state"],
+  }),
+  claims: queryCollection("claims", {
+    search: ["subject", "claim", "source_url", "support_summary"],
+    sort: ["claim", "source_url", "subject", "verified_at"],
+  }),
+  curation: queryCollection("curation", {
+    filters: {
+      netuid: integerSchema,
+      coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
+    },
+    sort: ["coverage_level", "curation_level", "name", "netuid"],
+  }),
+  "curated-surfaces": queryCollection("surfaces", {
+    filters: {
+      netuid: integerSchema,
+      kind: enumSchema(QUERY_ENUMS.surfaceKind),
+      provider: textSchema,
+    },
+    sort: ["id", "kind", "name", "netuid", "provider"],
+  }),
+  documents: queryCollection("documents", {
+    search: ["title", "subtitle", "slug", "tokens"],
+    sort: ["kind", "netuid", "slug", "title"],
+  }),
+  endpoints: queryCollection("endpoints", {
+    filters: {
+      kind: enumSchema(QUERY_ENUMS.surfaceKind),
+      provider: textSchema,
+      status: enumSchema(QUERY_ENUMS.healthStatus),
+    },
+    sort: ["kind", "latency_ms", "provider", "status"],
+  }),
+  gaps: queryCollection("gaps", {
+    filters: {
+      netuid: integerSchema,
+      coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
+      curation_level: enumSchema(QUERY_ENUMS.curationLevel),
+    },
+    sort: ["coverage_level", "curation_level", "gap_count", "name", "netuid"],
+  }),
+  "health-subnets": queryCollection("subnets", {
+    filters: {
+      netuid: integerSchema,
+      status: enumSchema(QUERY_ENUMS.healthStatus),
+    },
+    sort: [
+      "avg_latency_ms",
+      "degraded_count",
+      "failed_count",
+      "last_checked",
+      "last_ok",
+      "name",
+      "netuid",
+      "ok_count",
+      "status",
+      "surface_count",
+      "unknown_count",
+    ],
+  }),
+  "health-surfaces": queryCollection("surfaces", {
+    filters: {
+      netuid: integerSchema,
+      kind: enumSchema(QUERY_ENUMS.surfaceKind),
+      provider: textSchema,
+      status: enumSchema(QUERY_ENUMS.healthStatus),
+      classification: enumSchema(QUERY_ENUMS.healthClassification),
+    },
+    sort: [
+      "classification",
+      "kind",
+      "last_checked",
+      "last_ok",
+      "latency_ms",
+      "netuid",
+      "provider",
+      "status",
+      "status_code",
+      "surface_id",
+      "verified_at",
+    ],
+  }),
+  pools: queryCollection("pools", {
+    filters: {
+      id: textSchema,
+      kind: enumSchema(["rpc", "wss"]),
+    },
+    sort: ["eligible_count", "endpoint_count", "id", "kind"],
+  }),
+  providers: queryCollection("providers", {
+    filters: {
+      id: textSchema,
+      kind: enumSchema(QUERY_ENUMS.providerKind),
+      authority: enumSchema(QUERY_ENUMS.providerAuthority),
+    },
+    sort: ["authority", "id", "kind", "name"],
+  }),
+  sources: queryCollection("sources", {
+    search: ["id", "kind", "path"],
+    sort: ["id", "kind", "path", "record_count"],
+  }),
+  subnets: queryCollection("subnets", {
+    filters: {
+      netuid: integerSchema,
+      coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
+      curation_level: enumSchema(QUERY_ENUMS.curationLevel),
+      status: enumSchema(QUERY_ENUMS.subnetStatus),
+      subnet_type: enumSchema(QUERY_ENUMS.subnetType),
+    },
+    sort: [
+      "block",
+      "candidate_count",
+      "coverage_level",
+      "curation_level",
+      "mechanism_count",
+      "name",
+      "netuid",
+      "participant_count",
+      "probed_surface_count",
+      "status",
+      "subnet_type",
+      "surface_count",
+      "tempo",
+    ],
+  }),
+};
+
 export const PUBLIC_ARTIFACTS = [
   artifact(
     "contracts",
@@ -272,13 +470,7 @@ export const API_ROUTES = [
     "List active Finney subnets.",
     "standard",
     ["subnets"],
-    listQuery(
-      "netuid",
-      "coverage_level",
-      "curation_level",
-      "status",
-      "subnet_type",
-    ),
+    listQuery("subnets"),
   ),
   route(
     "subnet-detail",
@@ -299,7 +491,7 @@ export const API_ROUTES = [
     "List curated public surfaces.",
     "standard",
     ["surfaces"],
-    listQuery("netuid", "kind", "provider", "status", "classification"),
+    listQuery("curated-surfaces"),
   ),
   route(
     "subnet-surfaces",
@@ -309,7 +501,7 @@ export const API_ROUTES = [
     "List curated public surfaces for one subnet.",
     "standard",
     ["surfaces", "subnets"],
-    listQuery("kind", "provider", "status", "classification"),
+    listQuery("curated-surfaces", { exclude: ["netuid"] }),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -320,7 +512,7 @@ export const API_ROUTES = [
     "List unpromoted candidate surfaces.",
     "standard",
     ["candidates"],
-    listQuery("netuid", "kind", "provider", "state"),
+    listQuery("candidates"),
   ),
   route(
     "subnet-candidates",
@@ -330,7 +522,7 @@ export const API_ROUTES = [
     "List unpromoted candidate surfaces for one subnet.",
     "standard",
     ["candidates", "subnets"],
-    listQuery("kind", "provider", "state"),
+    listQuery("candidates", { exclude: ["netuid"] }),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -341,7 +533,7 @@ export const API_ROUTES = [
     "List providers and sources.",
     "standard",
     ["providers"],
-    listQuery("id", "kind", "authority"),
+    listQuery("providers"),
   ),
   route(
     "provider-detail",
@@ -371,7 +563,7 @@ export const API_ROUTES = [
     "Fetch curation states by subnet.",
     "standard",
     ["registry"],
-    listQuery("netuid", "coverage_level"),
+    listQuery("curation"),
   ),
   route(
     "gaps",
@@ -381,7 +573,7 @@ export const API_ROUTES = [
     "Fetch interface gap report.",
     "standard",
     ["registry"],
-    listQuery("netuid", "coverage_level", "curation_level"),
+    listQuery("gaps"),
   ),
   route(
     "health",
@@ -391,7 +583,7 @@ export const API_ROUTES = [
     "Fetch global health summary.",
     "short",
     ["health"],
-    listQuery("netuid", "status"),
+    listQuery("health-subnets"),
   ),
   route(
     "health-history",
@@ -401,7 +593,7 @@ export const API_ROUTES = [
     "Fetch compact daily health history.",
     "short",
     ["health"],
-    listQuery("netuid", "status", "classification"),
+    listQuery("health-surfaces"),
     [
       {
         name: "date",
@@ -417,7 +609,7 @@ export const API_ROUTES = [
     "Fetch health detail for one subnet.",
     "short",
     ["health", "subnets"],
-    listQuery("kind", "provider", "status", "classification"),
+    listQuery("health-surfaces", { exclude: ["netuid"] }),
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(
@@ -446,7 +638,7 @@ export const API_ROUTES = [
     "Fetch public evidence ledger.",
     "standard",
     ["evidence"],
-    listQuery("q"),
+    listQuery("claims"),
   ),
   route(
     "changelog",
@@ -465,7 +657,7 @@ export const API_ROUTES = [
     "Fetch source input hashes and counts.",
     "standard",
     ["operations"],
-    listQuery("q"),
+    listQuery("sources"),
   ),
   route(
     "rpc-endpoints",
@@ -475,7 +667,7 @@ export const API_ROUTES = [
     "Fetch Bittensor RPC endpoint status.",
     "short",
     ["rpc"],
-    listQuery("kind", "provider", "status"),
+    listQuery("endpoints"),
   ),
   route(
     "rpc-pools",
@@ -514,7 +706,7 @@ export const API_ROUTES = [
     "Fetch compact search index.",
     "standard",
     ["search"],
-    listQuery("q"),
+    listQuery("documents"),
   ),
   route(
     "contracts",
@@ -600,6 +792,8 @@ export function buildApiIndexArtifact(generatedAt, contractsArtifact) {
       method: entry.method,
       path: entry.path,
       public: true,
+      query_collection: entry.query_collection,
+      query_filter_names: entry.query_filter_names,
       query_parameters: entry.query_parameters || [],
     })),
     artifact_contracts: contractsArtifact.artifacts.map((entry) => ({
@@ -796,6 +990,7 @@ function route(
   queryParameters = [],
   pathParameters = [],
 ) {
+  const querySpec = normalizeQueryParameters(queryParameters);
   return {
     id,
     method,
@@ -804,39 +999,73 @@ function route(
     description,
     cache,
     tags,
-    query_parameters: queryParameters,
+    query_collection: querySpec.collection,
+    query_filter_names: querySpec.filterNames,
+    query_parameters: querySpec.parameters,
     path_parameters: pathParameters,
   };
 }
 
-function query(...names) {
-  return names.map((name) => ({
-    name,
-    schema:
-      name === "netuid" ? { type: "integer", minimum: 0 } : { type: "string" },
-  }));
+function queryCollection(dataKey, options = {}) {
+  return {
+    data_key: dataKey,
+    filters: options.filters || {},
+    search_keys: options.search || [],
+    sort_fields: options.sort || [],
+  };
 }
 
-function listQuery(...names) {
-  return [
-    ...query(...names),
-    {
-      name: "limit",
-      schema: { type: "integer", minimum: 1, maximum: 1000 },
-    },
-    {
-      name: "cursor",
-      schema: { type: "integer", minimum: 0 },
-    },
-    {
-      name: "sort",
-      schema: { type: "string" },
-    },
-    {
-      name: "order",
-      schema: { enum: ["asc", "desc"] },
-    },
-  ];
+function enumSchema(values) {
+  return { type: "string", enum: values };
+}
+
+function listQuery(collection, options = {}) {
+  const config = API_QUERY_COLLECTIONS[collection];
+  if (!config) {
+    throw new Error(`Unknown API query collection: ${collection}`);
+  }
+
+  const excluded = new Set(options.exclude || []);
+  const filterParameters = Object.entries(config.filters)
+    .map(([name, schema]) => ({ name, schema }))
+    .filter((parameter) => !excluded.has(parameter.name));
+  const searchParameters =
+    config.search_keys.length > 0 ? [{ name: "q", schema: textSchema }] : [];
+  return {
+    collection,
+    filterNames: filterParameters.map((parameter) => parameter.name),
+    parameters: [
+      ...filterParameters,
+      ...searchParameters,
+      {
+        name: "limit",
+        schema: { type: "integer", minimum: 1, maximum: 1000 },
+      },
+      {
+        name: "cursor",
+        schema: { type: "integer", minimum: 0 },
+      },
+      {
+        name: "sort",
+        schema: { type: "string", enum: config.sort_fields },
+      },
+      {
+        name: "order",
+        schema: { enum: ["asc", "desc"] },
+      },
+    ],
+  };
+}
+
+function normalizeQueryParameters(queryParameters) {
+  if (Array.isArray(queryParameters)) {
+    return { collection: null, filterNames: [], parameters: queryParameters };
+  }
+  return {
+    collection: queryParameters.collection || null,
+    filterNames: queryParameters.filterNames || [],
+    parameters: queryParameters.parameters || [],
+  };
 }
 
 function schemaRefForArtifactPath(artifactPath) {

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   API_ROUTES,
+  API_QUERY_COLLECTIONS,
   CACHE_SECONDS,
   CONTRACT_VERSION,
   PUBLIC_ARTIFACTS,
@@ -93,6 +94,16 @@ describe("public contract registry", () => {
     assert.equal(contracts.type_definitions_url, "/metagraph/types.d.ts");
     assert.equal(apiIndex.openapi_url, "/api/v1/openapi.json");
     assert.equal(apiIndex.routes.length, API_ROUTES.length);
+    assert.equal(
+      apiIndex.routes.find((route) => route.id === "subnets").query_collection,
+      "subnets",
+    );
+    assert.equal(
+      apiIndex.routes
+        .find((route) => route.id === "subnet-surfaces")
+        .query_parameters.some((parameter) => parameter.name === "netuid"),
+      false,
+    );
     assert.equal(openapi.openapi, "3.1.0");
     assert.equal(openapi.info.version, CONTRACT_VERSION);
     assert.equal(Object.keys(openapi.paths).length, API_ROUTES.length);
@@ -101,6 +112,27 @@ describe("public contract registry", () => {
     assert.equal(Boolean(openapi.components.schemas.Surface), true);
     assert.equal(Boolean(openapi.components.schemas.CandidateSurface), true);
     assert.equal(openapi["x-metagraphed"].generated_at, generatedAt);
+
+    const subnetParameters = openapi.paths["/api/v1/subnets"].get.parameters;
+    assert.deepEqual(
+      subnetParameters.find((parameter) => parameter.name === "sort").schema
+        .enum,
+      API_QUERY_COLLECTIONS.subnets.sort_fields,
+    );
+    assert.deepEqual(
+      subnetParameters.find((parameter) => parameter.name === "coverage_level")
+        .schema.enum,
+      ["native-only", "manifested", "probed"],
+    );
+
+    const candidateParameters =
+      openapi.paths["/api/v1/candidates"].get.parameters;
+    assert.equal(
+      candidateParameters
+        .find((parameter) => parameter.name === "state")
+        .schema.enum.includes("schema-valid"),
+      true,
+    );
   });
 
   test("keeps public API route payloads on typed artifact schemas", async () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -567,6 +567,9 @@ describe("Worker runtime", () => {
       "https://metagraph.sh/api/v1/subnets?order=sideways",
       "https://metagraph.sh/api/v1/subnets?sort=unknown_field",
       "https://metagraph.sh/api/v1/subnets?netuid=not-a-number",
+      "https://metagraph.sh/api/v1/subnets?coverage_level=fake",
+      "https://metagraph.sh/api/v1/candidates?state=approved",
+      "https://metagraph.sh/api/v1/subnets/7/health?status=alive",
     ];
 
     for (const url of routes) {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1,4 +1,5 @@
 import {
+  API_QUERY_COLLECTIONS,
   API_ROUTES,
   CACHE_SECONDS,
   CONTRACT_VERSION,
@@ -31,55 +32,6 @@ const DENIED_RPC_PREFIXES = [
 ];
 const MAX_RPC_BODY_BYTES = 65536;
 const METAGRAPH_LATEST_KEY = "metagraph:latest";
-const SORT_FIELDS = {
-  candidates: [
-    "confidence",
-    "id",
-    "kind",
-    "name",
-    "netuid",
-    "provider",
-    "state",
-  ],
-  claims: ["claim", "source_url", "subject", "verified_at"],
-  curation: ["coverage_level", "curation_level", "name", "netuid"],
-  documents: ["kind", "netuid", "slug", "title"],
-  endpoints: ["kind", "latency_ms", "provider", "status"],
-  gaps: ["coverage_level", "curation_level", "gap_count", "name", "netuid"],
-  pools: ["eligible_count", "endpoint_count", "id", "kind"],
-  providers: ["authority", "id", "kind", "name"],
-  sources: ["id", "kind", "path", "record_count"],
-  subnets: [
-    "block",
-    "candidate_count",
-    "coverage_level",
-    "curation_level",
-    "mechanism_count",
-    "name",
-    "netuid",
-    "participant_count",
-    "probed_surface_count",
-    "status",
-    "subnet_type",
-    "surface_count",
-    "tempo",
-  ],
-  surfaces: [
-    "classification",
-    "id",
-    "kind",
-    "last_checked",
-    "last_ok",
-    "latency_ms",
-    "name",
-    "netuid",
-    "provider",
-    "status",
-    "status_code",
-    "surface_id",
-    "verified_at",
-  ],
-};
 
 export default {
   async fetch(request, env, ctx) {
@@ -138,7 +90,12 @@ async function handleApiRequest(request, env, url) {
     });
   }
 
-  const transformed = applyQueryFilters(artifact.data, url);
+  const transformed = applyQueryFilters(
+    artifact.data,
+    url,
+    matched.queryCollection,
+    matched.queryFilterNames,
+  );
   if (transformed.error) {
     return errorResponse("invalid_query", transformed.error.message, 400, {
       artifact_path: matched.artifactPath,
@@ -295,6 +252,8 @@ function matchRoute(pathname) {
       artifactPath: candidate.artifactPath(params),
       cache: candidate.cache,
       params,
+      queryCollection: candidate.query_collection,
+      queryFilterNames: candidate.query_filter_names,
     };
   }
   return null;
@@ -393,92 +352,24 @@ async function latestPointer(env) {
   }
 }
 
-function applyQueryFilters(data, url) {
+function applyQueryFilters(data, url, queryCollection, queryFilterNames = []) {
   const params = url.searchParams;
-  if (Array.isArray(data?.subnets)) {
-    return applyListTransform(data, params, "subnets", [
-      "netuid",
-      "coverage_level",
-      "curation_level",
-      "status",
-      "subnet_type",
-    ]);
+  const config = API_QUERY_COLLECTIONS[queryCollection];
+  if (!config) {
+    return { data, meta: {} };
   }
-  if (Array.isArray(data?.surfaces)) {
-    return applyListTransform(data, params, "surfaces", [
-      "netuid",
-      "kind",
-      "provider",
-      "status",
-      "classification",
-    ]);
+  if (!Array.isArray(data?.[config.data_key])) {
+    return { data, meta: {} };
   }
-  if (Array.isArray(data?.providers)) {
-    return applyListTransform(data, params, "providers", [
-      "id",
-      "kind",
-      "authority",
-    ]);
-  }
-  if (Array.isArray(data?.candidates)) {
-    return applyListTransform(data, params, "candidates", [
-      "netuid",
-      "kind",
-      "provider",
-      "state",
-    ]);
-  }
-  if (Array.isArray(data?.curation)) {
-    return applyListTransform(data, params, "curation", [
-      "netuid",
-      "coverage_level",
-    ]);
-  }
-  if (Array.isArray(data?.gaps)) {
-    return applyListTransform(data, params, "gaps", [
-      "netuid",
-      "coverage_level",
-      "curation_level",
-    ]);
-  }
-  if (Array.isArray(data?.claims)) {
-    return applyListTransform(
-      data,
-      params,
-      "claims",
-      [],
-      ["subject", "claim", "source_url", "support_summary"],
-    );
-  }
-  if (Array.isArray(data?.documents)) {
-    return applyListTransform(
-      data,
-      params,
-      "documents",
-      [],
-      ["title", "subtitle", "slug", "tokens"],
-    );
-  }
-  if (Array.isArray(data?.sources)) {
-    return applyListTransform(
-      data,
-      params,
-      "sources",
-      [],
-      ["id", "kind", "path"],
-    );
-  }
-  if (Array.isArray(data?.endpoints)) {
-    return applyListTransform(data, params, "endpoints", [
-      "kind",
-      "provider",
-      "status",
-    ]);
-  }
-  if (Array.isArray(data?.pools)) {
-    return applyListTransform(data, params, "pools", ["id", "kind"]);
-  }
-  return { data, meta: {} };
+  return applyListTransform(data, params, {
+    ...config,
+    filters: Object.fromEntries(
+      (queryFilterNames.length > 0
+        ? queryFilterNames
+        : Object.keys(config.filters)
+      ).map((name) => [name, config.filters[name]]),
+    ),
+  });
 }
 
 function filterRows(rows, params, keys) {
@@ -492,13 +383,15 @@ function filterRows(rows, params, keys) {
   );
 }
 
-function applyListTransform(data, params, key, filterKeys, searchKeys = []) {
-  const queryError = validateListQuery(params, key, filterKeys);
+function applyListTransform(data, params, config) {
+  const queryError = validateListQuery(params, config);
   if (queryError) {
     return { error: queryError };
   }
+  const key = config.data_key;
+  const filterKeys = Object.keys(config.filters);
   const filtered = filterRows(
-    searchRows(data[key], params, searchKeys),
+    searchRows(data[key], params, config.search_keys),
     params,
     filterKeys,
   );
@@ -578,7 +471,7 @@ function paginateRows(rows, params) {
   };
 }
 
-function validateListQuery(params, collection, filterKeys) {
+function validateListQuery(params, config) {
   const limit = params.get("limit");
   if (limit !== null && (integerParam(limit) === null || Number(limit) < 1)) {
     return {
@@ -610,21 +503,28 @@ function validateListQuery(params, collection, filterKeys) {
   }
 
   const sort = params.get("sort");
-  if (sort !== null && !(SORT_FIELDS[collection] || []).includes(sort)) {
+  if (sort !== null && !config.sort_fields.includes(sort)) {
     return {
       parameter: "sort",
-      message: `sort is not supported for ${collection}.`,
+      message: `sort is not supported for ${config.data_key}.`,
     };
   }
 
-  for (const key of filterKeys) {
-    if (key !== "netuid" || !params.has(key)) {
+  for (const [key, schema] of Object.entries(config.filters)) {
+    if (!params.has(key)) {
       continue;
     }
-    if (integerParam(params.get(key)) === null) {
+    const value = params.get(key);
+    if (schema.type === "integer" && integerParam(value) === null) {
       return {
         parameter: key,
         message: `${key} must be a non-negative integer.`,
+      };
+    }
+    if (schema.enum && !schema.enum.includes(value)) {
+      return {
+        parameter: key,
+        message: `${key} is not supported for this route.`,
       };
     }
   }


### PR DESCRIPTION
## Summary
- Makes list-route query filters, search fields, and sort allowlists part of the shared API contract table.
- Exposes `query_collection` and `query_filter_names` in the generated API index.
- Regenerates OpenAPI and TypeScript types so external consumers see enum-backed filters and route-specific sort options.

## What changed
- Added route query collection metadata for subnet, surface, candidate, provider, curation, gap, health, evidence, source, endpoint, and search list routes.
- Updated the Worker to validate list filters and sort fields from the shared contract metadata.
- Tightened the API index schema to allow the new route metadata without relaxing strict validation.
- Removed unhelpful `status`/`classification` filters from curated surface routes while keeping them on health-surface routes.

## Why
- The Worker already rejected unsupported sorts, but OpenAPI still exposed many filters and sorts as broad strings.
- Builder-facing API consumers need route-specific query contracts that match runtime behavior.

## Validation
- `npm run check`
- `npm run test:coverage`
- `git diff --check`

## Notes
- During `npm run check`, unauthenticated GitHub enrichment sources intermittently returned HTTP 403. The pipeline treated those as source-health warnings; canonical subnet sync and all required validation still passed.
- No live registry data refresh is included in this PR.