### PR TITLE
fix(probes): block unsafe resolved targets

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
 import { createHash } from "node:crypto";
 import { isIP } from "node:net";
+import { Resolver } from "node:dns/promises";
 import path from "node:path";
 
 export const repoRoot = new URL("..", import.meta.url).pathname;
@@ -185,6 +186,44 @@ export function isValidUrl(value) {
   }
 }
 
+export function isUnsafeHost(hostname) {
+  const host = hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "localhost.localdomain"
+  ) {
+    return true;
+  }
+
+  return isUnsafeIp(host);
+}
+
+export function isUnsafeIp(host) {
+  const literalIp = isIP(host);
+  if (literalIp === 4) {
+    return (
+      host === "0.0.0.0" ||
+      host.startsWith("10.") ||
+      host.startsWith("127.") ||
+      host.startsWith("169.254.") ||
+      host.startsWith("192.168.") ||
+      /^172\.(1[6-9]|2\d|3[0-1])\./.test(host)
+    );
+  }
+  if (literalIp === 6) {
+    const normalized = host.toLowerCase();
+    return (
+      normalized === "::" ||
+      normalized === "::1" ||
+      normalized.startsWith("fc") ||
+      normalized.startsWith("fd") ||
+      normalized.startsWith("fe80")
+    );
+  }
+  return false;
+}
+
 export function isUnsafeUrl(value) {
   try {
     const url = new URL(value);
@@ -192,37 +231,47 @@ export function isUnsafeUrl(value) {
       return true;
     }
 
-    const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
-    const literalIp = isIP(host);
-    if (
-      host === "localhost" ||
-      host === "0.0.0.0" ||
-      host === "127.0.0.1" ||
-      host === "::1"
-    ) {
-      return true;
-    }
-    if (literalIp === 4) {
-      return (
-        host.startsWith("10.") ||
-        host.startsWith("127.") ||
-        host.startsWith("169.254.") ||
-        host.startsWith("192.168.") ||
-        /^172\.(1[6-9]|2\d|3[0-1])\./.test(host)
-      );
-    }
-    if (literalIp === 6) {
-      return (
-        host === "::" ||
-        host.startsWith("fc") ||
-        host.startsWith("fd") ||
-        host.startsWith("fe80")
-      );
-    }
-
-    return false;
+    return isUnsafeHost(url.hostname);
   } catch {
     return true;
+  }
+}
+
+const probeDnsSafetyCache = new Map();
+
+export async function isUnsafeProbeUrl(value) {
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return true;
+  }
+
+  if (isUnsafeUrl(url.toString())) {
+    return true;
+  }
+
+  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  if (!probeDnsSafetyCache.has(host)) {
+    probeDnsSafetyCache.set(host, resolvesToUnsafeAddress(host));
+  }
+  return probeDnsSafetyCache.get(host);
+}
+
+async function resolvesToUnsafeAddress(host) {
+  const resolver = new Resolver({ timeout: 1000, tries: 1 });
+  try {
+    const results = await Promise.allSettled([
+      resolver.resolve4(host),
+      resolver.resolve6(host),
+    ]);
+    return results.some(
+      (result) =>
+        result.status === "fulfilled" &&
+        result.value.some((address) => isUnsafeIp(address)),
+    );
+  } finally {
+    resolver.cancel();
   }
 }
 

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -6,7 +6,7 @@ import {
   buildTimestamp,
   flattenSurfaces,
   isJsonContentType,
-  isUnsafeUrl,
+  isUnsafeProbeUrl,
   loadSubnets,
   repoRoot,
   writeJson,
@@ -148,7 +148,7 @@ async function probeSubtensorSurface(surface) {
 }
 
 async function probeUrl(url, method, accept, timeoutMs, redirectCount = 0) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeProbeUrl(url)) {
     return {
       ok: false,
       error: "unsafe URL",
@@ -182,7 +182,7 @@ async function probeUrl(url, method, accept, timeoutMs, redirectCount = 0) {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeProbeUrl(redirectTarget)) {
         await response.body?.cancel();
         return {
           ok: false,
@@ -346,7 +346,7 @@ function statusForClassification(classification, surface = null) {
 }
 
 async function probeSubtensorHttp(url, timeoutMs) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeProbeUrl(url)) {
     return {
       unsafe_url: true,
       error: "unsafe URL",
@@ -392,7 +392,7 @@ async function probeSubtensorHttp(url, timeoutMs) {
 }
 
 async function probeSubtensorWss(url, timeoutMs) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeProbeUrl(url)) {
     return {
       unsafe_url: true,
       error: "unsafe URL",
@@ -455,7 +455,7 @@ async function jsonRpcHttp(url, method, params, id, timeoutMs) {
     const location = response.headers.get("location");
     if ([301, 302, 303, 307, 308].includes(response.status) && location) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeProbeUrl(redirectTarget)) {
         await response.body?.cancel();
         return {
           transport_error: true,

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -5,6 +5,7 @@ import {
   loadNativeSnapshot,
   loadProviders,
   loadSubnets,
+  isUnsafeProbeUrl,
   isValidUrl,
   readJson,
   registrySurfaceKey,
@@ -90,6 +91,7 @@ const reviewDecisions = new Set([
 const slugPattern = /^[a-z0-9][a-z0-9-]*$/;
 
 const errors = [];
+const asyncChecks = [];
 
 function assert(condition, message) {
   if (!condition) {
@@ -190,6 +192,16 @@ function validateSubnet(subnet, providerIds, surfaceIds, surfaceLocators) {
     assert(Boolean(surface.name), `${surfaceKey}: name is required`);
     assert(surfaceKinds.has(surface.kind), `${surfaceKey}: invalid kind`);
     assert(isValidUrl(surface.url), `${surfaceKey}: url must be a URL`);
+    if (surface.probe?.enabled && surface.public_safe) {
+      asyncChecks.push(
+        isUnsafeProbeUrl(surface.url).then((unsafe) =>
+          assert(
+            !unsafe,
+            `${surfaceKey}: probe target resolves to an unsafe URL`,
+          ),
+        ),
+      );
+    }
     assert(
       providerIds.has(surface.provider),
       `${surfaceKey}: unknown provider ${surface.provider}`,
@@ -1014,6 +1026,7 @@ for (const decision of reviewDecisionsDocument.decisions || []) {
   validateReviewDecision(decision, nativeNetuids);
 }
 
+await Promise.all(asyncChecks);
 await validateGeneratedArtifacts(nativeSnapshot, subnets, candidates);
 
 if (errors.length > 0) {

--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -3,6 +3,7 @@ import {
   buildTimestamp,
   isHtmlContentType,
   isJsonContentType,
+  isUnsafeProbeUrl,
   isUnsafeUrl,
   loadCandidates,
   repoRoot,
@@ -166,7 +167,7 @@ async function verifyHttpSurface(base, candidate) {
 }
 
 async function probeUrl(url, method, accept, redirectCount = 0) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeProbeUrl(url)) {
     return {
       ok: false,
       error: "unsafe URL",
@@ -197,7 +198,7 @@ async function probeUrl(url, method, accept, redirectCount = 0) {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeProbeUrl(redirectTarget)) {
         await response.body?.cancel();
         return {
           ok: false,

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -16,6 +16,7 @@ import {
   hashJson,
   isHtmlContentType,
   isJsonContentType,
+  isUnsafeProbeUrl,
   isUnsafeUrl,
   isValidUrl,
   listJsonFiles,
@@ -99,7 +100,7 @@ describe("script utility contracts", () => {
     assert.equal(path.basename(repoRoot), "metagraphed");
   });
 
-  test("normalizes names, URLs, keys, hashes, and slugs deterministically", () => {
+  test("normalizes names, URLs, keys, hashes, and slugs deterministically", async () => {
     assert.deepEqual(classifyNativeName("unknown", 87), {
       raw_name: "unknown",
       quality: "placeholder",
@@ -119,11 +120,13 @@ describe("script utility contracts", () => {
     assert.equal(isValidUrl("ftp://metagraph.sh"), false);
     assert.equal(isValidUrl("not a url"), false);
     assert.equal(isUnsafeUrl("http://127.0.0.1:9944"), true);
+    assert.equal(isUnsafeUrl("http://metadata.localhost"), true);
     assert.equal(isUnsafeUrl("ftp://metagraph.sh"), true);
     assert.equal(isUnsafeUrl("http://172.16.0.1"), true);
     assert.equal(isUnsafeUrl("http://[fd00::1]"), true);
     assert.equal(isUnsafeUrl("not a url"), true);
     assert.equal(isUnsafeUrl("https://metagraph.sh"), false);
+    assert.equal(await isUnsafeProbeUrl("http://localhost:9944"), true);
     assert.equal(
       normalizePublicUrl("metagraph.sh/docs/"),
       "https://metagraph.sh/docs",


### PR DESCRIPTION
### Motivation
- Probe code accepted any HTTP(S) URL and followed redirects, allowing registry-controlled surfaces to cause blind SSRF to localhost, RFC1918, link-local, or cloud metadata addresses.
- Validation only checked protocol via `isValidUrl`, so `public_safe` + `probe.enabled` surfaces could be probed even if they resolved to unsafe internal addresses.

### Description
- Add host/IP safety helpers `isUnsafeHost` and `isUnsafeIp` and an async `isUnsafeProbeUrl` that DNS-resolves names before probing in `scripts/lib.mjs`.
- Change smoke probes to call `await isUnsafeProbeUrl(...)` before the initial fetch and before following manual redirects in `scripts/probes-smoke.mjs`, preserving `redirect: "manual"` behavior.
- Apply the same async resolved-target checks to subtensor HTTP/WSS probes and JSON-RPC redirect handling in `scripts/probes-smoke.mjs` and `scripts/verify-candidates.mjs`.
- Add validation-time checks so registry surfaces with `probe.enabled && public_safe` fail validation if their URL resolves to an unsafe address by queuing async checks in `scripts/validate.mjs`.
- Update tests in `tests/script-utils.test.mjs` to cover `isUnsafeProbeUrl` and make the related test async.

### Testing
- Ran unit tests with `npm test -- tests/script-utils.test.mjs` and all tests passed (1 file, 10 tests).
- Ran full registry validation with `npm run validate` which completed successfully and reported validated artifacts.
- Ran linter and formatter checks with `npm run lint` and `npm run format:check`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d298ac40832ca8f0a8e6a624dcbe)