### PR TITLE
fix(probes): block resolved unsafe targets

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -220,7 +220,7 @@ export function isUnsafeUrl(value) {
   }
 }
 
-export async function isUnsafeResolvedUrl(value) {
+export async function isUnsafeResolvedUrl(value, resolver = lookup) {
   try {
     const url = new URL(value);
     if (isUnsafeUrl(url.toString())) {
@@ -232,7 +232,7 @@ export async function isUnsafeResolvedUrl(value) {
       return false;
     }
 
-    const records = await lookup(host, { all: true, verbatim: true });
+    const records = await resolver(host, { all: true, verbatim: true });
     return (
       records.length === 0 ||
       records.some((record) => isUnsafeIpAddress(record.address))

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -6,7 +6,7 @@ import {
   buildTimestamp,
   flattenSurfaces,
   isJsonContentType,
-  isUnsafeUrl,
+  isUnsafeResolvedUrl,
   loadSubnets,
   repoRoot,
   writeJson,
@@ -148,7 +148,7 @@ async function probeSubtensorSurface(surface) {
 }
 
 async function probeUrl(url, method, accept, timeoutMs, redirectCount = 0) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeResolvedUrl(url)) {
     return {
       ok: false,
       error: "unsafe URL",
@@ -182,7 +182,7 @@ async function probeUrl(url, method, accept, timeoutMs, redirectCount = 0) {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeResolvedUrl(redirectTarget)) {
         await response.body?.cancel();
         return {
           ok: false,
@@ -346,7 +346,7 @@ function statusForClassification(classification, surface = null) {
 }
 
 async function probeSubtensorHttp(url, timeoutMs) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeResolvedUrl(url)) {
     return {
       unsafe_url: true,
       error: "unsafe URL",
@@ -392,7 +392,7 @@ async function probeSubtensorHttp(url, timeoutMs) {
 }
 
 async function probeSubtensorWss(url, timeoutMs) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeResolvedUrl(url)) {
     return {
       unsafe_url: true,
       error: "unsafe URL",
@@ -455,7 +455,7 @@ async function jsonRpcHttp(url, method, params, id, timeoutMs) {
     const location = response.headers.get("location");
     if ([301, 302, 303, 307, 308].includes(response.status) && location) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeResolvedUrl(redirectTarget)) {
         await response.body?.cancel();
         return {
           transport_error: true,

--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -3,7 +3,7 @@ import {
   buildTimestamp,
   hashJson,
   isJsonContentType,
-  isUnsafeUrl,
+  isUnsafeResolvedUrl,
   repoRoot,
   stableStringify,
   writeJson,
@@ -159,7 +159,7 @@ async function fetchJsonSummary(url) {
 }
 
 async function fetchJson(url) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeResolvedUrl(url)) {
     return {
       ok: false,
       status: "unsafe",
@@ -238,7 +238,7 @@ async function fetchJson(url) {
 }
 
 async function fetchSseSummary(url) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeResolvedUrl(url)) {
     return {
       status: "unsafe",
       url,

--- a/scripts/snapshot-openapi.mjs
+++ b/scripts/snapshot-openapi.mjs
@@ -5,6 +5,7 @@ import {
   flattenSurfaces,
   hashJson,
   isJsonContentType,
+  isUnsafeResolvedUrl,
   isUnsafeUrl,
   loadSubnets,
   repoRoot,
@@ -228,7 +229,7 @@ function candidateSchemaUrls(surface) {
 }
 
 async function fetchJson(url, redirectCount = 0) {
-  if (isUnsafeUrl(url)) {
+  if (await isUnsafeResolvedUrl(url)) {
     return { ok: false, unsafe_url: true, error: "unsafe URL" };
   }
 
@@ -250,7 +251,7 @@ async function fetchJson(url, redirectCount = 0) {
       redirectCount < 5
     ) {
       const redirectTarget = new URL(location, url).toString();
-      if (isUnsafeUrl(redirectTarget)) {
+      if (await isUnsafeResolvedUrl(redirectTarget)) {
         await response.body?.cancel();
         return {
           ok: false,

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -16,6 +16,7 @@ import {
   hashJson,
   isHtmlContentType,
   isJsonContentType,
+  isUnsafeResolvedUrl,
   isUnsafeUrl,
   isValidUrl,
   listJsonFiles,
@@ -119,9 +120,13 @@ describe("script utility contracts", () => {
     assert.equal(isValidUrl("ftp://metagraph.sh"), false);
     assert.equal(isValidUrl("not a url"), false);
     assert.equal(isUnsafeUrl("http://127.0.0.1:9944"), true);
+    assert.equal(isUnsafeUrl("http://metadata.localhost"), true);
     assert.equal(isUnsafeUrl("ftp://metagraph.sh"), true);
+    assert.equal(isUnsafeUrl("http://100.64.0.1"), true);
     assert.equal(isUnsafeUrl("http://172.16.0.1"), true);
     assert.equal(isUnsafeUrl("http://[fd00::1]"), true);
+    assert.equal(isUnsafeUrl("http://[fe80::1]"), true);
+    assert.equal(isUnsafeUrl("http://[::ffff:127.0.0.1]"), true);
     assert.equal(isUnsafeUrl("not a url"), true);
     assert.equal(isUnsafeUrl("https://metagraph.sh"), false);
     assert.equal(
@@ -145,6 +150,10 @@ describe("script utility contracts", () => {
       stableStringify({ b: 1, a: { d: 2, c: 3 } }),
       '{\n  "a": {\n    "c": 3,\n    "d": 2\n  },\n  "b": 1\n}',
     );
+    assert.equal(
+      stableStringify([{ b: 1, a: 2 }]),
+      '[\n  {\n    "a": 2,\n    "b": 1\n  }\n]',
+    );
     assert.equal(hashJson({ b: 1, a: 2 }), hashJson({ a: 2, b: 1 }));
     assert.equal(
       registrySurfaceKey({
@@ -155,6 +164,29 @@ describe("script utility contracts", () => {
       "7|docs|https://docs.all-ways.io/",
     );
     assert.equal(slugify("TAO / Metagraph: Build"), "tao-metagraph-build");
+  });
+
+  test("resolves hostnames before treating probe URLs as safe", async () => {
+    const privateResolver = async () => [
+      { address: "192.168.1.10", family: 4 },
+    ];
+    const publicResolver = async () => [
+      { address: "93.184.216.34", family: 4 },
+    ];
+    const emptyResolver = async () => [];
+
+    assert.equal(
+      await isUnsafeResolvedUrl("https://metadata.example", privateResolver),
+      true,
+    );
+    assert.equal(
+      await isUnsafeResolvedUrl("https://metagraph.example", publicResolver),
+      false,
+    );
+    assert.equal(
+      await isUnsafeResolvedUrl("https://empty.example", emptyResolver),
+      true,
+    );
   });
 
   test("builds RPC endpoint and pool artifacts from surface health", () => {
@@ -219,8 +251,8 @@ describe("script utility contracts", () => {
         },
         {
           surface_id: "root-wss",
-          status: "degraded",
-          classification: "transient",
+          status: "ok",
+          classification: "live",
           latency_ms: 2500,
           methods_supported: ["chain_getHeader", "system_health"],
           last_checked: "1970-01-01T00:00:00.000Z",
@@ -258,6 +290,11 @@ describe("script utility contracts", () => {
     assert.equal(
       pools.pools.find((pool) => pool.id === "finney-wss").eligible_count,
       0,
+    );
+    assert.equal(
+      pools.pools.find((pool) => pool.id === "finney-wss").endpoints[0].score >
+        0,
+      true,
     );
   });
 
@@ -368,6 +405,18 @@ describe("submission policy helpers", () => {
       }).length,
       2,
     );
+    assert.equal(
+      validateSubmissionProvenance({
+        submitter: "jsonbored",
+        document: {
+          submission: {
+            submitted_by: "jsonbored",
+            submitted_by_url: "https://github.com/not-jsonbored",
+          },
+        },
+      })[0].message,
+      "submission.submitted_by_url must match submitted_by",
+    );
   });
 
   test("validates candidate submission edge cases", () => {
@@ -387,6 +436,13 @@ describe("submission policy helpers", () => {
       auth_required: false,
       public_safe: true,
     };
+
+    const missingCandidate = validateCandidateForSubmission({
+      candidate: null,
+      native,
+      providers,
+    });
+    assert.equal(missingCandidate.errors[0].category, "unsupported-shape");
 
     const valid = validateCandidateForSubmission({
       candidate: baseCandidate,
@@ -430,6 +486,58 @@ describe("submission policy helpers", () => {
     assert.equal(invalid.errors.length >= 10, true);
     assert.equal(invalid.manual_reasons.length >= 2, true);
     assert.equal(invalid.warnings.length, 1);
+
+    const badProvenanceList = validateCandidateForSubmission({
+      candidate: {
+        ...baseCandidate,
+        source_urls: ["https://docs.all-ways.io/extra/", "http://127.0.0.1"],
+      },
+      document: {
+        submission: {
+          submitted_by: "jsonbored",
+          submitted_by_url: "https://github.com/jsonbored",
+        },
+      },
+      submitter: "jsonbored",
+      native,
+      providers,
+      existingCandidates: [],
+      existingSubnets: [],
+    });
+    assert.equal(
+      badProvenanceList.errors.some(
+        (error) =>
+          error.message === "candidate source_urls[1] is invalid or unsafe",
+      ),
+      true,
+    );
+    assert.equal(
+      badProvenanceList.warnings.some((warning) =>
+        warning.includes("source_urls[0] will be normalized"),
+      ),
+      true,
+    );
+
+    const nonArrayProvenanceList = validateCandidateForSubmission({
+      candidate: { ...baseCandidate, source_urls: "https://docs.all-ways.io" },
+      document: {
+        submission: {
+          submitted_by: "jsonbored",
+          submitted_by_url: "https://github.com/jsonbored",
+        },
+      },
+      submitter: "jsonbored",
+      native,
+      providers,
+      existingCandidates: [],
+      existingSubnets: [],
+    });
+    assert.equal(
+      nonArrayProvenanceList.errors.some(
+        (error) => error.message === "candidate source_urls must be an array",
+      ),
+      true,
+    );
 
     const duplicate = validateCandidateForSubmission({
       candidate: {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -430,6 +430,101 @@ describe("Worker runtime", () => {
     }
   });
 
+  test("rejects unsafe RPC upstreams and falls back to the next trusted endpoint", async () => {
+    const originalFetch = globalThis.fetch;
+    const fetchedUrls = [];
+    globalThis.fetch = async (url, init) => {
+      fetchedUrls.push(String(url));
+      assert.equal(init.method, "POST");
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    };
+
+    const rpcRequest = () =>
+      new Request("https://metagraph.sh/rpc/v1/finney", {
+        method: "POST",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "chain_getHeader",
+          params: [],
+        }),
+      });
+
+    const poolEnv = (endpoints) => ({
+      METAGRAPH_ENABLE_RPC_PROXY: "true",
+      ASSETS: {
+        async fetch() {
+          return new Response(
+            JSON.stringify({
+              schema_version: 1,
+              generated_at: "1970-01-01T00:00:00.000Z",
+              pools: [{ id: "finney-rpc", endpoints }],
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          );
+        },
+      },
+    });
+
+    try {
+      const unsafeOnlyCases = [
+        "https://localhost/internal",
+        "https://metadata.localhost/internal",
+        "https://bittensor-finney.api.onfinality.io.evil.example/public",
+        "not a url",
+      ];
+
+      for (const unsafeUrl of unsafeOnlyCases) {
+        const response = await handleRequest(
+          rpcRequest(),
+          poolEnv([
+            {
+              id: "unsafe",
+              pool_eligible: true,
+              provider: "fixture",
+              url: unsafeUrl,
+            },
+          ]),
+          {},
+        );
+        assert.equal(response.status, 502);
+        assert.equal((await response.json()).error.code, "rpc_endpoint_unsafe");
+      }
+
+      const response = await handleRequest(
+        rpcRequest(),
+        poolEnv([
+          {
+            id: "unsafe",
+            pool_eligible: true,
+            provider: "fixture",
+            url: "https://localhost/internal",
+          },
+          {
+            id: "safe",
+            pool_eligible: true,
+            provider: "fixture",
+            url: "https://bittensor-finney.api.onfinality.io/public",
+          },
+        ]),
+        {},
+      );
+
+      assert.equal(response.status, 200);
+      assert.deepEqual(fetchedUrls, [
+        "https://bittensor-finney.api.onfinality.io/public",
+      ]);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("proxies explicitly enabled safe RPC methods through eligible pools", async () => {
     const originalFetch = globalThis.fetch;
     let called = false;


### PR DESCRIPTION
## Summary
- Consolidate the still-relevant URL/probe safety fixes from stale PRs #21 and #23.
- Resolve probe, schema snapshot, and adapter fetch targets before making network requests.
- Add focused regression coverage for private DNS resolution, unsafe RPC upstreams, and UGC provenance validation branches.

## What changed
- Switched smoke probes, OpenAPI snapshots, and adapter snapshots to `isUnsafeResolvedUrl`.
- Added resolver injection for deterministic URL safety tests.
- Added Worker runtime coverage for unsafe RPC upstream selection and safe fallback behavior.
- Added UGC candidate/provenance edge-case tests that restore coverage above threshold.

## Why
- The original branches conflicted after security fixes landed independently.
- This keeps current `main` safe without carrying stale branch conflicts forward.

## Validation
- `npm run check`
- `npm run test:coverage`
- `git diff --check`

## Notes
- Supersedes PR #21 and PR #23.