### PR TITLE
test(submission): exercise private gate webhook

### DIFF
--- a/registry/candidates/community/allways-private-gate-smoke.json
+++ b/registry/candidates/community/allways-private-gate-smoke.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "JSONbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  },
+  "candidates": [
+    {
+      "schema_version": 1,
+      "id": "community-sn-7-docs-private-gate-smoke",
+      "netuid": 7,
+      "state": "schema-valid",
+      "name": "Allways private gate smoke test",
+      "kind": "docs",
+      "url": "https://docs.all-ways.io/how-it-works.html?metagraphed_private_gate_smoke=1",
+      "source_url": "https://docs.all-ways.io/how-it-works.html",
+      "source_urls": [
+        "https://docs.all-ways.io/how-it-works.html"
+      ],
+      "source_type": "community-pr-intake",
+      "source_tier": "community-docs",
+      "confidence": "medium",
+      "provider": "allways",
+      "auth_required": false,
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Temporary direct-PR smoke test for the Metagraphed private submission gate webhook."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Adds a one-file community candidate smoke submission to exercise the private submission-gate webhook path.

## What changed
- Adds one temporary Allways docs candidate under `registry/candidates/community/`.

## Why
- Validates GitHub webhook delivery into the private Metagraphed submission gate without publishing real registry data.

## Validation
- `GITHUB_ACTOR=JSONbored npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json`
- `npm run validate:intake`
- `npm run scan:public-safety`

## Notes
- Temporary smoke PR; expected public preflight state is `submit_pr` with private review next action.