### PR TITLE
fix(intake): reject duplicate issue fields

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -49,6 +49,8 @@ const TERMINAL_FIX_CATEGORIES = new Set([
   "unsupported-shape",
 ]);
 
+const FIELD_PARSE_ERRORS = Symbol("metagraphed.issueFieldParseErrors");
+
 const SECRET_PATTERNS = [
   /\bgh[pousr]_[A-Za-z0-9_]{20,}\b/,
   /\bgithub_pat_[A-Za-z0-9_]{20,}\b/,
@@ -63,10 +65,11 @@ export function buildIssueIntakeReport({
   generatedAt = new Date().toISOString(),
 }) {
   const fields = parseIssueFields(issue?.body || "");
+  const fieldErrors = issueFieldParseErrors(fields);
   const labels = issueLabels(issue);
   const providerIds = new Set(providers.map((provider) => provider.id));
   const importApproved = labels.includes(SUBMISSION_LABELS.importApproved);
-  const errors = [];
+  const errors = [...fieldErrors];
   const manual_reasons = [];
 
   const netuid = Number(fields.netuid);
@@ -559,19 +562,34 @@ function normalizeChangedFilePath(file) {
 
 export function parseIssueFields(body) {
   const fields = {};
-  const sections = String(body || "")
-    .split(/^###\s+/m)
-    .slice(1);
+  const errors = [];
+  const sanitizedBody = String(body || "").replace(
+    /<!--[\s\S]*?(?:-->|$)/g,
+    "",
+  );
+  const sections = sanitizedBody.split(/^###\s+/m).slice(1);
   for (const section of sections) {
     const [heading, ...rest] = section.split(/\r?\n/);
     const key = heading.trim().toLowerCase();
+    if (Object.hasOwn(fields, key)) {
+      errors.push(`duplicate issue field heading: ${heading.trim()}`);
+      continue;
+    }
     const value = rest
       .join("\n")
       .trim()
       .replace(/^_No response_$/i, "");
     fields[key] = value;
   }
+  Object.defineProperty(fields, FIELD_PARSE_ERRORS, {
+    value: errors,
+    enumerable: false,
+  });
   return fields;
+}
+
+export function issueFieldParseErrors(fields) {
+  return fields?.[FIELD_PARSE_ERRORS] || [];
 }
 
 export function normalizeKind(value) {

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -158,6 +158,55 @@ describe("Metagraphed submission gate policy", () => {
     );
   });
 
+  test("rejects duplicate issue fields hidden in markdown", () => {
+    const body = [
+      "### Netuid",
+      "7",
+      "### Subnet name",
+      "Allways",
+      "### Interface kind",
+      "docs",
+      "### Public URL",
+      "https://docs.all-ways.io/community-submission-example",
+      "### Source URL",
+      "https://docs.all-ways.io/how-it-works.html",
+      "### Provider or team",
+      "allways",
+      "### Does this interface require authentication?",
+      "no",
+      "### Evidence",
+      "<!--",
+      "### Public URL",
+      "https://phishing.example.net/login",
+      "-->",
+      "### Source URL",
+      "https://evil.example.net/proof",
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 43,
+        title: "interface: hidden duplicate",
+        user: { login: "jsonbored" },
+        labels: [
+          { name: SUBMISSION_LABELS.interfaceSubmission },
+          { name: SUBMISSION_LABELS.importApproved },
+        ],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.state, "schema-invalid");
+    assert.equal(report.import_allowed, false);
+    assert.equal(
+      report.errors.includes("duplicate issue field heading: Source URL"),
+      true,
+    );
+    assert.equal(report.candidate, null);
+  });
+
   test("keeps issue approval explicit", () => {
     const body = [
       "### Netuid",


### PR DESCRIPTION
### Motivation
- The intake path parsed raw issue Markdown with last-write-wins semantics and did not ignore HTML comments, allowing hidden duplicate `###` headings to overwrite reviewed fields and poison import PRs.

### Description
- Strip HTML comments from the issue body before extracting `###` sections so hidden headings in comments cannot influence parsing. 
- Detect duplicate issue field headings during parse and record parse errors via a non-enumerable `FIELD_PARSE_ERRORS` symbol exposed by `issueFieldParseErrors`. 
- Propagate parse errors into the intake report `errors` so schema-valid/import approval is blocked when duplicates are present. 
- Add a regression test that demonstrates a hidden duplicate heading inside an HTML comment causes the report to become schema-invalid and prevents import.

### Testing
- Ran unit tests with `npm test`, and all test files passed (`5 files`, `37 tests` passed). 
- Ran intake/workflow validations with `npm run validate:intake` and `npm run validate:workflows`, and both succeeded. 
- Ran lint and formatting checks with `npm run lint` and `npm run format:check` (formatting issues were fixed with Prettier), and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d296d0ac832cb54875fb71e7215f)