### PR TITLE
fix(r2): skip control manifests during limited uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ npm run probes:smoke
 
 `probes:smoke` performs read-only checks against public surfaces. It does not submit transactions, mutate subnet state, send wallet data, or use credentials.
 
-`r2:manifest` generates the Cloudflare R2 upload manifest for the current artifact tree. `r2:upload` is delta-based by default, using `latest/r2-manifest.json` to skip unchanged artifacts while always refreshing R2 control files. `r2:upload`, `r2:download`, and `kv:publish` require explicit write flags so local validation cannot accidentally publish or restore.
+`r2:manifest` generates the Cloudflare R2 upload manifest for the current artifact tree. `r2:upload` is delta-based by default, using `latest/r2-manifest.json` to skip unchanged artifacts while refreshing R2 control files on full uploads. Smoke uploads with `METAGRAPH_R2_UPLOAD_LIMIT` upload only the limited artifact subset and intentionally skip control files so `latest/r2-manifest.json` never advertises artifacts that were not uploaded. `r2:upload`, `r2:download`, and `kv:publish` require explicit write flags so local validation cannot accidentally publish or restore.
 
 ## Community Submissions
 

--- a/docs/cloudflare-backend.md
+++ b/docs/cloudflare-backend.md
@@ -69,7 +69,7 @@ Write operations require explicit environment flags:
 - `METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload` uploads only artifacts whose SHA-256 differs from `latest/r2-manifest.json`, plus the current `latest/r2-manifest.json` and `latest/build-summary.json` control files.
 - `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_HISTORY=1 npm run r2:upload` also writes run-prefix copies for changed artifacts and control files.
 - `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_FORCE=1 npm run r2:upload` bypasses remote manifest comparison and republishes all planned artifacts.
-- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_LIMIT=5 npm run r2:upload` can be used for a remote permission smoke.
+- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_LIMIT=5 npm run r2:upload` can be used for a remote permission smoke. Limited smoke uploads skip `latest/r2-manifest.json` and `latest/build-summary.json` control files so the latest manifest cannot claim that unuploaded artifacts exist.
 - `METAGRAPH_ALLOW_R2_DOWNLOAD=1 npm run r2:download`
 - `METAGRAPH_ALLOW_KV_WRITE=1 METAGRAPH_KV_NAMESPACE_ID=... npm run kv:publish`
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -44,12 +44,12 @@ Actual writes require explicit environment gates:
 - `METAGRAPH_ALLOW_R2_UPLOAD=1`
 - `METAGRAPH_R2_UPLOAD_HISTORY=1` when the publish job should also write run-prefix history copies for changed artifacts and control files.
 - `METAGRAPH_R2_UPLOAD_FORCE=1` when a publish job should ignore the remote `latest/r2-manifest.json` comparison and republish every planned artifact.
-- `METAGRAPH_R2_UPLOAD_LIMIT` for smoke-only uploads against a small artifact subset.
+- `METAGRAPH_R2_UPLOAD_LIMIT` for smoke-only uploads against a small artifact subset. Limited smoke uploads skip control files so `latest/r2-manifest.json` continues to describe only a complete latest artifact set.
 - `METAGRAPH_ALLOW_KV_WRITE=1`
 - `METAGRAPH_KV_NAMESPACE_ID`
 - Cloudflare account/API credentials
 
-Normal R2 publishes are delta-based. The uploader reads `latest/r2-manifest.json`, compares artifact SHA-256 values, skips unchanged artifact files, and always refreshes `latest/r2-manifest.json` plus `latest/build-summary.json` so Worker fallback and operator summaries stay current.
+Normal R2 publishes are delta-based. The uploader reads `latest/r2-manifest.json`, compares artifact SHA-256 values, skips unchanged artifact files, and refreshes `latest/r2-manifest.json` plus `latest/build-summary.json` on full uploads so Worker fallback and operator summaries stay current.
 
 ## Restore From R2
 

--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -15,10 +15,13 @@ const plannedArtifacts = uploadLimit
   ? manifest.artifacts.slice(0, uploadLimit)
   : manifest.artifacts;
 const controlArtifacts = buildControlArtifacts(manifest);
+const plannedControlArtifacts = uploadLimit ? [] : controlArtifacts;
 const plannedObjectCount =
   plannedArtifacts.length +
-  controlArtifacts.length +
-  (uploadHistory ? plannedArtifacts.length + controlArtifacts.length : 0);
+  plannedControlArtifacts.length +
+  (uploadHistory
+    ? plannedArtifacts.length + plannedControlArtifacts.length
+    : 0);
 
 if (!write) {
   console.log(
@@ -26,7 +29,9 @@ if (!write) {
       mode: "dry-run",
       artifact_count: manifest.artifact_count,
       bucket_name: manifest.bucket_name,
-      control_artifact_count: controlArtifacts.length,
+      control_artifact_count: plannedControlArtifacts.length,
+      skipped_control_artifact_count:
+        controlArtifacts.length - plannedControlArtifacts.length,
       force_upload: forceUpload,
       limited_artifact_count: plannedArtifacts.length,
       latest_prefix: manifest.latest_prefix,
@@ -96,7 +101,7 @@ for (const artifact of plannedArtifacts) {
   }
 }
 
-for (const controlArtifact of controlArtifacts) {
+for (const controlArtifact of plannedControlArtifacts) {
   putObject(
     controlArtifact.local_path,
     controlArtifact.latest_key,
@@ -121,7 +126,9 @@ console.log(
     artifact_count: manifest.artifact_count,
     bucket_name: manifest.bucket_name,
     changed_artifact_count: changedArtifactCount,
-    control_artifact_count: controlArtifacts.length,
+    control_artifact_count: plannedControlArtifacts.length,
+    skipped_control_artifact_count:
+      controlArtifacts.length - plannedControlArtifacts.length,
     force_upload: forceUpload,
     limited_artifact_count: plannedArtifacts.length,
     latest_prefix: manifest.latest_prefix,

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -344,6 +344,28 @@ test("public artifacts are internally consistent", () => {
   }
 });
 
+test("limited R2 upload dry run skips control manifests", () => {
+  const output = execFileSync(
+    process.execPath,
+    ["scripts/r2-upload.mjs", "--dry-run"],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        METAGRAPH_R2_UPLOAD_LIMIT: "5",
+      },
+      stdio: "pipe",
+    },
+  );
+  const summary = JSON.parse(output);
+
+  assert.equal(summary.limited_artifact_count, 5);
+  assert.equal(summary.control_artifact_count, 0);
+  assert.equal(summary.skipped_control_artifact_count, 2);
+  assert.equal(summary.planned_object_count, 5);
+});
+
 test("Worker API serves public artifact envelopes", async () => {
   const env = {
     ASSETS: {


### PR DESCRIPTION
### Motivation
- Prevent limited smoke uploads controlled by `METAGRAPH_R2_UPLOAD_LIMIT` from publishing full `latest/r2-manifest.json` and `latest/build-summary.json`, which can poison future delta uploads by making the remote manifest claim artifacts that were never uploaded.
- Make dry-run/write summaries reflect the true planned object set so operators can safely perform permission/connection checks without altering registry state.

### Description
- Introduce `plannedControlArtifacts` and make it an empty array when `METAGRAPH_R2_UPLOAD_LIMIT` is set so control files are omitted from limited uploads in `scripts/r2-upload.mjs`.
- Adjust `plannedObjectCount` and the dry-run/write JSON summaries to report `control_artifact_count` as the planned value and add `skipped_control_artifact_count` to indicate omitted control files.
- Only iterate over and upload `plannedControlArtifacts` so control manifests are not uploaded during limited smoke runs.
- Update operator docs in `README.md`, `docs/cloudflare-backend.md`, and `docs/operations.md` to document that limited smoke uploads intentionally skip control files, and add a regression test in `tests/artifacts.test.mjs` asserting the dry-run summary for a limited upload.

### Testing
- Ran the uploader dry-run commands `node scripts/r2-upload.mjs --dry-run` and `METAGRAPH_R2_UPLOAD_LIMIT=5 node scripts/r2-upload.mjs --dry-run` to verify limited runs report zero control artifacts and a reduced `planned_object_count`, which succeeded.
- Executed the targeted test `npx vitest run tests/artifacts.test.mjs` and it passed (new regression test covers limited dry-run behavior).
- Ran `npm run lint` and `npm run format:check` which both succeeded with no style errors.
- Ran the full test matrix with `npm test`, which completed but reported an unrelated failure in `tests/public-safety.test.mjs` (environment-specific DNS resolution) not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a253ac66328832ca2435d0bbd6c1b7e)