### PR TITLE
fix(contracts): remove no-op OpenAPI path replacements

### DIFF
--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -958,9 +958,7 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
 
   const paths = {};
   for (const entry of API_ROUTES) {
-    const openApiPath = entry.path
-      .replace(/\{netuid\}/g, "{netuid}")
-      .replace(/\{slug\}/g, "{slug}");
+    const openApiPath = entry.path;
     paths[openApiPath] = {
       ...(paths[openApiPath] || {}),
       [entry.method.toLowerCase()]: {


### PR DESCRIPTION
## Summary
- resolves the two open CodeQL `js/identity-replacement` alerts in `src/contracts.mjs`
- removes no-op OpenAPI path replacements for `{netuid}` and `{slug}`

## What changed
- uses `entry.path` directly when building OpenAPI paths
- leaves generated OpenAPI/types unchanged because route paths were already OpenAPI-compatible

## Why
- CodeQL flagged the prior replacement calls as identity replacements
- the transform added noise without changing behavior

## Validation
- `npm run validate:openapi`
- `npm run validate:contract-drift`
- `npm run validate:types`
- `npm run check`
- `npm run test:coverage`
- `npm run scan:public-safety`
- `git diff --check`

## Notes
- fixes CodeQL alerts #1 and #2
- no generated registry artifacts changed
