### PR TITLE
feat(intake): add submission notification contract

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Public-safety scan
         run: npm run scan:public-safety
 
+      - name: Validate private boundary
+        run: npm run validate:private-boundary
+
       - name: Upload artifact history to R2
         if: env.CLOUDFLARE_API_TOKEN != '' && env.CLOUDFLARE_ACCOUNT_ID != ''
         run: npm run r2:upload

--- a/.github/workflows/sync-subnets.yml
+++ b/.github/workflows/sync-subnets.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Public-safety scan
         run: npm run scan:public-safety
 
+      - name: Validate private boundary
+        run: npm run validate:private-boundary
+
       - name: Generate sync summary
         run: npm run sync:summary > "$RUNNER_TEMP/metagraphed-sync-summary.md"
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -80,3 +80,6 @@ jobs:
 
       - name: Public-safety scan
         run: npm run scan:public-safety
+
+      - name: Validate private boundary
+        run: npm run validate:private-boundary

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -89,3 +89,45 @@ The private `metagraphed-submission-gate` should run on Cloudflare:
 
 The public workflow job `metagraphed-submission-gate` only runs deterministic
 preflight. It must not publish, merge, or expose private review details.
+
+## Discord Notifications
+
+Discord delivery belongs to the private Cloudflare gate runtime, not GitHub
+Actions. The public repo only documents the contract and validates that secrets
+and private reviewer internals are not tracked.
+
+V1 sends one notification for terminal UGC decisions only:
+
+- `merged`: the gate merged a clean direct PR or imported an approved issue.
+- `closed`: the gate closed a hard failure.
+- `manual-review`: the gate persisted a manual-review decision.
+- `retry-exhausted`: automation stopped after retryable reviewer or platform
+  failures exceeded the retry budget.
+
+The gate should not notify for `route_away`, `submit_pr`, `fix_required`, or
+normal backend/code PRs.
+
+The Worker stores a `last_notification_key` in D1. The key must include the
+target, PR head SHA or issue revision, terminal status, and verdict. Repeated
+queue retries for the same head or issue revision must not send duplicate
+Discord messages; a new PR head or edited issue revision may send a new terminal
+notification.
+
+The Discord webhook is configured only as a Worker secret:
+
+```bash
+wrangler secret put DISCORD_SUBMISSION_WEBHOOK_URL
+```
+
+Other private gate secrets are also Worker secrets:
+
+- `GITHUB_WEBHOOK_SECRET`
+- `GITHUB_APP_PRIVATE_KEY`
+- `INTERNAL_SHARED_SECRET`
+- private reviewer service credentials, if used
+
+Discord embeds must be compact and public-safe. They can include the result,
+netuid, interface kind, submitter, source URL, GitHub URL, and a short AI
+rationale. They must strip marker comments, webhook URLs, wallet/PAT-like text,
+private AI prompts, private scoring thresholds, corpus weights, and provider
+model details.

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "validate:artifact-budgets": "node scripts/validate-artifact-budgets.mjs",
     "validate:docs": "node scripts/validate-docs.mjs",
     "validate:intake": "node scripts/validate-intake.mjs",
+    "validate:private-boundary": "node scripts/validate-private-boundary.mjs",
     "validate:workflows": "node scripts/validate-workflows.mjs",
     "openapi:generate": "node scripts/generate-openapi.mjs --write",
     "openapi:generate:dry-run": "node scripts/generate-openapi.mjs",

--- a/scripts/pipeline.mjs
+++ b/scripts/pipeline.mjs
@@ -74,6 +74,7 @@ function checkCommands() {
     step("worker:test"),
     step("worker:deploy:dry-run"),
     step("scan:public-safety"),
+    step("validate:private-boundary"),
     step("test"),
   ];
 }
@@ -110,6 +111,7 @@ function refreshCommands() {
     step("worker:test"),
     step("worker:deploy:dry-run"),
     step("scan:public-safety"),
+    step("validate:private-boundary"),
     step("test"),
   ];
 }

--- a/scripts/submission-notifications.mjs
+++ b/scripts/submission-notifications.mjs
@@ -1,0 +1,248 @@
+export const SUBMISSION_REVIEW_MARKER = "<!-- metagraphed-submission-gate -->";
+
+export const TERMINAL_NOTIFICATION_VERDICTS = new Set([
+  "merged",
+  "closed",
+  "manual-review",
+  "retry-exhausted",
+]);
+
+export const NON_TERMINAL_NOTIFICATION_STATES = new Set([
+  "route_away",
+  "submit_pr",
+  "fix_required",
+]);
+
+const DISCORD_MAX_TITLE_LENGTH = 256;
+const DISCORD_MAX_DESCRIPTION_LENGTH = 320;
+const DISCORD_MAX_FIELD_LENGTH = 220;
+
+const VERDICT_META = {
+  merged: {
+    action: "merged",
+    label: "Merged",
+    color: 0x238636,
+  },
+  closed: {
+    action: "closed",
+    label: "Closed",
+    color: 0xda3633,
+  },
+  "manual-review": {
+    action: "needs review",
+    label: "Manual review",
+    color: 0x8957e5,
+  },
+  "retry-exhausted": {
+    action: "needs attention",
+    label: "Retry exhausted",
+    color: 0xfb8500,
+  },
+};
+
+const SAFE_DISCORD_WEBHOOK_HOSTS = new Set([
+  "discord.com",
+  "discordapp.com",
+  "canary.discord.com",
+  "ptb.discord.com",
+]);
+
+const SENSITIVE_LINE_PATTERNS = [
+  /metagraphed-submission-gate/i,
+  /discord(?:app)?\.com\/api\/webhooks/i,
+  /(?:github_pat|gh[pousr]_|pat[_-]?|api[_-]?key|secret|token)/i,
+  /\b(?:wallet|hotkey|coldkey|seed phrase|mnemonic|private key)\b/i,
+  /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|provider model|model detail)\b/i,
+];
+
+const SECTION_HEADING_PATTERN =
+  /^(summary|recommended action|required shape|source review|security review|validation review|duplicate \/ history review|ai rationale):?$/i;
+
+export function shouldNotifySubmissionDecision(decision = {}) {
+  if (!("status" in decision) && !("public_state" in decision)) {
+    return false;
+  }
+  if (NON_TERMINAL_NOTIFICATION_STATES.has(String(decision.public_state))) {
+    return false;
+  }
+  return TERMINAL_NOTIFICATION_VERDICTS.has(String(decision.verdict));
+}
+
+export function buildNotificationKey({ target = {}, decision = {} }) {
+  const kind = target.kind || target.target_kind || "submission";
+  const repo = target.repo || target.repo_full_name || "unknown-repo";
+  const number =
+    target.number || target.pr_number || target.issue_number || "0";
+  const revision =
+    target.head_sha ||
+    target.headSha ||
+    target.head_ref ||
+    target.headRef ||
+    target.issue_revision ||
+    target.issueRevision ||
+    "unknown-revision";
+  const status =
+    decision.status || decision.public_state || decision.state || "terminal";
+  const verdict = decision.verdict || "unknown-verdict";
+  return [kind, repo, number, revision, status, verdict].join(":");
+}
+
+export function buildSubmissionDiscordPayload(decision = {}) {
+  if (!shouldNotifySubmissionDecision(decision)) {
+    return null;
+  }
+
+  const meta = VERDICT_META[decision.verdict];
+  const number = decision.pr_number || decision.issue_number || "submission";
+  const targetUrl = decision.pr_url || decision.issue_url || undefined;
+  const candidate = decision.candidate || {};
+  const subjectSource = {
+    ...candidate,
+    netuid: candidate.netuid ?? decision.netuid,
+    kind: candidate.kind || decision.kind,
+  };
+  const fields = [
+    field("Result", meta.label),
+    field("Netuid", candidate.netuid ?? decision.netuid ?? "n/a"),
+    field("Kind", candidate.kind || decision.kind || "n/a"),
+    field("Submitter", decision.submitter || "n/a"),
+  ];
+
+  if (candidate.source_url || decision.source_url) {
+    fields.push(
+      field("Source", candidate.source_url || decision.source_url, false),
+    );
+  }
+  if (targetUrl) {
+    fields.push(field("GitHub", targetUrl, false));
+  }
+
+  return {
+    username: "Metagraphed Maintainer Agent",
+    embeds: [
+      {
+        title: truncate(
+          `#${number} ${meta.action} · ${compactSubject(decision.title, subjectSource)}`,
+          DISCORD_MAX_TITLE_LENGTH,
+        ),
+        url: targetUrl,
+        color: meta.color,
+        description:
+          sanitizeNotificationSummary(decision.summary) ||
+          "Metagraphed submission gate completed a terminal decision.",
+        fields,
+        footer: {
+          text: "JSONbored/metagraphed · Metagraphed submission gate",
+        },
+        timestamp: normalizeTimestamp(decision.now),
+      },
+    ],
+  };
+}
+
+export function sanitizeNotificationSummary(value) {
+  const lines = String(value || "")
+    .split(/\r?\n/)
+    .map((line) =>
+      stripHtmlComments(line)
+        .replace(/^#{1,6}\s*/, "")
+        .replace(/^[-*]\s*/, "")
+        .replace(/\*\*/g, "")
+        .replace(/`/g, "")
+        .trim(),
+    )
+    .filter(Boolean)
+    .filter((line) => !SECTION_HEADING_PATTERN.test(line))
+    .filter(
+      (line) => !SENSITIVE_LINE_PATTERNS.some((pattern) => pattern.test(line)),
+    );
+
+  return truncate(lines.slice(0, 2).join(" "), DISCORD_MAX_DESCRIPTION_LENGTH);
+}
+
+export function truncate(value, limit) {
+  const text = String(value || "")
+    .replace(/\s+/g, " ")
+    .trim();
+  const codePoints = Array.from(text);
+  if (codePoints.length <= limit) {
+    return text;
+  }
+  return `${codePoints
+    .slice(0, Math.max(0, limit - 3))
+    .join("")
+    .trimEnd()}...`;
+}
+
+export function validateDiscordWebhookUrl(value) {
+  let url;
+  try {
+    url = new URL(String(value || ""));
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "https:") {
+    return null;
+  }
+  if (!SAFE_DISCORD_WEBHOOK_HOSTS.has(url.hostname)) {
+    return null;
+  }
+  if (!/^\/api\/webhooks\/\d+\/[A-Za-z0-9._-]{20,}$/.test(url.pathname)) {
+    return null;
+  }
+  return url.toString();
+}
+
+function field(name, value, inline = true) {
+  return {
+    name,
+    value: truncate(value || "n/a", DISCORD_MAX_FIELD_LENGTH),
+    inline,
+  };
+}
+
+function compactSubject(title, candidate = {}) {
+  const fromCandidate = [
+    candidate.netuid ? `SN${candidate.netuid}` : "",
+    candidate.kind,
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const text = String(title || fromCandidate || "submission")
+    .replace(/^[a-z]+(?:\([^)]+\))?:\s*/i, "")
+    .replace(/^(add|create|submit|update)\s+/i, "")
+    .trim();
+  return truncate(text || fromCandidate || "submission", 120);
+}
+
+function normalizeTimestamp(value) {
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+  if (value) {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString();
+    }
+  }
+  return new Date().toISOString();
+}
+
+function stripHtmlComments(value) {
+  let output = "";
+  let cursor = 0;
+  while (cursor < value.length) {
+    const start = value.indexOf("<!--", cursor);
+    if (start === -1) {
+      output += value.slice(cursor);
+      break;
+    }
+    output += value.slice(cursor, start);
+    const end = value.indexOf("-->", start + 4);
+    if (end === -1) {
+      break;
+    }
+    cursor = end + 3;
+  }
+  return output;
+}

--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -76,6 +76,14 @@ checkIncludes(submissionGateDocs, "submission gate docs", [
   "metagraphed-merged-by-gate",
   "metagraphed-import-approved",
   "<!-- metagraphed-submission-gate -->",
+  "Discord Notifications",
+  "DISCORD_SUBMISSION_WEBHOOK_URL",
+  "last_notification_key",
+  "merged",
+  "closed",
+  "manual-review",
+  "retry-exhausted",
+  "route_away",
 ]);
 
 if (errors.length > 0) {

--- a/scripts/validate-private-boundary.mjs
+++ b/scripts/validate-private-boundary.mjs
@@ -1,0 +1,98 @@
+import { execFileSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { repoRoot } from "./lib.mjs";
+
+const trackedFiles = execFileSync("git", ["ls-files"], {
+  cwd: repoRoot,
+  encoding: "utf8",
+})
+  .split("\n")
+  .filter(Boolean);
+
+const pathPatterns = [
+  {
+    name: "private submission-gate implementation path",
+    regex:
+      /(^|\/)(?:private-reviewer|review-corpus|review-fixtures|private-prompts|accepted-rejected-examples|metagraphed-submission-gate-private)(?:\/|$)/i,
+  },
+];
+
+const contentPatterns = [
+  {
+    name: "real Discord webhook URL",
+    regex:
+      /https:\/\/(?:discord\.com|discordapp\.com|canary\.discord\.com|ptb\.discord\.com)\/api\/webhooks\/\d+\/[A-Za-z0-9._-]{20,}/,
+  },
+  {
+    name: "private AI scoring internals",
+    regex:
+      /\b(?:private prompt|private rubric|private score|private threshold|corpus weight|accepted rejected example|accepted\/rejected example)\b/i,
+  },
+  {
+    name: "provider-specific private model route",
+    regex: /\b(?:AI_GATEWAY|WORKERS_AI|@cf\/openai\/|gpt-oss-)\b/i,
+  },
+];
+
+const allowedContentMentions = new Set([
+  "docs/submission-gate.md",
+  "CONTRIBUTING.md",
+  "scripts/submission-notifications.mjs",
+  "scripts/validate-private-boundary.mjs",
+  "tests/submission-gate.test.mjs",
+]);
+
+const findings = [];
+
+for (const file of trackedFiles) {
+  for (const pattern of pathPatterns) {
+    if (pattern.regex.test(file)) {
+      findings.push(`${file}: ${pattern.name}`);
+    }
+  }
+
+  if (isBinaryOrLarge(file)) {
+    continue;
+  }
+
+  const content = await fs.readFile(path.join(repoRoot, file), "utf8");
+  for (const [index, line] of content.split(/\r?\n/).entries()) {
+    for (const pattern of contentPatterns) {
+      if (!pattern.regex.test(line)) {
+        continue;
+      }
+      if (
+        pattern.name !== "real Discord webhook URL" &&
+        allowedContentMentions.has(file)
+      ) {
+        continue;
+      }
+      findings.push(`${file}:${index + 1}: ${pattern.name}`);
+    }
+  }
+}
+
+if (findings.length > 0) {
+  console.error(
+    `Private-boundary validation found ${findings.length} issue(s):`,
+  );
+  for (const finding of findings) {
+    console.error(`- ${finding}`);
+  }
+  process.exit(1);
+}
+
+console.log("Private-boundary validation passed.");
+
+function isBinaryOrLarge(file) {
+  return (
+    file.endsWith(".png") ||
+    file.endsWith(".jpg") ||
+    file.endsWith(".jpeg") ||
+    file.endsWith(".gif") ||
+    file.endsWith(".webp") ||
+    file.endsWith(".ico") ||
+    file.startsWith("public/metagraph/")
+  );
+}

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -38,6 +38,13 @@ for (const workflow of workflows) {
     "predictable heredoc delimiter in run block",
   );
   check(
+    !/discord(?:app)?\.com\/api\/webhooks|DISCORD_SUBMISSION_WEBHOOK_URL/i.test(
+      content,
+    ),
+    workflow,
+    "Discord notifications must be sent by the private Cloudflare gate, not GitHub Actions",
+  );
+  check(
     /uses:\s+actions\/checkout@/.test(content),
     workflow,
     "missing checkout action",
@@ -115,6 +122,11 @@ for (const workflow of workflows) {
       content.includes("npm run validate:docs"),
       workflow,
       "workflow must validate public documentation contracts",
+    );
+    check(
+      content.includes("npm run validate:private-boundary"),
+      workflow,
+      "workflow must validate private reviewer and notification boundaries",
     );
   }
 }

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -12,6 +12,14 @@ import {
   buildPrSubmissionReport,
   classifyPrScope,
 } from "../scripts/submission-policy.mjs";
+import {
+  buildNotificationKey,
+  buildSubmissionDiscordPayload,
+  sanitizeNotificationSummary,
+  shouldNotifySubmissionDecision,
+  truncate,
+  validateDiscordWebhookUrl,
+} from "../scripts/submission-notifications.mjs";
 
 const validCandidateDocument = JSON.parse(
   readFileSync(
@@ -195,5 +203,216 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(report.public_state, "submit_pr");
     assert.equal(report.import_allowed, true);
     assert.equal(report.next_action, "open-import-pr");
+  });
+
+  test("notifies only terminal UGC decisions", () => {
+    assert.equal(
+      shouldNotifySubmissionDecision({
+        public_state: "submit_pr",
+        verdict: "merged",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldNotifySubmissionDecision({
+        public_state: "route_away",
+        verdict: "merged",
+      }),
+      false,
+    );
+    assert.equal(
+      shouldNotifySubmissionDecision({
+        public_state: "manual_review",
+        verdict: "manual-review",
+      }),
+      true,
+    );
+    assert.equal(
+      shouldNotifySubmissionDecision({
+        public_state: "done",
+        verdict: "retry-exhausted",
+      }),
+      true,
+    );
+  });
+
+  test("formats terminal Discord payloads without private marker or secrets", () => {
+    const payload = buildSubmissionDiscordPayload({
+      verdict: "closed",
+      status: "closed",
+      pr_number: 42,
+      pr_url: "https://github.com/JSONbored/metagraphed/pull/42",
+      title: "feat(intake): add Allways docs",
+      submitter: "jsonbored",
+      candidate: {
+        netuid: 7,
+        kind: "docs",
+        source_url: "https://docs.all-ways.io/how-it-works.html",
+      },
+      summary: [
+        "<!-- metagraphed-submission-gate -->",
+        "Summary:",
+        "- Closed because the submitted surface duplicates an existing entry.",
+        "- github_pat_should-not-leak-even-in-test-fixtures",
+      ].join("\n"),
+      now: "1970-01-01T00:00:00.000Z",
+    });
+
+    const serialized = JSON.stringify(payload);
+    assert.equal(payload.username, "Metagraphed Maintainer Agent");
+    assert.equal(payload.embeds[0].title, "#42 closed · Allways docs");
+    assert.equal(payload.embeds[0].color, 0xda3633);
+    assert.equal(payload.embeds[0].timestamp, "1970-01-01T00:00:00.000Z");
+    assert.equal(serialized.includes("metagraphed-submission-gate"), false);
+    assert.equal(serialized.includes("github_pat_should"), false);
+    assert.equal(serialized.includes("private prompt"), false);
+  });
+
+  test("sanitizes notification summaries and preserves code points", () => {
+    assert.equal(
+      sanitizeNotificationSummary(
+        [
+          "Summary:",
+          "- Discord webhook https://discord.com/api/webhooks/redacted",
+          "- Private prompt score must never be exposed.",
+          "- Manual review needed because source evidence conflicts.",
+        ].join("\n"),
+      ),
+      "Manual review needed because source evidence conflicts.",
+    );
+
+    const capped = truncate(`${"a".repeat(12)}😀tail`, 14);
+    assert.equal(capped.includes("�"), false);
+    assert.doesNotThrow(() => encodeURIComponent(capped));
+  });
+
+  test("builds notification keys from target revision and terminal verdict", () => {
+    assert.equal(
+      buildNotificationKey({
+        target: {
+          kind: "pull_request",
+          repo: "JSONbored/metagraphed",
+          number: 42,
+          head_sha: "abc123",
+        },
+        decision: {
+          status: "merged",
+          verdict: "merged",
+        },
+      }),
+      "pull_request:JSONbored/metagraphed:42:abc123:merged:merged",
+    );
+
+    assert.equal(
+      buildNotificationKey({
+        target: {
+          kind: "issue",
+          repo: "JSONbored/metagraphed",
+          number: 7,
+          issue_revision: "edited-1",
+        },
+        decision: {
+          status: "manual",
+          verdict: "manual-review",
+        },
+      }),
+      "issue:JSONbored/metagraphed:7:edited-1:manual:manual-review",
+    );
+
+    assert.equal(
+      buildNotificationKey({}),
+      "submission:unknown-repo:0:unknown-revision:terminal:unknown-verdict",
+    );
+  });
+
+  test("validates Discord webhook URLs and skips non-terminal payloads", () => {
+    assert.equal(buildSubmissionDiscordPayload({ verdict: "closed" }), null);
+    assert.equal(
+      buildSubmissionDiscordPayload({
+        public_state: "fix_required",
+        verdict: "closed",
+      }),
+      null,
+    );
+    assert.equal(validateDiscordWebhookUrl("not a url"), null);
+    assert.equal(
+      validateDiscordWebhookUrl("http://discord.com/api/webhooks/1/token"),
+      null,
+    );
+    assert.equal(
+      validateDiscordWebhookUrl("https://example.com/api/webhooks/1/token"),
+      null,
+    );
+    assert.equal(
+      validateDiscordWebhookUrl("https://discord.com/api/webhooks/redacted"),
+      null,
+    );
+
+    const webhook = [
+      "https://discord.com/api/webhooks",
+      "123456789012345678",
+      "abcdefghijklmnopqrstuvwxyzABCDEF",
+    ].join("/");
+    assert.equal(validateDiscordWebhookUrl(webhook), webhook);
+  });
+
+  test("builds compact issue payloads with fallback descriptions", () => {
+    const payload = buildSubmissionDiscordPayload({
+      public_state: "terminal",
+      verdict: "retry-exhausted",
+      status: "error_retryable",
+      issue_number: 55,
+      issue_url: "https://github.com/JSONbored/metagraphed/issues/55",
+      submitter: "jsonbored",
+      netuid: 12,
+      kind: "openapi",
+      source_url: "https://docs.example.com/openapi.json",
+      summary: "",
+      now: "invalid-date",
+    });
+
+    assert.equal(payload.embeds[0].title, "#55 needs attention · SN12 openapi");
+    assert.equal(payload.embeds[0].color, 0xfb8500);
+    assert.equal(
+      payload.embeds[0].description,
+      "Metagraphed submission gate completed a terminal decision.",
+    );
+    assert.equal(
+      Number.isNaN(new Date(payload.embeds[0].timestamp).getTime()),
+      false,
+    );
+    assert.equal(
+      payload.embeds[0].fields.some(
+        (field) =>
+          field.name === "Source" &&
+          field.value === "https://docs.example.com/openapi.json",
+      ),
+      true,
+    );
+  });
+
+  test("handles notification summary edge cases", () => {
+    const datePayload = buildSubmissionDiscordPayload({
+      public_state: "terminal",
+      verdict: "merged",
+      status: "merged",
+      pr_number: 1,
+      title: "",
+      candidate: {
+        netuid: 7,
+        kind: "docs",
+      },
+      summary: "Useful public source confirmed.",
+      now: new Date("1970-01-01T00:00:00.000Z"),
+    });
+
+    assert.equal(datePayload.embeds[0].title, "#1 merged · SN7 docs");
+    assert.equal(datePayload.embeds[0].timestamp, "1970-01-01T00:00:00.000Z");
+    assert.equal(
+      sanitizeNotificationSummary(
+        "prefix <!-- unterminated comment\nsource review:\nPublic evidence OK.",
+      ),
+      "prefix Public evidence OK.",
+    );
   });
 });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -3,13 +3,14 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
+    exclude: ["node_modules/**", "private/**"],
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],
       include: [
         "src/**/*.mjs",
         "workers/**/*.mjs",
-        "scripts/{artifact-budgets,lib,openapi-components,submission-policy}.mjs",
+        "scripts/{artifact-budgets,lib,openapi-components,submission-notifications,submission-policy}.mjs",
       ],
       thresholds: {
         branches: 85,


### PR DESCRIPTION
## Summary
- Adds a public-safe submission notification contract for terminal UGC gate decisions.
- Documents Discord notification states and Worker secret boundaries.
- Adds private-boundary validation and CI enforcement so webhook URLs and private reviewer internals cannot land in the public repo.

## What changed
- Added sanitized notification payload/key helpers for public contract tests.
- Extended intake docs and validators for Discord notification states.
- Added `validate:private-boundary` and wired it into the local pipeline plus validate/sync/publish workflows.
- Kept Discord delivery, AI review, D1 state, and webhook secrets out of the public repo.

## Why
- Metagraphed should mirror the proven Awesome Claude notification model without exposing Discord webhooks, AI scoring, prompts, or private reviewer implementation details.

## Validation
- `npm run validate:intake`
- `npm run validate:workflows`
- `npm run validate:private-boundary`
- `npm run scan:public-safety`
- `npm test`
- `npm run test:coverage`
- `npm run check`
- `git diff --check`

## Notes
- The private Cloudflare runtime remains outside public git and should receive the real Discord webhook only through Worker secrets.