### PR TITLE
ci(cloudflare): enable metagraph production publishing

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 node_modules
 public/metagraph
 generated
+schemas/api-components.schema.json
 registry/native
 registry/candidates/generated
 registry/subnets/generated

--- a/docs/cloudflare-backend.md
+++ b/docs/cloudflare-backend.md
@@ -6,7 +6,7 @@ Metagraphed uses Cloudflare as the serving, cache, and artifact-history layer. G
 
 - Workers serve `metagraph.sh/api/v1/*` routes over canonical `/metagraph/*` artifacts.
 - Workers Static Assets serve the checked-in `public/metagraph` artifact tree.
-- R2 stores versioned artifact history under `runs/{generated_at}/` and current copies under `latest/`.
+- R2 stores current artifact copies under `latest/`; versioned artifact history under `runs/{generated_at}/` is opt-in for publish jobs that set `METAGRAPH_R2_UPLOAD_HISTORY=1`.
 - KV stores small latest pointers, feature flags, endpoint-pool summaries, and source-freshness summaries when configured.
 - D1 is not used for canonical registry truth in v1.
 - The read-only RPC proxy/load-balancer prototype exists behind `METAGRAPH_ENABLE_RPC_PROXY=false`; write and unsafe RPC methods remain blocked by default.
@@ -66,6 +66,8 @@ If no KV binding is configured, the Worker falls back to `METAGRAPH_R2_LATEST_PR
 Write operations require explicit environment flags:
 
 - `METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload`
+- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_HISTORY=1 npm run r2:upload` also writes the manifest run-prefix copies.
+- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_LIMIT=5 npm run r2:upload` can be used for a remote permission smoke.
 - `METAGRAPH_ALLOW_R2_DOWNLOAD=1 npm run r2:download`
 - `METAGRAPH_ALLOW_KV_WRITE=1 METAGRAPH_KV_NAMESPACE_ID=... npm run kv:publish`
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -42,6 +42,8 @@ npm run worker:deploy:dry-run
 Actual writes require explicit environment gates:
 
 - `METAGRAPH_ALLOW_R2_UPLOAD=1`
+- `METAGRAPH_R2_UPLOAD_HISTORY=1` when the publish job should also write run-prefix history copies.
+- `METAGRAPH_R2_UPLOAD_LIMIT` for smoke-only uploads against a small artifact subset.
 - `METAGRAPH_ALLOW_KV_WRITE=1`
 - `METAGRAPH_KV_NAMESPACE_ID`
 - Cloudflare account/API credentials
@@ -71,5 +73,3 @@ Rollback is pointer-first:
 ## Known Non-Blocking Drift
 
 `sync:subnets:dry-run` can report chain metadata changes, such as subnet names. These should become reviewed sync PRs, not silent direct pushes.
-
-Current known drift from the live dry run: SN92 reports `TensorClaw -> luis` and SN95 reports `nion -> Actual`. The endpoint registry PR intentionally did not refresh native subnet identity data; handle this as a separate reviewed registry-data PR.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,6 +9,8 @@ export default [
       "registry/subnets/generated/**",
       "registry/verification/**",
       "registry/adapters/latest/**",
+      "private/**",
+      "ops/private/**",
       "tmp/**",
     ],
   },

--- a/scripts/kv-publish-pointer.mjs
+++ b/scripts/kv-publish-pointer.mjs
@@ -106,6 +106,7 @@ function putKv(key, value) {
       JSON.stringify(value),
       "--namespace-id",
       process.env.METAGRAPH_KV_NAMESPACE_ID,
+      "--remote",
     ],
     {
       encoding: "utf8",

--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -5,9 +5,16 @@ import { readJson, repoRoot, sha256Hex, stableStringify } from "./lib.mjs";
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
+const uploadHistory = process.env.METAGRAPH_R2_UPLOAD_HISTORY === "1";
+const uploadLimit = parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_LIMIT);
 const manifest = await readJson(
   path.join(repoRoot, "public/metagraph/r2-manifest.json"),
 );
+const plannedArtifacts = uploadLimit
+  ? manifest.artifacts.slice(0, uploadLimit)
+  : manifest.artifacts;
+const plannedObjectCount =
+  plannedArtifacts.length + (uploadHistory ? plannedArtifacts.length : 0);
 
 if (!write) {
   console.log(
@@ -15,8 +22,12 @@ if (!write) {
       mode: "dry-run",
       artifact_count: manifest.artifact_count,
       bucket_name: manifest.bucket_name,
+      limited_artifact_count: plannedArtifacts.length,
       latest_prefix: manifest.latest_prefix,
       run_prefix: manifest.run_prefix,
+      upload_history: uploadHistory,
+      upload_limit: uploadLimit,
+      planned_object_count: plannedObjectCount,
     }),
   );
   process.exit(0);
@@ -29,20 +40,33 @@ if (process.env.METAGRAPH_ALLOW_R2_UPLOAD !== "1") {
   process.exit(1);
 }
 
-for (const artifact of manifest.artifacts) {
+for (const artifact of plannedArtifacts) {
   const localPath = path.join(
     repoRoot,
     "public/metagraph",
     artifact.path.replace(/^\/metagraph\//, ""),
   );
   verifyLocalArtifact(localPath, artifact);
-  putObject(localPath, artifact.key, manifest.bucket_name);
   putObject(localPath, artifact.latest_key, manifest.bucket_name);
+  if (uploadHistory) {
+    putObject(localPath, artifact.key, manifest.bucket_name);
+  }
 }
 
 console.log(
-  `Uploaded ${manifest.artifact_count} artifact(s) to R2 bucket ${manifest.bucket_name}.`,
+  `Uploaded ${plannedObjectCount} object(s) for ${plannedArtifacts.length} artifact(s) to R2 bucket ${manifest.bucket_name}.`,
 );
+
+function parsePositiveInteger(value) {
+  if (!value) {
+    return null;
+  }
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isInteger(parsed) || parsed < 1 || String(parsed) !== value) {
+    throw new Error("METAGRAPH_R2_UPLOAD_LIMIT must be a positive integer.");
+  }
+  return parsed;
+}
 
 function verifyLocalArtifact(localPath, artifact) {
   const actual = sha256Hex(readFileSync(localPath));
@@ -62,7 +86,15 @@ function putObject(localPath, key, bucketName) {
   );
   const result = spawnSync(
     wranglerBin,
-    ["r2", "object", "put", `${bucketName}/${key}`, "--file", localPath],
+    [
+      "r2",
+      "object",
+      "put",
+      `${bucketName}/${key}`,
+      "--file",
+      localPath,
+      "--remote",
+    ],
     {
       encoding: "utf8",
       stdio: "pipe",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -19,6 +19,18 @@
     "METAGRAPH_ENABLE_RPC_PROXY": "false",
     "METAGRAPH_R2_LATEST_PREFIX": "latest/",
   },
+  "routes": [
+    {
+      "pattern": "metagraph.sh",
+      "custom_domain": true,
+    },
+  ],
+  "kv_namespaces": [
+    {
+      "binding": "METAGRAPH_CONTROL",
+      "id": "9c5577a3454d4830b2ffd2f83775efb1",
+    },
+  ],
   "r2_buckets": [
     {
       "binding": "METAGRAPH_ARCHIVE",


### PR DESCRIPTION
## Summary
- configure the production Worker for the `metagraph.sh` custom domain and the `METAGRAPH_CONTROL` KV binding
- force R2/KV publish scripts to use remote Cloudflare resources instead of Wrangler local storage
- add smoke-safe R2 upload limiting and opt-in run-prefix history uploads
- keep ignored private automation and generated schema bundles out of public lint/format churn

## What changed
- added the `metagraph.sh` custom-domain route in `wrangler.jsonc`
- added the production KV binding for `METAGRAPH_CONTROL`
- updated `r2:upload` to upload `latest/` objects by default, support `METAGRAPH_R2_UPLOAD_HISTORY=1`, and support `METAGRAPH_R2_UPLOAD_LIMIT` for remote smoke tests
- updated `kv:publish` to write to remote KV
- documented Cloudflare publish flags and removed the stale SN92/SN95 drift note
- ignored `private/**` and `ops/private/**` for public lint and ignored the generated API component bundle for Prettier

## Why
- production publishing previously used Wrangler local storage during local writes, which made R2/KV verification misleading and could lock local storage
- the Worker needed explicit production bindings and the `metagraph.sh` route before the public API could be treated as deployable

## Validation
- `npm run check`
- `npm run worker:deploy:dry-run`
- `METAGRAPH_R2_UPLOAD_LIMIT=5 METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload`
- `METAGRAPH_KV_NAMESPACE_ID=<configured> METAGRAPH_ALLOW_KV_WRITE=1 npm run kv:publish`
- `npx wrangler deploy`
- smoked `https://metagraph.sh/api/v1/health`, `https://metagraph.sh/api/v1/subnets?limit=3`, `https://metagraph.sh/api/v1/openapi.json`, `https://metagraph.sh/api/v1/endpoints?layer=bittensor-base&limit=10`, and `https://metagraph.sh/api/v1/endpoint-pools` through Cloudflare edge
- verified `/rpc/v1/finney` returns the intentional `rpc_proxy_disabled` error while proxying is off

## Notes
- full R2 current-artifact backfill remains available via `METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload`; the smoke path intentionally uploads a small subset
- versioned run-prefix uploads are opt-in with `METAGRAPH_R2_UPLOAD_HISTORY=1`
- local DNS may lag briefly after custom-domain attachment, but authoritative Cloudflare DNS and edge routing are configured
