### PR TITLE
fix: harden private boundary validation

### DIFF
--- a/scripts/validate-private-boundary.mjs
+++ b/scripts/validate-private-boundary.mjs
@@ -3,6 +3,8 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { repoRoot } from "./lib.mjs";
 
+const maxScannedFileBytes = 1024 * 1024;
+
 const trackedFiles = execFileSync("git", ["ls-files"], {
   cwd: repoRoot,
   encoding: "utf8",
@@ -52,11 +54,35 @@ for (const file of trackedFiles) {
     }
   }
 
-  if (isBinaryOrLarge(file)) {
+  if (isBinaryOrGenerated(file)) {
     continue;
   }
 
-  const content = await fs.readFile(path.join(repoRoot, file), "utf8");
+  const absolutePath = path.join(repoRoot, file);
+  let stat;
+  try {
+    stat = await fs.lstat(absolutePath);
+  } catch (error) {
+    console.warn(`Skipping unreadable path ${file}: ${error.message}`);
+    continue;
+  }
+
+  if (
+    stat.isSymbolicLink() ||
+    !stat.isFile() ||
+    stat.size > maxScannedFileBytes
+  ) {
+    continue;
+  }
+
+  let content;
+  try {
+    content = await fs.readFile(absolutePath, "utf8");
+  } catch (error) {
+    console.warn(`Skipping unreadable file ${file}: ${error.message}`);
+    continue;
+  }
+
   for (const [index, line] of content.split(/\r?\n/).entries()) {
     for (const pattern of contentPatterns) {
       if (!pattern.regex.test(line)) {
@@ -85,7 +111,7 @@ if (findings.length > 0) {
 
 console.log("Private-boundary validation passed.");
 
-function isBinaryOrLarge(file) {
+function isBinaryOrGenerated(file) {
   return (
     file.endsWith(".png") ||
     file.endsWith(".jpg") ||


### PR DESCRIPTION
### Motivation
- Prevent a CI denial-of-service where the private-boundary validator follows tracked symlinks or reads very large/special files (e.g. `/dev/zero`) from pull requests. 
- Limit scanning to safe regular files and preserve the intended path/content checks for genuine text files.

### Description
- Add a `maxScannedFileBytes` (1 MiB) threshold and skip files larger than this limit before reading their contents. 
- Use `fs.lstat` to inspect each tracked path and skip symbolic links and non-regular files. 
- Wrap `readFile` in a per-file `try/catch` to skip unreadable files and avoid propagating I/O errors. 
- Rename the skip helper to `isBinaryOrGenerated` and preserve existing path- and content-pattern checks for files that pass safety gates.

### Testing
- `npm run validate:private-boundary` completed successfully and printed `Private-boundary validation passed.`. 
- Simulated a tracked symlink to `/dev/zero` using `GIT_INDEX_FILE=...` with a short `timeout` and observed the validator skip the symlink (command completed successfully). 
- `npx prettier --write` and `npm run format:check` passed formatting checks. 
- `npm run lint` passed; `npm test` ran but one unrelated DNS-dependent test failed in this environment and `npm run test -- --runInBand` failed because Vitest does not accept `--runInBand`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f4941c6c832cab04ce2cc59a54b1)