### PR TITLE
ci(cloudflare): ignore static asset metadata

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,6 @@
 node_modules
 public/metagraph
+public/.assetsignore
 generated
 schemas/api-components.schema.json
 registry/native

--- a/public/.assetsignore
+++ b/public/.assetsignore
@@ -1,0 +1,4 @@
+.DS_Store
+**/.DS_Store
+Thumbs.db
+desktop.ini

--- a/scripts/cloudflare-verify.mjs
+++ b/scripts/cloudflare-verify.mjs
@@ -3,8 +3,10 @@ import path from "node:path";
 import { readJson, repoRoot, stableStringify } from "./lib.mjs";
 
 const configPath = path.join(repoRoot, "wrangler.jsonc");
+const assetsIgnorePath = path.join(repoRoot, "public/.assetsignore");
 const rawConfig = await fs.readFile(configPath, "utf8");
 const config = JSON.parse(stripJsonComments(rawConfig));
+const assetsIgnore = await fs.readFile(assetsIgnorePath, "utf8");
 const manifest = await readJson(
   path.join(repoRoot, "public/metagraph/r2-manifest.json"),
 );
@@ -50,6 +52,10 @@ check(
   Array.isArray(config.assets?.run_worker_first) &&
     config.assets.run_worker_first.includes("/rpc/*"),
   "RPC routes must run Worker first",
+);
+check(
+  assetsIgnore.includes(".DS_Store") && assetsIgnore.includes("Thumbs.db"),
+  "public/.assetsignore must block OS metadata uploads",
 );
 check(
   config.vars?.METAGRAPH_ENABLE_RPC_PROXY === "false",

--- a/scripts/worker-deploy-dry-run.mjs
+++ b/scripts/worker-deploy-dry-run.mjs
@@ -4,8 +4,10 @@ import { repoRoot } from "./lib.mjs";
 
 const configPath = path.join(repoRoot, "wrangler.jsonc");
 const workerPath = path.join(repoRoot, "workers/api.mjs");
+const assetsIgnorePath = path.join(repoRoot, "public/.assetsignore");
 const rawConfig = await fs.readFile(configPath, "utf8");
 const config = JSON.parse(stripJsonComments(rawConfig));
+const assetsIgnore = await fs.readFile(assetsIgnorePath, "utf8");
 const errors = [];
 
 check(config.name === "metagraphed", "wrangler name must be metagraphed");
@@ -36,6 +38,10 @@ check(
   Array.isArray(config.assets?.run_worker_first) &&
     config.assets.run_worker_first.includes("/rpc/*"),
   "RPC proxy routes must run Worker first",
+);
+check(
+  assetsIgnore.includes(".DS_Store") && assetsIgnore.includes("Thumbs.db"),
+  "public/.assetsignore must block OS metadata uploads",
 );
 check(
   config.vars?.METAGRAPH_ENABLE_RPC_PROXY === "false",


### PR DESCRIPTION
## Summary
- prevents OS metadata files from being uploaded as Cloudflare Workers static assets
- enforces the asset ignore policy in Cloudflare dry-run verification

## What changed
- added `public/.assetsignore` for Workers static assets
- ignored `public/.assetsignore` in Prettier scans
- made Worker deploy dry-run and Cloudflare verification require OS metadata ignore patterns

## Why
- Wrangler uploads files from `public/` unless the assets directory has its own `.assetsignore`
- this prevents local `.DS_Store` or Windows metadata from becoming public static assets

## Validation
- `npm run worker:deploy:dry-run`
- `npm run cloudflare:verify:dry-run`
- `npm run format:check`
- `npm run check`
- `git diff --check`

## Notes
- no registry data or public API contracts changed
