### PR TITLE
feat(intake): add contributor submission tooling

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 - [ ] Generated artifacts came from repo scripts, not hand-edited public JSON.
 - [ ] Direct community submissions change exactly one `registry/candidates/community/*.json` file and no generated artifacts.
 - [ ] Community-submitted interfaces pass public preflight before private gate review.
+- [ ] Direct community submission files were generated with `npm run candidate:new` or match `docs/examples/submissions/direct-candidate.json`.
 
 ## Validation
 

--- a/.github/workflows/intake-validation.yml
+++ b/.github/workflows/intake-validation.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   validate:
-    if: contains(github.event.issue.labels.*.name, 'interface-submission')
+    if: contains(github.event.issue.labels.*.name, 'interface-submission') || contains(github.event.issue.labels.*.name, 'endpoint-submission') || contains(github.event.issue.labels.*.name, 'provider-submission') || contains(github.event.issue.labels.*.name, 'status-report')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -47,18 +47,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const report = JSON.parse(fs.readFileSync('intake-report.json', 'utf8'));
-            const body = [
-              '## Metagraphed intake dry-run',
-              '',
-              `State: \`${report.state}\``,
-              `Next action: \`${report.next_action}\``,
-              `Publish allowed: \`${report.publish_allowed}\``,
-              '',
-              report.errors.length > 0
-                ? `Errors:\n${report.errors.map((error) => `- ${error}`).join('\n')}`
-                : 'Candidate parsed successfully. Private gate review is still required before promotion.'
-            ].join('\n');
+            const { execFileSync } = require('child_process');
+            execFileSync('npm', ['run', 'submission:comment', '--', '--report', 'intake-report.json', '--out', 'intake-comment.md'], { stdio: 'inherit' });
+            const body = fs.readFileSync('intake-comment.md', 'utf8');
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/submission-gate.yml
+++ b/.github/workflows/submission-gate.yml
@@ -48,4 +48,6 @@ jobs:
         run: npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json
 
       - name: Show public preflight report
-        run: node -e "const fs=require('fs'); const report=JSON.parse(fs.readFileSync('submission-report.json','utf8')); console.log(JSON.stringify({public_state:report.public_state,next_action:report.next_action,blocking:report.blocking,error_categories:report.error_categories,manual_reasons:report.manual_reasons},null,2));"
+        run: |
+          npm run submission:comment -- --report submission-report.json --out submission-comment.md
+          cat submission-comment.md >> "$GITHUB_STEP_SUMMARY"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,17 @@ two supported paths:
   document and no other files.
 - Issue-first: submit an `interface-submission` issue and let the import
   workflow create the candidate PR after approval.
+- Endpoint/provider/status issues: submit endpoint resources, provider profiles,
+  or status reports through the matching issue template. These create review or
+  re-probe work; they do not directly change observed health.
+
+You can generate a direct candidate PR file locally:
+
+```bash
+npm run candidate:new -- --netuid 7 --kind docs --url https://docs.all-ways.io/community-submission-example --source-url https://docs.all-ways.io/how-it-works.html --provider allways --submitted-by <github-login> --write
+```
+
+Example payloads live under `docs/examples/submissions`.
 
 Do not include generated `public/metagraph/**` artifacts, native snapshots,
 workflow/script changes, secrets, wallet/PAT material, private URLs, or
@@ -69,6 +80,10 @@ private reviewer may merge/import clean submissions, close hard failures, or
 route rare edge cases to manual review. Public comments expose broad reason
 categories only; private scoring prompts, thresholds, and corpus weights are not
 part of the public repo.
+
+Status reports never set uptime, latency, health status, incident state, or pool
+eligibility. They can only trigger review or a future re-probe; operational state
+comes from Metagraphed probes and adapters.
 
 The issue import flow is:
 

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -126,6 +126,8 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `npm run contract:summary`: compare schema contracts against a base ref and classify changes as additive, risky, or breaking.
 - `npm run validate:docs`: validate public docs against current artifact and API contracts.
 - `npm run validate:intake`: validate GitHub issue intake templates.
+- `npm run candidate:new`: generate a one-candidate community PR file.
+- `npm run submission:comment`: render a deterministic Markdown submission report.
 - `npm run validate:workflows`: validate workflow hardening rules.
 - `npm run worker:deploy:dry-run`: validate Worker/Wrangler deployment shape without contacting Cloudflare.
 - `npm run sync:summary`: generate a registry-refresh PR summary from actual artifact diffs.

--- a/docs/examples/submissions/direct-candidate.json
+++ b/docs/examples/submissions/direct-candidate.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "example-contributor",
+    "submitted_by_url": "https://github.com/example-contributor"
+  },
+  "candidates": [
+    {
+      "schema_version": 1,
+      "id": "community-sn-7-docs-docs-all-ways-io",
+      "netuid": 7,
+      "state": "schema-valid",
+      "name": "Allways community docs",
+      "kind": "docs",
+      "url": "https://docs.all-ways.io/community-submission-example",
+      "source_url": "https://docs.all-ways.io/how-it-works.html",
+      "source_urls": ["https://docs.all-ways.io/how-it-works.html"],
+      "source_type": "community-pr-intake",
+      "source_tier": "community-docs",
+      "confidence": "medium",
+      "provider": "allways",
+      "auth_required": false,
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate."
+    }
+  ]
+}

--- a/docs/examples/submissions/provider-profile.json
+++ b/docs/examples/submissions/provider-profile.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": 1,
+  "id": "example-operator",
+  "name": "Example Operator",
+  "kind": "infrastructure-provider",
+  "website_url": "https://example.com",
+  "docs_url": "https://docs.example.com",
+  "github_url": "https://github.com/example",
+  "contact_url": "https://example.com/contact",
+  "authority": "community",
+  "public_notes": "Example public-safe provider profile submission."
+}

--- a/docs/examples/submissions/status-report.json
+++ b/docs/examples/submissions/status-report.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "netuid": 7,
+  "surface": "allways-api-health",
+  "issue_type": "degraded",
+  "evidence": "Public endpoint returned HTTP 503 during a read-only check.",
+  "source": "community-status-report",
+  "affects_observed_health": false,
+  "next_action": "review-or-reprobe"
+}

--- a/package.json
+++ b/package.json
@@ -59,6 +59,8 @@
     "intake:dry-run": "node scripts/intake-dry-run.mjs",
     "intake:import": "node scripts/intake-dry-run.mjs --write",
     "submission:pr": "node scripts/submission-pr.mjs",
+    "submission:comment": "node scripts/submission-comment.mjs",
+    "candidate:new": "node scripts/candidate-new.mjs",
     "r2:manifest": "node scripts/r2-manifest.mjs --write",
     "r2:manifest:dry-run": "node scripts/r2-manifest.mjs",
     "build-summary:refresh": "node scripts/refresh-build-summary.mjs",

--- a/registry/candidates/README.md
+++ b/registry/candidates/README.md
@@ -13,6 +13,15 @@ Candidate entries are not published as verified registry surfaces. They must sta
 Generated public-source candidates live in `generated/public-sources.json`.
 Community-submitted direct PR candidates live in `community/*.json`.
 
+Use the helper to generate the direct PR file shape:
+
+```bash
+npm run candidate:new -- --netuid 7 --kind docs --url https://docs.all-ways.io/community-submission-example --source-url https://docs.all-ways.io/how-it-works.html --provider allways --submitted-by <github-login> --write
+```
+
+Schema-backed examples live under `docs/examples/submissions` so they do not get
+ingested as registry data.
+
 Direct PR submissions must:
 
 - change exactly one `registry/candidates/community/*.json` file;

--- a/scripts/candidate-new.mjs
+++ b/scripts/candidate-new.mjs
@@ -1,0 +1,137 @@
+import path from "node:path";
+import {
+  loadCandidates,
+  loadNativeSnapshot,
+  loadProviders,
+  loadSubnets,
+  normalizePublicUrl,
+  repoRoot,
+  slugify,
+  stableStringify,
+  writeJson,
+} from "./lib.mjs";
+import {
+  buildPrSubmissionReport,
+  normalizeGitHubLogin,
+} from "./submission-policy.mjs";
+
+const args = process.argv.slice(2);
+const write = args.includes("--write");
+const netuid = Number(valueAfter("--netuid"));
+const kind = valueAfter("--kind");
+const url = normalizePublicUrl(valueAfter("--url"));
+const sourceUrl = normalizePublicUrl(valueAfter("--source-url"));
+const provider = slugify(valueAfter("--provider") || "community");
+const submittedBy = normalizeGitHubLogin(
+  valueAfter("--submitted-by") || process.env.GITHUB_ACTOR || process.env.USER,
+);
+const name = valueAfter("--name");
+const authRequired = parseBoolean(valueAfter("--auth-required") || "false");
+const rateLimitNotes = valueAfter("--rate-limit-notes") || "";
+const outArg = valueAfter("--out");
+
+const native = await loadNativeSnapshot();
+const subnet = native.subnets.find((candidate) => candidate.netuid === netuid);
+
+if (!subnet) {
+  fail("--netuid must be an active Finney netuid");
+}
+if (!kind) {
+  fail("--kind is required");
+}
+if (!url) {
+  fail("--url must be a public http(s), wss, or ws URL");
+}
+if (!sourceUrl) {
+  fail("--source-url must be a public http(s), wss, or ws URL");
+}
+if (!submittedBy) {
+  fail("--submitted-by or GITHUB_ACTOR is required");
+}
+if (authRequired === null) {
+  fail("--auth-required must be true or false");
+}
+
+const host = new URL(url).hostname;
+const id = `community-sn-${netuid}-${kind}-${slugify(host)}`;
+const outPath =
+  outArg || path.join(repoRoot, "registry/candidates/community", `${id}.json`);
+const outputPath = path.resolve(outPath);
+const document = {
+  schema_version: 1,
+  submission: {
+    submitted_by: submittedBy,
+    submitted_by_url: `https://github.com/${submittedBy}`,
+  },
+  candidates: [
+    {
+      schema_version: 1,
+      id,
+      netuid,
+      state: "schema-valid",
+      name: name || `${subnet.name} community ${kind}`,
+      kind,
+      url,
+      source_url: sourceUrl,
+      source_urls: [sourceUrl],
+      source_type: "community-pr-intake",
+      source_tier: "community-docs",
+      confidence: "medium",
+      provider,
+      auth_required: authRequired,
+      public_safe: true,
+      rate_limit_notes: rateLimitNotes,
+      review_notes: "Community-submitted public interface candidate.",
+    },
+  ],
+};
+
+const report = buildPrSubmissionReport({
+  changedFiles: [path.relative(repoRoot, outputPath)],
+  candidateDocument: document,
+  submitter: submittedBy,
+  native,
+  providers: await loadProviders(),
+  existingCandidates: await loadCandidates(),
+  existingSubnets: await loadSubnets(),
+});
+
+if (report.blocking) {
+  console.error(stableStringify(report));
+  process.exit(1);
+}
+
+if (write) {
+  await writeJson(outputPath, document);
+}
+
+console.log(
+  stableStringify({
+    mode: write ? "write" : "dry-run",
+    output_path: path.relative(repoRoot, outputPath),
+    public_state: report.public_state,
+    next_action: report.next_action,
+    manual_reasons: report.manual_reasons,
+    warnings: report.warnings,
+    candidate: document.candidates[0],
+  }),
+);
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1] || null;
+}
+
+function parseBoolean(value) {
+  const normalized = String(value || "")
+    .trim()
+    .toLowerCase();
+  if (["true", "yes", "1"].includes(normalized)) return true;
+  if (["false", "no", "0"].includes(normalized)) return false;
+  return null;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/submission-comment.mjs
+++ b/scripts/submission-comment.mjs
@@ -1,0 +1,95 @@
+import { promises as fs } from "node:fs";
+import { pathToFileURL } from "node:url";
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  await main(process.argv.slice(2));
+}
+
+export function buildSubmissionMarkdown(report) {
+  const lines = [
+    "## Metagraphed Submission Preflight",
+    "",
+    `State: \`${report.public_state || report.state || "unknown"}\``,
+    `Next action: \`${report.next_action || "unknown"}\``,
+    `Blocking: \`${Boolean(report.blocking)}\``,
+  ];
+
+  if (report.direct_candidate_file) {
+    lines.push(`Candidate file: \`${report.direct_candidate_file}\``);
+  }
+
+  lines.push("");
+  appendList(lines, "Errors", report.errors);
+  appendList(lines, "Warnings", report.warnings);
+  appendList(lines, "Manual review reasons", report.manual_reasons);
+
+  const candidate = report.candidate || report.candidates?.[0] || null;
+  if (candidate) {
+    lines.push("Candidate:", "");
+    lines.push(`- netuid: \`${candidate.netuid}\``);
+    lines.push(`- kind: \`${candidate.kind}\``);
+    lines.push(`- provider: \`${candidate.provider}\``);
+    lines.push(`- url: ${candidate.url}`);
+    lines.push(`- source: ${candidate.source_url}`);
+  }
+
+  if (report.provider) {
+    lines.push("Provider:", "");
+    lines.push(`- id: \`${report.provider.id}\``);
+    lines.push(`- kind: \`${report.provider.kind}\``);
+    lines.push(`- website: ${report.provider.website_url}`);
+  }
+
+  if (report.report) {
+    lines.push("Status report:", "");
+    lines.push(`- netuid: \`${report.report.netuid}\``);
+    lines.push(`- issue_type: \`${report.report.issue_type}\``);
+    lines.push("- observed health remains probe-derived");
+  }
+
+  lines.push(
+    "",
+    "Public preflight is deterministic validation only. Private gate review or maintainer review is still required before publication.",
+    "",
+  );
+  return lines.join("\n");
+}
+
+async function main(args) {
+  const reportPath = valueAfter(args, "--report");
+  const outPath = valueAfter(args, "--out");
+
+  if (!reportPath) {
+    console.error("--report is required");
+    process.exit(1);
+  }
+
+  const report = JSON.parse(await fs.readFile(reportPath, "utf8"));
+  const markdown = buildSubmissionMarkdown(report);
+
+  if (outPath) {
+    await fs.writeFile(outPath, markdown, "utf8");
+  }
+
+  console.log(markdown);
+}
+
+function appendList(lines, title, values = []) {
+  if (!values?.length) {
+    return;
+  }
+  lines.push(`${title}:`);
+  lines.push("");
+  for (const value of values) {
+    lines.push(`- ${String(value)}`);
+  }
+  lines.push("");
+}
+
+function valueAfter(args, flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1] || null;
+}

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -14,8 +14,29 @@ export const SUBMISSION_LABELS = {
   mergedByGate: "metagraphed-merged-by-gate",
   importApproved: "metagraphed-import-approved",
   interfaceSubmission: "interface-submission",
+  endpointSubmission: "endpoint-submission",
+  providerSubmission: "provider-submission",
   statusReport: "status-report",
 };
+
+const PROVIDER_KINDS = new Set([
+  "infrastructure-provider",
+  "subnet-team",
+  "data-provider",
+  "docs-provider",
+  "registry",
+]);
+
+const STATUS_REPORT_TYPES = new Set([
+  "down",
+  "degraded",
+  "stale",
+  "wrong-auth-label",
+  "wrong-rate-limit-label",
+  "unsafe-or-private",
+  "wrong-subnet",
+  "other",
+]);
 
 export const PUBLIC_PREFLIGHT_STATES = new Set([
   "submit_pr",
@@ -70,6 +91,26 @@ export function buildIssueIntakeReport({
   const fields = parseIssueFields(issue?.body || "");
   const fieldErrors = issueFieldParseErrors(fields);
   const labels = issueLabels(issue);
+  if (labels.includes(SUBMISSION_LABELS.providerSubmission)) {
+    return buildProviderProfileIntakeReport({
+      fields,
+      fieldErrors,
+      generatedAt,
+      issue,
+      labels,
+      providers,
+    });
+  }
+  if (labels.includes(SUBMISSION_LABELS.statusReport)) {
+    return buildEndpointStatusReportIntakeReport({
+      fields,
+      fieldErrors,
+      generatedAt,
+      issue,
+      labels,
+      native,
+    });
+  }
   const providerIds = new Set(providers.map((provider) => provider.id));
   const importApproved = labels.includes(SUBMISSION_LABELS.importApproved);
   const errors = [...fieldErrors];
@@ -212,6 +253,178 @@ export function buildIssueIntakeReport({
           ? "manual-review"
           : "private-review",
   };
+}
+
+export function buildProviderProfileIntakeReport({
+  fields,
+  fieldErrors = [],
+  generatedAt = new Date().toISOString(),
+  issue = null,
+  labels = [],
+  providers = [],
+}) {
+  const errors = [...fieldErrors];
+  const manual_reasons = ["provider profile submissions require review"];
+  const id = slugify(fields["provider slug"] || fields.provider_slug || "");
+  const name = String(
+    fields["provider name"] || fields.provider_name || "",
+  ).trim();
+  const kind = String(
+    fields["provider kind"] || fields.provider_kind || "",
+  ).trim();
+  const websiteUrl = normalizePublicUrl(
+    fields["website url"] || fields.website_url,
+  );
+  const docsUrl = normalizePublicUrl(fields["docs url"] || fields.docs_url);
+  const githubUrl = normalizePublicUrl(
+    fields["github org or repo url"] || fields.github_url,
+  );
+  const contactUrl = normalizePublicUrl(
+    fields["public contact url"] || fields.contact_url,
+  );
+  const providerExists = providers.some((provider) => provider.id === id);
+
+  if (!id)
+    errors.push("provider slug is required and must be a lowercase slug");
+  if (!name) errors.push("provider name is required");
+  if (!PROVIDER_KINDS.has(kind)) errors.push("provider kind is unsupported");
+  if (!websiteUrl) errors.push("website URL is missing, invalid, or unsafe");
+  if ((fields["docs url"] || fields.docs_url) && !docsUrl) {
+    errors.push("docs URL is invalid or unsafe");
+  }
+  if ((fields["github org or repo url"] || fields.github_url) && !githubUrl) {
+    errors.push("GitHub URL is invalid or unsafe");
+  }
+  if ((fields["public contact url"] || fields.contact_url) && !contactUrl) {
+    errors.push("public contact URL is invalid or unsafe");
+  }
+  errors.push(
+    ...unsafeTextReasons(
+      [
+        fields["public notes"],
+        fields.public_notes,
+        fields["website url"],
+        fields["docs url"],
+        fields["github org or repo url"],
+        fields["public contact url"],
+      ].join("\n"),
+    ).map((error) => error.message),
+  );
+
+  const schemaValid = errors.length === 0;
+  return {
+    schema_version: 1,
+    generated_at: generatedAt,
+    source: "github-provider-intake",
+    issue: issueSummary(issue),
+    state: schemaValid ? "schema-valid" : "schema-invalid",
+    public_state: schemaValid ? "manual_review" : "fix_required",
+    labels,
+    errors,
+    manual_reasons,
+    provider: schemaValid
+      ? {
+          schema_version: 1,
+          id,
+          name,
+          kind,
+          website_url: websiteUrl,
+          ...(docsUrl ? { docs_url: docsUrl } : {}),
+          ...(githubUrl ? { github_url: githubUrl } : {}),
+          ...(contactUrl ? { contact_url: contactUrl } : {}),
+          authority: providerExists ? "provider-claimed" : "community",
+          public_notes: fields["public notes"] || fields.public_notes || "",
+        }
+      : null,
+    publish_allowed: false,
+    import_allowed: false,
+    review_marker: SUBMISSION_REVIEW_MARKER,
+    next_action: schemaValid ? "manual-review" : "resubmission-needed",
+  };
+}
+
+export function buildEndpointStatusReportIntakeReport({
+  fields,
+  fieldErrors = [],
+  generatedAt = new Date().toISOString(),
+  issue = null,
+  labels = [],
+  native,
+}) {
+  const errors = [...fieldErrors];
+  const manual_reasons = [
+    "status reports trigger review or re-probes and cannot set observed health",
+  ];
+  const netuid = Number(fields.netuid);
+  const activeNetuid = native.subnets.some(
+    (subnet) => subnet.netuid === netuid,
+  );
+  const surface = String(
+    fields["surface id or url"] || fields.surface_id || "",
+  ).trim();
+  const issueType = String(
+    fields["issue type"] || fields.issue_type || "",
+  ).trim();
+  const evidence = String(fields.evidence || "").trim();
+
+  if (!Number.isInteger(netuid) || !activeNetuid) {
+    errors.push("netuid must be an active Finney netuid");
+  }
+  if (!surface) {
+    errors.push("surface ID or URL is required");
+  } else if (surface.includes("://") && !normalizePublicUrl(surface)) {
+    errors.push("surface URL is invalid or unsafe");
+  }
+  if (!STATUS_REPORT_TYPES.has(issueType)) {
+    errors.push("issue type is unsupported");
+  }
+  if (!evidence) {
+    errors.push("public evidence is required");
+  }
+  errors.push(
+    ...unsafeTextReasons([surface, evidence].join("\n")).map(
+      (error) => error.message,
+    ),
+  );
+
+  const schemaValid = errors.length === 0;
+  return {
+    schema_version: 1,
+    generated_at: generatedAt,
+    source: "github-status-report-intake",
+    issue: issueSummary(issue),
+    state: schemaValid ? "schema-valid" : "schema-invalid",
+    public_state: schemaValid ? "manual_review" : "fix_required",
+    labels,
+    errors,
+    manual_reasons,
+    report: schemaValid
+      ? {
+          schema_version: 1,
+          netuid,
+          surface,
+          issue_type: issueType,
+          evidence,
+          source: "community-status-report",
+          affects_observed_health: false,
+          next_action: "review-or-reprobe",
+        }
+      : null,
+    publish_allowed: false,
+    import_allowed: false,
+    review_marker: SUBMISSION_REVIEW_MARKER,
+    next_action: schemaValid ? "manual-review" : "resubmission-needed",
+  };
+}
+
+function issueSummary(issue) {
+  return issue
+    ? {
+        number: issue.number || null,
+        title: issue.title || null,
+        author: issue.user?.login || null,
+      }
+    : null;
 }
 
 export function buildPrSubmissionReport({

--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { repoRoot } from "./lib.mjs";
+import { readJson, repoRoot } from "./lib.mjs";
 
 const templateRoot = path.join(repoRoot, ".github/ISSUE_TEMPLATE");
 const interfaceTemplate = await fs.readFile(
@@ -26,6 +26,15 @@ const pullRequestTemplate = await fs.readFile(
 const submissionGateDocs = await fs.readFile(
   path.join(repoRoot, "docs/submission-gate.md"),
   "utf8",
+);
+const candidateExample = await readJson(
+  path.join(repoRoot, "docs/examples/submissions/direct-candidate.json"),
+);
+const providerExample = await readJson(
+  path.join(repoRoot, "docs/examples/submissions/provider-profile.json"),
+);
+const statusReportExample = await readJson(
+  path.join(repoRoot, "docs/examples/submissions/status-report.json"),
 );
 const errors = [];
 
@@ -130,6 +139,10 @@ checkIncludes(submissionGateDocs, "submission gate docs", [
   "route_away",
 ]);
 
+checkExampleCandidate(candidateExample);
+checkExampleProvider(providerExample);
+checkExampleStatusReport(statusReportExample);
+
 if (errors.length > 0) {
   console.error(`Intake validation failed with ${errors.length} issue(s):`);
   for (const error of errors) {
@@ -144,6 +157,57 @@ function checkIncludes(content, label, needles) {
   for (const needle of needles) {
     if (!content.includes(needle)) {
       errors.push(`${label}: missing ${needle}`);
+    }
+  }
+}
+
+function checkExampleCandidate(document) {
+  const candidate = document?.candidates?.[0];
+  if (document?.schema_version !== 1 || !candidate) {
+    errors.push(
+      "direct candidate example: missing schema_version or candidate",
+    );
+    return;
+  }
+  for (const field of [
+    "id",
+    "netuid",
+    "kind",
+    "url",
+    "source_url",
+    "provider",
+    "public_safe",
+  ]) {
+    if (candidate[field] === undefined || candidate[field] === "") {
+      errors.push(`direct candidate example: missing ${field}`);
+    }
+  }
+}
+
+function checkExampleProvider(provider) {
+  for (const field of [
+    "schema_version",
+    "id",
+    "name",
+    "kind",
+    "website_url",
+    "authority",
+  ]) {
+    if (provider?.[field] === undefined || provider?.[field] === "") {
+      errors.push(`provider example: missing ${field}`);
+    }
+  }
+}
+
+function checkExampleStatusReport(report) {
+  if (report?.affects_observed_health !== false) {
+    errors.push(
+      "status report example: affects_observed_health must remain false",
+    );
+  }
+  for (const field of ["schema_version", "netuid", "surface", "issue_type"]) {
+    if (report?.[field] === undefined || report?.[field] === "") {
+      errors.push(`status report example: missing ${field}`);
     }
   }
 }

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -39,6 +39,8 @@ import {
 import { buildCanonicalOpenApiArtifact } from "../scripts/openapi-components.mjs";
 import {
   buildIssueIntakeReport,
+  buildEndpointStatusReportIntakeReport,
+  buildProviderProfileIntakeReport,
   classifyPrScope,
   extractSingleCandidate,
   issueLabels,
@@ -455,6 +457,36 @@ describe("submission policy helpers", () => {
       "jsonbored",
     );
     assert.deepEqual(normalizeChangedFiles("b\n./a\n"), ["a", "b"]);
+  });
+
+  test("builds provider and status-report intake reports", () => {
+    const providerReport = buildProviderProfileIntakeReport({
+      fields: {
+        "provider slug": "example-operator",
+        "provider name": "Example Operator",
+        "provider kind": "infrastructure-provider",
+        "website url": "https://example.com",
+        "docs url": "https://docs.example.com",
+      },
+      providers,
+    });
+    assert.equal(providerReport.state, "schema-valid");
+    assert.equal(providerReport.public_state, "manual_review");
+    assert.equal(providerReport.provider.id, "example-operator");
+    assert.equal(providerReport.provider.authority, "community");
+
+    const statusReport = buildEndpointStatusReportIntakeReport({
+      fields: {
+        netuid: "7",
+        "surface id or url": "allways-api-health",
+        "issue type": "degraded",
+        evidence: "Public endpoint returned HTTP 503 during a read-only check.",
+      },
+      native,
+    });
+    assert.equal(statusReport.state, "schema-valid");
+    assert.equal(statusReport.report.affects_observed_health, false);
+    assert.equal(statusReport.next_action, "manual-review");
   });
 
   test("flags invalid candidate documents and unsafe submission text", () => {

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -281,6 +281,217 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(report.next_action, "open-import-pr");
   });
 
+  test("routes provider profile issue submissions to manual review", () => {
+    const body = [
+      "### Provider slug",
+      "allways",
+      "### Provider name",
+      "Allways",
+      "### Provider kind",
+      "subnet-team",
+      "### Website URL",
+      "https://all-ways.io",
+      "### Docs URL",
+      "https://docs.all-ways.io/how-it-works.html",
+      "### GitHub org or repo URL",
+      "https://github.com/Ent-Rho/allways-subnet",
+      "### Public contact URL",
+      "https://docs.all-ways.io/how-it-works.html",
+      "### Public notes",
+      "Public subnet team profile update.",
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 50,
+        title: "provider: allways",
+        user: { login: "jsonbored" },
+        labels: [{ name: SUBMISSION_LABELS.providerSubmission }],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.source, "github-provider-intake");
+    assert.equal(report.state, "schema-valid");
+    assert.equal(report.public_state, "manual_review");
+    assert.equal(report.provider.id, "allways");
+    assert.equal(report.provider.authority, "provider-claimed");
+    assert.equal(
+      report.provider.docs_url,
+      "https://docs.all-ways.io/how-it-works.html",
+    );
+    assert.equal(
+      report.provider.github_url,
+      "https://github.com/Ent-Rho/allways-subnet",
+    );
+    assert.equal(report.next_action, "manual-review");
+  });
+
+  test("rejects malformed provider profile issue submissions", () => {
+    const body = [
+      "### Provider slug",
+      "",
+      "### Provider name",
+      "",
+      "### Provider kind",
+      "paid-promo",
+      "### Website URL",
+      "http://127.0.0.1",
+      "### Docs URL",
+      "http://10.0.0.5/docs",
+      "### GitHub org or repo URL",
+      "not a url",
+      "### Public contact URL",
+      "http://169.254.169.254/latest/meta-data/",
+      "### Public notes",
+      "github_pat_abcdefghijklmnopqrstuvwxyz123456 should fail",
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 51,
+        title: "provider: unsafe",
+        user: { login: "jsonbored" },
+        labels: [{ name: SUBMISSION_LABELS.providerSubmission }],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.source, "github-provider-intake");
+    assert.equal(report.state, "schema-invalid");
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.provider, null);
+    assert.equal(report.errors.includes("provider kind is unsupported"), true);
+    assert.equal(
+      report.errors.includes("website URL is missing, invalid, or unsafe"),
+      true,
+    );
+    assert.equal(report.errors.includes("docs URL is invalid or unsafe"), true);
+    assert.equal(
+      report.errors.includes("GitHub URL is invalid or unsafe"),
+      true,
+    );
+    assert.equal(
+      report.errors.includes("public contact URL is invalid or unsafe"),
+      true,
+    );
+    assert.equal(
+      report.errors.includes(
+        "submission appears to include wallet, PAT, token, or private credential material",
+      ),
+      true,
+    );
+  });
+
+  test("routes endpoint status reports without mutating observed health", () => {
+    const body = [
+      "### Netuid",
+      "7",
+      "### Surface ID or URL",
+      "https://api.all-ways.io/health",
+      "### Issue type",
+      "stale",
+      "### Evidence",
+      "Public health response looked stale during a read-only check.",
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 52,
+        title: "status: allways api stale",
+        user: { login: "jsonbored" },
+        labels: [{ name: SUBMISSION_LABELS.statusReport }],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.source, "github-status-report-intake");
+    assert.equal(report.state, "schema-valid");
+    assert.equal(report.public_state, "manual_review");
+    assert.equal(report.report.affects_observed_health, false);
+    assert.equal(report.report.next_action, "review-or-reprobe");
+  });
+
+  test("rejects malformed endpoint status reports", () => {
+    const body = [
+      "### Netuid",
+      "999",
+      "### Surface ID or URL",
+      "http://127.0.0.1:9944",
+      "### Issue type",
+      "please-rank-this",
+      "### Evidence",
+      "",
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 53,
+        title: "status: unsafe",
+        user: { login: "jsonbored" },
+        labels: [{ name: SUBMISSION_LABELS.statusReport }],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.source, "github-status-report-intake");
+    assert.equal(report.state, "schema-invalid");
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.report, null);
+    assert.equal(
+      report.errors.includes("netuid must be an active Finney netuid"),
+      true,
+    );
+    assert.equal(
+      report.errors.includes("surface URL is invalid or unsafe"),
+      true,
+    );
+    assert.equal(report.errors.includes("issue type is unsupported"), true);
+    assert.equal(report.errors.includes("public evidence is required"), true);
+  });
+
+  test("rejects blank status surfaces and credential-like evidence", () => {
+    const body = [
+      "### Netuid",
+      "7",
+      "### Surface ID or URL",
+      "",
+      "### Issue type",
+      "down",
+      "### Evidence",
+      "github_pat_abcdefghijklmnopqrstuvwxyz123456 token should not pass.",
+    ].join("\n\n");
+    const report = buildIssueIntakeReport({
+      issue: {
+        number: 54,
+        title: "status: secret",
+        user: { login: "jsonbored" },
+        labels: [{ name: SUBMISSION_LABELS.statusReport }],
+        body,
+      },
+      native,
+      providers,
+      generatedAt: "1970-01-01T00:00:00.000Z",
+    });
+
+    assert.equal(report.state, "schema-invalid");
+    assert.equal(report.errors.includes("surface ID or URL is required"), true);
+    assert.equal(
+      report.errors.includes(
+        "submission appears to include wallet, PAT, token, or private credential material",
+      ),
+      true,
+    );
+  });
+
   test("notifies only terminal UGC decisions", () => {
     assert.equal(
       shouldNotifySubmissionDecision({


### PR DESCRIPTION
## Summary
- adds contributor-facing helpers and examples for one-file community candidate submissions
- extends intake handling for provider profiles and endpoint status reports
- renders deterministic preflight summaries for PR and issue workflows

## What changed
- added `npm run candidate:new` for schema-shaped direct candidate files
- added `npm run submission:comment` for stable Markdown preflight summaries
- routed provider-profile and status-report issue labels through deterministic intake reports
- added schema-backed examples under `docs/examples/submissions`
- updated contributor docs, candidate docs, PR template, and workflow summaries
- expanded tests for provider/status intake and kept coverage above configured thresholds

## Why
- gives contributors a clearer, safer way to submit endpoint/provider/interface metadata
- keeps health and uptime probe-derived only; status reports create review or re-probe work instead of mutating observed state
- keeps public workflows deterministic while private gate review remains authoritative

## Validation
- `npm run candidate:new -- --netuid 7 --kind docs --url https://docs.all-ways.io/community-submission-example --source-url https://docs.all-ways.io/how-it-works.html --provider allways --submitted-by jsonbored`
- one-file submission smoke using `npm run submission:pr` and `npm run submission:comment`
- `npm run validate:intake`
- `npm run validate:workflows`
- `npm test`
- `npm run test:coverage`
- `npm run check`
- `npm run scan:public-safety`
- `git diff --check`

## Notes
- no generated registry artifacts are changed in this PR
- live dry-run discovery remains upstream-sensitive and can vary slightly between runs
