### PR TITLE
fix: harden URL safety checks

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -1,6 +1,8 @@
 import path from "node:path";
 import {
   buildTimestamp,
+  isUnsafeHostname,
+  isUnsafeUrlResolved,
   loadNativeSnapshot,
   loadSubnets,
   nativeDisplayName,
@@ -955,16 +957,7 @@ function isBadgeOrAssetUrl(value) {
 }
 
 function isUnsafeHost(hostname) {
-  const host = hostname.toLowerCase();
-  return (
-    host === "localhost" ||
-    host === "0.0.0.0" ||
-    host === "127.0.0.1" ||
-    host === "::1" ||
-    host.startsWith("10.") ||
-    host.startsWith("192.168.") ||
-    /^172\.(1[6-9]|2\d|3[0-1])\./.test(host)
-  );
+  return isUnsafeHostname(hostname);
 }
 
 function isSocialUrl(value) {
@@ -996,6 +989,11 @@ function stripHtml(value) {
 }
 
 async function fetchJson(url, headers = {}) {
+  if (await isUnsafeUrlResolved(url)) {
+    warnings.push(`${url}: unsafe URL`);
+    return null;
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), 15000);
   try {
@@ -1021,6 +1019,13 @@ async function fetchJson(url, headers = {}) {
 }
 
 async function fetchText(url, options = {}) {
+  if (await isUnsafeUrlResolved(url)) {
+    if (options.warn !== false) {
+      warnings.push(`${url}: unsafe URL`);
+    }
+    return null;
+  }
+
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(),

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { createHash } from "node:crypto";
+import { lookup as dnsLookup } from "node:dns/promises";
 import { isIP } from "node:net";
 import path from "node:path";
 
@@ -192,38 +193,146 @@ export function isUnsafeUrl(value) {
       return true;
     }
 
-    const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-    const literalIp = isIP(host);
-    if (
-      host === "localhost" ||
-      host === "0.0.0.0" ||
-      host === "127.0.0.1" ||
-      host === "::1"
-    ) {
-      return true;
-    }
-    if (literalIp === 4) {
-      return (
-        host.startsWith("10.") ||
-        host.startsWith("127.") ||
-        host.startsWith("169.254.") ||
-        host.startsWith("192.168.") ||
-        /^172\.(1[6-9]|2\d|3[0-1])\./.test(host)
-      );
-    }
-    if (literalIp === 6) {
-      return (
-        host === "::" ||
-        host.startsWith("fc") ||
-        host.startsWith("fd") ||
-        host.startsWith("fe80")
-      );
-    }
-
-    return false;
+    return isUnsafeHostname(url.hostname);
   } catch {
     return true;
   }
+}
+
+export async function isUnsafeUrlResolved(value, resolver = dnsLookup) {
+  if (isUnsafeUrl(value)) {
+    return true;
+  }
+
+  try {
+    const url = new URL(value);
+    const host = normalizeHostname(url.hostname);
+    if (isIP(host)) {
+      return false;
+    }
+
+    const records = await resolver(host, { all: true, verbatim: true });
+    return records.some((record) => isUnsafeHostname(record.address));
+  } catch {
+    return false;
+  }
+}
+
+export function isUnsafeHostname(hostname) {
+  const host = normalizeHostname(hostname);
+  const literalIp = isIP(host);
+  if (host === "localhost") {
+    return true;
+  }
+  if (literalIp === 4) {
+    return isUnsafeIpv4(host);
+  }
+  if (literalIp === 6) {
+    return isUnsafeIpv6(host);
+  }
+
+  return false;
+}
+
+function normalizeHostname(hostname) {
+  return String(hostname || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+}
+
+function isUnsafeIpv4(host) {
+  const octets = host.split(".").map((part) => Number(part));
+  const [first, second] = octets;
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 0) ||
+    (first === 192 && second === 168) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    first >= 224
+  );
+}
+
+function isUnsafeIpv6(host) {
+  const value = parseIpv6(host);
+  if (value === null) {
+    return true;
+  }
+
+  if (value === 0n || value === 1n) {
+    return true;
+  }
+
+  const mappedPrefix = 0xffffn << 32n;
+  if (value >> 32n === mappedPrefix >> 32n) {
+    return isUnsafeIpv4(bigIntToIpv4(value & 0xffffffffn));
+  }
+
+  return (
+    inIpv6Range(value, 0xfc00n << 112n, 7n) ||
+    inIpv6Range(value, 0xfe80n << 112n, 10n) ||
+    inIpv6Range(value, 0xfec0n << 112n, 10n) ||
+    inIpv6Range(value, 0xff00n << 112n, 8n)
+  );
+}
+
+function inIpv6Range(value, prefix, bits) {
+  return value >> (128n - bits) === prefix >> (128n - bits);
+}
+
+function parseIpv6(host) {
+  const normalized = host.includes(".") ? expandEmbeddedIpv4(host) : host;
+  const parts = normalized.split("::");
+  if (parts.length > 2) {
+    return null;
+  }
+
+  const head = parts[0] ? parts[0].split(":") : [];
+  const tail = parts[1] ? parts[1].split(":") : [];
+  const missing = 8 - head.length - tail.length;
+  if (missing < 0 || (parts.length === 1 && missing !== 0)) {
+    return null;
+  }
+
+  const groups = [...head, ...Array(missing).fill("0"), ...tail];
+  if (groups.length !== 8) {
+    return null;
+  }
+
+  return groups.reduce((accumulator, group) => {
+    if (!/^[0-9a-f]{1,4}$/i.test(group)) {
+      return null;
+    }
+    const parsed = BigInt(`0x${group}`);
+    return accumulator === null ? null : (accumulator << 16n) + parsed;
+  }, 0n);
+}
+
+function expandEmbeddedIpv4(host) {
+  const lastColon = host.lastIndexOf(":");
+  const prefix = host.slice(0, lastColon + 1);
+  const octets = host
+    .slice(lastColon + 1)
+    .split(".")
+    .map((part) => Number(part));
+  if (octets.length !== 4 || octets.some((part) => part < 0 || part > 255)) {
+    return host;
+  }
+
+  const high = (octets[0] << 8) + octets[1];
+  const low = (octets[2] << 8) + octets[3];
+  return `${prefix}${high.toString(16)}:${low.toString(16)}`;
+}
+
+function bigIntToIpv4(value) {
+  return [24n, 16n, 8n, 0n]
+    .map((shift) => Number((value >> shift) & 255n))
+    .join(".");
 }
 
 export function normalizePublicUrl(value) {

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -6,7 +6,7 @@ import {
   buildTimestamp,
   flattenSurfaces,
   isJsonContentType,
-  isUnsafeUrl,
+  isUnsafeUrlResolved,
   loadSubnets,
   repoRoot,
   writeJson,
@@ -148,7 +148,7 @@ async function probeSubtensorSurface(surface) {
 }
 
 async function probeUrl(url, method, accept, timeoutMs, redirectCount = 0) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeUrlResolved(url)) {
     return {
       ok: false,
       error: "unsafe URL",
@@ -182,7 +182,7 @@ async function probeUrl(url, method, accept, timeoutMs, redirectCount = 0) {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeUrlResolved(redirectTarget)) {
         await response.body?.cancel();
         return {
           ok: false,
@@ -346,7 +346,7 @@ function statusForClassification(classification, surface = null) {
 }
 
 async function probeSubtensorHttp(url, timeoutMs) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeUrlResolved(url)) {
     return {
       unsafe_url: true,
       error: "unsafe URL",
@@ -392,7 +392,7 @@ async function probeSubtensorHttp(url, timeoutMs) {
 }
 
 async function probeSubtensorWss(url, timeoutMs) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeUrlResolved(url)) {
     return {
       unsafe_url: true,
       error: "unsafe URL",
@@ -455,7 +455,7 @@ async function jsonRpcHttp(url, method, params, id, timeoutMs) {
     const location = response.headers.get("location");
     if ([301, 302, 303, 307, 308].includes(response.status) && location) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeUrlResolved(redirectTarget)) {
         await response.body?.cancel();
         return {
           transport_error: true,

--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -3,7 +3,7 @@ import {
   buildTimestamp,
   hashJson,
   isJsonContentType,
-  isUnsafeUrl,
+  isUnsafeUrlResolved,
   repoRoot,
   stableStringify,
   writeJson,
@@ -159,7 +159,7 @@ async function fetchJsonSummary(url) {
 }
 
 async function fetchJson(url) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeUrlResolved(url)) {
     return {
       ok: false,
       status: "unsafe",
@@ -238,7 +238,7 @@ async function fetchJson(url) {
 }
 
 async function fetchSseSummary(url) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeUrlResolved(url)) {
     return {
       status: "unsafe",
       url,

--- a/scripts/snapshot-openapi.mjs
+++ b/scripts/snapshot-openapi.mjs
@@ -6,6 +6,7 @@ import {
   hashJson,
   isJsonContentType,
   isUnsafeUrl,
+  isUnsafeUrlResolved,
   loadSubnets,
   repoRoot,
   stableStringify,
@@ -228,7 +229,7 @@ function candidateSchemaUrls(surface) {
 }
 
 async function fetchJson(url, redirectCount = 0) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeUrlResolved(url)) {
     return { ok: false, unsafe_url: true, error: "unsafe URL" };
   }
 
@@ -250,7 +251,7 @@ async function fetchJson(url, redirectCount = 0) {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeUrlResolved(redirectTarget)) {
         await response.body?.cancel();
         return {
           ok: false,

--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -3,7 +3,7 @@ import {
   buildTimestamp,
   isHtmlContentType,
   isJsonContentType,
-  isUnsafeUrl,
+  isUnsafeUrlResolved,
   loadCandidates,
   repoRoot,
   stableStringify,
@@ -63,7 +63,7 @@ async function verifyCandidate(candidate) {
     verified_at: new Date().toISOString(),
   };
 
-  if (!candidate.public_safe || isUnsafeUrl(candidate.url)) {
+  if (!candidate.public_safe || (await isUnsafeUrlResolved(candidate.url))) {
     return {
       ...base,
       classification: "unsafe",
@@ -166,7 +166,7 @@ async function verifyHttpSurface(base, candidate) {
 }
 
 async function probeUrl(url, method, accept, redirectCount = 0) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeUrlResolved(url)) {
     return {
       ok: false,
       error: "unsafe URL",
@@ -197,7 +197,7 @@ async function probeUrl(url, method, accept, redirectCount = 0) {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeUrlResolved(redirectTarget)) {
         await response.body?.cancel();
         return {
           ok: false,

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -16,7 +16,9 @@ import {
   hashJson,
   isHtmlContentType,
   isJsonContentType,
+  isUnsafeHostname,
   isUnsafeUrl,
+  isUnsafeUrlResolved,
   isValidUrl,
   listJsonFiles,
   listJsonFilesRecursive,
@@ -121,7 +123,12 @@ describe("script utility contracts", () => {
     assert.equal(isUnsafeUrl("http://127.0.0.1:9944"), true);
     assert.equal(isUnsafeUrl("ftp://metagraph.sh"), true);
     assert.equal(isUnsafeUrl("http://172.16.0.1"), true);
+    assert.equal(isUnsafeUrl("http://[::1]"), true);
     assert.equal(isUnsafeUrl("http://[fd00::1]"), true);
+    assert.equal(isUnsafeUrl("http://[fe80::1]"), true);
+    assert.equal(isUnsafeUrl("http://[::ffff:127.0.0.1]"), true);
+    assert.equal(isUnsafeHostname("[::1]"), true);
+    assert.equal(isUnsafeHostname("::ffff:7f00:1"), true);
     assert.equal(isUnsafeUrl("not a url"), true);
     assert.equal(isUnsafeUrl("https://metagraph.sh"), false);
     assert.equal(
@@ -155,6 +162,24 @@ describe("script utility contracts", () => {
       "7|docs|https://docs.all-ways.io/",
     );
     assert.equal(slugify("TAO / Metagraph: Build"), "tao-metagraph-build");
+  });
+
+  test("resolves hostnames before treating probe URLs as safe", async () => {
+    const privateResolver = async () => [
+      { address: "192.168.1.10", family: 4 },
+    ];
+    const publicResolver = async () => [
+      { address: "93.184.216.34", family: 4 },
+    ];
+
+    assert.equal(
+      await isUnsafeUrlResolved("https://metadata.example", privateResolver),
+      true,
+    );
+    assert.equal(
+      await isUnsafeUrlResolved("https://metagraph.example", publicResolver),
+      false,
+    );
   });
 
   test("builds RPC endpoint and pool artifacts from surface health", () => {


### PR DESCRIPTION
### Motivation
- The prior URL-safety gate compared `URL.hostname` directly (including bracketed IPv6) and performed no DNS resolution, allowing bracketed IPv6 literals (e.g. `[::1]`), IPv4-mapped IPv6 forms, and hostnames that resolve to private addresses to bypass the check and trigger CI network probes.  
- This exposed scheduled discovery/verification/snapshot/probe stages to SSRF/port-scanning risks when attacker-controlled public candidates were ingested.

### Description
- Centralized and hardened hostname checks by adding `isUnsafeHostname` and `isUnsafeUrlResolved` in `scripts/lib.mjs`, normalizing bracketed IPv6 hostnames and handling IPv4-mapped IPv6 and special IPv4/IPv6 ranges.  
- Implemented IPv6 parsing and range checks (including ULA/link-local/mapped prefixes) and added DNS resolution using `node:dns/promises` to detect hostnames that resolve to unsafe addresses.  
- Replaced literal-only checks and switched callers to the resolved check across network-facing scripts: `scripts/discover-candidates.mjs`, `scripts/verify-candidates.mjs`, `scripts/snapshot-openapi.mjs`, `scripts/snapshot-adapters.mjs`, and `scripts/probes-smoke.mjs`.  
- Added/updated unit assertions in `tests/script-utils.test.mjs` to cover bracketed IPv6, IPv4-mapped IPv6, ULA/link-local forms, and DNS-to-private resolution behavior.

### Testing
- Ran linter and formatter checks with `npm run lint` and `npm run format:check`, which completed successfully.  
- Ran the test suite with `npm test`; all tests passed (`5` test files, `37` tests in the working run).  
- Performed `node --check`/static checks on modified scripts during development and ensured no syntax errors and no `git diff --check` whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d2983d10832ca1f3e26e48c02472)