### PR TITLE
fix(security): harden candidate URL probing

### DIFF
--- a/scripts/curate-baseline.mjs
+++ b/scripts/curate-baseline.mjs
@@ -4,6 +4,7 @@ import {
   listJsonFiles,
   loadCandidates,
   loadNativeSnapshot,
+  isUnsafeUrl,
   loadVerification,
   nativeDisplayName,
   nativeNameQuality,
@@ -158,6 +159,14 @@ function isPromotable(candidate, verification) {
   if (
     !verification ||
     !["live", "redirected"].includes(verification.classification)
+  ) {
+    return false;
+  }
+  if (
+    isUnsafeUrl(candidate.url) ||
+    (verification.redirect_target &&
+      isUnsafeUrl(verification.redirect_target)) ||
+    verification.private_redirect_blocked
   ) {
     return false;
   }

--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -1,6 +1,7 @@
 import path from "node:path";
 import {
   buildTimestamp,
+  isUnsafeResolvedUrl,
   loadNativeSnapshot,
   loadSubnets,
   nativeDisplayName,
@@ -999,7 +1000,7 @@ async function fetchJson(url, headers = {}) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 15000);
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithSafeRedirects(url, {
       headers: {
         accept: "application/json",
         "user-agent": "metagraphed-candidate-discovery/0.0",
@@ -1027,7 +1028,7 @@ async function fetchText(url, options = {}) {
     options.timeoutMs || 10000,
   );
   try {
-    const response = await fetch(url, {
+    const response = await fetchWithSafeRedirects(url, {
       headers: {
         accept: options.accept || "*/*",
         "user-agent": "metagraphed-candidate-discovery/0.0",
@@ -1050,6 +1051,37 @@ async function fetchText(url, options = {}) {
   } finally {
     clearTimeout(timer);
   }
+}
+
+async function fetchWithSafeRedirects(url, init, redirectCount = 0) {
+  if (await isUnsafeResolvedUrl(url)) {
+    throw new Error("unsafe URL");
+  }
+
+  const response = await fetch(url, {
+    ...init,
+    redirect: "manual",
+  });
+  const location = response.headers.get("location");
+  if (
+    [301, 302, 303, 307, 308].includes(response.status) &&
+    location &&
+    redirectCount < 5
+  ) {
+    const redirectTarget = new URL(location, url).toString();
+    if (await isUnsafeResolvedUrl(redirectTarget)) {
+      await response.body?.cancel();
+      throw new Error("redirect target is unsafe");
+    }
+    await response.body?.cancel();
+    const nextInit =
+      response.status === 303 && init.method && init.method !== "GET"
+        ? { ...init, method: "GET" }
+        : init;
+    return fetchWithSafeRedirects(redirectTarget, nextInit, redirectCount + 1);
+  }
+
+  return response;
 }
 
 function githubHeaders() {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1,9 +1,30 @@
 import { promises as fs } from "node:fs";
 import { createHash } from "node:crypto";
-import { isIP } from "node:net";
+import { lookup } from "node:dns/promises";
+import { BlockList, isIP } from "node:net";
 import path from "node:path";
 
 export const repoRoot = new URL("..", import.meta.url).pathname;
+
+const unsafeIpBlocks = new BlockList();
+unsafeIpBlocks.addSubnet("0.0.0.0", 8);
+unsafeIpBlocks.addSubnet("10.0.0.0", 8);
+unsafeIpBlocks.addSubnet("100.64.0.0", 10);
+unsafeIpBlocks.addSubnet("127.0.0.0", 8);
+unsafeIpBlocks.addSubnet("169.254.0.0", 16);
+unsafeIpBlocks.addSubnet("172.16.0.0", 12);
+unsafeIpBlocks.addSubnet("192.0.0.0", 24);
+unsafeIpBlocks.addSubnet("192.168.0.0", 16);
+unsafeIpBlocks.addSubnet("198.18.0.0", 15);
+unsafeIpBlocks.addSubnet("224.0.0.0", 4);
+unsafeIpBlocks.addSubnet("255.255.255.255", 32);
+unsafeIpBlocks.addSubnet("::", 128, "ipv6");
+unsafeIpBlocks.addSubnet("::1", 128, "ipv6");
+unsafeIpBlocks.addSubnet("64:ff9b:1::", 48, "ipv6");
+unsafeIpBlocks.addSubnet("100::", 64, "ipv6");
+unsafeIpBlocks.addSubnet("fc00::", 7, "ipv6");
+unsafeIpBlocks.addSubnet("fe80::", 10, "ipv6");
+unsafeIpBlocks.addSubnet("ff00::", 8, "ipv6");
 
 export async function readJson(filePath) {
   const raw = await fs.readFile(filePath, "utf8");
@@ -192,38 +213,58 @@ export function isUnsafeUrl(value) {
       return true;
     }
 
-    const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-    const literalIp = isIP(host);
-    if (
-      host === "localhost" ||
-      host === "0.0.0.0" ||
-      host === "127.0.0.1" ||
-      host === "::1"
-    ) {
-      return true;
-    }
-    if (literalIp === 4) {
-      return (
-        host.startsWith("10.") ||
-        host.startsWith("127.") ||
-        host.startsWith("169.254.") ||
-        host.startsWith("192.168.") ||
-        /^172\.(1[6-9]|2\d|3[0-1])\./.test(host)
-      );
-    }
-    if (literalIp === 6) {
-      return (
-        host === "::" ||
-        host.startsWith("fc") ||
-        host.startsWith("fd") ||
-        host.startsWith("fe80")
-      );
-    }
-
-    return false;
+    const host = normalizeHostname(url.hostname);
+    return isUnsafeHostname(host);
   } catch {
     return true;
   }
+}
+
+export async function isUnsafeResolvedUrl(value) {
+  try {
+    const url = new URL(value);
+    if (isUnsafeUrl(url.toString())) {
+      return true;
+    }
+
+    const host = normalizeHostname(url.hostname);
+    if (isIP(host)) {
+      return false;
+    }
+
+    const records = await lookup(host, { all: true, verbatim: true });
+    return (
+      records.length === 0 ||
+      records.some((record) => isUnsafeIpAddress(record.address))
+    );
+  } catch {
+    return true;
+  }
+}
+
+function isUnsafeHostname(host) {
+  if (!host || host === "localhost" || host.endsWith(".localhost")) {
+    return true;
+  }
+
+  return isUnsafeIpAddress(host);
+}
+
+function isUnsafeIpAddress(address) {
+  const normalized = normalizeHostname(address);
+  const family = isIP(normalized);
+  return (
+    family !== 0 &&
+    unsafeIpBlocks.check(normalized, family === 4 ? "ipv4" : "ipv6")
+  );
+}
+
+function normalizeHostname(hostname) {
+  return String(hostname || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[(.*)\]$/, "$1")
+    .replace(/\.$/, "");
 }
 
 export function normalizePublicUrl(value) {

--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -3,7 +3,7 @@ import {
   buildTimestamp,
   isHtmlContentType,
   isJsonContentType,
-  isUnsafeUrl,
+  isUnsafeResolvedUrl,
   loadCandidates,
   repoRoot,
   stableStringify,
@@ -63,7 +63,7 @@ async function verifyCandidate(candidate) {
     verified_at: new Date().toISOString(),
   };
 
-  if (!candidate.public_safe || isUnsafeUrl(candidate.url)) {
+  if (!candidate.public_safe || (await isUnsafeResolvedUrl(candidate.url))) {
     return {
       ...base,
       classification: "unsafe",
@@ -166,7 +166,7 @@ async function verifyHttpSurface(base, candidate) {
 }
 
 async function probeUrl(url, method, accept, redirectCount = 0) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeResolvedUrl(url)) {
     return {
       ok: false,
       error: "unsafe URL",
@@ -197,7 +197,7 @@ async function probeUrl(url, method, accept, redirectCount = 0) {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeResolvedUrl(redirectTarget)) {
         await response.body?.cancel();
         return {
           ok: false,

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { isUnsafeResolvedUrl, isUnsafeUrl } from "../scripts/lib.mjs";
+
+describe("public URL safety checks", () => {
+  test("blocks private, loopback, and link-local literal targets", () => {
+    const unsafeUrls = [
+      "http://127.0.0.1/",
+      "http://169.254.169.254/latest/meta-data/",
+      "http://10.0.0.5/",
+      "http://172.20.0.5/",
+      "http://192.168.1.5/",
+      "http://[::1]/",
+      "http://[fc00::1]/",
+      "http://[fd00::1]/",
+      "http://[fe80::1]/",
+      "http://[::ffff:127.0.0.1]/",
+    ];
+
+    for (const url of unsafeUrls) {
+      assert.equal(isUnsafeUrl(url), true, url);
+    }
+  });
+
+  test("blocks hostnames that resolve to private addresses", async () => {
+    assert.equal(await isUnsafeResolvedUrl("http://localhost/"), true);
+  });
+
+  test("allows syntactically valid public HTTP URLs before DNS resolution", () => {
+    assert.equal(isUnsafeUrl("https://example.com/api"), false);
+    assert.equal(isUnsafeUrl("http://8.8.8.8/dns-query"), false);
+    assert.equal(isUnsafeUrl("http://[::ffff:8.8.8.8]/dns-query"), false);
+  });
+
+  test("allows public literal IPs without DNS lookup", async () => {
+    assert.equal(await isUnsafeResolvedUrl("http://8.8.8.8/dns-query"), false);
+  });
+
+  test("resolves public hosts and blocks failed DNS lookups", async () => {
+    assert.equal(await isUnsafeResolvedUrl("https://example.com/"), false);
+    assert.equal(await isUnsafeResolvedUrl("https://metagraphed.invalid/"), true);
+  });
+});


### PR DESCRIPTION
### Motivation

- Close an SSRF/persistence gap where discovery and verification followed redirects and promoted surfaces without validating resolved targets, allowing runner access to link-local/internal addresses. 

### Description

- Add DNS-aware safety checks in `scripts/lib.mjs` by introducing `isUnsafeResolvedUrl`, hostname/ip normalization, and a `BlockList` of non-public IPv4/IPv6 ranges and checks used to detect loopback, private, link-local, unique-local, multicast, and other unsafe addresses. 
- Use safe manual-redirect handling in discovery by adding `fetchWithSafeRedirects` and replace direct `fetch` calls in `scripts/discover-candidates.mjs` with it so every redirect target is validated before following. 
- Harden verification in `scripts/verify-candidates.mjs` to call `isUnsafeResolvedUrl` before probing and to reject unsafe redirect targets prior to following them. 
- Prevent promotion of unsafe surfaces in `scripts/curate-baseline.mjs` by blocking candidates whose original URL or verified redirect target is unsafe or whose probe indicated a blocked private redirect. 
- Add tests in `tests/public-safety.test.mjs` covering literal private/link-local/IPv6 URL blocking, hostname resolution to private addresses, and that public HTTP URLs pass the syntactic check. 

### Testing

- Ran `npm run lint` and the linter completed with no errors. 
- Ran `npm run format:check` and code was formatted correctly after applying Prettier fixes. 
- Ran `npm test` and the test suite passed (`Test Files 4 passed`, `Tests 19 passed`). 
- Ran repository validation via `npm run validate` and validation completed successfully (validated native subnets, curated overlays, surfaces, providers, and candidates).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2403ebad8c832c8e6cb4267d0f657f)