### PR TITLE
fix(worker): validate RPC proxy upstream URLs

### DIFF
--- a/scripts/worker-test.mjs
+++ b/scripts/worker-test.mjs
@@ -177,6 +177,90 @@ const blockedRpc = await handleRequest(
 assert.equal(blockedRpc.status, 403, "unsafe RPC methods must be blocked");
 assert.equal((await blockedRpc.json()).error.code, "rpc_method_blocked");
 
+for (const unsafeUrl of [
+  "http://127.0.0.1:9650/internal",
+  "http://10.0.0.2:9650/internal",
+  "http://169.254.169.254/latest/meta-data",
+]) {
+  let unsafeFetchCalled = false;
+  const unsafeOriginalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    unsafeFetchCalled = true;
+    throw new Error("unsafe endpoint should not be fetched");
+  };
+
+  try {
+    const unsafeRpc = await handleRequest(
+      new Request("https://metagraph.sh/rpc/v1/finney", {
+        method: "POST",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "chain_getHeader",
+          params: [],
+        }),
+      }),
+      {
+        ...env,
+        METAGRAPH_ENABLE_RPC_PROXY: "true",
+        ASSETS: {
+          async fetch(request) {
+            const url = new URL(request.url);
+            if (url.pathname === "/metagraph/rpc/pools.json") {
+              return new Response(
+                JSON.stringify({
+                  schema_version: 1,
+                  contract_version: "2026-06-06.1",
+                  generated_at: "1970-01-01T00:00:00.000Z",
+                  pools: [
+                    {
+                      id: "finney-rpc",
+                      kind: "subtensor-rpc",
+                      endpoint_count: 1,
+                      eligible_count: 1,
+                      endpoints: [
+                        {
+                          id: "unsafe-rpc",
+                          provider: "fixture",
+                          pool_eligible: true,
+                          score: 100,
+                          status: "ok",
+                          url: unsafeUrl,
+                        },
+                      ],
+                    },
+                  ],
+                }),
+                {
+                  status: 200,
+                  headers: {
+                    "content-type": "application/json",
+                  },
+                },
+              );
+            }
+            return env.ASSETS.fetch(request);
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(
+      unsafeRpc.status,
+      502,
+      `unsafe endpoint ${unsafeUrl} should be rejected before fetch`,
+    );
+    assert.equal((await unsafeRpc.json()).error.code, "rpc_endpoint_unsafe");
+    assert.equal(
+      unsafeFetchCalled,
+      false,
+      `unsafe endpoint ${unsafeUrl} should not reach fetch`,
+    );
+  } finally {
+    globalThis.fetch = unsafeOriginalFetch;
+  }
+}
+
 const originalFetch = globalThis.fetch;
 let upstreamCalled = false;
 globalThis.fetch = async (url, init) => {
@@ -220,7 +304,7 @@ try {
                       pool_eligible: true,
                       score: 100,
                       status: "ok",
-                      url: "https://rpc.example.test",
+                      url: "https://bittensor-finney.api.onfinality.io/public",
                     },
                   ],
                 },

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -362,6 +362,72 @@ describe("Worker runtime", () => {
       {},
     );
     assert.equal(noEligibleEndpoint.status, 503);
+
+    const originalFetch = globalThis.fetch;
+    let unsafeFetchCalled = false;
+    globalThis.fetch = async () => {
+      unsafeFetchCalled = true;
+      throw new Error("unsafe endpoint should not be fetched");
+    };
+
+    try {
+      for (const unsafeUrl of [
+        "http://127.0.0.1:9650/internal",
+        "http://10.0.0.2:9650/internal",
+        "http://169.254.169.254/latest/meta-data",
+      ]) {
+        const unsafeEndpoint = await handleRequest(
+          new Request("https://metagraph.sh/rpc/v1/finney", {
+            method: "POST",
+            body: JSON.stringify({
+              jsonrpc: "2.0",
+              id: 1,
+              method: "chain_getHeader",
+              params: [],
+            }),
+          }),
+          {
+            METAGRAPH_ENABLE_RPC_PROXY: "true",
+            ASSETS: {
+              async fetch() {
+                return new Response(
+                  JSON.stringify({
+                    schema_version: 1,
+                    generated_at: "1970-01-01T00:00:00.000Z",
+                    pools: [
+                      {
+                        id: "finney-rpc",
+                        endpoints: [
+                          {
+                            id: "unsafe",
+                            pool_eligible: true,
+                            provider: "fixture",
+                            url: unsafeUrl,
+                          },
+                        ],
+                      },
+                    ],
+                  }),
+                  {
+                    status: 200,
+                    headers: { "content-type": "application/json" },
+                  },
+                );
+              },
+            },
+          },
+          {},
+        );
+        assert.equal(unsafeEndpoint.status, 502);
+        assert.equal(
+          (await unsafeEndpoint.json()).error.code,
+          "rpc_endpoint_unsafe",
+        );
+      }
+      assert.equal(unsafeFetchCalled, false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
   });
 
   test("proxies explicitly enabled safe RPC methods through eligible pools", async () => {
@@ -403,7 +469,7 @@ describe("Worker runtime", () => {
                           pool_eligible: true,
                           provider: "fixture",
                           status: "ok",
-                          url: "https://rpc.example.test",
+                          url: "https://bittensor-finney.api.onfinality.io/public",
                         },
                       ],
                     },
@@ -415,7 +481,7 @@ describe("Worker runtime", () => {
                           pool_eligible: true,
                           provider: "fixture",
                           status: "ok",
-                          url: "https://wss.example.test",
+                          url: "wss://lite.chain.opentensor.ai:443",
                         },
                       ],
                     },

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -32,6 +32,14 @@ const DENIED_RPC_PREFIXES = [
 ];
 const MAX_RPC_BODY_BYTES = 65536;
 const METAGRAPH_LATEST_KEY = "metagraph:latest";
+const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
+  "https://bittensor-finney.api.onfinality.io",
+  "https://bittensor-public.nodies.app",
+  "wss://archive.chain.opentensor.ai",
+  "wss://bittensor-finney.api.onfinality.io",
+  "wss://entrypoint-finney.opentensor.ai",
+  "wss://lite.chain.opentensor.ai",
+]);
 
 export default {
   async fetch(request, env, ctx) {
@@ -209,10 +217,19 @@ async function handleRpcProxyRequest(request, env, url) {
   const pool = (poolArtifact.data.pools || []).find(
     (candidate) => candidate.id === poolId,
   );
-  const endpoint = pool?.endpoints?.find(
-    (candidate) => candidate.pool_eligible,
-  );
-  if (!endpoint) {
+  const endpointSelection = selectSafeRpcEndpoint(pool);
+  if (endpointSelection.unsafeEndpoint) {
+    return errorResponse(
+      "rpc_endpoint_unsafe",
+      "Eligible RPC endpoint URL is not allowed by the Worker upstream safety policy.",
+      502,
+      {
+        endpoint_id: endpointSelection.unsafeEndpoint.id || null,
+        pool_id: poolId,
+      },
+    );
+  }
+  if (!endpointSelection.endpoint) {
     return errorResponse(
       "rpc_endpoint_unavailable",
       "No eligible public RPC endpoint is available for proxy routing.",
@@ -223,6 +240,7 @@ async function handleRpcProxyRequest(request, env, url) {
     );
   }
 
+  const endpoint = endpointSelection.endpoint;
   const upstream = await fetch(endpoint.url, {
     method: "POST",
     headers: {
@@ -637,6 +655,87 @@ async function weakEtag(body) {
 
 function contractVersion(env) {
   return env.METAGRAPH_CONTRACT_VERSION || CONTRACT_VERSION;
+}
+
+function selectSafeRpcEndpoint(pool) {
+  let unsafeEndpoint = null;
+  for (const endpoint of pool?.endpoints || []) {
+    if (!endpoint?.pool_eligible) {
+      continue;
+    }
+    if (isSafeRpcEndpointUrl(endpoint.url)) {
+      return { endpoint, unsafeEndpoint: null };
+    }
+    unsafeEndpoint ||= endpoint;
+  }
+
+  return { endpoint: null, unsafeEndpoint };
+}
+
+function isSafeRpcEndpointUrl(value) {
+  if (typeof value !== "string") {
+    return false;
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (!["https:", "wss:"].includes(parsed.protocol)) {
+    return false;
+  }
+
+  if (!TRUSTED_RPC_UPSTREAM_ORIGINS.has(parsed.origin)) {
+    return false;
+  }
+
+  return !isPrivateOrLocalHostname(parsed.hostname);
+}
+
+function isPrivateOrLocalHostname(hostname) {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    return true;
+  }
+
+  const ipv4 = parseIpv4Address(host);
+  if (ipv4) {
+    const [first, second] = ipv4;
+    return (
+      first === 0 ||
+      first === 10 ||
+      first === 127 ||
+      (first === 169 && second === 254) ||
+      (first === 172 && second >= 16 && second <= 31) ||
+      (first === 192 && second === 168)
+    );
+  }
+
+  return (
+    host === "::" ||
+    host === "::1" ||
+    host.startsWith("fc") ||
+    host.startsWith("fd") ||
+    host.startsWith("fe80") ||
+    host.startsWith("::ffff:127.") ||
+    host.startsWith("::ffff:10.") ||
+    host.startsWith("::ffff:169.254.") ||
+    host.startsWith("::ffff:192.168.") ||
+    /^::ffff:172\.(1[6-9]|2\d|3[0-1])\./.test(host)
+  );
+}
+
+function parseIpv4Address(host) {
+  const match = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host);
+  if (!match) {
+    return null;
+  }
+
+  const octets = match.slice(1).map(Number);
+  return octets.every((octet) => octet >= 0 && octet <= 255) ? octets : null;
 }
 
 function isSafeRpcMethod(method) {


### PR DESCRIPTION
### Motivation
- The RPC proxy path previously forwarded eligible upstream `endpoint.url` values directly to `fetch()` without runtime scheme/host safety checks, creating an SSRF risk if artifacts are poisoned or DNS is rebound.

### Description
- Add a worker-side trusted-origin allowlist `TRUSTED_RPC_UPSTREAM_ORIGINS` and require `https:`/`wss:` schemes before proxying upstream endpoints in `workers/api.mjs`.
- Replace naive pool selection with `selectSafeRpcEndpoint(pool)` which refuses eligible endpoints that fail the Worker safety policy and returns `rpc_endpoint_unsafe` instead of forwarding.
- Implement URL safety helpers `isSafeRpcEndpointUrl`, `isPrivateOrLocalHostname`, and `parseIpv4Address` to reject localhost, link-local, private IPv4/IPv6, and other unsafe hostnames prior to `fetch()` in `workers/api.mjs`.
- Add and update runtime tests in `scripts/worker-test.mjs` and `tests/worker-runtime.test.mjs` to assert that loopback/private/cloud-metadata endpoints are rejected and that known trusted fixtures still proxy successfully.

### Testing
- Ran `npm run worker:test` and the included worker runtime checks, which passed; tests output: "Worker runtime tests passed.".
- Ran `npm test` (Vitest) and all repository tests passed (`36 passed / 36`).
- Ran `npm run lint` and `npm run format:check` and both checks passed.
- Ran `npm run validate:api` which validated Worker API routes successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d298bc10832c8072ec528693b8e0)