### PR TITLE
fix(registry): redact signed redirect targets

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 974,
-  "artifact_size_bytes": 29872942,
+  "artifact_size_bytes": 29870955,
   "artifacts": [
     {
       "path": "adapters/allways.json",
@@ -26,8 +26,8 @@
     },
     {
       "path": "candidates.json",
-      "sha256": "64e0fa52ae812f4d980c37cd9ae8a9410dbfbf2215767053aeb81d64020bd62b",
-      "size_bytes": 3433999
+      "sha256": "5d81e7c3fafede9d998cbb6b5e93e49db6f7a5f07692a26f448a43eaf7a6c220",
+      "size_bytes": 3433657
     },
     {
       "path": "candidates/0.json",
@@ -621,8 +621,8 @@
     },
     {
       "path": "candidates/9.json",
-      "sha256": "c84369ac8a5052815a2ff1ff1f87c06c02e0365130beb7997f2fd8299a82f39e",
-      "size_bytes": 48916
+      "sha256": "2e40143e66e05884ac6d917018641b017461d12d55f31be9cffb9469e9954188",
+      "size_bytes": 48574
     },
     {
       "path": "candidates/90.json",
@@ -676,8 +676,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "a5a63597efe508d7f8dd4a09413a19044c311307c6707028b83098a4b16d91fa",
-      "size_bytes": 1486
+      "sha256": "444aa1078bf9e3fd54f899df9c336eebdb15b99c3d56c594f3434fcf7805f5cc",
+      "size_bytes": 1209
     },
     {
       "path": "contracts.json",

--- a/public/metagraph/candidates.json
+++ b/public/metagraph/candidates.json
@@ -8286,7 +8286,7 @@
           "source_tier": "provider-claimed",
           "transient_failure": false
         },
-        "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=DO801VW62ENXU4TLZHMF%2F20260607%2Fams3%2Fs3%2Faws4_request&X-Amz-Date=20260607T070641Z&X-Amz-Expires=600&X-Amz-Signature=f69c6e0501e91d4f4e2cf55842cfb3b87b5880146a180a4c771122b5c0e73d4d&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject",
+        "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg",
         "source_tier": "provider-claimed",
         "source_type": "project-website-link",
         "source_url": "https://iota.macrocosmos.ai/",

--- a/public/metagraph/candidates/9.json
+++ b/public/metagraph/candidates/9.json
@@ -1253,7 +1253,7 @@
           "source_tier": "provider-claimed",
           "transient_failure": false
         },
-        "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=DO801VW62ENXU4TLZHMF%2F20260607%2Fams3%2Fs3%2Faws4_request&X-Amz-Date=20260607T070641Z&X-Amz-Expires=600&X-Amz-Signature=f69c6e0501e91d4f4e2cf55842cfb3b87b5880146a180a4c771122b5c0e73d4d&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject",
+        "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg",
         "source_tier": "provider-claimed",
         "source_type": "project-website-link",
         "source_url": "https://iota.macrocosmos.ai/",

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,16 +1,7 @@
 {
   "artifacts": {
     "added": [],
-    "modified": [
-      {
-        "hash": "58e73a4a000b6ee92a4e0b382bcaa768dca58d8b46eaf3c7268e737f75fa8aa1",
-        "path": "endpoint-pools.json"
-      },
-      {
-        "hash": "5086b1a275a112aa0be553bb44397434a38acca5e8cbcbb87106537981f98436",
-        "path": "rpc/pools.json"
-      }
-    ],
+    "modified": [],
     "removed": []
   },
   "contract_version": "2026-06-06.1",
@@ -28,7 +19,7 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 2,
+    "artifact_modified_count": 0,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 975,
-  "artifact_size_bytes": 30023458,
+  "artifact_size_bytes": 30021471,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -31,8 +31,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/candidates.json",
       "latest_key": "latest/candidates.json",
       "path": "/metagraph/candidates.json",
-      "sha256": "64e0fa52ae812f4d980c37cd9ae8a9410dbfbf2215767053aeb81d64020bd62b",
-      "size_bytes": 3433999
+      "sha256": "5d81e7c3fafede9d998cbb6b5e93e49db6f7a5f07692a26f448a43eaf7a6c220",
+      "size_bytes": 3433657
     },
     {
       "content_type": "application/json",
@@ -983,8 +983,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/candidates/9.json",
       "latest_key": "latest/candidates/9.json",
       "path": "/metagraph/candidates/9.json",
-      "sha256": "c84369ac8a5052815a2ff1ff1f87c06c02e0365130beb7997f2fd8299a82f39e",
-      "size_bytes": 48916
+      "sha256": "2e40143e66e05884ac6d917018641b017461d12d55f31be9cffb9469e9954188",
+      "size_bytes": 48574
     },
     {
       "content_type": "application/json",
@@ -1071,8 +1071,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "a5a63597efe508d7f8dd4a09413a19044c311307c6707028b83098a4b16d91fa",
-      "size_bytes": 1486
+      "sha256": "444aa1078bf9e3fd54f899df9c336eebdb15b99c3d56c594f3434fcf7805f5cc",
+      "size_bytes": 1209
     },
     {
       "content_type": "application/json",
@@ -4527,8 +4527,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review-queue.json",
       "latest_key": "latest/review-queue.json",
       "path": "/metagraph/review-queue.json",
-      "sha256": "79a1dd964e81c823bdff0bf351a04ba041c140d4024e0d7df59c1529e6ed0157",
-      "size_bytes": 3433982
+      "sha256": "9908d96ec9bf0f7bf8d4f5f36312abc8d9d59df154d8e98a0e19bb1d0349f833",
+      "size_bytes": 3433640
     },
     {
       "content_type": "application/json",
@@ -4671,7 +4671,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/source-snapshots.json",
       "latest_key": "latest/source-snapshots.json",
       "path": "/metagraph/source-snapshots.json",
-      "sha256": "731f2cf225283560eae083a535ed8b57fcbba60000f0baedfa2363b98633ba24",
+      "sha256": "fe5751a8842d72e8fb817f8193f35b52b288871e35d89aba2c3e3b60d6fcfc38",
       "size_bytes": 2743
     },
     {
@@ -6767,8 +6767,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/verification/latest.json",
       "latest_key": "latest/verification/latest.json",
       "path": "/metagraph/verification/latest.json",
-      "sha256": "1a76091f4bb61d61de88de13cd6d2bf3fa298995cda90f077f188caf4a1562d3",
-      "size_bytes": 1790147
+      "sha256": "556a90ebe80f77063d34a47c08be290f063ea09d0ab88f3f7453c2bb1b5c4c16",
+      "size_bytes": 1789805
     },
     {
       "content_type": "application/json",
@@ -7719,8 +7719,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/verification/subnets/9.json",
       "latest_key": "latest/verification/subnets/9.json",
       "path": "/metagraph/verification/subnets/9.json",
-      "sha256": "11559c7166d720b17d923247f717a278a12fea607240a810957aa79b6f60815b",
-      "size_bytes": 26224
+      "sha256": "040bcd9c8604880d047137fc41ce7470188dba02b4327edd50891c9a1be61349",
+      "size_bytes": 25882
     },
     {
       "content_type": "application/json",

--- a/public/metagraph/review-queue.json
+++ b/public/metagraph/review-queue.json
@@ -8286,7 +8286,7 @@
           "source_tier": "provider-claimed",
           "transient_failure": false
         },
-        "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=DO801VW62ENXU4TLZHMF%2F20260607%2Fams3%2Fs3%2Faws4_request&X-Amz-Date=20260607T070641Z&X-Amz-Expires=600&X-Amz-Signature=f69c6e0501e91d4f4e2cf55842cfb3b87b5880146a180a4c771122b5c0e73d4d&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject",
+        "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg",
         "source_tier": "provider-claimed",
         "source_type": "project-website-link",
         "source_url": "https://iota.macrocosmos.ai/",

--- a/public/metagraph/source-snapshots.json
+++ b/public/metagraph/source-snapshots.json
@@ -30,7 +30,7 @@
     },
     {
       "captured_at": "1970-01-01T00:00:00.000Z",
-      "hash": "4ddb05c7ec8bacb34d5d623e75da84b2189eed27f1c455fbd09c8a229b84eb4c",
+      "hash": "ec37037c719a1a09e3131bd8d138296bcfe044b5ea6c6d68516bad62235542f0",
       "id": "candidate-verification",
       "kind": "probe-results",
       "path": "registry/verification/latest.json",

--- a/public/metagraph/verification/latest.json
+++ b/public/metagraph/verification/latest.json
@@ -4967,7 +4967,7 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=DO801VW62ENXU4TLZHMF%2F20260607%2Fams3%2Fs3%2Faws4_request&X-Amz-Date=20260607T070641Z&X-Amz-Expires=600&X-Amz-Signature=f69c6e0501e91d4f4e2cf55842cfb3b87b5880146a180a4c771122b5c0e73d4d&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject",
+      "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg",
       "source_tier": "provider-claimed",
       "source_type": "project-website-link",
       "source_url": "https://iota.macrocosmos.ai/",

--- a/public/metagraph/verification/subnets/9.json
+++ b/public/metagraph/verification/subnets/9.json
@@ -753,7 +753,7 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=DO801VW62ENXU4TLZHMF%2F20260607%2Fams3%2Fs3%2Faws4_request&X-Amz-Date=20260607T070641Z&X-Amz-Expires=600&X-Amz-Signature=f69c6e0501e91d4f4e2cf55842cfb3b87b5880146a180a4c771122b5c0e73d4d&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject",
+      "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg",
       "source_tier": "provider-claimed",
       "source_type": "project-website-link",
       "source_url": "https://iota.macrocosmos.ai/",

--- a/registry/verification/latest.json
+++ b/registry/verification/latest.json
@@ -4967,7 +4967,7 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=DO801VW62ENXU4TLZHMF%2F20260607%2Fams3%2Fs3%2Faws4_request&X-Amz-Date=20260607T070641Z&X-Amz-Expires=600&X-Amz-Signature=f69c6e0501e91d4f4e2cf55842cfb3b87b5880146a180a4c771122b5c0e73d4d&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject",
+      "redirect_target": "https://ams3.digitaloceanspaces.com/iota-train-at-home-releases/releases/prod/darwin/arm64/IOTA%20Train%20at%20Home-3.3.4-arm64.dmg",
       "source_tier": "provider-claimed",
       "source_type": "project-website-link",
       "source_url": "https://iota.macrocosmos.ai/",

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -17,6 +17,7 @@ import {
   nativeDisplayName,
   nativeNameQuality,
   readJson,
+  redactCredentialedUrls,
   repoRoot,
   sha256Hex,
   slugify,
@@ -36,7 +37,7 @@ import { buildCanonicalOpenApiArtifact } from "./openapi-components.mjs";
 const providers = await loadProviders();
 const overlays = await loadSubnets();
 const candidates = await loadCandidates();
-const verification = await loadVerification();
+const verification = redactCredentialedUrls(await loadVerification());
 const adapterSnapshots = await loadAdapterSnapshots();
 const reviewDecisions = await loadReviewDecisions();
 const nativeSnapshot = await loadNativeSnapshot();

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -6,6 +6,19 @@ import path from "node:path";
 
 export const repoRoot = new URL("..", import.meta.url).pathname;
 
+const credentialedUrlParams = new Set([
+  "x-amz-credential",
+  "x-amz-signature",
+  "x-amz-security-token",
+  "x-goog-credential",
+  "x-goog-signature",
+  "x-goog-security-token",
+  "x-goog-signedheaders",
+  "x-goog-expires",
+  "x-oss-signature",
+  "x-oss-credential",
+]);
+
 const unsafeIpBlocks = new BlockList();
 unsafeIpBlocks.addSubnet("0.0.0.0", 8);
 unsafeIpBlocks.addSubnet("10.0.0.0", 8);
@@ -265,6 +278,48 @@ function normalizeHostname(hostname) {
     .toLowerCase()
     .replace(/^\[(.*)\]$/, "$1")
     .replace(/\.$/, "");
+}
+
+export function isCredentialedUrl(value) {
+  try {
+    const url = new URL(value);
+    for (const key of url.searchParams.keys()) {
+      if (credentialedUrlParams.has(key.toLowerCase())) {
+        return true;
+      }
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+export function redactCredentialedUrl(value) {
+  if (!isCredentialedUrl(value)) {
+    return value;
+  }
+
+  const url = new URL(value);
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+export function redactCredentialedUrls(value) {
+  if (Array.isArray(value)) {
+    return value.map(redactCredentialedUrls);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nested]) => [
+        key,
+        redactCredentialedUrls(nested),
+      ]),
+    );
+  }
+
+  return typeof value === "string" ? redactCredentialedUrl(value) : value;
 }
 
 export function normalizePublicUrl(value) {

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -20,6 +20,11 @@ const patterns = [
   { name: "openai-style token", regex: /sk-[A-Za-z0-9]{20,}/ },
   { name: "slack-style token", regex: /xox[baprs]-[A-Za-z0-9-]+/ },
   {
+    name: "signed object-storage URL parameter",
+    regex:
+      /[?&](?:X-Amz-(?:Credential|Signature|Security-Token)|X-Goog-(?:Credential|Signature|Security-Token|SignedHeaders|Expires)|X-Oss-(?:Credential|Signature))=/i,
+  },
+  {
     name: "private or loopback URL",
     regex:
       /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|10\.\d+\.\d+\.\d+|192\.168\.\d+\.\d+|172\.(?:1[6-9]|2\d|3[0-1])\.\d+\.\d+)/i,

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -6,6 +6,7 @@ import {
   loadNativeSnapshot,
   loadProviders,
   loadSubnets,
+  isCredentialedUrl,
   isValidUrl,
   nativeDisplayName,
   nativeNameQuality,
@@ -320,6 +321,29 @@ function validateLinks(key, links) {
         `${key}: links[${index}].source_url must be a URL`,
       );
     }
+  }
+}
+
+function validatePublicSafeJson(value, pathSegments = []) {
+  if (Array.isArray(value)) {
+    for (const [index, nested] of value.entries()) {
+      validatePublicSafeJson(nested, [...pathSegments, index]);
+    }
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, nested] of Object.entries(value)) {
+      validatePublicSafeJson(nested, [...pathSegments, key]);
+    }
+    return;
+  }
+
+  if (typeof value === "string" && isCredentialedUrl(value)) {
+    assert(
+      false,
+      `${pathSegments.join(".") || "value"}: must not expose credentialed URL query parameters`,
+    );
   }
 }
 
@@ -751,6 +775,14 @@ async function validateGeneratedArtifacts(
     path.join(repoRoot, "public/metagraph/review/maintainer-decisions.json"),
   );
 
+  for (const [artifactName, artifact] of [
+    ["public candidates", candidatesArtifact],
+    ["public review queue", reviewQueueArtifact],
+    ["public verification", verificationArtifact],
+  ]) {
+    validatePublicSafeJson(artifact, [artifactName]);
+  }
+
   const nativeNetuids = nativeSnapshot.subnets.map((subnet) => subnet.netuid);
   const generatedNetuids = subnetsArtifact.subnets.map(
     (subnet) => subnet.netuid,
@@ -1128,6 +1160,10 @@ const candidates = await loadCandidates();
 const reviewDecisionsDocument = await readJson(
   path.join(repoRoot, "registry/reviews/maintainer-reviewed.json"),
 );
+const verificationDocument = await readJson(
+  path.join(repoRoot, "registry/verification/latest.json"),
+);
+validatePublicSafeJson(verificationDocument, ["registry verification"]);
 const providerIds = new Set();
 const netuids = new Set();
 const slugs = new Set();

--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -4,6 +4,7 @@ import {
   isHtmlContentType,
   isJsonContentType,
   isUnsafeResolvedUrl,
+  redactCredentialedUrl,
   loadCandidates,
   repoRoot,
   stableStringify,
@@ -135,7 +136,7 @@ async function verifyGithubRepo(base, repo) {
       { ...base, kind: "source-repo", public_safe: true },
       { ...fallback, classification },
     ),
-    redirect_target: fallback.redirect_target,
+    redirect_target: redactCredentialedUrl(fallback.redirect_target),
     status: fallback.ok ? "ok" : "failed",
     status_code: fallback.status_code || null,
   };
@@ -157,7 +158,7 @@ async function verifyHttpSurface(base, candidate) {
     latency_ms: probe.latency_ms,
     method_tested: probe.method_tested,
     private_redirect_blocked: probe.private_redirect_blocked || false,
-    redirect_target: probe.redirect_target,
+    redirect_target: redactCredentialedUrl(probe.redirect_target),
     status: probe.ok ? "ok" : "failed",
     status_code: probe.status_code || null,
     confidence_score: scoreCandidate(candidate, { ...probe, classification }),
@@ -205,7 +206,7 @@ async function probeUrl(url, method, accept, redirectCount = 0) {
           latency_ms: latencyMs,
           method_tested: method,
           private_redirect_blocked: true,
-          redirect_target: redirectTarget,
+          redirect_target: redactCredentialedUrl(redirectTarget),
           status_code: response.status,
         };
       }
@@ -219,7 +220,9 @@ async function probeUrl(url, method, accept, redirectCount = 0) {
       return {
         ...redirected,
         latency_ms: latencyMs + (redirected.latency_ms || 0),
-        redirect_target: redirected.redirect_target || redirectTarget,
+        redirect_target: redactCredentialedUrl(
+          redirected.redirect_target || redirectTarget,
+        ),
       };
     }
 

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -16,6 +16,7 @@ import {
   classifyNativeName,
   flattenSurfaces,
   hashJson,
+  isCredentialedUrl,
   isHtmlContentType,
   isJsonContentType,
   isUnsafeResolvedUrl,
@@ -29,6 +30,8 @@ import {
   nativeNameQuality,
   normalizePublicUrl,
   readJson,
+  redactCredentialedUrl,
+  redactCredentialedUrls,
   registrySurfaceKey,
   repoRoot,
   sha256Hex,
@@ -93,6 +96,39 @@ describe("script utility contracts", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  test("redacts credentialed object-storage URLs", () => {
+    const signedUrl =
+      "https://ams3.digitaloceanspaces.com/releases/file.dmg?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=KEY%2F20260607%2Fams3%2Fs3%2Faws4_request&X-Amz-Signature=abc&x-id=GetObject";
+
+    assert.equal(isCredentialedUrl(signedUrl), true);
+    assert.equal(
+      redactCredentialedUrl(signedUrl),
+      "https://ams3.digitaloceanspaces.com/releases/file.dmg",
+    );
+    assert.equal(
+      redactCredentialedUrl(`${signedUrl}#fragment`),
+      "https://ams3.digitaloceanspaces.com/releases/file.dmg",
+    );
+    assert.deepEqual(redactCredentialedUrls({ nested: [signedUrl] }), {
+      nested: ["https://ams3.digitaloceanspaces.com/releases/file.dmg"],
+    });
+    assert.deepEqual(redactCredentialedUrls([null, 7, false]), [
+      null,
+      7,
+      false,
+    ]);
+    assert.equal(redactCredentialedUrl("not a url"), "not a url");
+    assert.equal(
+      redactCredentialedUrl("https://example.com/download?file=1"),
+      "https://example.com/download?file=1",
+    );
+    assert.equal(isCredentialedUrl("not a url"), false);
+    assert.equal(
+      isCredentialedUrl("https://example.com/download?file=1"),
+      false,
+    );
   });
 
   test("loads checked-in candidates and verification fallback contracts", async () => {


### PR DESCRIPTION
### Motivation
- Prevent leaking presigned object-storage URLs (S3/DigitalOcean/GCS/OSS) with credential/query parameters into checked-in registry verification snapshots and public artifacts.
- Ensure public artifacts and API consumers never expose `X-Amz-*`, `X-Goog-*`, or similar signed URL query parameters that disclose credential identifiers.

### Description
- Added detection and redaction helpers `isCredentialedUrl`, `redactCredentialedUrl`, and `redactCredentialedUrls` in `scripts/lib.mjs` to identify common signed-object-storage query parameters and strip the query/hash portion from matching URLs.
- Applied redaction during verification and probing flows in `scripts/verify-candidates.mjs` so `redirect_target` values are stored redacted when they contain credentialed parameters.
- Applied recursive redaction to the loaded verification artifact in `scripts/build-artifacts.mjs` by calling `redactCredentialedUrls` so generated public artifacts never copy signed query parameters into `public/metagraph/*` outputs.
- Added a JSON validation pass `validatePublicSafeJson` in `scripts/validate.mjs` and extended `scripts/scan-public-safety.mjs` with a regex for signed object-storage parameters so builds/CI flag any remaining occurrences; updated tests (`tests/script-utils.test.mjs`) to cover detection and redaction behavior.

### Testing
- Ran `npm run build` successfully to regenerate public artifacts with redactions applied. (passed)
- Ran `npm run validate` and the repository validation completed with no failures. (passed)
- Ran the public-safety scanner `npm run scan:public-safety` which passed after adding the signed-URL pattern. (passed)
- Ran unit tests `npx vitest run tests/script-utils.test.mjs` which passed including new redaction tests. (passed)
- Ran formatting and checks: `npx prettier --check` and `npm run lint` which succeeded. (passed)
- Verified there are no remaining checked-in signed URL query parameters via a targeted `rg` search for `X-Amz-*`, `X-Goog-*`, and `X-Oss-*`. (no matches)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a251c45f488832c9e4535bc49f2b3bb)