### PR TITLE
fix(probes): refresh endpoint incident artifact

### DIFF
--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -2,6 +2,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import {
   buildEndpointResourceArtifact,
+  buildEndpointIncidentArtifact,
   buildEndpointPoolArtifact,
   buildRpcEndpointArtifact,
   buildTimestamp,
@@ -682,6 +683,14 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
   await writeJson(
     path.join(outputRoot, "endpoints.json"),
     endpointResourceArtifact,
+  );
+  await writeJson(
+    path.join(outputRoot, "endpoint-incidents.json"),
+    buildEndpointIncidentArtifact({
+      endpointArtifact: endpointResourceArtifact,
+      generatedAt: buildTimestamp(),
+      contractVersion,
+    }),
   );
   await writeJson(
     path.join(outputRoot, "rpc/pools.json"),


### PR DESCRIPTION
### Motivation
- Ensure the public `endpoint-incidents.json` reflects live probe results instead of the build-time placeholder so failed/degraded endpoints discovered by probes are published immediately.

### Description
- Import `buildEndpointIncidentArtifact` in `scripts/probes-smoke.mjs` and write `public/metagraph/endpoint-incidents.json` from the live `endpointResourceArtifact` inside the `METAGRAPH_WRITE_PROBE_RESULTS === "1"` write path.

### Testing
- Ran `npm test -- --run tests/script-utils.test.mjs` which passed (1 file, 12 tests) and `npm run lint` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25326e3e4c832ca2a5493a2007a818)