### PR TITLE
fix(submission): reject unsafe provenance urls

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -447,6 +447,28 @@ export function validateCandidateForSubmission({
       message: "candidate source_url is missing, invalid, or unsafe",
     });
   }
+  if (candidate.source_urls !== undefined) {
+    if (!Array.isArray(candidate.source_urls)) {
+      errors.push({
+        category: "unsupported-shape",
+        message: "candidate source_urls must be an array",
+      });
+    } else {
+      for (const [index, sourceUrl] of candidate.source_urls.entries()) {
+        const normalizedProvenanceUrl = normalizePublicUrl(sourceUrl);
+        if (!normalizedProvenanceUrl) {
+          errors.push({
+            category: "private-or-unsafe-url",
+            message: `candidate source_urls[${index}] is invalid or unsafe`,
+          });
+        } else if (sourceUrl !== normalizedProvenanceUrl) {
+          warnings.push(
+            `candidate source_urls[${index}] will be normalized by registry tooling`,
+          );
+        }
+      }
+    }
+  }
   if (candidate.url && normalizedUrl && candidate.url !== normalizedUrl) {
     warnings.push("candidate url will be normalized by registry tooling");
   }

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -86,6 +86,33 @@ describe("Metagraphed submission gate policy", () => {
     );
   });
 
+  test("blocks unsafe candidate provenance URLs", () => {
+    const document = structuredClone(validCandidateDocument);
+    document.candidates[0].source_urls = [
+      "https://docs.all-ways.io/how-it-works.html",
+      "http://169.254.169.254/latest/meta-data/",
+    ];
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/bad-provenance.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.blocking, true);
+    assert.equal(
+      report.errors.includes("candidate source_urls[1] is invalid or unsafe"),
+      true,
+    );
+    assert.equal(
+      report.error_categories.includes("private-or-unsafe-url"),
+      true,
+    );
+  });
+
   test("routes auth-required and base-layer endpoint claims to manual review", () => {
     const authDocument = structuredClone(validCandidateDocument);
     authDocument.candidates[0].auth_required = true;


### PR DESCRIPTION
### Motivation
- The direct-PR preflight validated `candidate.url` and `candidate.source_url` but ignored `candidate.source_urls`, allowing private/link-local provenance URLs (e.g. `169.254.169.254`) to pass the public gate and be emitted in public artifacts.  
- The change aims to ensure all provenance URLs that may be published are checked with the same public-safety policy used for `url`/`source_url` to avoid leaking internal endpoints.

### Description
- Add validation in `validateCandidateForSubmission` (scripts/submission-policy.mjs) to reject non-array `candidate.source_urls` and to normalize/validate each `source_urls` entry with `normalizePublicUrl`, pushing `private-or-unsafe-url` errors for invalid/unsafe entries and warnings when normalization changes a value.  
- Add a regression test in `tests/submission-gate.test.mjs` that asserts a candidate with a safe `url`/`source_url` but a link-local entry in `source_urls` yields `public_state: fix_required`, `blocking: true`, and the appropriate error message.

### Testing
- Attempted `npm test -- --runInBand tests/submission-gate.test.mjs` failed because Vitest does not accept the Jest `--runInBand` option.  
- `npm test -- tests/submission-gate.test.mjs` exercised the modified test file and passed.  
- `npm run validate` completed successfully and reported validated snapshots/candidates.  
- `npm run lint` and `npm run format:check` both completed successfully and `git diff --check` reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d13ccbf8832cb692b9632b3d0af1)