### PR TITLE
fix(security): scan large private-boundary files

### DIFF
--- a/scripts/validate-private-boundary.mjs
+++ b/scripts/validate-private-boundary.mjs
@@ -1,9 +1,8 @@
 import { execFileSync } from "node:child_process";
-import { promises as fs } from "node:fs";
+import { createReadStream, promises as fs } from "node:fs";
 import path from "node:path";
+import { createInterface } from "node:readline";
 import { repoRoot } from "./lib.mjs";
-
-const maxScannedFileBytes = 1024 * 1024;
 
 const trackedFiles = execFileSync("git", ["ls-files"], {
   cwd: repoRoot,
@@ -67,35 +66,37 @@ for (const file of trackedFiles) {
     continue;
   }
 
-  if (
-    stat.isSymbolicLink() ||
-    !stat.isFile() ||
-    stat.size > maxScannedFileBytes
-  ) {
+  if (stat.isSymbolicLink() || !stat.isFile()) {
     continue;
   }
 
-  let content;
+  let lines;
   try {
-    content = await fs.readFile(absolutePath, "utf8");
+    lines = createInterface({
+      input: createReadStream(absolutePath, { encoding: "utf8" }),
+      crlfDelay: Infinity,
+    });
+
+    let lineNumber = 0;
+    for await (const line of lines) {
+      lineNumber += 1;
+      for (const pattern of contentPatterns) {
+        if (!pattern.regex.test(line)) {
+          continue;
+        }
+        if (
+          pattern.name !== "real Discord webhook URL" &&
+          allowedContentMentions.has(file)
+        ) {
+          continue;
+        }
+        findings.push(`${file}:${lineNumber}: ${pattern.name}`);
+      }
+    }
   } catch (error) {
     console.warn(`Skipping unreadable file ${file}: ${error.message}`);
+    lines?.close();
     continue;
-  }
-
-  for (const [index, line] of content.split(/\r?\n/).entries()) {
-    for (const pattern of contentPatterns) {
-      if (!pattern.regex.test(line)) {
-        continue;
-      }
-      if (
-        pattern.name !== "real Discord webhook URL" &&
-        allowedContentMentions.has(file)
-      ) {
-        continue;
-      }
-      findings.push(`${file}:${index + 1}: ${pattern.name}`);
-    }
   }
 }
 


### PR DESCRIPTION
### Motivation

- The private-boundary validator previously skipped tracked files larger than 1 MiB, allowing forbidden content (e.g., real Discord webhook URLs and private scoring internals) to bypass CI checks when padded into oversized text files.
- The validator must still avoid loading whole files into memory while ensuring all tracked, non-binary text files are scanned for sensitive patterns.

### Description

- Removed the 1 MiB size cutoff and the silent skip for oversized tracked files in `scripts/validate-private-boundary.mjs` so large text files are no longer excluded from content checks.
- Stream-file scanning was implemented using `createReadStream` and `readline` (`createInterface`) to iterate lines incrementally and preserve low memory usage while keeping accurate line numbers for findings.
- Existing path-based and binary/generated exemptions in `isBinaryOrGenerated` and the configured `contentPatterns` and `allowedContentMentions` behavior were preserved.
- Findings are reported as `file:line: pattern name` for any matched forbidden content to keep current validation output format.

### Testing

- Ran `npm run validate:private-boundary` and it completed (validator reported pass when no issues and fails when issues exist) which verifies the script executes successfully.
- Ran `npx prettier --check scripts/validate-private-boundary.mjs` and `npm run lint`, both of which succeeded to ensure style and linting are intact.
- Created a large tracked PoC file containing a Discord webhook URL and confirmed the validator now flags the oversized file (manual PoC reproduction succeeded and produced the expected failure output).
- Ran `npm test` where one test failed in this environment due to DNS resolution returning `EAI_AGAIN` for `example.com`, causing `tests/public-safety.test.mjs` to fail; this failure is environmental and unrelated to the validator change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a250dc09c00832ca2c9a77adb8243d4)