### PR TITLE
ci(intake): route UGC submissions through narrow validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -30,56 +32,107 @@ jobs:
       - name: Install
         run: npm ci
 
+      - name: Capture changed files
+        if: github.event_name == 'pull_request'
+        env:
+          BASE_REF: ${{ github.base_ref || 'main' }}
+        run: |
+          git fetch origin "$BASE_REF" --depth=1
+          git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
+
+      - name: Capture changed files for full validation
+        if: github.event_name != 'pull_request'
+        run: ": > changed-files.txt"
+
+      - name: Classify validation route
+        id: route
+        run: npm run ci:validate-route -- --changed-files changed-files.txt --out validate-route.json
+
+      - name: Run UGC submission preflight
+        if: steps.route.outputs.mode == 'ugc'
+        env:
+          GITHUB_ACTOR: ${{ github.actor }}
+        run: npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json
+
+      - name: Validate UGC intake templates
+        if: steps.route.outputs.mode == 'ugc'
+        run: npm run validate:intake
+
+      - name: Public-safety scan for UGC submission
+        if: steps.route.outputs.mode == 'ugc'
+        run: npm run scan:public-safety
+
+      - name: Validate private boundary for UGC submission
+        if: steps.route.outputs.mode == 'ugc'
+        run: npm run validate:private-boundary
+
       - name: Validate registry
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate
 
       - name: Test
+        if: steps.route.outputs.mode == 'full'
         run: npm test
 
       - name: Build artifacts
+        if: steps.route.outputs.mode == 'full'
         run: npm run build
 
       - name: Generate R2 manifest
+        if: steps.route.outputs.mode == 'full'
         run: npm run r2:manifest
 
       - name: Validate JSON schemas
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:schemas
 
       - name: Validate Worker API
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:api
 
       - name: Validate OpenAPI
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:openapi
 
       - name: Validate generated API types
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:types
 
       - name: Validate artifact size budgets
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:artifact-budgets
 
       - name: Validate documentation contracts
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:docs
 
       - name: Validate intake templates
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:intake
 
       - name: Validate workflows
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:workflows
 
       - name: Validate Cloudflare config
+        if: steps.route.outputs.mode == 'full'
         run: npm run cloudflare:verify:dry-run
 
       - name: Validate R2 manifest
+        if: steps.route.outputs.mode == 'full'
         run: |
           npm run r2:manifest:dry-run
           npm run r2:download:dry-run
           npm run kv:publish:dry-run
 
       - name: Worker deploy dry-run
+        if: steps.route.outputs.mode == 'full'
         run: npm run worker:deploy:dry-run
 
       - name: Public-safety scan
+        if: steps.route.outputs.mode == 'full'
         run: npm run scan:public-safety
 
       - name: Validate private boundary
+        if: steps.route.outputs.mode == 'full'
         run: npm run validate:private-boundary

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "validate:intake": "node scripts/validate-intake.mjs",
     "validate:private-boundary": "node scripts/validate-private-boundary.mjs",
     "validate:workflows": "node scripts/validate-workflows.mjs",
+    "ci:validate-route": "node scripts/ci-validate-route.mjs",
     "openapi:generate": "node scripts/generate-openapi.mjs --write",
     "openapi:generate:dry-run": "node scripts/generate-openapi.mjs",
     "types:generate": "node scripts/generate-types.mjs",

--- a/scripts/ci-validate-route.mjs
+++ b/scripts/ci-validate-route.mjs
@@ -1,0 +1,66 @@
+import { promises as fs } from "node:fs";
+import {
+  classifyPrScope,
+  normalizeChangedFiles,
+} from "./submission-policy.mjs";
+
+const options = parseArgs(process.argv.slice(2));
+const changedFiles = await readChangedFiles(options.changedFiles);
+const classification = classifyPrScope(changedFiles);
+const mode =
+  classification.scope === "direct-candidate" &&
+  classification.errors.length === 0
+    ? "ugc"
+    : "full";
+
+const report = {
+  schema_version: 1,
+  mode,
+  scope: classification.scope,
+  changed_files: normalizeChangedFiles(changedFiles),
+  candidate_files: classification.candidateFiles,
+  errors: classification.errors,
+};
+
+if (options.out) {
+  await fs.writeFile(options.out, `${JSON.stringify(report, null, 2)}\n`);
+}
+
+if (process.env.GITHUB_OUTPUT) {
+  await fs.appendFile(
+    process.env.GITHUB_OUTPUT,
+    [`mode=${mode}`, `scope=${classification.scope}`].join("\n") + "\n",
+  );
+}
+
+console.log(JSON.stringify(report, null, 2));
+
+function parseArgs(args) {
+  const parsed = {
+    changedFiles: null,
+    out: null,
+  };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--changed-files") {
+      parsed.changedFiles = args[++index];
+    } else if (arg === "--out") {
+      parsed.out = args[++index];
+    }
+  }
+  return parsed;
+}
+
+async function readChangedFiles(filePath) {
+  if (!filePath) {
+    return "";
+  }
+  try {
+    return await fs.readFile(filePath, "utf8");
+  } catch (error) {
+    if (error?.code === "ENOENT") {
+      return "";
+    }
+    throw error;
+  }
+}


### PR DESCRIPTION
## Summary
- Routes one-file community candidate PRs through a narrow UGC validation lane in the required Validate workflow.

## What changed
- Adds a reusable CI validation-route classifier for PR changed files.
- Updates `validate.yml` to run the full backend matrix for normal changes and a submission/intake/safety lane for direct UGC candidates.
- Adds an npm script for the route classifier.

## Why
- Direct UGC submission PRs should not fail because generated registry artifacts were not regenerated by contributors. Normal backend and generated-data changes still run the full validation matrix.

## Validation
- `npm run check`
- `npm run test:coverage`
- `npm run validate:workflows`
- `npm run scan:public-safety`
- `git diff --check`

## Notes
- This keeps the public deterministic gate and required Validate workflow aligned on the same direct-candidate scope rules.