### PR TITLE
fix(workflows): isolate subnet sync write token

### DIFF
--- a/.github/workflows/sync-subnets.yml
+++ b/.github/workflows/sync-subnets.yml
@@ -6,8 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 concurrency:
   group: sync-subnets
@@ -16,9 +15,15 @@ concurrency:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      has_changes: ${{ steps.changes.outputs.has_changes }}
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -122,13 +127,87 @@ jobs:
         run: npm run validate:private-boundary
 
       - name: Generate sync summary
-        run: npm run sync:summary > "$RUNNER_TEMP/metagraphed-sync-summary.md"
+        run: |
+          mkdir -p "$RUNNER_TEMP/sync-output"
+          npm run sync:summary > "$RUNNER_TEMP/sync-output/metagraphed-sync-summary.md"
+
+      - name: Capture generated changes
+        id: changes
+        run: |
+          allowed_paths=(
+            public/metagraph
+            registry/candidates/generated
+            registry/candidates/verification
+            registry/native/finney-subnets.json
+            registry/subnets
+          )
+          git ls-files --others --exclude-standard > "$RUNNER_TEMP/sync-output/untracked-files.txt"
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            case "$file" in
+              public/metagraph/*|registry/candidates/generated/*|registry/candidates/verification/*|registry/native/finney-subnets.json|registry/subnets/*) ;;
+              *)
+                echo "Unexpected untracked file outside the sync allowlist: $file" >&2
+                exit 1
+                ;;
+            esac
+          done < "$RUNNER_TEMP/sync-output/untracked-files.txt"
+          git add -N -- "${allowed_paths[@]}"
+          git diff --name-only > "$RUNNER_TEMP/sync-output/changed-files.txt"
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            case "$file" in
+              public/metagraph/*|registry/candidates/generated/*|registry/candidates/verification/*|registry/native/finney-subnets.json|registry/subnets/*) ;;
+              *)
+                echo "Unexpected generated change outside the sync allowlist: $file" >&2
+                exit 1
+                ;;
+            esac
+          done < "$RUNNER_TEMP/sync-output/changed-files.txt"
+          git diff --binary -- "${allowed_paths[@]}" > "$RUNNER_TEMP/sync-output/subnet-registry.patch"
+          if git diff --quiet -- "${allowed_paths[@]}"; then
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload generated changes
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: subnet-registry-sync
+          path: ${{ runner.temp }}/sync-output
+          if-no-files-found: error
+          retention-days: 1
+
+  pull-request:
+    runs-on: ubuntu-latest
+    needs: sync
+    if: needs.sync.outputs.has_changes == 'true'
+    permissions:
+      actions: read
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
+
+      - name: Download generated changes
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: subnet-registry-sync
+          path: ${{ runner.temp }}/sync-output
+
+      - name: Apply generated changes
+        run: git apply --index --whitespace=nowarn "$RUNNER_TEMP/sync-output/subnet-registry.patch"
 
       - name: Open sync pull request
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
         with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           branch: codex/sync-subnets
           delete-branch: true
           title: "chore(sync): refresh subnet registry data"
           commit-message: "chore(sync): refresh subnet registry data"
-          body-path: ${{ runner.temp }}/metagraphed-sync-summary.md
+          body-path: ${{ runner.temp }}/sync-output/metagraphed-sync-summary.md


### PR DESCRIPTION
### Motivation
- The scheduled `sync-subnets` workflow previously ran network-installed tooling and mutable third-party actions while the job had `contents: write` and persisted checkout credentials, exposing a write-capable token to untrusted code. 
- The change isolates repository write permission to a minimal job so discovery/sync steps run read-only and cannot use persisted credentials or `GITHUB_TOKEN` to modify the repo.

### Description
- Reduce top-level/write exposure by changing the workflow to `permissions: contents: read` and adding `permissions: contents: read` to the `sync` job while setting `persist-credentials: false` on `actions/checkout` for read-phase steps. 
- Split the flow into two jobs: a `sync` job that generates artifacts and an isolated `pull-request` job that runs only when `sync` reports `has_changes` and is granted write permissions; the `pull-request` job downloads the generated patch and applies it before opening the PR. 
- Add a generated-change validation step that builds an allowlist of expected output paths, rejects unexpected tracked or untracked changes, produces a binary patch at `$RUNNER_TEMP/sync-output/subnet-registry.patch`, and uploads it as an artifact using a pinned `upload-artifact` ref. 
- Ensure the PR creation step is limited to the minimal write-scoped job and uses the `peter-evans/create-pull-request` action with the token only in that job, and adjust paths so the summary/patch are read from the `sync-output` directory.

### Testing
- Ran `npm run validate:workflows`, which completed successfully and reported `Validated 5 workflow file(s)`. 
- Ran `npx prettier --check .github/workflows/sync-subnets.yml`, which verified formatting without changes. 
- Ran `npm test` (Vitest), which finished with all tests passing (`Test Files 3 passed`, `Tests 16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24039e4b40832ca04d4429d996da72)