### PR TITLE
fix(submission): escape preflight summary markdown

### DIFF
--- a/scripts/submission-comment.mjs
+++ b/scripts/submission-comment.mjs
@@ -12,13 +12,15 @@ export function buildSubmissionMarkdown(report) {
   const lines = [
     "## Metagraphed Submission Preflight",
     "",
-    `State: \`${report.public_state || report.state || "unknown"}\``,
-    `Next action: \`${report.next_action || "unknown"}\``,
-    `Blocking: \`${Boolean(report.blocking)}\``,
+    `State: ${formatMarkdownValue(report.public_state || report.state || "unknown")}`,
+    `Next action: ${formatMarkdownValue(report.next_action || "unknown")}`,
+    `Blocking: ${formatMarkdownValue(Boolean(report.blocking))}`,
   ];
 
   if (report.direct_candidate_file) {
-    lines.push(`Candidate file: \`${report.direct_candidate_file}\``);
+    lines.push(
+      `Candidate file: ${formatMarkdownValue(report.direct_candidate_file)}`,
+    );
   }
 
   lines.push("");
@@ -29,24 +31,28 @@ export function buildSubmissionMarkdown(report) {
   const candidate = report.candidate || report.candidates?.[0] || null;
   if (candidate) {
     lines.push("Candidate:", "");
-    lines.push(`- netuid: \`${candidate.netuid}\``);
-    lines.push(`- kind: \`${candidate.kind}\``);
-    lines.push(`- provider: \`${candidate.provider}\``);
-    lines.push(`- url: ${candidate.url}`);
-    lines.push(`- source: ${candidate.source_url}`);
+    lines.push(`- netuid: ${formatMarkdownValue(candidate.netuid)}`);
+    lines.push(`- kind: ${formatMarkdownValue(candidate.kind)}`);
+    lines.push(`- provider: ${formatMarkdownValue(candidate.provider)}`);
+    lines.push(`- url: ${formatMarkdownValue(candidate.url)}`);
+    lines.push(`- source: ${formatMarkdownValue(candidate.source_url)}`);
   }
 
   if (report.provider) {
     lines.push("Provider:", "");
-    lines.push(`- id: \`${report.provider.id}\``);
-    lines.push(`- kind: \`${report.provider.kind}\``);
-    lines.push(`- website: ${report.provider.website_url}`);
+    lines.push(`- id: ${formatMarkdownValue(report.provider.id)}`);
+    lines.push(`- kind: ${formatMarkdownValue(report.provider.kind)}`);
+    lines.push(
+      `- website: ${formatMarkdownValue(report.provider.website_url)}`,
+    );
   }
 
   if (report.report) {
     lines.push("Status report:", "");
-    lines.push(`- netuid: \`${report.report.netuid}\``);
-    lines.push(`- issue_type: \`${report.report.issue_type}\``);
+    lines.push(`- netuid: ${formatMarkdownValue(report.report.netuid)}`);
+    lines.push(
+      `- issue_type: ${formatMarkdownValue(report.report.issue_type)}`,
+    );
     lines.push("- observed health remains probe-derived");
   }
 
@@ -84,9 +90,33 @@ function appendList(lines, title, values = []) {
   lines.push(`${title}:`);
   lines.push("");
   for (const value of values) {
-    lines.push(`- ${String(value)}`);
+    lines.push(`- ${formatMarkdownValue(value)}`);
   }
   lines.push("");
+}
+
+function formatMarkdownValue(value) {
+  const markdownCharacters = new Set("\\&<>{}[]()#*_`|.!+-");
+  let safeValue = "";
+
+  for (const char of String(value)) {
+    const codePoint = char.codePointAt(0);
+    if (char === "\r") {
+      safeValue += "\\r";
+    } else if (char === "\n") {
+      safeValue += "\\n";
+    } else if (char === "\t") {
+      safeValue += "\\t";
+    } else if (codePoint < 0x20 || codePoint === 0x7f) {
+      safeValue += `\\u${codePoint.toString(16).padStart(4, "0")}`;
+    } else if (markdownCharacters.has(char)) {
+      safeValue += `\\${char}`;
+    } else {
+      safeValue += char;
+    }
+  }
+
+  return safeValue;
 }
 
 function valueAfter(args, flag) {

--- a/tests/submission-comment.test.mjs
+++ b/tests/submission-comment.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { buildSubmissionMarkdown } from "../scripts/submission-comment.mjs";
+
+describe("submission comment Markdown rendering", () => {
+  test("escapes candidate and list values before rendering GitHub summaries", () => {
+    const markdown = buildSubmissionMarkdown({
+      public_state: "submit_pr",
+      next_action: "private-review",
+      blocking: false,
+      warnings: ["review\n![spoof](https://attacker.example/pixel.png)"],
+      manual_reasons: ["- approve this PR"],
+      candidate: {
+        netuid: "7` spoof",
+        kind: "http-json",
+        provider: "AllWays",
+        url: "https://example.com/path\n![Injected trusted CI badge](https://attacker.example/pixel.png)",
+        source_url:
+          "https://example.com/source?x=[spoof](https://attacker.example)",
+      },
+    });
+
+    assert.equal(
+      markdown.includes(
+        "- url: https://example\\.com/path\\n\\!\\[Injected trusted CI badge\\]\\(https://attacker\\.example/pixel\\.png\\)",
+      ),
+      true,
+    );
+    assert.equal(
+      markdown.includes(
+        "- review\\n\\!\\[spoof\\]\\(https://attacker\\.example/pixel\\.png\\)",
+      ),
+      true,
+    );
+    assert.equal(markdown.includes("- \\- approve this PR"), true);
+    assert.doesNotMatch(markdown, /^!\\[Injected trusted CI badge]/m);
+    assert.doesNotMatch(markdown, /^- approve this PR$/m);
+  });
+});


### PR DESCRIPTION
### Motivation
- The submission preflight renderer emitted untrusted report fields (candidate URLs, source_urls, list items) directly into GitHub Actions step summaries, allowing contributor-controlled Markdown to render in trusted CI output. 
- The intent of the change is to prevent content-injection/spoofing in the official step summary without changing preflight validation behavior.

### Description
- Add `formatMarkdownValue` to `scripts/submission-comment.mjs` to escape Markdown metacharacters and convert control characters (newlines, tabs, other control codepoints) into visible escaped sequences. 
- Pipe all dynamic values rendered by `buildSubmissionMarkdown` (candidate fields, provider/report fields, `direct_candidate_file`, and list items emitted by `appendList`) through `formatMarkdownValue` to ensure summaries cannot create new Markdown blocks or images. 
- Add `tests/submission-comment.test.mjs` with a regression test asserting candidate URLs and list entries are escaped and do not produce rendered Markdown elements.

### Testing
- Ran `npm run lint` and `npm run format:check`, both succeeded after changes. 
- Ran the new unit test: `npm test -- --run tests/submission-comment.test.mjs`, which passed. 
- Ran existing gate tests: `npm test -- --run tests/submission-gate.test.mjs`, which passed; the full `npm test` run hit an unrelated environment-sensitive DNS/public-safety test that failed in this environment but is not impacted by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25315a9ac8832cb370557390246fec)