### PR TITLE
ci(cloudflare): skip unchanged R2 artifact uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ npm run probes:smoke
 
 `probes:smoke` performs read-only checks against public surfaces. It does not submit transactions, mutate subnet state, send wallet data, or use credentials.
 
-`r2:manifest` generates the Cloudflare R2 upload manifest for the current artifact tree. `r2:upload`, `r2:download`, and `kv:publish` require explicit write flags so local validation cannot accidentally publish or restore.
+`r2:manifest` generates the Cloudflare R2 upload manifest for the current artifact tree. `r2:upload` is delta-based by default, using `latest/r2-manifest.json` to skip unchanged artifacts while always refreshing R2 control files. `r2:upload`, `r2:download`, and `kv:publish` require explicit write flags so local validation cannot accidentally publish or restore.
 
 ## Community Submissions
 

--- a/docs/cloudflare-backend.md
+++ b/docs/cloudflare-backend.md
@@ -66,11 +66,14 @@ If no KV binding is configured, the Worker falls back to `METAGRAPH_R2_LATEST_PR
 
 Write operations require explicit environment flags:
 
-- `METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload`
-- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_HISTORY=1 npm run r2:upload` also writes the manifest run-prefix copies.
+- `METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload` uploads only artifacts whose SHA-256 differs from `latest/r2-manifest.json`, plus the current `latest/r2-manifest.json` and `latest/build-summary.json` control files.
+- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_HISTORY=1 npm run r2:upload` also writes run-prefix copies for changed artifacts and control files.
+- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_FORCE=1 npm run r2:upload` bypasses remote manifest comparison and republishes all planned artifacts.
 - `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_LIMIT=5 npm run r2:upload` can be used for a remote permission smoke.
 - `METAGRAPH_ALLOW_R2_DOWNLOAD=1 npm run r2:download`
 - `METAGRAPH_ALLOW_KV_WRITE=1 METAGRAPH_KV_NAMESPACE_ID=... npm run kv:publish`
+
+If `latest/r2-manifest.json` is missing or unreadable, the uploader falls back to uploading all planned artifacts. Full historical backfills should use `METAGRAPH_R2_UPLOAD_FORCE=1 METAGRAPH_R2_UPLOAD_HISTORY=1` deliberately rather than relying on the normal delta publish path.
 
 ## Safety Boundary
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -42,11 +42,14 @@ npm run worker:deploy:dry-run
 Actual writes require explicit environment gates:
 
 - `METAGRAPH_ALLOW_R2_UPLOAD=1`
-- `METAGRAPH_R2_UPLOAD_HISTORY=1` when the publish job should also write run-prefix history copies.
+- `METAGRAPH_R2_UPLOAD_HISTORY=1` when the publish job should also write run-prefix history copies for changed artifacts and control files.
+- `METAGRAPH_R2_UPLOAD_FORCE=1` when a publish job should ignore the remote `latest/r2-manifest.json` comparison and republish every planned artifact.
 - `METAGRAPH_R2_UPLOAD_LIMIT` for smoke-only uploads against a small artifact subset.
 - `METAGRAPH_ALLOW_KV_WRITE=1`
 - `METAGRAPH_KV_NAMESPACE_ID`
 - Cloudflare account/API credentials
+
+Normal R2 publishes are delta-based. The uploader reads `latest/r2-manifest.json`, compares artifact SHA-256 values, skips unchanged artifact files, and always refreshes `latest/r2-manifest.json` plus `latest/build-summary.json` so Worker fallback and operator summaries stay current.
 
 ## Restore From R2
 

--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -6,6 +6,7 @@ import { readJson, repoRoot, sha256Hex, stableStringify } from "./lib.mjs";
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
 const uploadHistory = process.env.METAGRAPH_R2_UPLOAD_HISTORY === "1";
+const forceUpload = process.env.METAGRAPH_R2_UPLOAD_FORCE === "1";
 const uploadLimit = parsePositiveInteger(process.env.METAGRAPH_R2_UPLOAD_LIMIT);
 const manifest = await readJson(
   path.join(repoRoot, "public/metagraph/r2-manifest.json"),
@@ -13,8 +14,11 @@ const manifest = await readJson(
 const plannedArtifacts = uploadLimit
   ? manifest.artifacts.slice(0, uploadLimit)
   : manifest.artifacts;
+const controlArtifacts = buildControlArtifacts(manifest);
 const plannedObjectCount =
-  plannedArtifacts.length + (uploadHistory ? plannedArtifacts.length : 0);
+  plannedArtifacts.length +
+  controlArtifacts.length +
+  (uploadHistory ? plannedArtifacts.length + controlArtifacts.length : 0);
 
 if (!write) {
   console.log(
@@ -22,12 +26,15 @@ if (!write) {
       mode: "dry-run",
       artifact_count: manifest.artifact_count,
       bucket_name: manifest.bucket_name,
+      control_artifact_count: controlArtifacts.length,
+      force_upload: forceUpload,
       limited_artifact_count: plannedArtifacts.length,
       latest_prefix: manifest.latest_prefix,
       run_prefix: manifest.run_prefix,
       upload_history: uploadHistory,
       upload_limit: uploadLimit,
       planned_object_count: plannedObjectCount,
+      remote_manifest_status: "not-checked",
     }),
   );
   process.exit(0);
@@ -40,6 +47,21 @@ if (process.env.METAGRAPH_ALLOW_R2_UPLOAD !== "1") {
   process.exit(1);
 }
 
+const remoteManifestResult = forceUpload
+  ? { status: "not-checked", manifest: null }
+  : getRemoteManifest(manifest.bucket_name, "latest/r2-manifest.json");
+const remoteManifestByPath = new Map(
+  (remoteManifestResult.manifest?.artifacts ?? []).map((artifact) => [
+    artifact.path,
+    artifact.sha256,
+  ]),
+);
+let changedArtifactCount = 0;
+let skippedArtifactCount = 0;
+let uploadedLatestCount = 0;
+let uploadedHistoryCount = 0;
+let uploadedControlCount = 0;
+
 for (const artifact of plannedArtifacts) {
   const localPath = path.join(
     repoRoot,
@@ -47,14 +69,74 @@ for (const artifact of plannedArtifacts) {
     artifact.path.replace(/^\/metagraph\//, ""),
   );
   verifyLocalArtifact(localPath, artifact);
-  putObject(localPath, artifact.latest_key, manifest.bucket_name);
+  const changed =
+    forceUpload ||
+    remoteManifestResult.status !== "found" ||
+    remoteManifestByPath.get(artifact.path) !== artifact.sha256;
+  if (!changed) {
+    skippedArtifactCount += 1;
+    continue;
+  }
+  changedArtifactCount += 1;
+  putObject(
+    localPath,
+    artifact.latest_key,
+    manifest.bucket_name,
+    artifact.content_type,
+  );
+  uploadedLatestCount += 1;
   if (uploadHistory) {
-    putObject(localPath, artifact.key, manifest.bucket_name);
+    putObject(
+      localPath,
+      artifact.key,
+      manifest.bucket_name,
+      artifact.content_type,
+    );
+    uploadedHistoryCount += 1;
+  }
+}
+
+for (const controlArtifact of controlArtifacts) {
+  putObject(
+    controlArtifact.local_path,
+    controlArtifact.latest_key,
+    manifest.bucket_name,
+    controlArtifact.content_type,
+  );
+  uploadedControlCount += 1;
+  if (uploadHistory) {
+    putObject(
+      controlArtifact.local_path,
+      controlArtifact.key,
+      manifest.bucket_name,
+      controlArtifact.content_type,
+    );
+    uploadedHistoryCount += 1;
   }
 }
 
 console.log(
-  `Uploaded ${plannedObjectCount} object(s) for ${plannedArtifacts.length} artifact(s) to R2 bucket ${manifest.bucket_name}.`,
+  stableStringify({
+    mode: "write",
+    artifact_count: manifest.artifact_count,
+    bucket_name: manifest.bucket_name,
+    changed_artifact_count: changedArtifactCount,
+    control_artifact_count: controlArtifacts.length,
+    force_upload: forceUpload,
+    limited_artifact_count: plannedArtifacts.length,
+    latest_prefix: manifest.latest_prefix,
+    planned_object_count: plannedObjectCount,
+    remote_manifest_status: remoteManifestResult.status,
+    run_prefix: manifest.run_prefix,
+    skipped_artifact_count: skippedArtifactCount,
+    upload_history: uploadHistory,
+    upload_limit: uploadLimit,
+    uploaded_control_count: uploadedControlCount,
+    uploaded_history_count: uploadedHistoryCount,
+    uploaded_latest_count: uploadedLatestCount,
+    uploaded_object_count:
+      uploadedLatestCount + uploadedHistoryCount + uploadedControlCount,
+  }),
 );
 
 function parsePositiveInteger(value) {
@@ -77,32 +159,78 @@ function verifyLocalArtifact(localPath, artifact) {
   }
 }
 
-function putObject(localPath, key, bucketName) {
-  const wranglerBin = path.join(
-    repoRoot,
-    "node_modules",
-    ".bin",
-    process.platform === "win32" ? "wrangler.cmd" : "wrangler",
-  );
+function buildControlArtifacts(manifest) {
+  return [
+    {
+      content_type: "application/json; charset=utf-8",
+      key: `${manifest.run_prefix}r2-manifest.json`,
+      latest_key: "latest/r2-manifest.json",
+      local_path: path.join(repoRoot, "public/metagraph/r2-manifest.json"),
+      path: "/metagraph/r2-manifest.json",
+    },
+    {
+      content_type: "application/json; charset=utf-8",
+      key: `${manifest.run_prefix}build-summary.json`,
+      latest_key: "latest/build-summary.json",
+      local_path: path.join(repoRoot, "public/metagraph/build-summary.json"),
+      path: "/metagraph/build-summary.json",
+    },
+  ];
+}
+
+function getRemoteManifest(bucketName, key) {
   const result = spawnSync(
-    wranglerBin,
-    [
-      "r2",
-      "object",
-      "put",
-      `${bucketName}/${key}`,
-      "--file",
-      localPath,
-      "--remote",
-    ],
+    wranglerBin(),
+    ["r2", "object", "get", `${bucketName}/${key}`, "--remote", "--pipe"],
     {
       encoding: "utf8",
+      maxBuffer: 20 * 1024 * 1024,
       stdio: "pipe",
     },
   );
+  if (result.status !== 0) {
+    return { status: "missing", manifest: null };
+  }
+  try {
+    const parsed = JSON.parse(result.stdout);
+    if (!Array.isArray(parsed.artifacts)) {
+      return { status: "unavailable", manifest: null };
+    }
+    return { status: "found", manifest: parsed };
+  } catch {
+    return { status: "unavailable", manifest: null };
+  }
+}
+
+function putObject(localPath, key, bucketName, contentType) {
+  const args = [
+    "r2",
+    "object",
+    "put",
+    `${bucketName}/${key}`,
+    "--file",
+    localPath,
+    "--remote",
+  ];
+  if (contentType) {
+    args.push("--content-type", contentType);
+  }
+  const result = spawnSync(wranglerBin(), args, {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
   if (result.status !== 0) {
     console.error(result.stdout);
     console.error(result.stderr);
     throw new Error(`wrangler r2 object put failed for ${key}`);
   }
+}
+
+function wranglerBin() {
+  return path.join(
+    repoRoot,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "wrangler.cmd" : "wrangler",
+  );
 }


### PR DESCRIPTION
## Summary
- make R2 publishing delta-based by comparing local artifact hashes against the remote `latest/r2-manifest.json`
- always refresh the small R2 control files so Worker fallback and operator summaries stay current
- document the default delta path, force-upload mode, and history/backfill behavior

## What changed
- Added remote manifest lookup before R2 writes.
- Skips unchanged artifacts unless `METAGRAPH_R2_UPLOAD_FORCE=1` is set.
- Keeps `latest/r2-manifest.json` and `latest/build-summary.json` refreshed on every publish.
- Emits structured JSON upload summaries for CI and operator logs.
- Documents `METAGRAPH_R2_UPLOAD_FORCE` and clarified history upload behavior.

## Why
The R2 artifact tree is already large enough that full uploads are slow and noisy. Publishing should move only changed registry artifacts by default while preserving an explicit full-backfill path for recovery or history jobs.

## Validation
- `npm run check`
- `npm run test:coverage`
- `npm run validate:types`
- `npm run validate:artifact-budgets`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:workflows`
- `npm run cloudflare:verify:dry-run`
- `npm run scan:public-safety`
- `git diff --check`
- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_LIMIT=5 npm run r2:upload`
- `METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload`

R2 smoke result: remote manifest found, unchanged artifacts skipped, and only the two control files uploaded.

## Notes
- Normal publish does not write versioned history unless `METAGRAPH_R2_UPLOAD_HISTORY=1` is set.
- Full backfills remain explicit through `METAGRAPH_R2_UPLOAD_FORCE=1`.
