### PR TITLE
feat(artifacts): stage volatile registry output for R2

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Credentialed flows, wallet paths, validator-sensitive internals, private dashboa
 
 ## Artifact Contract
 
-Generated public artifacts live under `public/metagraph`:
+Generated public artifact routes live under `/metagraph/*`. Compact indexes and contracts are checked in under `public/metagraph`; high-churn detail, health, verification, schema, adapter, and per-subnet files are written to the ignored R2 staging tree under `dist/metagraph-r2/metagraph` and uploaded to R2. The Worker keeps the same public paths either way.
 
 - `/metagraph/contracts.json`
 - `/metagraph/providers.json`
@@ -118,7 +118,7 @@ Generated public artifacts live under `public/metagraph`:
 - `/metagraph/review/maintainer-decisions.json`
 - `/metagraph/build-summary.json`
 
-The generated files are deterministic and suitable for static hosting, CI review, and downstream consumption.
+The generated files are deterministic and suitable for static hosting, R2-backed serving, CI review, and downstream consumption. Artifact contracts include `storage_tier` so validators, OpenAPI generation, R2 upload, and Worker loading agree on where each artifact belongs.
 
 ## Contract Source Of Truth
 
@@ -224,7 +224,7 @@ npm run probes:smoke
 
 `probes:smoke` performs read-only checks against public surfaces. It does not submit transactions, mutate subnet state, send wallet data, or use credentials.
 
-`r2:manifest` generates the Cloudflare R2 upload manifest for the current artifact tree. `r2:upload` is delta-based by default, using `latest/r2-manifest.json` to skip unchanged artifacts while refreshing R2 control files on full uploads. Smoke uploads with `METAGRAPH_R2_UPLOAD_LIMIT` upload only the limited artifact subset and intentionally skip control files so `latest/r2-manifest.json` never advertises artifacts that were not uploaded. `r2:upload`, `r2:download`, and `kv:publish` require explicit write flags so local validation cannot accidentally publish or restore.
+`r2:manifest` generates the Cloudflare R2 upload manifest from compact Git artifacts plus the ignored R2 staging tree. `r2:upload` is delta-based by default, using `latest/r2-manifest.json` to skip unchanged artifacts while refreshing R2 control files on full uploads. Smoke uploads with `METAGRAPH_R2_UPLOAD_LIMIT` upload only the limited artifact subset and intentionally skip control files so `latest/r2-manifest.json` never advertises artifacts that were not uploaded. `r2:upload`, `r2:download`, and `kv:publish` require explicit write flags so local validation cannot accidentally publish or restore.
 
 ## Community Submissions
 
@@ -246,7 +246,8 @@ schemas/              public JSON schema contracts
 scripts/              validation, artifact generation, probe, and safety scripts
 generated/            generated TypeScript handoff types and client helpers
 workers/              Cloudflare Worker API routes over static artifacts
-public/metagraph/     generated public JSON artifacts
+public/metagraph/     compact generated JSON artifacts and public contracts
+dist/metagraph-r2/    ignored R2 staging tree for volatile/detail artifacts
 tests/                node test runner checks
 ```
 

--- a/docs/all-subnet-registry.md
+++ b/docs/all-subnet-registry.md
@@ -96,6 +96,8 @@ Generated artifacts expose review state through:
 
 ## Generated Artifacts
 
+`/metagraph/*` is the public path contract. Compact indexes are checked into `public/metagraph`; volatile detail artifacts are generated into the ignored R2 staging tree and served through the same public paths after upload.
+
 `public/metagraph/subnets.json` lists every active chain subnet.
 
 `public/metagraph/surfaces.json` lists only curated/verified public interface surfaces.
@@ -106,9 +108,9 @@ Generated artifacts expose review state through:
 
 `public/metagraph/endpoints.json` lists generalized endpoint resources derived from curated surfaces plus probe-derived health.
 
-`public/metagraph/endpoints/{netuid}.json` exposes endpoint resources for one subnet.
+`/metagraph/endpoints/{netuid}.json` exposes R2-backed endpoint resources for one subnet.
 
-`public/metagraph/providers/{slug}/endpoints.json` exposes endpoint resources for one provider/operator.
+`/metagraph/providers/{slug}/endpoints.json` exposes R2-backed endpoint resources for one provider/operator.
 
 `public/metagraph/endpoint-pools.json` scores monitored endpoint pools. In v1, only root/system RPC/WSS/archive-capable endpoints are candidates for future routing.
 
@@ -122,18 +124,18 @@ Generated artifacts expose review state through:
 
 `public/metagraph/gaps.json` lists missing docs/repo/site/dashboard/API/OpenAPI/SSE/data-artifact facets by subnet.
 
-`public/metagraph/verification/latest.json` exposes the latest candidate verification snapshot.
+`/metagraph/verification/latest.json` exposes the latest R2-backed candidate verification snapshot.
 
-`public/metagraph/subnets/{netuid}.json` exposes per-subnet static detail artifacts for app and API consumers.
+`/metagraph/subnets/{netuid}.json` exposes R2-backed per-subnet detail artifacts for app and API consumers.
 
-`public/metagraph/health/*` exposes surface health, per-subnet health, history, and badge-input data under `metagraph.sh`.
+`/metagraph/health/*` exposes surface health, per-subnet health, history, and badge-input data under `metagraph.sh`. Health status is probe-derived only; submissions can trigger review or re-probes, not set uptime.
 
-`public/metagraph/adapters/*` exposes safe subnet-specific public metrics for adapter-backed pilots.
+`/metagraph/adapters/*` exposes R2-backed safe subnet-specific public metrics for adapter-backed pilots.
 
 `public/metagraph/search.json` exposes a compact search index for subnets, surfaces, and providers.
 
 `public/metagraph/freshness.json`, `source-health.json`, `source-snapshots.json`, `changelog.json`, and `evidence-ledger.json` expose backend freshness, upstream source health, source-input hashes, generated change summaries, and public evidence records.
 
-`public/metagraph/r2-manifest.json` lists artifacts intended for versioned R2 history upload.
+`public/metagraph/r2-manifest.json` lists compact and R2-backed artifacts intended for latest/history upload.
 
 Worker API routes under `/api/v1/*` wrap these artifacts without replacing them as canonical truth. The Worker reads static assets first, can fall back to R2, and can use an optional KV latest pointer when configured.

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -12,7 +12,9 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `schemas/components/*.schema.json` is canonical for public API/artifact component schemas.
 - `schemas/api-components.schema.json` is a generated bundle and should not be edited by hand.
 - `/metagraph/openapi.json`, `/metagraph/types.d.ts`, `generated/metagraphed-api.d.ts`, and `generated/metagraphed-client.ts` are generated from the canonical schema and route metadata.
-- `public/metagraph/*` files are generated projections and should not be edited by hand.
+- `public/metagraph/*` files are compact generated projections and should not be edited by hand.
+- `dist/metagraph-r2/metagraph/*` is the ignored staging tree for volatile/detail generated projections that are uploaded to R2.
+- Artifact contracts carry `storage_tier`: `dual` for compact Git-plus-R2 artifacts, `r2` for volatile/detail artifacts, and `git` for local-only generated support artifacts.
 - Health, RPC, adapter, and schema-drift artifacts are operational observations, not protocol authority.
 - No secrets, wallet data, PATs, private dashboards, or validator-sensitive flows belong in any public artifact.
 - Zod is not backend contract authority in v1. Zod helpers can be generated later for frontend consumers, but JSON Schema plus AJV remains canonical.
@@ -21,43 +23,43 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 
 - `/metagraph/contracts.json`: current public artifact contract version and artifact map.
 - `/metagraph/providers.json`: provider/source registry.
-- `/metagraph/providers/{slug}.json`: per-provider detail payload.
-- `/metagraph/providers/{slug}/endpoints.json`: endpoint resources for one provider or operator.
+- `/metagraph/providers/{slug}.json`: per-provider detail payload. R2-backed.
+- `/metagraph/providers/{slug}/endpoints.json`: endpoint resources for one provider or operator. R2-backed.
 - `/metagraph/api-index.json`: Worker API route map and response-envelope contract.
 - `/metagraph/openapi.json`: OpenAPI 3.1 contract for backend API consumers.
 - `/metagraph/types.d.ts`: generated TypeScript definitions for consumers.
 - `/metagraph/changelog.json`: reviewable generated artifact and subnet-change summary.
 - `/metagraph/subnets.json`: compact all-subnet index.
-- `/metagraph/subnets/{netuid}.json`: per-subnet detail with native data, curated surfaces, candidates, curation, and gaps.
+- `/metagraph/subnets/{netuid}.json`: per-subnet detail with native data, curated surfaces, candidates, curation, and gaps. R2-backed.
 - `/metagraph/surfaces.json`: curated public surfaces only.
-- `/metagraph/surfaces/{netuid}.json`: curated public surfaces for one subnet.
+- `/metagraph/surfaces/{netuid}.json`: curated public surfaces for one subnet. R2-backed.
 - `/metagraph/endpoints.json`: generalized endpoint/resource registry derived from curated surfaces and probe observations.
-- `/metagraph/endpoints/{netuid}.json`: generalized endpoint/resource registry for one subnet.
+- `/metagraph/endpoints/{netuid}.json`: generalized endpoint/resource registry for one subnet. R2-backed.
 - `/metagraph/candidates.json`: unpromoted candidate surfaces from public discovery.
-- `/metagraph/candidates/{netuid}.json`: unpromoted candidate surfaces for one subnet.
+- `/metagraph/candidates/{netuid}.json`: unpromoted candidate surfaces for one subnet. R2-backed.
 - `/metagraph/review-queue.json`: candidate surfaces queued for maintainer review.
 - `/metagraph/search.json`: compact search index for subnets, surfaces, and providers.
 - `/metagraph/coverage.json`: count parity and coverage levels.
 - `/metagraph/curation.json`: curation state for every active subnet.
 - `/metagraph/gaps.json`: missing public interface facets by subnet.
-- `/metagraph/verification/latest.json`: latest candidate verification results.
-- `/metagraph/verification/subnets/{netuid}.json`: latest candidate verification results for one subnet.
+- `/metagraph/verification/latest.json`: latest candidate verification results. R2-backed.
+- `/metagraph/verification/subnets/{netuid}.json`: latest candidate verification results for one subnet. R2-backed.
 - `/metagraph/freshness.json`: freshness and staleness metadata for generated backend data.
 - `/metagraph/source-health.json`: source/provider health summary.
-- `/metagraph/source-snapshots.json`: compact hashes and counts for canonical source inputs.
+- `/metagraph/source-snapshots.json`: compact hashes and counts for canonical source inputs. R2-backed.
 - `/metagraph/evidence-ledger.json`: public evidence ledger for material registry claims.
-- `/metagraph/health/latest.json`: latest live or build-time surface health snapshot.
+- `/metagraph/health/latest.json`: latest live or build-time surface health snapshot. R2-backed.
 - `/metagraph/health/summary.json`: global and per-subnet health rollup.
-- `/metagraph/health/history/{date}.json`: compact daily health-history snapshot.
-- `/metagraph/health/subnets/{netuid}.json`: per-subnet health detail.
-- `/metagraph/health/badges/{netuid}.json`: badge data for future metagraph.sh renderers.
+- `/metagraph/health/history/{date}.json`: compact daily health-history snapshot. R2-backed.
+- `/metagraph/health/subnets/{netuid}.json`: per-subnet health detail. R2-backed.
+- `/metagraph/health/badges/{netuid}.json`: badge data for future metagraph.sh renderers. R2-backed.
 - `/metagraph/rpc-endpoints.json`: Bittensor base-layer RPC/WSS endpoint registry and probe status.
 - `/metagraph/rpc/pools.json`: endpoint pool scoring for future read-only routing.
 - `/metagraph/endpoint-pools.json`: generalized endpoint pool scoring for future read-only routing.
 - `/metagraph/endpoint-incidents.json`: probe-derived endpoint incident summary and active endpoint failures.
 - `/metagraph/schema-drift.json`: OpenAPI snapshot/drift status.
 - `/metagraph/schemas/index.json`: captured machine-readable schema index.
-- `/metagraph/adapters/{slug}.json`: adapter-backed public metrics snapshot.
+- `/metagraph/adapters/{slug}.json`: adapter-backed public metrics snapshot. R2-backed.
 - `/metagraph/r2-manifest.json`: Cloudflare R2 upload manifest for artifact history.
 - `/metagraph/review/curation.json`: maintainer review and adapter candidate report.
 - `/metagraph/review/gap-priorities.json`: prioritized backend curation gaps.

--- a/docs/cloudflare-backend.md
+++ b/docs/cloudflare-backend.md
@@ -1,12 +1,12 @@
 # Cloudflare Backend
 
-Metagraphed uses Cloudflare as the serving, cache, and artifact-history layer. GitHub-reviewed registry inputs and generated JSON remain canonical.
+Metagraphed uses Cloudflare as the serving, cache, and artifact-history layer. GitHub-reviewed registry inputs, compact generated indexes, and compact release manifests remain canonical; volatile generated detail is staged locally and published to R2.
 
 ## Runtime Shape
 
-- Workers serve `metagraph.sh/api/v1/*` routes over canonical `/metagraph/*` artifacts.
-- Workers Static Assets serve the checked-in `public/metagraph` artifact tree.
-- R2 stores current artifact copies under `latest/`; versioned artifact history under `runs/{generated_at}/` is opt-in for publish jobs that set `METAGRAPH_R2_UPLOAD_HISTORY=1`.
+- Workers serve `metagraph.sh/api/v1/*` routes over canonical `/metagraph/*` artifact paths.
+- Workers Static Assets serve compact checked-in artifacts from `public/metagraph`.
+- R2 stores high-churn/detail artifacts staged under `dist/metagraph-r2/metagraph`, plus current artifact copies under `latest/`; versioned artifact history under `runs/{generated_at}/` is opt-in for publish jobs that set `METAGRAPH_R2_UPLOAD_HISTORY=1`.
 - KV stores small latest pointers, feature flags, endpoint-pool summaries, and source-freshness summaries when configured.
 - D1 is not used for canonical registry truth in v1.
 - The read-only RPC proxy/load-balancer prototype exists behind `METAGRAPH_ENABLE_RPC_PROXY=false`; write and unsafe RPC methods remain blocked by default.
@@ -52,13 +52,13 @@ Worker responses include CORS, cache-control, ETags, and `x-metagraph-contract-v
 - Optional KV binding: `METAGRAPH_CONTROL`
 - KV keys: `metagraph:latest`, `metagraph:feature-flags`, `metagraph:endpoint-pools`, `metagraph:source-freshness`
 
-If no KV binding is configured, the Worker falls back to `METAGRAPH_R2_LATEST_PREFIX` for R2 reads.
+If no KV binding is configured, the Worker falls back to `METAGRAPH_R2_LATEST_PREFIX` for R2 reads. R2-tier artifacts are read from R2 first; static fallback is only allowed when `METAGRAPH_ALLOW_R2_STATIC_FALLBACK=true` is set for local migration/testing.
 
 ## Local Commands
 
 - `npm run validate:api`: validate Worker API routes against local artifacts.
 - `npm run worker:deploy:dry-run`: validate `wrangler.jsonc` and Worker entrypoint shape.
-- `npm run r2:manifest`: regenerate the R2 upload manifest from `public/metagraph`.
+- `npm run r2:manifest`: regenerate the R2 upload manifest from compact `public/metagraph` artifacts plus the ignored R2 staging tree.
 - `npm run r2:manifest:dry-run`: validate and summarize the current manifest.
 - `npm run r2:upload:dry-run`: summarize the upload without writing to Cloudflare.
 - `npm run r2:download:dry-run`: summarize a restore/download without writing local files.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,7 +2,7 @@
 
 ## Source Of Truth
 
-GitHub-reviewed registry source and generated JSON artifacts are canonical for v1. Cloudflare serves and stores artifacts; it does not become the registry truth source.
+GitHub-reviewed registry source, compact generated indexes, and compact release manifests are canonical for v1. High-churn generated detail is staged under `dist/metagraph-r2/metagraph` and published to R2; Cloudflare serves and stores artifacts, but it does not become the registry truth source.
 
 ## Routine Validation
 
@@ -21,6 +21,8 @@ npm run pipeline:refresh
 ```
 
 This updates native subnet data, candidates, verification, baseline curation, adapter snapshots, generated artifacts, schema snapshots, R2 manifest, and validation outputs.
+
+The refresh keeps Git reviewable: compact artifacts remain in `public/metagraph`, while per-subnet candidates, verification details, health detail/history, adapter snapshots, schema snapshots, and provider detail outputs are staged for R2 and should not be committed.
 
 Live health probes are only written when explicitly enabled:
 
@@ -49,7 +51,7 @@ Actual writes require explicit environment gates:
 - `METAGRAPH_KV_NAMESPACE_ID`
 - Cloudflare account/API credentials
 
-Normal R2 publishes are delta-based. The uploader reads `latest/r2-manifest.json`, compares artifact SHA-256 values, skips unchanged artifact files, and refreshes `latest/r2-manifest.json` plus `latest/build-summary.json` on full uploads so Worker fallback and operator summaries stay current.
+Normal R2 publishes are delta-based. The uploader reads `latest/r2-manifest.json`, compares artifact SHA-256 values, reads R2-tier files from the staging tree, skips unchanged artifact files, and refreshes `latest/r2-manifest.json` plus `latest/build-summary.json` on full uploads so Worker fallback and operator summaries stay current.
 
 ## Restore From R2
 

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -633,6 +633,8 @@ export interface components {
             id: string;
             path: string;
             schema_ref: string | null;
+            /** @enum {unknown} */
+            storage_tier: "dual" | "git" | "r2";
         };
         ArtifactDiffEntry: string | {
             hash?: string;
@@ -1218,6 +1220,8 @@ export interface components {
             path: string;
             sha256: string;
             size_bytes: number;
+            /** @enum {unknown} */
+            storage_tier: "dual" | "git" | "r2";
         };
         ResponseEnvelopeContract: {
             /** @constant */

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -4,271 +4,316 @@
       "contract_version": "2026-06-06.1",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
-      "schema_ref": "#/components/schemas/ContractsArtifact"
+      "schema_ref": "#/components/schemas/ContractsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "providers",
       "path": "/metagraph/providers.json",
-      "schema_ref": "#/components/schemas/ProvidersArtifact"
+      "schema_ref": "#/components/schemas/ProvidersArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
-      "schema_ref": "#/components/schemas/ProviderArtifact"
+      "schema_ref": "#/components/schemas/ProviderArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
-      "schema_ref": "#/components/schemas/ProviderEndpointsArtifact"
+      "schema_ref": "#/components/schemas/ProviderEndpointsArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
-      "schema_ref": "#/components/schemas/ApiIndexArtifact"
+      "schema_ref": "#/components/schemas/ApiIndexArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
-      "schema_ref": "#/components/schemas/OpenApiArtifact"
+      "schema_ref": "#/components/schemas/OpenApiArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
-      "schema_ref": null
+      "schema_ref": null,
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
-      "schema_ref": "#/components/schemas/ChangelogArtifact"
+      "schema_ref": "#/components/schemas/ChangelogArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
-      "schema_ref": "#/components/schemas/SubnetsArtifact"
+      "schema_ref": "#/components/schemas/SubnetsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetDetailArtifact"
+      "schema_ref": "#/components/schemas/SubnetDetailArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
-      "schema_ref": "#/components/schemas/SurfacesArtifact"
+      "schema_ref": "#/components/schemas/SurfacesArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetSurfacesArtifact"
+      "schema_ref": "#/components/schemas/SubnetSurfacesArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
-      "schema_ref": "#/components/schemas/EndpointsArtifact"
+      "schema_ref": "#/components/schemas/EndpointsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetEndpointsArtifact"
+      "schema_ref": "#/components/schemas/SubnetEndpointsArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
-      "schema_ref": "#/components/schemas/CandidatesArtifact"
+      "schema_ref": "#/components/schemas/CandidatesArtifact",
+      "storage_tier": "git"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetCandidatesArtifact"
+      "schema_ref": "#/components/schemas/SubnetCandidatesArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
-      "schema_ref": "#/components/schemas/ReviewQueueArtifact"
+      "schema_ref": "#/components/schemas/ReviewQueueArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "search",
       "path": "/metagraph/search.json",
-      "schema_ref": "#/components/schemas/SearchArtifact"
+      "schema_ref": "#/components/schemas/SearchArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
-      "schema_ref": "#/components/schemas/CoverageArtifact"
+      "schema_ref": "#/components/schemas/CoverageArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "curation",
       "path": "/metagraph/curation.json",
-      "schema_ref": "#/components/schemas/CurationArtifact"
+      "schema_ref": "#/components/schemas/CurationArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
-      "schema_ref": "#/components/schemas/GapsArtifact"
+      "schema_ref": "#/components/schemas/GapsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
-      "schema_ref": "#/components/schemas/VerificationArtifact"
+      "schema_ref": "#/components/schemas/VerificationArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetVerificationArtifact"
+      "schema_ref": "#/components/schemas/SubnetVerificationArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
-      "schema_ref": "#/components/schemas/FreshnessArtifact"
+      "schema_ref": "#/components/schemas/FreshnessArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
-      "schema_ref": "#/components/schemas/SourceHealthArtifact"
+      "schema_ref": "#/components/schemas/SourceHealthArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
-      "schema_ref": "#/components/schemas/SourceSnapshotsArtifact"
+      "schema_ref": "#/components/schemas/SourceSnapshotsArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
-      "schema_ref": "#/components/schemas/EvidenceLedgerArtifact"
+      "schema_ref": "#/components/schemas/EvidenceLedgerArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
-      "schema_ref": "#/components/schemas/HealthLatestArtifact"
+      "schema_ref": "#/components/schemas/HealthLatestArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
-      "schema_ref": "#/components/schemas/HealthSummaryArtifact"
+      "schema_ref": "#/components/schemas/HealthSummaryArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
-      "schema_ref": "#/components/schemas/HealthHistoryArtifact"
+      "schema_ref": "#/components/schemas/HealthHistoryArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
-      "schema_ref": "#/components/schemas/HealthSubnetArtifact"
+      "schema_ref": "#/components/schemas/HealthSubnetArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
-      "schema_ref": "#/components/schemas/HealthBadgeArtifact"
+      "schema_ref": "#/components/schemas/HealthBadgeArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
-      "schema_ref": "#/components/schemas/RpcEndpointsArtifact"
+      "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
-      "schema_ref": "#/components/schemas/RpcPoolsArtifact"
+      "schema_ref": "#/components/schemas/RpcPoolsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
-      "schema_ref": "#/components/schemas/EndpointPoolsArtifact"
+      "schema_ref": "#/components/schemas/EndpointPoolsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
-      "schema_ref": "#/components/schemas/EndpointIncidentsArtifact"
+      "schema_ref": "#/components/schemas/EndpointIncidentsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
-      "schema_ref": "#/components/schemas/SchemaDriftArtifact"
+      "schema_ref": "#/components/schemas/SchemaDriftArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
-      "schema_ref": "#/components/schemas/SchemaIndexArtifact"
+      "schema_ref": "#/components/schemas/SchemaIndexArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
-      "schema_ref": "#/components/schemas/AdapterArtifact"
+      "schema_ref": "#/components/schemas/AdapterArtifact",
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
-      "schema_ref": "#/components/schemas/R2ManifestArtifact"
+      "schema_ref": "#/components/schemas/R2ManifestArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
-      "schema_ref": "#/components/schemas/ReviewCurationArtifact"
+      "schema_ref": "#/components/schemas/ReviewCurationArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
-      "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact"
+      "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
-      "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact"
+      "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
-      "schema_ref": "#/components/schemas/ReviewDecisionsArtifact"
+      "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
+      "storage_tier": "dual"
     },
     {
       "contract_version": "2026-06-06.1",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
-      "schema_ref": "#/components/schemas/BuildSummaryArtifact"
+      "schema_ref": "#/components/schemas/BuildSummaryArtifact",
+      "storage_tier": "dual"
     }
   ],
   "base_path": "/api/v1",

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -2,1262 +2,1512 @@
   "adapter_count": 2,
   "artifact_budget_summary": {
     "fail_count": 0,
-    "ok_count": 974,
+    "ok_count": 965,
     "warn_count": 0
   },
   "artifact_budgets": [],
-  "artifact_count": 974,
-  "artifact_size_bytes": 29870955,
+  "artifact_count": 965,
+  "artifact_size_bytes": 29261018,
   "artifacts": [
     {
       "path": "adapters/allways.json",
       "sha256": "fbc29b60a44c5e68fb876a3c240173e43bfc76be29edac44676e00cfb8666503",
-      "size_bytes": 8275
+      "size_bytes": 8275,
+      "storage_tier": "r2"
     },
     {
       "path": "adapters/gittensor.json",
       "sha256": "80d3d747129a603b7a8cb6a75babe2f633f3a5d9f807b70056badd2cb6276c36",
-      "size_bytes": 11552
+      "size_bytes": 11552,
+      "storage_tier": "r2"
     },
     {
       "path": "api-index.json",
-      "sha256": "e68f80af05042fd3d48379ed56d87bc88fd42392821dec2f98e25c2393007dfe",
-      "size_bytes": 57593
+      "sha256": "e4061fa8c3f111f1e5aa8c17652b92c72e7b21b11cb566c3f5c687cd234f2036",
+      "size_bytes": 58914,
+      "storage_tier": "dual"
     },
     {
       "path": "candidates.json",
       "sha256": "5d81e7c3fafede9d998cbb6b5e93e49db6f7a5f07692a26f448a43eaf7a6c220",
-      "size_bytes": 3433657
+      "size_bytes": 3433657,
+      "storage_tier": "git"
     },
     {
       "path": "candidates/0.json",
       "sha256": "2abbc5809a19be7d12f4a8571e64aabff92b35ea82ad47f592daf0b88ebeb226",
-      "size_bytes": 4541
+      "size_bytes": 4541,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/1.json",
       "sha256": "31cacd7416c1a3a68a101ff6fbed0b0e11c5111a816dbaaeaf0e5f0f996d251c",
-      "size_bytes": 53362
+      "size_bytes": 53362,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/10.json",
       "sha256": "eb28b0947c92e63c04a3c2aa1d9b9c2f41f438d8ed87086f3b5e640ed9d789f5",
-      "size_bytes": 20882
+      "size_bytes": 20882,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/100.json",
       "sha256": "cd2f9bb7cd4bdceb16d47c1c4bb4ea8c069a47c9c5a0de8dafbdd696449b09f5",
-      "size_bytes": 34343
+      "size_bytes": 34343,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/101.json",
       "sha256": "da745222ac34520582390bcd9d8871644f955299757a4efb2113963ecd70843f",
-      "size_bytes": 4577
+      "size_bytes": 4577,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/102.json",
       "sha256": "51a105b2fe80643a7e85fbeb88d0fc4aba6d0e40c3c7003e47e4438becb34836",
-      "size_bytes": 33205
+      "size_bytes": 33205,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/103.json",
       "sha256": "9afd4aacc1d63c2c79d2c6cab3938b907243002fd638fd9580fc2678e1868c07",
-      "size_bytes": 40930
+      "size_bytes": 40930,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/104.json",
       "sha256": "8b307c16febeeb69f459bd7195b46c918b142d037b35acfbc1925b6b33b1c312",
-      "size_bytes": 4717
+      "size_bytes": 4717,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/105.json",
       "sha256": "14718a01b29f8de7f1f669f56840bf8824ccbe7943f3db1aafcee665ef1a35ef",
-      "size_bytes": 20652
+      "size_bytes": 20652,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/106.json",
       "sha256": "5b6dcddc9955cb4bb5e42462ad8a1aae8cb077df2a1fe9e984906036ebe39215",
-      "size_bytes": 20759
+      "size_bytes": 20759,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/107.json",
       "sha256": "fb49da3535540ec680383c28470d55dbbc669aa03826fc7d4fb5689811df4262",
-      "size_bytes": 42174
+      "size_bytes": 42174,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/108.json",
       "sha256": "ce4eb5dcaa19ad2d6905d8e49c2405f5bd151bbea6b6618c13e0de76f747e944",
-      "size_bytes": 33281
+      "size_bytes": 33281,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/109.json",
       "sha256": "60cfeda6cd6ace48102ce8ab275dadbd83ec43247a827b52ec323f900422a369",
-      "size_bytes": 6786
+      "size_bytes": 6786,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/11.json",
       "sha256": "b408716af70c1e9bded689cbd38b33f23643012487b2a5718fe32dafe3fbb0b1",
-      "size_bytes": 28918
+      "size_bytes": 28918,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/110.json",
       "sha256": "0656674dc6ca4efca4c4580d445a32c250c3ce7d3a69b5fdc1a0bac56c752930",
-      "size_bytes": 43312
+      "size_bytes": 43312,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/111.json",
       "sha256": "045337d13e8bf261bb78eda53d66454fedc69c446a81e3d9c915f94baebe6fa6",
-      "size_bytes": 15690
+      "size_bytes": 15690,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/112.json",
       "sha256": "767d01cdb38737cd93d68346c84773b4a522d0af23006b1143098d5c28f5cd41",
-      "size_bytes": 27209
+      "size_bytes": 27209,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/113.json",
       "sha256": "8bae7faeb26b0be6c10d37b7ba8b5631900ab9975bedfbb414f7973587f2eb70",
-      "size_bytes": 35424
+      "size_bytes": 35424,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/114.json",
       "sha256": "5ea263a826a94a9a7f6d70ae3138cd2181f68438fc294f060e4e8bb0d1d470ee",
-      "size_bytes": 36953
+      "size_bytes": 36953,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/115.json",
       "sha256": "e778d1d329460262a3de73bb0bebccb427f162d8a027111686e029d8e2eb51ca",
-      "size_bytes": 6803
+      "size_bytes": 6803,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/116.json",
       "sha256": "574fde4acd03c5dc835b3d0a1cb8c96862ef1c0f0087bc724ecf90ee1f27fbdc",
-      "size_bytes": 6947
+      "size_bytes": 6947,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/117.json",
       "sha256": "498fab52845e06cd99b8dec75a0ed812b9b8e1688111515e789d5e6e9a375c78",
-      "size_bytes": 9187
+      "size_bytes": 9187,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/118.json",
       "sha256": "7be98df4b819f140a612aac1b830d412049c1428b4d7590ad65c635e3b4e1137",
-      "size_bytes": 47827
+      "size_bytes": 47827,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/119.json",
       "sha256": "117a9561e9ed424603bedd1aa1735f36514085cef203baf2e7a2e82ba6dd8fac",
-      "size_bytes": 6757
+      "size_bytes": 6757,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/12.json",
       "sha256": "74eef8074118f3e168e473748b3e1865de32fcac55e8668bb9de35b1fba17d72",
-      "size_bytes": 11570
+      "size_bytes": 11570,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/120.json",
       "sha256": "2e7951cc278db4a237e77c6859ef7807dfe217645df6a159181a993202b47c44",
-      "size_bytes": 23127
+      "size_bytes": 23127,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/121.json",
       "sha256": "84c581f14195a3178ec380a4ae90833a8aec27d9179e5f9439204b1a9316b7c0",
-      "size_bytes": 41629
+      "size_bytes": 41629,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/122.json",
       "sha256": "9985ac27d511f0cd3d586d6b76dede87d8ab0fed14155ef8c311c59e4fe57849",
-      "size_bytes": 9305
+      "size_bytes": 9305,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/123.json",
       "sha256": "e934b312d78f2a691bbe6ca7c8357e5977387afe23f72b862204ead7c72a4080",
-      "size_bytes": 6763
+      "size_bytes": 6763,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/124.json",
       "sha256": "c59e519d3ed69bf162463660c5441bea98d6c1bce9cde8354429dfae288162c6",
-      "size_bytes": 23344
+      "size_bytes": 23344,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/125.json",
       "sha256": "215770a8c68a1c48ecb76368bd62526d74de422213834d66ea8bf571de4f62ef",
-      "size_bytes": 4598
+      "size_bytes": 4598,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/126.json",
       "sha256": "4d4fb34eb40e77bb66ef3f89b511da903dc501e78f61266a19194ef4763e376e",
-      "size_bytes": 28863
+      "size_bytes": 28863,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/127.json",
       "sha256": "b417d20718a6e0d11a30a876674d04cd3bf051daaba23225b49b090fce49c9c6",
-      "size_bytes": 29549
+      "size_bytes": 29549,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/128.json",
       "sha256": "2dc38640505bdda60a3466aeac7c4433d5b2823bac49aa324fb27ff13d945940",
-      "size_bytes": 23171
+      "size_bytes": 23171,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/13.json",
       "sha256": "dcf5f3ed57d76dcad00c406caa92d3a6e8a452a54812332758d390e681aaf1ad",
-      "size_bytes": 57230
+      "size_bytes": 57230,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/14.json",
       "sha256": "f90a0f420168bd788bde0e1e2aff54e3f0595550669f34dad272547d82111420",
-      "size_bytes": 57350
+      "size_bytes": 57350,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/15.json",
       "sha256": "4821f184abe8642f92b1aecf4ce1e57b1c600d05fbe8c90f385b712ca9f8794d",
-      "size_bytes": 49713
+      "size_bytes": 49713,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/16.json",
       "sha256": "9a83606b75b62139721f70d9e91433cc563a8af48a8a83905f99a235357cec34",
-      "size_bytes": 20604
+      "size_bytes": 20604,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/17.json",
       "sha256": "2f1944ecffe2216f5d3bfc3d727c611495b6da67df6abddf5872205785f9e816",
-      "size_bytes": 33536
+      "size_bytes": 33536,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/18.json",
       "sha256": "e2984acf7d07dc121ab595a74bd589d85d29f2db14cdf6c32ff6edeeda617b35",
-      "size_bytes": 31167
+      "size_bytes": 31167,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/19.json",
       "sha256": "ca9fd7e868fa16f048ecb30e26a4c72a9ce3f1f0ee0b78e51147ef7cf58acb0c",
-      "size_bytes": 41661
+      "size_bytes": 41661,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/2.json",
       "sha256": "8b410044af4ffd4601edad2fa3ecf90b29f710675d35f5303fca069f47c01b6c",
-      "size_bytes": 32561
+      "size_bytes": 32561,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/20.json",
       "sha256": "272fd57f5e59ef1710f976c840da162cfd426882167db3718f4001d9c111250f",
-      "size_bytes": 25447
+      "size_bytes": 25447,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/21.json",
       "sha256": "b1d736c8296fbc9a392919928297d4492e0db6bef8dd43188fe9e0933e76b31f",
-      "size_bytes": 29087
+      "size_bytes": 29087,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/22.json",
       "sha256": "48f0a9a18cef69b766c9dbe3e8065a747f0a72fecca8bcb1e18f3b4980f95416",
-      "size_bytes": 21094
+      "size_bytes": 21094,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/23.json",
       "sha256": "8d671dcf14eb9cae642125f6536ba21a85b4f331af2b9ed7a28b44c10fc002a3",
-      "size_bytes": 35986
+      "size_bytes": 35986,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/24.json",
       "sha256": "a2ed3408ef36ed954c544bbcc0ef6c640384e941bc659d4e667ead158ccb2dc0",
-      "size_bytes": 31280
+      "size_bytes": 31280,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/25.json",
       "sha256": "8bd033d8085e26188f57f029487fbb6e5bb648dc90eec2730a0d7c7486004b14",
-      "size_bytes": 42459
+      "size_bytes": 42459,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/26.json",
       "sha256": "19a8dccb72baee74f8fb817314e39987c5277fc31728d5c6a1c8295614c03393",
-      "size_bytes": 31514
+      "size_bytes": 31514,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/27.json",
       "sha256": "5049597f443de3329099efb4522a64ab6acb0cd6c8331338e514e251eb3a10a3",
-      "size_bytes": 20458
+      "size_bytes": 20458,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/28.json",
       "sha256": "1268a48865419c69c15cef80324033278d08e5339e658a286c2387963855cbb4",
-      "size_bytes": 4548
+      "size_bytes": 4548,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/29.json",
       "sha256": "11a124ae1bd37d1fa5bfa61e495fc4b206373e4e79ebaa37fa8e795840eaeaea",
-      "size_bytes": 18064
+      "size_bytes": 18064,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/3.json",
       "sha256": "f8258544f3a05df240ecb71d41bff4cf731cdabbb1462de9f38e99a38c34ae65",
-      "size_bytes": 6936
+      "size_bytes": 6936,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/30.json",
       "sha256": "b4dbfb174ac3c56a0a7414d7749f0e6a393bd2e6005b7e28f8b05b244b070119",
-      "size_bytes": 22990
+      "size_bytes": 22990,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/31.json",
       "sha256": "6625d051bf57f4f2499d383e4c4a2e0e1b5bfc92348ef3245dbb0205c71cadc4",
-      "size_bytes": 4576
+      "size_bytes": 4576,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/32.json",
       "sha256": "b1915ea56fc7ae5e8823a0a339fc83f92347b67cd2fce2f0ed3840ef8d663470",
-      "size_bytes": 45136
+      "size_bytes": 45136,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/33.json",
       "sha256": "dda5c718bed4482ac7854afe3e8bc546067c81ab0259d01ed6e472aa4c962b4b",
-      "size_bytes": 28361
+      "size_bytes": 28361,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/34.json",
       "sha256": "d1e1394a2c1fa8256560b84f00101743cbe76a651a82d123f31d7d1bc86ba68f",
-      "size_bytes": 11267
+      "size_bytes": 11267,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/35.json",
       "sha256": "b3cc14bcc89a7b644c4d275ef97144515b9fb4fb619e632748aa03c8c496a29d",
-      "size_bytes": 25733
+      "size_bytes": 25733,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/36.json",
       "sha256": "c38b192b8597cc70c4f3d5cab21737aefbce1a3de81fc88ce6d3d5024894e4fe",
-      "size_bytes": 26541
+      "size_bytes": 26541,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/37.json",
       "sha256": "f2828dad97a384303119edbc26b54de4fb9c5d59226c61cbe6c584032a808e37",
-      "size_bytes": 45382
+      "size_bytes": 45382,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/38.json",
       "sha256": "06c6075e27016b6d5d1b9f451ce78ae8e793acec5c4c9ba3e6ffc16673b945d0",
-      "size_bytes": 21145
+      "size_bytes": 21145,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/39.json",
       "sha256": "fff237f61b0691b35bab64fbc36935ba0fbeea4d569ea2d8278cbfbca3c35825",
-      "size_bytes": 9148
+      "size_bytes": 9148,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/4.json",
       "sha256": "3531648cbe059dbbab63e20e95fdd03c4e8e6872bb7ca4b3980c9c341ab12441",
-      "size_bytes": 45150
+      "size_bytes": 45150,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/40.json",
       "sha256": "3a941d2ddec9557bebd20e0af5ada2e8e1c031f0b75c19e9383361e747ddb2fd",
-      "size_bytes": 6777
+      "size_bytes": 6777,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/41.json",
       "sha256": "8eed4708a396058007c72a01e9c22ef70e04f0b42accbbb01d232dad5b5f13ad",
-      "size_bytes": 27180
+      "size_bytes": 27180,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/42.json",
       "sha256": "e94de14842a4bb423dbf621dd6c2a98fdd5e819a54202c28bd312137f726ce27",
-      "size_bytes": 4593
+      "size_bytes": 4593,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/43.json",
       "sha256": "63a7dab739db38e11c0109024e72e7482563c18ab4fa0a0eba73c119b1d98a21",
-      "size_bytes": 9059
+      "size_bytes": 9059,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/44.json",
       "sha256": "7d577f27c37bccc86854e9156b3508d19daa8018a8a04505d7cb80b867099987",
-      "size_bytes": 25429
+      "size_bytes": 25429,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/45.json",
       "sha256": "414420440ed071a88febbc1013a47245d92d7af61db542012d428f49567c9175",
-      "size_bytes": 41502
+      "size_bytes": 41502,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/46.json",
       "sha256": "6b32cbb619d7a0c75b913f0da2f62bd17e695416fb730ac3030cc411132146a9",
-      "size_bytes": 58130
+      "size_bytes": 58130,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/47.json",
       "sha256": "e6bffddb71daed13740e822e594ceff50cccbb53ba5f317632dee485f4f40f83",
-      "size_bytes": 13535
+      "size_bytes": 13535,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/48.json",
       "sha256": "a6e0c9ea2e60e0eda5739cc1fc19b5fc497ae2df1b2d69381f10e2fd9020677e",
-      "size_bytes": 42820
+      "size_bytes": 42820,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/49.json",
       "sha256": "7cb710887e32f402db642185d71250aad8c6678172255502620514e3a2ef6990",
-      "size_bytes": 25236
+      "size_bytes": 25236,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/5.json",
       "sha256": "f33edc11b115e64600e024a0c9d97f5dd07420b205e39ee7b7d97b9e2dea2fd6",
-      "size_bytes": 35704
+      "size_bytes": 35704,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/50.json",
       "sha256": "e136d6fd36a06baa8d69b955cbc41365cf13cf15d45da7b97ad2a1a37f3afb3a",
-      "size_bytes": 23035
+      "size_bytes": 23035,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/51.json",
       "sha256": "1e1be9fcb33e3b99ebd75ee43c7273dda33184b898c9c3e18ca11c0864230f68",
-      "size_bytes": 42442
+      "size_bytes": 42442,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/52.json",
       "sha256": "f250303d9189c536664b56530e99e6e44e377ecd2977abaec3b2d08413525e75",
-      "size_bytes": 27256
+      "size_bytes": 27256,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/53.json",
       "sha256": "d3c6427f6be160159c4078a0935feaf932cfd139ba296c3658cf3c80ded51b87",
-      "size_bytes": 6927
+      "size_bytes": 6927,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/54.json",
       "sha256": "42c99d45c9ec79009b84962def2953aa87a4d1f7872368a2e90eafc358550825",
-      "size_bytes": 27216
+      "size_bytes": 27216,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/55.json",
       "sha256": "7f780703d7fbc33a5fee70ab2d742c8f7e603af38f4705f09d8be1aaa13f2a64",
-      "size_bytes": 29058
+      "size_bytes": 29058,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/56.json",
       "sha256": "104887df82ab439638d32976f6949e2c730881c6587132e69c9e009d8f0a1b6f",
-      "size_bytes": 43844
+      "size_bytes": 43844,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/57.json",
       "sha256": "f55d7d3767566e0499fb5589956a977ec3ea8e987214fd9b8b166bfd05e71576",
-      "size_bytes": 6882
+      "size_bytes": 6882,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/58.json",
       "sha256": "e65cfe96f814188a86585f53b8aaf3f3080d7d629ec8076235f34f5279d06ebc",
-      "size_bytes": 15690
+      "size_bytes": 15690,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/59.json",
       "sha256": "c45ae4a90b16408ffc8cc52d48b800ee2d5c5fee815ac4e429a2c291b3c97973",
-      "size_bytes": 30992
+      "size_bytes": 30992,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/6.json",
       "sha256": "d8fa8a3d979b7bfb7cd8fe8bf5951dce2300328de2ac1846e790a078c0083903",
-      "size_bytes": 35897
+      "size_bytes": 35897,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/60.json",
       "sha256": "98e2530e43fefb141ccf80b1cc8fe99d56445b447b8ef382106680ebf0bd3587",
-      "size_bytes": 33855
+      "size_bytes": 33855,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/61.json",
       "sha256": "112296b0a3c0cb620eda9d616577444c34217e11ae525be03d80e94c880692a3",
-      "size_bytes": 25331
+      "size_bytes": 25331,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/62.json",
       "sha256": "b25eec2351630247f75efe06db53ab5a8bd389c8053e77c8b04b9f90621acbab",
-      "size_bytes": 20868
+      "size_bytes": 20868,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/63.json",
       "sha256": "5a89ebdd0e25b8649b8913b3dd63a184fd2696fc99706008f724c6ea7b693cc4",
-      "size_bytes": 44418
+      "size_bytes": 44418,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/64.json",
       "sha256": "cfaf326118d5bb43ea8c64eb4b144991fb575084cef7c301ed8cdf9d60577de7",
-      "size_bytes": 55875
+      "size_bytes": 55875,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/65.json",
       "sha256": "3be521ae840d0082d5ef2573a8098b980f7bb1dca5904b29fea1d37881b8953e",
-      "size_bytes": 36048
+      "size_bytes": 36048,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/66.json",
       "sha256": "ca8aae234af71f0f8e9402722b50e7ae3a8a21cf2649589da23dfd194c3e3845",
-      "size_bytes": 31114
+      "size_bytes": 31114,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/67.json",
       "sha256": "d580e157968fe54426ae4118dfa721a63939e646826407784fa12153c03f1e77",
-      "size_bytes": 26812
+      "size_bytes": 26812,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/68.json",
       "sha256": "35e03ddef018c0d46e5aa724d2ac7d8c9a2a5d3376b103f2571c9532ee1959a6",
-      "size_bytes": 31211
+      "size_bytes": 31211,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/69.json",
       "sha256": "0f870dadbd682513acdb944b8c2610e26ec55cd7ab0386d213f19c4d137f9336",
-      "size_bytes": 4555
+      "size_bytes": 4555,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/7.json",
       "sha256": "a3733ed2ec7023d5ede62d38d664f2a63e588a86f7513022d780879b2c8e6fc3",
-      "size_bytes": 23015
+      "size_bytes": 23015,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/70.json",
       "sha256": "240cc63d812f48ee192691f9ad7ed347fedc31591179bd2d5a4abafb7ce2d319",
-      "size_bytes": 31257
+      "size_bytes": 31257,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/71.json",
       "sha256": "6690e1356f13352d6e01a37eb1a145d278abb2fe685f694ca3495e31ac9b0703",
-      "size_bytes": 23018
+      "size_bytes": 23018,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/72.json",
       "sha256": "67e610007702bb6c326463886b0b157a9be1aa3b1ad6211df3c7ac075d7d03bd",
-      "size_bytes": 48624
+      "size_bytes": 48624,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/73.json",
       "sha256": "ece1190ecba48a33ace07b4287d2f11fcba6c38ddc4568f71d232258999f4694",
-      "size_bytes": 6902
+      "size_bytes": 6902,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/74.json",
       "sha256": "332996079e6384423c24f95526705ea4a0af9c02031a5b855f27949f6d8c9268",
-      "size_bytes": 31713
+      "size_bytes": 31713,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/75.json",
       "sha256": "0ba6f9d21d5e42228a087fc5489a53023b3c8f5666fae78b413a37f8e1d446f0",
-      "size_bytes": 45490
+      "size_bytes": 45490,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/76.json",
       "sha256": "944e4abb9ac6100a4c0bba477e5f6db2ad2960e29f7ea9d3f1e56f02d965787c",
-      "size_bytes": 4597
+      "size_bytes": 4597,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/77.json",
       "sha256": "5a999352f07816d1588a2a3e3cfaef03d9150042dd2c208e9287d351d92f273e",
-      "size_bytes": 25186
+      "size_bytes": 25186,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/78.json",
       "sha256": "4af635ee35927086a6758c0f8275adf030b60789e4baf3ab3ad7425ca0b2e676",
-      "size_bytes": 25525
+      "size_bytes": 25525,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/79.json",
       "sha256": "29133a8690300212f903d03f53f39695d923e0d330f4c946db924645f9248e16",
-      "size_bytes": 45000
+      "size_bytes": 45000,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/8.json",
       "sha256": "6567e7876e717d0e54f1f5e26a962d125b5aa5e8f4892915486ac23de34d81fe",
-      "size_bytes": 33807
+      "size_bytes": 33807,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/80.json",
       "sha256": "50a3a61226b6073584ed2eb704444b7c4149763c76e26f528c2af547f8d104c9",
-      "size_bytes": 42533
+      "size_bytes": 42533,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/81.json",
       "sha256": "1e0ef96661e57e3c8fdf087abc8677423212d7be3d76306c68a7041cffbe29ac",
-      "size_bytes": 9136
+      "size_bytes": 9136,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/82.json",
       "sha256": "4ee1f44c4370628fa20e34d608c9b8ca94b410dc3b29d28140020634d5d71228",
-      "size_bytes": 47752
+      "size_bytes": 47752,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/83.json",
       "sha256": "c496a076c7879ee920611c02def173514385d10b39cdf1132e9fcaea3afada50",
-      "size_bytes": 21104
+      "size_bytes": 21104,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/84.json",
       "sha256": "d1bb8e3750c383fee6f51de54df71d8960ce80d295563765f98c9269344fa8f9",
-      "size_bytes": 15000
+      "size_bytes": 15000,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/85.json",
       "sha256": "cb3ff1a4497e7ed5f33372e0b459af17ee1700c00996364a7075702e4d406213",
-      "size_bytes": 37190
+      "size_bytes": 37190,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/86.json",
       "sha256": "e9284dad91956424c20f175fb314f5d71af3223849c9b30dc3ec7e022c845219",
-      "size_bytes": 4555
+      "size_bytes": 4555,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/87.json",
       "sha256": "32f406474f6323f724076e7c30d6c3914355b70c5c79fbdcf12721b2fa710666",
-      "size_bytes": 4623
+      "size_bytes": 4623,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/88.json",
       "sha256": "18e73617386fa842d5dc967b82963c6f3380ab5438b5ccd868f906bb28c79fb8",
-      "size_bytes": 37772
+      "size_bytes": 37772,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/89.json",
       "sha256": "49c225a5bec3ae280286e5565203519d75cca963761f9d3397bfcda8af2562b5",
-      "size_bytes": 28069
+      "size_bytes": 28069,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/9.json",
       "sha256": "2e40143e66e05884ac6d917018641b017461d12d55f31be9cffb9469e9954188",
-      "size_bytes": 48574
+      "size_bytes": 48574,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/90.json",
       "sha256": "700c754a957f134232fc2905caa7fb8aa3d37b889e91b067f5c3c4a651da0f16",
-      "size_bytes": 4569
+      "size_bytes": 4569,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/91.json",
       "sha256": "1d0b5453b001e5bb2cf72aabc8bfadac501d8720fe938bdd87fc0ed651e7cecf",
-      "size_bytes": 29464
+      "size_bytes": 29464,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/92.json",
       "sha256": "e51d58455c84b52753820869d613ec63934685acdd9b5f9dac014faefdc50556",
-      "size_bytes": 18887
+      "size_bytes": 18887,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/93.json",
       "sha256": "effdae7d25ad516806b0271c3ceae825ae9a929131153425b905625f6e3c31a7",
-      "size_bytes": 35944
+      "size_bytes": 35944,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/94.json",
       "sha256": "6cddd9c2f7120d9590b52bfa8945dd83ae091bb28523a2d4f95d817b433b2c73",
-      "size_bytes": 26731
+      "size_bytes": 26731,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/95.json",
       "sha256": "8dd0ab5e93037c5ac5dcbe9481f7fbb62946a7704440790f7af842f75a2454bc",
-      "size_bytes": 8794
+      "size_bytes": 8794,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/96.json",
       "sha256": "6491c641ed26045fccf5139ef06e88222bb03378a34a44ea61cf07aa15054e2f",
-      "size_bytes": 27600
+      "size_bytes": 27600,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/97.json",
       "sha256": "c7f06edb1f22fdd317d5ff6be960e713ea65b29b1517dea24d9f32c00ea2a8e4",
-      "size_bytes": 39330
+      "size_bytes": 39330,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/98.json",
       "sha256": "aa33077833f5b96b39800c650b5ab49c09884cd9910cc3ced665f59d7f94d242",
-      "size_bytes": 37768
+      "size_bytes": 37768,
+      "storage_tier": "r2"
     },
     {
       "path": "candidates/99.json",
       "sha256": "33a50dcd524a79d9e378a46f8b744a7e1bae5709aeb99a59319c020e93c5b35e",
-      "size_bytes": 35720
+      "size_bytes": 35720,
+      "storage_tier": "r2"
     },
     {
       "path": "changelog.json",
-      "sha256": "444aa1078bf9e3fd54f899df9c336eebdb15b99c3d56c594f3434fcf7805f5cc",
-      "size_bytes": 1209
+      "sha256": "9f943ac61e51f7d58aa680182107a4322bbbac4a60e969cad3a9b32e582b5975",
+      "size_bytes": 36046,
+      "storage_tier": "dual"
     },
     {
       "path": "contracts.json",
-      "sha256": "534dde0d7d88bc13cb1407d49a1e928cdb9702d28a9f66ce052f70444a6f9dff",
-      "size_bytes": 14650
+      "sha256": "1bcbbd5e15001b525d021024668b106f3693e3a3532b0e5235728699d5be744e",
+      "size_bytes": 15971,
+      "storage_tier": "dual"
     },
     {
       "path": "coverage.json",
       "sha256": "f1afda027d7a6aab9721c2056269b69a2168c99558813188f3a34de4daa773ff",
-      "size_bytes": 982
+      "size_bytes": 982,
+      "storage_tier": "dual"
     },
     {
       "path": "curation.json",
       "sha256": "034eb2f3c88286478bcedffcd3406bccc1b564238fa05682a3adf9f9ac272c75",
-      "size_bytes": 147849
+      "size_bytes": 147849,
+      "storage_tier": "dual"
     },
     {
       "path": "endpoint-incidents.json",
       "sha256": "dfb414fa01911fe9697d45f365c9a82d2d7209b689231dcdfcf6dc179378cdb0",
-      "size_bytes": 659
+      "size_bytes": 659,
+      "storage_tier": "dual"
     },
     {
       "path": "endpoint-pools.json",
       "sha256": "7dac9d34860831eebf6fb11160e866a690460b9b7d0541c713248683ac498904",
-      "size_bytes": 7131
+      "size_bytes": 7131,
+      "storage_tier": "dual"
     },
     {
       "path": "endpoints.json",
       "sha256": "83d225d3d96472c124707d8e198e4aff4f97dbffe775e491c5493e6a5a0e315a",
-      "size_bytes": 1113597
+      "size_bytes": 1113597,
+      "storage_tier": "dual"
     },
     {
       "path": "endpoints/0.json",
       "sha256": "54843c7b258f884c66a9362cddc323778ca732ad4dfcedb3a486111c0ba67c8f",
-      "size_bytes": 17508
+      "size_bytes": 17508,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/1.json",
       "sha256": "46e509bfb052c8a308863121360db459517c51aba216f6c663b192da4bed3794",
-      "size_bytes": 11000
+      "size_bytes": 11000,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/10.json",
       "sha256": "cc44807741a528015ff25879b8ca8cb7d0b3f7b81d654d87c83c5fcae97f40fe",
-      "size_bytes": 6442
+      "size_bytes": 6442,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/100.json",
       "sha256": "a1127c69c8ae8cc05a919cd7db075c5cf5f1091b2c803d8ee385ea06362b6705",
-      "size_bytes": 10953
+      "size_bytes": 10953,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/101.json",
       "sha256": "26d5be80a5706d2e9e5da35dcb0da286b5dfce290c8150ec299feb3ab1dbc48b",
-      "size_bytes": 3499
+      "size_bytes": 3499,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/102.json",
       "sha256": "97850a8352fabfcb5b58ee67302eca0f8532d92b7c5b0d48407b17c7db1b5bc1",
-      "size_bytes": 10785
+      "size_bytes": 10785,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/103.json",
       "sha256": "088163d97a2fbe571d1757782429e46263df64b38e4d875507a4a2fb11a3e338",
-      "size_bytes": 10778
+      "size_bytes": 10778,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/104.json",
       "sha256": "a708dbc46482a6a3b3c10933f4fc1592d4a1ed344f5377c80277a1e5f30e376c",
-      "size_bytes": 3559
+      "size_bytes": 3559,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/105.json",
       "sha256": "77822f1dc5c379296cc6ac02b765968d52ed42c8a6838df867de683abecca2a1",
-      "size_bytes": 9287
+      "size_bytes": 9287,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/106.json",
       "sha256": "9b5a54950131bb92fa7e336a82750c6080fd34777edd5814e260c3339700ca03",
-      "size_bytes": 7867
+      "size_bytes": 7867,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/107.json",
       "sha256": "34b7df39b5ec1656dd23d96c2e5dca5c0218a16606aeb309c02549558b635d7a",
-      "size_bytes": 16930
+      "size_bytes": 16930,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/108.json",
       "sha256": "5f62b93c458fac12af6b0ad1faa4d647e5a32ef5a15faf3afe87fbd342ea6834",
-      "size_bytes": 6487
+      "size_bytes": 6487,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/109.json",
       "sha256": "7d23547cf65d54c5cf670b5772888d7fe31f9b2773d3aea2f48e4e1e6691a333",
-      "size_bytes": 5013
+      "size_bytes": 5013,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/11.json",
       "sha256": "7d5fa85016ff963085c34c4c90f0d8195b285ad292c0c66187348261b49dd08e",
-      "size_bytes": 9340
+      "size_bytes": 9340,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/110.json",
       "sha256": "5daade2bf923ba0bb875c7b0b6d2346217805ecd463812780b5bd5701dc31cf6",
-      "size_bytes": 11236
+      "size_bytes": 11236,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/111.json",
       "sha256": "69505e14628aef91441a91688d03c3194f31d7d5c1c23a6dc200f5a9da278aec",
-      "size_bytes": 5020
+      "size_bytes": 5020,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/112.json",
       "sha256": "97c1ed79fdcac44e76eb2193da3a722bbdd6b5007e31d6fd8771993a7ca20495",
-      "size_bytes": 8025
+      "size_bytes": 8025,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/113.json",
       "sha256": "e8dd5ea7a3c05c56040700fec6ef035fa83a95a4b91282ec18fc4430dd2dc737",
-      "size_bytes": 10918
+      "size_bytes": 10918,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/114.json",
       "sha256": "5d7888583dc358ef32c64c820b64991aae95f5acd4d8a9b3646422462faebcfa",
-      "size_bytes": 10926
+      "size_bytes": 10926,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/115.json",
       "sha256": "ab67194afe07bc223a7e021dec3f4c27900562799d320bd241aa10e8b746aded",
-      "size_bytes": 5020
+      "size_bytes": 5020,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/116.json",
       "sha256": "1913beea94e98640b9a2b9cb6cdec2f7c53ec33a20c014f4798e7d7d70dce8eb",
-      "size_bytes": 3517
+      "size_bytes": 3517,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/117.json",
       "sha256": "319dc14b2532c64f973209ffbfe0eb1c5485e4f5067ac67380710ea5e050279d",
-      "size_bytes": 6550
+      "size_bytes": 6550,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/118.json",
       "sha256": "03a63af75f2f165c4a3588c826b54e0d1de1df9d2d9314c4de859f5d483c3812",
-      "size_bytes": 12436
+      "size_bytes": 12436,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/119.json",
       "sha256": "2a4cd0bd8f6b87522a4b1417b56e7969be2b24df96e5c6b041ed6b5343a65f22",
-      "size_bytes": 3508
+      "size_bytes": 3508,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/12.json",
       "sha256": "0a93fe740c050c9ce7972b4a8b09656a7b689b1f4ca61ad5e29fdf95bc68ee34",
-      "size_bytes": 6591
+      "size_bytes": 6591,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/120.json",
       "sha256": "fa2c262fe95a12d39402e652e2238011218cbcc77f42d8930d3145ed68079f06",
-      "size_bytes": 7985
+      "size_bytes": 7985,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/121.json",
       "sha256": "c2c6de0aafb35cb6879b856c5c335f60d3e8f6445c2f8fd1541427e1f6716f02",
-      "size_bytes": 6499
+      "size_bytes": 6499,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/122.json",
       "sha256": "ab3cbfac03d7ea1dad20996f98cc800dd514ca01fef472d85cdede1ddf53fbd5",
-      "size_bytes": 5074
+      "size_bytes": 5074,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/123.json",
       "sha256": "35f7932d46b58a764c4a8e35733a0dfb628e50d4d466c94120a82158c4ab3af2",
-      "size_bytes": 5004
+      "size_bytes": 5004,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/124.json",
       "sha256": "7a22aa00cfba72ab242a611a7473f8e22db097a49854eb62e2757ed2886b40f9",
-      "size_bytes": 10837
+      "size_bytes": 10837,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/125.json",
       "sha256": "ca640fff98f8d14d54d70b366ed341d4f7e50adb88adac7c087d7705c863e3d2",
-      "size_bytes": 3508
+      "size_bytes": 3508,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/126.json",
       "sha256": "5da22ac45c32e5c6f0a17cc81d4ae3325f6ab36f55949da933de50ba32feeef0",
-      "size_bytes": 7927
+      "size_bytes": 7927,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/127.json",
       "sha256": "07f14f6c3a3c0eaf9dcd30dad820c5d98c301aa42e509caf48a4b2372c7fadee",
-      "size_bytes": 8029
+      "size_bytes": 8029,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/128.json",
       "sha256": "5e0399a2e14bcad5f87472bf370a799454e1127d7482a86ad5c2fcbe3b89853c",
-      "size_bytes": 10866
+      "size_bytes": 10866,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/13.json",
       "sha256": "5d5450fe262cbeaf283694243fda9491e4927deefa2f3b2b436a858fadfe4665",
-      "size_bytes": 11352
+      "size_bytes": 11352,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/14.json",
       "sha256": "ef495f3ee2bae6b4bd472edba320689838c23f3a2b3de85270dcb533035dbeb0",
-      "size_bytes": 15391
+      "size_bytes": 15391,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/15.json",
       "sha256": "00b0e8245360acbc657507f8ba07526581bfae8cd00c06289291056ab71379de",
-      "size_bytes": 13747
+      "size_bytes": 13747,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/16.json",
       "sha256": "24e6fdfbd161b0218156372658fb1105edc41fb67ed6f9f0cc6a5e5b3df3a198",
-      "size_bytes": 9276
+      "size_bytes": 9276,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/17.json",
       "sha256": "827e89d000c70b4b94c2687476244a8ff206d5cce5c4f02047ddf52fa4f7e48d",
-      "size_bytes": 9540
+      "size_bytes": 9540,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/18.json",
       "sha256": "aef8e1744815c523dc14b69c93c1c6258d354191368213c42d61c34043a3bfd1",
-      "size_bytes": 9380
+      "size_bytes": 9380,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/19.json",
       "sha256": "ca26d47823b0b47d2383f6c1a98eed1d28cd6d90b6f4f62c20945419f3aa4963",
-      "size_bytes": 10867
+      "size_bytes": 10867,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/2.json",
       "sha256": "04cc583749d49f26ef1015dce4e3d7e88cf225f1ab6f160bab607b9595efd95f",
-      "size_bytes": 15577
+      "size_bytes": 15577,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/20.json",
       "sha256": "e53655c423df87f82e0afeaadbd30abaa0e2dfaa2a395a4887b82c2df181077d",
-      "size_bytes": 4975
+      "size_bytes": 4975,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/21.json",
       "sha256": "fd49e26e8526b1abb2edb24d1a6beb03ab876ce41214ba07b05f19ae7d2c416d",
-      "size_bytes": 6434
+      "size_bytes": 6434,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/22.json",
       "sha256": "0ea7508edf89ca9cf9758a44c836b79cf35b98b1cafdfbca330e37b694369da6",
-      "size_bytes": 10727
+      "size_bytes": 10727,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/23.json",
       "sha256": "d9bad47057d572638ccb04404dd3109bbb9a43cb71ff87fc6045b7da5528befa",
-      "size_bytes": 17018
+      "size_bytes": 17018,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/24.json",
       "sha256": "bd535d35a64e1a1e63b25db7318c357aff3c344c98857318109a9ee89b904800",
-      "size_bytes": 11086
+      "size_bytes": 11086,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/25.json",
       "sha256": "175c4803c299252aa042c464d0bd283dd52383343ec5c58b49b1d065b904ee49",
-      "size_bytes": 10908
+      "size_bytes": 10908,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/26.json",
       "sha256": "f83f91ff38013089be0b7a978388714f09ba7089e0d351736e41f40d23cceebe",
-      "size_bytes": 9430
+      "size_bytes": 9430,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/27.json",
       "sha256": "e6c57d3b54a31b3ac2cd1a7eec51952977573ec55ff5279d8f7810e23ee1399c",
-      "size_bytes": 3494
+      "size_bytes": 3494,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/28.json",
       "sha256": "23015625018bb1e9c48e082b714d43a4561650d74d770fcaae9a2d4896613ecd",
-      "size_bytes": 3482
+      "size_bytes": 3482,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/29.json",
       "sha256": "96fcaf012c9d648f1f8c3baef40d556a47ea3179e54c585d058577aa4daa8422",
-      "size_bytes": 9660
+      "size_bytes": 9660,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/3.json",
       "sha256": "189afa8602c2bfef8831c79abc65af42634703d25ef16bdfccf37f3b4dc5c52a",
-      "size_bytes": 5025
+      "size_bytes": 5025,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/30.json",
       "sha256": "af3271cb9e83c66e14857e4f3fd1a91f8592028ec91517b307f0431525bb71da",
-      "size_bytes": 6438
+      "size_bytes": 6438,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/31.json",
       "sha256": "b73c04778d102c47c57b2f81b9bbb32778f55d5fabd0d0ab428299947e0ef907",
-      "size_bytes": 3494
+      "size_bytes": 3494,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/32.json",
       "sha256": "bddb6f0057c7efab30c97f69e63da8c3f1104196caeb942081c2994782b89b8a",
-      "size_bytes": 7940
+      "size_bytes": 7940,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/33.json",
       "sha256": "3289b9e736b40a293efc3374bdc514831a24cf754339c314c2efe9f6ecd12152",
-      "size_bytes": 14881
+      "size_bytes": 14881,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/34.json",
       "sha256": "62a530b9dba1f40e7a54651dc62f0df028a02a3d63286496e9d115d3e4c38797",
-      "size_bytes": 6589
+      "size_bytes": 6589,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/35.json",
       "sha256": "47dbd37b73502ee846209b27820c9dc1c9d77449b12913cf1dc317da4ec3d447",
-      "size_bytes": 9585
+      "size_bytes": 9585,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/36.json",
       "sha256": "e1aae66c62e17c0aa45bda3006a7f891d6408e71c460c70e3b5c407c0353b2ab",
-      "size_bytes": 9275
+      "size_bytes": 9275,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/37.json",
       "sha256": "cfad4724bb1ae014657e2243ba0873cdcb79e3177ab8afecf48bb85c76c8fe08",
-      "size_bytes": 11136
+      "size_bytes": 11136,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/38.json",
       "sha256": "f84fd63596959102df8e7eb950c7dab963873350ad26949266c8c53b7ced792b",
-      "size_bytes": 9364
+      "size_bytes": 9364,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/39.json",
       "sha256": "604e627686b1dd5b46f7f7a6c75764f61117341151af778946fe292cb46ed4cd",
-      "size_bytes": 5045
+      "size_bytes": 5045,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/4.json",
       "sha256": "ff09009878cfb6cedb646ff0bc775da1a30eba8f720184209ae882d11af1c60e",
-      "size_bytes": 12326
+      "size_bytes": 12326,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/40.json",
       "sha256": "37b2f5caa1bb517ca08d8e706d8b1d3c510694c290fa8fc53b88c7622f624cb1",
-      "size_bytes": 3500
+      "size_bytes": 3500,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/41.json",
       "sha256": "dfe6c4c8424f1cad8566bc3d5c4f316280c66bc2be9399e984e0f42934a0d125",
-      "size_bytes": 12301
+      "size_bytes": 12301,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/42.json",
       "sha256": "4eb5cb04b6b91d1e8d54ad38c70c4d13115c4375dda0095e0f023ab0fab70841",
-      "size_bytes": 3503
+      "size_bytes": 3503,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/43.json",
       "sha256": "0714ea9c3330664f6b0a1ba2a10e65438f9d682e9fd17547ab771f213128e724",
-      "size_bytes": 5000
+      "size_bytes": 5000,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/44.json",
       "sha256": "1baff931c192ce0c84cc1d2e112375d3ba9da605de192e625dff8ae0c3c1408f",
-      "size_bytes": 7980
+      "size_bytes": 7980,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/45.json",
       "sha256": "e6cce45531792d64f1701856afe77edd1ef1073e1081fd22d73dab848bb9f2bb",
-      "size_bytes": 10905
+      "size_bytes": 10905,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/46.json",
       "sha256": "b04e1cf6907819263fde882b1cd70949e33179a9dda234dbdcd822c26ed7fa8d",
-      "size_bytes": 16843
+      "size_bytes": 16843,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/47.json",
       "sha256": "615377a32a4884cde2f92c6480d9efd5257bbcd5057838321ab03cc384137373",
-      "size_bytes": 9639
+      "size_bytes": 9639,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/48.json",
       "sha256": "1586787b808a9a76c7ee3c40a83fa206a605b590f7f1d02237854f3ff7a8a1f1",
-      "size_bytes": 6510
+      "size_bytes": 6510,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/49.json",
       "sha256": "c558b75439f46290223281787ebc58745de5049e0fa3f50ac012f4aaf284b119",
-      "size_bytes": 6532
+      "size_bytes": 6532,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/5.json",
       "sha256": "bec76c7746bd774c7c628323d61788072a81504559e3d6bc93e26b846637a4b2",
-      "size_bytes": 10982
+      "size_bytes": 10982,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/50.json",
       "sha256": "af8821583940f0e5f70e89361d5444dab7489086a8f713e4629c798cb2e7fb1e",
-      "size_bytes": 9287
+      "size_bytes": 9287,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/51.json",
       "sha256": "b5a5179fa2b79b9773bd95db0800c27416400f9cf40a4fabdfa19db0c5f19e24",
-      "size_bytes": 10783
+      "size_bytes": 10783,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/52.json",
       "sha256": "6121264d8e4272079ea9b29903e7adc0e9b41ef89956aff9c4d666a606cacd25",
-      "size_bytes": 12653
+      "size_bytes": 12653,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/53.json",
       "sha256": "cb64fcdba090bd1228b30d8659c2a2a9f0a50e716fbee6cab86e8677a8394e46",
-      "size_bytes": 3527
+      "size_bytes": 3527,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/54.json",
       "sha256": "2838c6d303819e2cddf9d37df25fb9d684de28e639e0dd3f8194b2ab6d586a8b",
-      "size_bytes": 8012
+      "size_bytes": 8012,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/55.json",
       "sha256": "cdd388b027d2237b4101f461eb679bbea6f18988122ae0f4d410cf203d58f481",
-      "size_bytes": 6445
+      "size_bytes": 6445,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/56.json",
       "sha256": "adf3270671a5bed2024cd40054902b70031a82ecd885d9bdb7d5cd847be0dd9d",
-      "size_bytes": 12383
+      "size_bytes": 12383,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/57.json",
       "sha256": "16319e2fbe641c9858cf202a6e1ae87fd1e74cc9a540d5d07158f937a20ec77f",
-      "size_bytes": 5026
+      "size_bytes": 5026,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/58.json",
       "sha256": "1e04ac3aeedf8c42513f3412d88a546537c55b8028b39f9296bd2f8bf17f9d14",
-      "size_bytes": 11204
+      "size_bytes": 11204,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/59.json",
       "sha256": "7a8ba94c56391416e3ef23f6826b2e8ea20eede156e62e5b2fd01de3a7e4cfce",
-      "size_bytes": 9452
+      "size_bytes": 9452,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/6.json",
       "sha256": "1ade41f2adcb8b9b0bce4efa0e530f79bda0738409b6521a7ff1c1d62ac2fb21",
-      "size_bytes": 11072
+      "size_bytes": 11072,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/60.json",
       "sha256": "c325e0513c520bd1d78773b3739203a51d8982b672a9f7175b62bdd2f30b2c8a",
-      "size_bytes": 15381
+      "size_bytes": 15381,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/61.json",
       "sha256": "456f2b259bc46e270e52aab8f0d7ce7d486f2c9e3570be97708345cbf6812ff7",
-      "size_bytes": 9466
+      "size_bytes": 9466,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/62.json",
       "sha256": "6f70075413451361821672887faf0f2e0fd718fc9349aa60b0e28a635cc41319",
-      "size_bytes": 4981
+      "size_bytes": 4981,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/63.json",
       "sha256": "6fff1d92ebc3a3dba62d5ce225e3f0aaf88bd898cfcde81a063b89e4edf1bbe9",
-      "size_bytes": 7970
+      "size_bytes": 7970,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/64.json",
       "sha256": "54f757f795c49f5e641b7155fbf326d476e518a5539e512ff81848969a1ac444",
-      "size_bytes": 16897
+      "size_bytes": 16897,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/65.json",
       "sha256": "252eccb6c8a4bd1c2b97b52aaf887b3d91dd31efa9a8239301910f6899179c94",
-      "size_bytes": 13854
+      "size_bytes": 13854,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/66.json",
       "sha256": "b3aaef3fd25bcc6548fda6ca439b5c7dd10a147272a22c7557ba669a58bb8bc7",
-      "size_bytes": 13704
+      "size_bytes": 13704,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/67.json",
       "sha256": "5e25afa37e58c505dc19741942eb16f85bbd1fa1cfa900e18bb26744d4629613",
-      "size_bytes": 9436
+      "size_bytes": 9436,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/68.json",
       "sha256": "5aba5b8dc768131a2bd34b4340bdd0750e71c73b8dffba345ca3e2ec927fa5f2",
-      "size_bytes": 10940
+      "size_bytes": 10940,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/69.json",
       "sha256": "2e5a555d88e043225e3cab1ca23d0a931937cf0c5fcfa9b53b19a43d4822a7d5",
-      "size_bytes": 3485
+      "size_bytes": 3485,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/7.json",
       "sha256": "50141a8161e943bc30eeb4b8d99d3f0aa59ea1f7fb4c56d02bb5bf621bac2ff7",
-      "size_bytes": 19977
+      "size_bytes": 19977,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/70.json",
       "sha256": "f61946e865a279cc1bdef35993564ea7b1a9d83f549fc2dda64910579fdbd99d",
-      "size_bytes": 9382
+      "size_bytes": 9382,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/71.json",
       "sha256": "9e556cbf3478e05d7416190e6ccc530e45d0f4c6876f491baeb653adba6aab63",
-      "size_bytes": 9300
+      "size_bytes": 9300,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/72.json",
       "sha256": "c6079af58e845595d9f00bc836f3e15321f30a6894756da200b2c038e8d0d055",
-      "size_bytes": 9693
+      "size_bytes": 9693,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/73.json",
       "sha256": "41507b0788a89b98fb1be4a7eccc9f3360564986dbc5b89c8bd5e6a68c656953",
-      "size_bytes": 3494
+      "size_bytes": 3494,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/74.json",
       "sha256": "ada7e24c97d62217da743fd40ad2e6178a5d073dcbc3254cf87d592e2b7f7775",
-      "size_bytes": 9997
+      "size_bytes": 9997,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/75.json",
       "sha256": "8b9645536dd413d179c16b96cba4d957d1440ba14f913c4ea7d09a5e4af9e5d2",
-      "size_bytes": 10935
+      "size_bytes": 10935,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/76.json",
       "sha256": "85249b7c1a3c002f1bd8a1d72829943b8dc2eedab117f174baac3da92b38d45d",
-      "size_bytes": 3503
+      "size_bytes": 3503,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/77.json",
       "sha256": "af5e996d5a3d288f30e2d04f6720832cedf88d852a7f30eef8b8e2e127eff4e9",
-      "size_bytes": 9289
+      "size_bytes": 9289,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/78.json",
       "sha256": "b8fcb74b920ccf03adb9cbbdb7d81b656f375a9b0bffafd23c7af4fb8ca4e029",
-      "size_bytes": 12339
+      "size_bytes": 12339,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/79.json",
       "sha256": "a6682bfec2336680b520eb05d6591a3651baa4ffe3371dc3b84d23398e8c1c27",
-      "size_bytes": 7976
+      "size_bytes": 7976,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/8.json",
       "sha256": "cd031d0fd51dcb149514bd4600e2970b245e9efe37743444ebdee3e2ca568ab0",
-      "size_bytes": 12452
+      "size_bytes": 12452,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/80.json",
       "sha256": "a6fd2d669e47e440a90b6acecc9a698e39d97f46884c8d56805f4baf8983f826",
-      "size_bytes": 13915
+      "size_bytes": 13915,
+      "storage_tier": "r2"
     },
     {
       "path": "endpoints/81.json",
       "sha256": "627aa47dcce984b9e62f310e9e943abd400621b65a9c44bd22b9de9aa91d4306",
-      "size_bytes": 5042
+      "size_bytes": 5042,
+      "storage_tier": "r2"
     }
   ],
   "candidate_count": 1635,

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,7 +1,1021 @@
 {
   "artifacts": {
-    "added": [],
-    "modified": [],
+    "added": [
+      {
+        "hash": "fbc29b60a44c5e68fb876a3c240173e43bfc76be29edac44676e00cfb8666503",
+        "path": "adapters/allways.json"
+      },
+      {
+        "hash": "80d3d747129a603b7a8cb6a75babe2f633f3a5d9f807b70056badd2cb6276c36",
+        "path": "adapters/gittensor.json"
+      },
+      {
+        "hash": "2abbc5809a19be7d12f4a8571e64aabff92b35ea82ad47f592daf0b88ebeb226",
+        "path": "candidates/0.json"
+      },
+      {
+        "hash": "31cacd7416c1a3a68a101ff6fbed0b0e11c5111a816dbaaeaf0e5f0f996d251c",
+        "path": "candidates/1.json"
+      },
+      {
+        "hash": "eb28b0947c92e63c04a3c2aa1d9b9c2f41f438d8ed87086f3b5e640ed9d789f5",
+        "path": "candidates/10.json"
+      },
+      {
+        "hash": "cd2f9bb7cd4bdceb16d47c1c4bb4ea8c069a47c9c5a0de8dafbdd696449b09f5",
+        "path": "candidates/100.json"
+      },
+      {
+        "hash": "da745222ac34520582390bcd9d8871644f955299757a4efb2113963ecd70843f",
+        "path": "candidates/101.json"
+      },
+      {
+        "hash": "51a105b2fe80643a7e85fbeb88d0fc4aba6d0e40c3c7003e47e4438becb34836",
+        "path": "candidates/102.json"
+      },
+      {
+        "hash": "9afd4aacc1d63c2c79d2c6cab3938b907243002fd638fd9580fc2678e1868c07",
+        "path": "candidates/103.json"
+      },
+      {
+        "hash": "8b307c16febeeb69f459bd7195b46c918b142d037b35acfbc1925b6b33b1c312",
+        "path": "candidates/104.json"
+      },
+      {
+        "hash": "14718a01b29f8de7f1f669f56840bf8824ccbe7943f3db1aafcee665ef1a35ef",
+        "path": "candidates/105.json"
+      },
+      {
+        "hash": "5b6dcddc9955cb4bb5e42462ad8a1aae8cb077df2a1fe9e984906036ebe39215",
+        "path": "candidates/106.json"
+      },
+      {
+        "hash": "fb49da3535540ec680383c28470d55dbbc669aa03826fc7d4fb5689811df4262",
+        "path": "candidates/107.json"
+      },
+      {
+        "hash": "ce4eb5dcaa19ad2d6905d8e49c2405f5bd151bbea6b6618c13e0de76f747e944",
+        "path": "candidates/108.json"
+      },
+      {
+        "hash": "60cfeda6cd6ace48102ce8ab275dadbd83ec43247a827b52ec323f900422a369",
+        "path": "candidates/109.json"
+      },
+      {
+        "hash": "b408716af70c1e9bded689cbd38b33f23643012487b2a5718fe32dafe3fbb0b1",
+        "path": "candidates/11.json"
+      },
+      {
+        "hash": "0656674dc6ca4efca4c4580d445a32c250c3ce7d3a69b5fdc1a0bac56c752930",
+        "path": "candidates/110.json"
+      },
+      {
+        "hash": "045337d13e8bf261bb78eda53d66454fedc69c446a81e3d9c915f94baebe6fa6",
+        "path": "candidates/111.json"
+      },
+      {
+        "hash": "767d01cdb38737cd93d68346c84773b4a522d0af23006b1143098d5c28f5cd41",
+        "path": "candidates/112.json"
+      },
+      {
+        "hash": "8bae7faeb26b0be6c10d37b7ba8b5631900ab9975bedfbb414f7973587f2eb70",
+        "path": "candidates/113.json"
+      },
+      {
+        "hash": "5ea263a826a94a9a7f6d70ae3138cd2181f68438fc294f060e4e8bb0d1d470ee",
+        "path": "candidates/114.json"
+      },
+      {
+        "hash": "e778d1d329460262a3de73bb0bebccb427f162d8a027111686e029d8e2eb51ca",
+        "path": "candidates/115.json"
+      },
+      {
+        "hash": "574fde4acd03c5dc835b3d0a1cb8c96862ef1c0f0087bc724ecf90ee1f27fbdc",
+        "path": "candidates/116.json"
+      },
+      {
+        "hash": "498fab52845e06cd99b8dec75a0ed812b9b8e1688111515e789d5e6e9a375c78",
+        "path": "candidates/117.json"
+      },
+      {
+        "hash": "7be98df4b819f140a612aac1b830d412049c1428b4d7590ad65c635e3b4e1137",
+        "path": "candidates/118.json"
+      },
+      {
+        "hash": "117a9561e9ed424603bedd1aa1735f36514085cef203baf2e7a2e82ba6dd8fac",
+        "path": "candidates/119.json"
+      },
+      {
+        "hash": "74eef8074118f3e168e473748b3e1865de32fcac55e8668bb9de35b1fba17d72",
+        "path": "candidates/12.json"
+      },
+      {
+        "hash": "2e7951cc278db4a237e77c6859ef7807dfe217645df6a159181a993202b47c44",
+        "path": "candidates/120.json"
+      },
+      {
+        "hash": "84c581f14195a3178ec380a4ae90833a8aec27d9179e5f9439204b1a9316b7c0",
+        "path": "candidates/121.json"
+      },
+      {
+        "hash": "9985ac27d511f0cd3d586d6b76dede87d8ab0fed14155ef8c311c59e4fe57849",
+        "path": "candidates/122.json"
+      },
+      {
+        "hash": "e934b312d78f2a691bbe6ca7c8357e5977387afe23f72b862204ead7c72a4080",
+        "path": "candidates/123.json"
+      },
+      {
+        "hash": "c59e519d3ed69bf162463660c5441bea98d6c1bce9cde8354429dfae288162c6",
+        "path": "candidates/124.json"
+      },
+      {
+        "hash": "215770a8c68a1c48ecb76368bd62526d74de422213834d66ea8bf571de4f62ef",
+        "path": "candidates/125.json"
+      },
+      {
+        "hash": "4d4fb34eb40e77bb66ef3f89b511da903dc501e78f61266a19194ef4763e376e",
+        "path": "candidates/126.json"
+      },
+      {
+        "hash": "b417d20718a6e0d11a30a876674d04cd3bf051daaba23225b49b090fce49c9c6",
+        "path": "candidates/127.json"
+      },
+      {
+        "hash": "2dc38640505bdda60a3466aeac7c4433d5b2823bac49aa324fb27ff13d945940",
+        "path": "candidates/128.json"
+      },
+      {
+        "hash": "dcf5f3ed57d76dcad00c406caa92d3a6e8a452a54812332758d390e681aaf1ad",
+        "path": "candidates/13.json"
+      },
+      {
+        "hash": "f90a0f420168bd788bde0e1e2aff54e3f0595550669f34dad272547d82111420",
+        "path": "candidates/14.json"
+      },
+      {
+        "hash": "4821f184abe8642f92b1aecf4ce1e57b1c600d05fbe8c90f385b712ca9f8794d",
+        "path": "candidates/15.json"
+      },
+      {
+        "hash": "9a83606b75b62139721f70d9e91433cc563a8af48a8a83905f99a235357cec34",
+        "path": "candidates/16.json"
+      },
+      {
+        "hash": "2f1944ecffe2216f5d3bfc3d727c611495b6da67df6abddf5872205785f9e816",
+        "path": "candidates/17.json"
+      },
+      {
+        "hash": "e2984acf7d07dc121ab595a74bd589d85d29f2db14cdf6c32ff6edeeda617b35",
+        "path": "candidates/18.json"
+      },
+      {
+        "hash": "ca9fd7e868fa16f048ecb30e26a4c72a9ce3f1f0ee0b78e51147ef7cf58acb0c",
+        "path": "candidates/19.json"
+      },
+      {
+        "hash": "8b410044af4ffd4601edad2fa3ecf90b29f710675d35f5303fca069f47c01b6c",
+        "path": "candidates/2.json"
+      },
+      {
+        "hash": "272fd57f5e59ef1710f976c840da162cfd426882167db3718f4001d9c111250f",
+        "path": "candidates/20.json"
+      },
+      {
+        "hash": "b1d736c8296fbc9a392919928297d4492e0db6bef8dd43188fe9e0933e76b31f",
+        "path": "candidates/21.json"
+      },
+      {
+        "hash": "48f0a9a18cef69b766c9dbe3e8065a747f0a72fecca8bcb1e18f3b4980f95416",
+        "path": "candidates/22.json"
+      },
+      {
+        "hash": "8d671dcf14eb9cae642125f6536ba21a85b4f331af2b9ed7a28b44c10fc002a3",
+        "path": "candidates/23.json"
+      },
+      {
+        "hash": "a2ed3408ef36ed954c544bbcc0ef6c640384e941bc659d4e667ead158ccb2dc0",
+        "path": "candidates/24.json"
+      },
+      {
+        "hash": "8bd033d8085e26188f57f029487fbb6e5bb648dc90eec2730a0d7c7486004b14",
+        "path": "candidates/25.json"
+      },
+      {
+        "hash": "19a8dccb72baee74f8fb817314e39987c5277fc31728d5c6a1c8295614c03393",
+        "path": "candidates/26.json"
+      },
+      {
+        "hash": "5049597f443de3329099efb4522a64ab6acb0cd6c8331338e514e251eb3a10a3",
+        "path": "candidates/27.json"
+      },
+      {
+        "hash": "1268a48865419c69c15cef80324033278d08e5339e658a286c2387963855cbb4",
+        "path": "candidates/28.json"
+      },
+      {
+        "hash": "11a124ae1bd37d1fa5bfa61e495fc4b206373e4e79ebaa37fa8e795840eaeaea",
+        "path": "candidates/29.json"
+      },
+      {
+        "hash": "f8258544f3a05df240ecb71d41bff4cf731cdabbb1462de9f38e99a38c34ae65",
+        "path": "candidates/3.json"
+      },
+      {
+        "hash": "b4dbfb174ac3c56a0a7414d7749f0e6a393bd2e6005b7e28f8b05b244b070119",
+        "path": "candidates/30.json"
+      },
+      {
+        "hash": "6625d051bf57f4f2499d383e4c4a2e0e1b5bfc92348ef3245dbb0205c71cadc4",
+        "path": "candidates/31.json"
+      },
+      {
+        "hash": "b1915ea56fc7ae5e8823a0a339fc83f92347b67cd2fce2f0ed3840ef8d663470",
+        "path": "candidates/32.json"
+      },
+      {
+        "hash": "dda5c718bed4482ac7854afe3e8bc546067c81ab0259d01ed6e472aa4c962b4b",
+        "path": "candidates/33.json"
+      },
+      {
+        "hash": "d1e1394a2c1fa8256560b84f00101743cbe76a651a82d123f31d7d1bc86ba68f",
+        "path": "candidates/34.json"
+      },
+      {
+        "hash": "b3cc14bcc89a7b644c4d275ef97144515b9fb4fb619e632748aa03c8c496a29d",
+        "path": "candidates/35.json"
+      },
+      {
+        "hash": "c38b192b8597cc70c4f3d5cab21737aefbce1a3de81fc88ce6d3d5024894e4fe",
+        "path": "candidates/36.json"
+      },
+      {
+        "hash": "f2828dad97a384303119edbc26b54de4fb9c5d59226c61cbe6c584032a808e37",
+        "path": "candidates/37.json"
+      },
+      {
+        "hash": "06c6075e27016b6d5d1b9f451ce78ae8e793acec5c4c9ba3e6ffc16673b945d0",
+        "path": "candidates/38.json"
+      },
+      {
+        "hash": "fff237f61b0691b35bab64fbc36935ba0fbeea4d569ea2d8278cbfbca3c35825",
+        "path": "candidates/39.json"
+      },
+      {
+        "hash": "3531648cbe059dbbab63e20e95fdd03c4e8e6872bb7ca4b3980c9c341ab12441",
+        "path": "candidates/4.json"
+      },
+      {
+        "hash": "3a941d2ddec9557bebd20e0af5ada2e8e1c031f0b75c19e9383361e747ddb2fd",
+        "path": "candidates/40.json"
+      },
+      {
+        "hash": "8eed4708a396058007c72a01e9c22ef70e04f0b42accbbb01d232dad5b5f13ad",
+        "path": "candidates/41.json"
+      },
+      {
+        "hash": "e94de14842a4bb423dbf621dd6c2a98fdd5e819a54202c28bd312137f726ce27",
+        "path": "candidates/42.json"
+      },
+      {
+        "hash": "63a7dab739db38e11c0109024e72e7482563c18ab4fa0a0eba73c119b1d98a21",
+        "path": "candidates/43.json"
+      },
+      {
+        "hash": "7d577f27c37bccc86854e9156b3508d19daa8018a8a04505d7cb80b867099987",
+        "path": "candidates/44.json"
+      },
+      {
+        "hash": "414420440ed071a88febbc1013a47245d92d7af61db542012d428f49567c9175",
+        "path": "candidates/45.json"
+      },
+      {
+        "hash": "6b32cbb619d7a0c75b913f0da2f62bd17e695416fb730ac3030cc411132146a9",
+        "path": "candidates/46.json"
+      },
+      {
+        "hash": "e6bffddb71daed13740e822e594ceff50cccbb53ba5f317632dee485f4f40f83",
+        "path": "candidates/47.json"
+      },
+      {
+        "hash": "a6e0c9ea2e60e0eda5739cc1fc19b5fc497ae2df1b2d69381f10e2fd9020677e",
+        "path": "candidates/48.json"
+      },
+      {
+        "hash": "7cb710887e32f402db642185d71250aad8c6678172255502620514e3a2ef6990",
+        "path": "candidates/49.json"
+      },
+      {
+        "hash": "f33edc11b115e64600e024a0c9d97f5dd07420b205e39ee7b7d97b9e2dea2fd6",
+        "path": "candidates/5.json"
+      },
+      {
+        "hash": "e136d6fd36a06baa8d69b955cbc41365cf13cf15d45da7b97ad2a1a37f3afb3a",
+        "path": "candidates/50.json"
+      },
+      {
+        "hash": "1e1be9fcb33e3b99ebd75ee43c7273dda33184b898c9c3e18ca11c0864230f68",
+        "path": "candidates/51.json"
+      },
+      {
+        "hash": "f250303d9189c536664b56530e99e6e44e377ecd2977abaec3b2d08413525e75",
+        "path": "candidates/52.json"
+      },
+      {
+        "hash": "d3c6427f6be160159c4078a0935feaf932cfd139ba296c3658cf3c80ded51b87",
+        "path": "candidates/53.json"
+      },
+      {
+        "hash": "42c99d45c9ec79009b84962def2953aa87a4d1f7872368a2e90eafc358550825",
+        "path": "candidates/54.json"
+      },
+      {
+        "hash": "7f780703d7fbc33a5fee70ab2d742c8f7e603af38f4705f09d8be1aaa13f2a64",
+        "path": "candidates/55.json"
+      },
+      {
+        "hash": "104887df82ab439638d32976f6949e2c730881c6587132e69c9e009d8f0a1b6f",
+        "path": "candidates/56.json"
+      },
+      {
+        "hash": "f55d7d3767566e0499fb5589956a977ec3ea8e987214fd9b8b166bfd05e71576",
+        "path": "candidates/57.json"
+      },
+      {
+        "hash": "e65cfe96f814188a86585f53b8aaf3f3080d7d629ec8076235f34f5279d06ebc",
+        "path": "candidates/58.json"
+      },
+      {
+        "hash": "c45ae4a90b16408ffc8cc52d48b800ee2d5c5fee815ac4e429a2c291b3c97973",
+        "path": "candidates/59.json"
+      },
+      {
+        "hash": "d8fa8a3d979b7bfb7cd8fe8bf5951dce2300328de2ac1846e790a078c0083903",
+        "path": "candidates/6.json"
+      },
+      {
+        "hash": "98e2530e43fefb141ccf80b1cc8fe99d56445b447b8ef382106680ebf0bd3587",
+        "path": "candidates/60.json"
+      },
+      {
+        "hash": "112296b0a3c0cb620eda9d616577444c34217e11ae525be03d80e94c880692a3",
+        "path": "candidates/61.json"
+      },
+      {
+        "hash": "b25eec2351630247f75efe06db53ab5a8bd389c8053e77c8b04b9f90621acbab",
+        "path": "candidates/62.json"
+      },
+      {
+        "hash": "5a89ebdd0e25b8649b8913b3dd63a184fd2696fc99706008f724c6ea7b693cc4",
+        "path": "candidates/63.json"
+      },
+      {
+        "hash": "cfaf326118d5bb43ea8c64eb4b144991fb575084cef7c301ed8cdf9d60577de7",
+        "path": "candidates/64.json"
+      },
+      {
+        "hash": "3be521ae840d0082d5ef2573a8098b980f7bb1dca5904b29fea1d37881b8953e",
+        "path": "candidates/65.json"
+      },
+      {
+        "hash": "ca8aae234af71f0f8e9402722b50e7ae3a8a21cf2649589da23dfd194c3e3845",
+        "path": "candidates/66.json"
+      },
+      {
+        "hash": "d580e157968fe54426ae4118dfa721a63939e646826407784fa12153c03f1e77",
+        "path": "candidates/67.json"
+      },
+      {
+        "hash": "35e03ddef018c0d46e5aa724d2ac7d8c9a2a5d3376b103f2571c9532ee1959a6",
+        "path": "candidates/68.json"
+      },
+      {
+        "hash": "0f870dadbd682513acdb944b8c2610e26ec55cd7ab0386d213f19c4d137f9336",
+        "path": "candidates/69.json"
+      },
+      {
+        "hash": "a3733ed2ec7023d5ede62d38d664f2a63e588a86f7513022d780879b2c8e6fc3",
+        "path": "candidates/7.json"
+      },
+      {
+        "hash": "240cc63d812f48ee192691f9ad7ed347fedc31591179bd2d5a4abafb7ce2d319",
+        "path": "candidates/70.json"
+      },
+      {
+        "hash": "6690e1356f13352d6e01a37eb1a145d278abb2fe685f694ca3495e31ac9b0703",
+        "path": "candidates/71.json"
+      },
+      {
+        "hash": "67e610007702bb6c326463886b0b157a9be1aa3b1ad6211df3c7ac075d7d03bd",
+        "path": "candidates/72.json"
+      },
+      {
+        "hash": "ece1190ecba48a33ace07b4287d2f11fcba6c38ddc4568f71d232258999f4694",
+        "path": "candidates/73.json"
+      },
+      {
+        "hash": "332996079e6384423c24f95526705ea4a0af9c02031a5b855f27949f6d8c9268",
+        "path": "candidates/74.json"
+      },
+      {
+        "hash": "0ba6f9d21d5e42228a087fc5489a53023b3c8f5666fae78b413a37f8e1d446f0",
+        "path": "candidates/75.json"
+      },
+      {
+        "hash": "944e4abb9ac6100a4c0bba477e5f6db2ad2960e29f7ea9d3f1e56f02d965787c",
+        "path": "candidates/76.json"
+      },
+      {
+        "hash": "5a999352f07816d1588a2a3e3cfaef03d9150042dd2c208e9287d351d92f273e",
+        "path": "candidates/77.json"
+      },
+      {
+        "hash": "4af635ee35927086a6758c0f8275adf030b60789e4baf3ab3ad7425ca0b2e676",
+        "path": "candidates/78.json"
+      },
+      {
+        "hash": "29133a8690300212f903d03f53f39695d923e0d330f4c946db924645f9248e16",
+        "path": "candidates/79.json"
+      },
+      {
+        "hash": "6567e7876e717d0e54f1f5e26a962d125b5aa5e8f4892915486ac23de34d81fe",
+        "path": "candidates/8.json"
+      },
+      {
+        "hash": "50a3a61226b6073584ed2eb704444b7c4149763c76e26f528c2af547f8d104c9",
+        "path": "candidates/80.json"
+      },
+      {
+        "hash": "1e0ef96661e57e3c8fdf087abc8677423212d7be3d76306c68a7041cffbe29ac",
+        "path": "candidates/81.json"
+      },
+      {
+        "hash": "4ee1f44c4370628fa20e34d608c9b8ca94b410dc3b29d28140020634d5d71228",
+        "path": "candidates/82.json"
+      },
+      {
+        "hash": "c496a076c7879ee920611c02def173514385d10b39cdf1132e9fcaea3afada50",
+        "path": "candidates/83.json"
+      },
+      {
+        "hash": "d1bb8e3750c383fee6f51de54df71d8960ce80d295563765f98c9269344fa8f9",
+        "path": "candidates/84.json"
+      },
+      {
+        "hash": "cb3ff1a4497e7ed5f33372e0b459af17ee1700c00996364a7075702e4d406213",
+        "path": "candidates/85.json"
+      },
+      {
+        "hash": "e9284dad91956424c20f175fb314f5d71af3223849c9b30dc3ec7e022c845219",
+        "path": "candidates/86.json"
+      },
+      {
+        "hash": "32f406474f6323f724076e7c30d6c3914355b70c5c79fbdcf12721b2fa710666",
+        "path": "candidates/87.json"
+      },
+      {
+        "hash": "18e73617386fa842d5dc967b82963c6f3380ab5438b5ccd868f906bb28c79fb8",
+        "path": "candidates/88.json"
+      },
+      {
+        "hash": "49c225a5bec3ae280286e5565203519d75cca963761f9d3397bfcda8af2562b5",
+        "path": "candidates/89.json"
+      },
+      {
+        "hash": "2e40143e66e05884ac6d917018641b017461d12d55f31be9cffb9469e9954188",
+        "path": "candidates/9.json"
+      },
+      {
+        "hash": "700c754a957f134232fc2905caa7fb8aa3d37b889e91b067f5c3c4a651da0f16",
+        "path": "candidates/90.json"
+      },
+      {
+        "hash": "1d0b5453b001e5bb2cf72aabc8bfadac501d8720fe938bdd87fc0ed651e7cecf",
+        "path": "candidates/91.json"
+      },
+      {
+        "hash": "e51d58455c84b52753820869d613ec63934685acdd9b5f9dac014faefdc50556",
+        "path": "candidates/92.json"
+      },
+      {
+        "hash": "effdae7d25ad516806b0271c3ceae825ae9a929131153425b905625f6e3c31a7",
+        "path": "candidates/93.json"
+      },
+      {
+        "hash": "6cddd9c2f7120d9590b52bfa8945dd83ae091bb28523a2d4f95d817b433b2c73",
+        "path": "candidates/94.json"
+      },
+      {
+        "hash": "8dd0ab5e93037c5ac5dcbe9481f7fbb62946a7704440790f7af842f75a2454bc",
+        "path": "candidates/95.json"
+      },
+      {
+        "hash": "6491c641ed26045fccf5139ef06e88222bb03378a34a44ea61cf07aa15054e2f",
+        "path": "candidates/96.json"
+      },
+      {
+        "hash": "c7f06edb1f22fdd317d5ff6be960e713ea65b29b1517dea24d9f32c00ea2a8e4",
+        "path": "candidates/97.json"
+      },
+      {
+        "hash": "aa33077833f5b96b39800c650b5ab49c09884cd9910cc3ced665f59d7f94d242",
+        "path": "candidates/98.json"
+      },
+      {
+        "hash": "33a50dcd524a79d9e378a46f8b744a7e1bae5709aeb99a59319c020e93c5b35e",
+        "path": "candidates/99.json"
+      },
+      {
+        "hash": "54843c7b258f884c66a9362cddc323778ca732ad4dfcedb3a486111c0ba67c8f",
+        "path": "endpoints/0.json"
+      },
+      {
+        "hash": "46e509bfb052c8a308863121360db459517c51aba216f6c663b192da4bed3794",
+        "path": "endpoints/1.json"
+      },
+      {
+        "hash": "cc44807741a528015ff25879b8ca8cb7d0b3f7b81d654d87c83c5fcae97f40fe",
+        "path": "endpoints/10.json"
+      },
+      {
+        "hash": "a1127c69c8ae8cc05a919cd7db075c5cf5f1091b2c803d8ee385ea06362b6705",
+        "path": "endpoints/100.json"
+      },
+      {
+        "hash": "26d5be80a5706d2e9e5da35dcb0da286b5dfce290c8150ec299feb3ab1dbc48b",
+        "path": "endpoints/101.json"
+      },
+      {
+        "hash": "97850a8352fabfcb5b58ee67302eca0f8532d92b7c5b0d48407b17c7db1b5bc1",
+        "path": "endpoints/102.json"
+      },
+      {
+        "hash": "088163d97a2fbe571d1757782429e46263df64b38e4d875507a4a2fb11a3e338",
+        "path": "endpoints/103.json"
+      },
+      {
+        "hash": "a708dbc46482a6a3b3c10933f4fc1592d4a1ed344f5377c80277a1e5f30e376c",
+        "path": "endpoints/104.json"
+      },
+      {
+        "hash": "77822f1dc5c379296cc6ac02b765968d52ed42c8a6838df867de683abecca2a1",
+        "path": "endpoints/105.json"
+      },
+      {
+        "hash": "9b5a54950131bb92fa7e336a82750c6080fd34777edd5814e260c3339700ca03",
+        "path": "endpoints/106.json"
+      },
+      {
+        "hash": "34b7df39b5ec1656dd23d96c2e5dca5c0218a16606aeb309c02549558b635d7a",
+        "path": "endpoints/107.json"
+      },
+      {
+        "hash": "5f62b93c458fac12af6b0ad1faa4d647e5a32ef5a15faf3afe87fbd342ea6834",
+        "path": "endpoints/108.json"
+      },
+      {
+        "hash": "7d23547cf65d54c5cf670b5772888d7fe31f9b2773d3aea2f48e4e1e6691a333",
+        "path": "endpoints/109.json"
+      },
+      {
+        "hash": "7d5fa85016ff963085c34c4c90f0d8195b285ad292c0c66187348261b49dd08e",
+        "path": "endpoints/11.json"
+      },
+      {
+        "hash": "5daade2bf923ba0bb875c7b0b6d2346217805ecd463812780b5bd5701dc31cf6",
+        "path": "endpoints/110.json"
+      },
+      {
+        "hash": "69505e14628aef91441a91688d03c3194f31d7d5c1c23a6dc200f5a9da278aec",
+        "path": "endpoints/111.json"
+      },
+      {
+        "hash": "97c1ed79fdcac44e76eb2193da3a722bbdd6b5007e31d6fd8771993a7ca20495",
+        "path": "endpoints/112.json"
+      },
+      {
+        "hash": "e8dd5ea7a3c05c56040700fec6ef035fa83a95a4b91282ec18fc4430dd2dc737",
+        "path": "endpoints/113.json"
+      },
+      {
+        "hash": "5d7888583dc358ef32c64c820b64991aae95f5acd4d8a9b3646422462faebcfa",
+        "path": "endpoints/114.json"
+      },
+      {
+        "hash": "ab67194afe07bc223a7e021dec3f4c27900562799d320bd241aa10e8b746aded",
+        "path": "endpoints/115.json"
+      },
+      {
+        "hash": "1913beea94e98640b9a2b9cb6cdec2f7c53ec33a20c014f4798e7d7d70dce8eb",
+        "path": "endpoints/116.json"
+      },
+      {
+        "hash": "319dc14b2532c64f973209ffbfe0eb1c5485e4f5067ac67380710ea5e050279d",
+        "path": "endpoints/117.json"
+      },
+      {
+        "hash": "03a63af75f2f165c4a3588c826b54e0d1de1df9d2d9314c4de859f5d483c3812",
+        "path": "endpoints/118.json"
+      },
+      {
+        "hash": "2a4cd0bd8f6b87522a4b1417b56e7969be2b24df96e5c6b041ed6b5343a65f22",
+        "path": "endpoints/119.json"
+      },
+      {
+        "hash": "0a93fe740c050c9ce7972b4a8b09656a7b689b1f4ca61ad5e29fdf95bc68ee34",
+        "path": "endpoints/12.json"
+      },
+      {
+        "hash": "fa2c262fe95a12d39402e652e2238011218cbcc77f42d8930d3145ed68079f06",
+        "path": "endpoints/120.json"
+      },
+      {
+        "hash": "c2c6de0aafb35cb6879b856c5c335f60d3e8f6445c2f8fd1541427e1f6716f02",
+        "path": "endpoints/121.json"
+      },
+      {
+        "hash": "ab3cbfac03d7ea1dad20996f98cc800dd514ca01fef472d85cdede1ddf53fbd5",
+        "path": "endpoints/122.json"
+      },
+      {
+        "hash": "35f7932d46b58a764c4a8e35733a0dfb628e50d4d466c94120a82158c4ab3af2",
+        "path": "endpoints/123.json"
+      },
+      {
+        "hash": "7a22aa00cfba72ab242a611a7473f8e22db097a49854eb62e2757ed2886b40f9",
+        "path": "endpoints/124.json"
+      },
+      {
+        "hash": "ca640fff98f8d14d54d70b366ed341d4f7e50adb88adac7c087d7705c863e3d2",
+        "path": "endpoints/125.json"
+      },
+      {
+        "hash": "5da22ac45c32e5c6f0a17cc81d4ae3325f6ab36f55949da933de50ba32feeef0",
+        "path": "endpoints/126.json"
+      },
+      {
+        "hash": "07f14f6c3a3c0eaf9dcd30dad820c5d98c301aa42e509caf48a4b2372c7fadee",
+        "path": "endpoints/127.json"
+      },
+      {
+        "hash": "5e0399a2e14bcad5f87472bf370a799454e1127d7482a86ad5c2fcbe3b89853c",
+        "path": "endpoints/128.json"
+      },
+      {
+        "hash": "5d5450fe262cbeaf283694243fda9491e4927deefa2f3b2b436a858fadfe4665",
+        "path": "endpoints/13.json"
+      },
+      {
+        "hash": "ef495f3ee2bae6b4bd472edba320689838c23f3a2b3de85270dcb533035dbeb0",
+        "path": "endpoints/14.json"
+      },
+      {
+        "hash": "00b0e8245360acbc657507f8ba07526581bfae8cd00c06289291056ab71379de",
+        "path": "endpoints/15.json"
+      },
+      {
+        "hash": "24e6fdfbd161b0218156372658fb1105edc41fb67ed6f9f0cc6a5e5b3df3a198",
+        "path": "endpoints/16.json"
+      },
+      {
+        "hash": "827e89d000c70b4b94c2687476244a8ff206d5cce5c4f02047ddf52fa4f7e48d",
+        "path": "endpoints/17.json"
+      },
+      {
+        "hash": "aef8e1744815c523dc14b69c93c1c6258d354191368213c42d61c34043a3bfd1",
+        "path": "endpoints/18.json"
+      },
+      {
+        "hash": "ca26d47823b0b47d2383f6c1a98eed1d28cd6d90b6f4f62c20945419f3aa4963",
+        "path": "endpoints/19.json"
+      },
+      {
+        "hash": "04cc583749d49f26ef1015dce4e3d7e88cf225f1ab6f160bab607b9595efd95f",
+        "path": "endpoints/2.json"
+      },
+      {
+        "hash": "e53655c423df87f82e0afeaadbd30abaa0e2dfaa2a395a4887b82c2df181077d",
+        "path": "endpoints/20.json"
+      },
+      {
+        "hash": "fd49e26e8526b1abb2edb24d1a6beb03ab876ce41214ba07b05f19ae7d2c416d",
+        "path": "endpoints/21.json"
+      },
+      {
+        "hash": "0ea7508edf89ca9cf9758a44c836b79cf35b98b1cafdfbca330e37b694369da6",
+        "path": "endpoints/22.json"
+      },
+      {
+        "hash": "d9bad47057d572638ccb04404dd3109bbb9a43cb71ff87fc6045b7da5528befa",
+        "path": "endpoints/23.json"
+      },
+      {
+        "hash": "bd535d35a64e1a1e63b25db7318c357aff3c344c98857318109a9ee89b904800",
+        "path": "endpoints/24.json"
+      },
+      {
+        "hash": "175c4803c299252aa042c464d0bd283dd52383343ec5c58b49b1d065b904ee49",
+        "path": "endpoints/25.json"
+      },
+      {
+        "hash": "f83f91ff38013089be0b7a978388714f09ba7089e0d351736e41f40d23cceebe",
+        "path": "endpoints/26.json"
+      },
+      {
+        "hash": "e6c57d3b54a31b3ac2cd1a7eec51952977573ec55ff5279d8f7810e23ee1399c",
+        "path": "endpoints/27.json"
+      },
+      {
+        "hash": "23015625018bb1e9c48e082b714d43a4561650d74d770fcaae9a2d4896613ecd",
+        "path": "endpoints/28.json"
+      },
+      {
+        "hash": "96fcaf012c9d648f1f8c3baef40d556a47ea3179e54c585d058577aa4daa8422",
+        "path": "endpoints/29.json"
+      },
+      {
+        "hash": "189afa8602c2bfef8831c79abc65af42634703d25ef16bdfccf37f3b4dc5c52a",
+        "path": "endpoints/3.json"
+      },
+      {
+        "hash": "af3271cb9e83c66e14857e4f3fd1a91f8592028ec91517b307f0431525bb71da",
+        "path": "endpoints/30.json"
+      },
+      {
+        "hash": "b73c04778d102c47c57b2f81b9bbb32778f55d5fabd0d0ab428299947e0ef907",
+        "path": "endpoints/31.json"
+      },
+      {
+        "hash": "bddb6f0057c7efab30c97f69e63da8c3f1104196caeb942081c2994782b89b8a",
+        "path": "endpoints/32.json"
+      },
+      {
+        "hash": "3289b9e736b40a293efc3374bdc514831a24cf754339c314c2efe9f6ecd12152",
+        "path": "endpoints/33.json"
+      },
+      {
+        "hash": "62a530b9dba1f40e7a54651dc62f0df028a02a3d63286496e9d115d3e4c38797",
+        "path": "endpoints/34.json"
+      },
+      {
+        "hash": "47dbd37b73502ee846209b27820c9dc1c9d77449b12913cf1dc317da4ec3d447",
+        "path": "endpoints/35.json"
+      },
+      {
+        "hash": "e1aae66c62e17c0aa45bda3006a7f891d6408e71c460c70e3b5c407c0353b2ab",
+        "path": "endpoints/36.json"
+      },
+      {
+        "hash": "cfad4724bb1ae014657e2243ba0873cdcb79e3177ab8afecf48bb85c76c8fe08",
+        "path": "endpoints/37.json"
+      },
+      {
+        "hash": "f84fd63596959102df8e7eb950c7dab963873350ad26949266c8c53b7ced792b",
+        "path": "endpoints/38.json"
+      },
+      {
+        "hash": "604e627686b1dd5b46f7f7a6c75764f61117341151af778946fe292cb46ed4cd",
+        "path": "endpoints/39.json"
+      },
+      {
+        "hash": "ff09009878cfb6cedb646ff0bc775da1a30eba8f720184209ae882d11af1c60e",
+        "path": "endpoints/4.json"
+      },
+      {
+        "hash": "37b2f5caa1bb517ca08d8e706d8b1d3c510694c290fa8fc53b88c7622f624cb1",
+        "path": "endpoints/40.json"
+      },
+      {
+        "hash": "dfe6c4c8424f1cad8566bc3d5c4f316280c66bc2be9399e984e0f42934a0d125",
+        "path": "endpoints/41.json"
+      },
+      {
+        "hash": "4eb5cb04b6b91d1e8d54ad38c70c4d13115c4375dda0095e0f023ab0fab70841",
+        "path": "endpoints/42.json"
+      },
+      {
+        "hash": "0714ea9c3330664f6b0a1ba2a10e65438f9d682e9fd17547ab771f213128e724",
+        "path": "endpoints/43.json"
+      },
+      {
+        "hash": "1baff931c192ce0c84cc1d2e112375d3ba9da605de192e625dff8ae0c3c1408f",
+        "path": "endpoints/44.json"
+      },
+      {
+        "hash": "e6cce45531792d64f1701856afe77edd1ef1073e1081fd22d73dab848bb9f2bb",
+        "path": "endpoints/45.json"
+      },
+      {
+        "hash": "b04e1cf6907819263fde882b1cd70949e33179a9dda234dbdcd822c26ed7fa8d",
+        "path": "endpoints/46.json"
+      },
+      {
+        "hash": "615377a32a4884cde2f92c6480d9efd5257bbcd5057838321ab03cc384137373",
+        "path": "endpoints/47.json"
+      },
+      {
+        "hash": "1586787b808a9a76c7ee3c40a83fa206a605b590f7f1d02237854f3ff7a8a1f1",
+        "path": "endpoints/48.json"
+      },
+      {
+        "hash": "c558b75439f46290223281787ebc58745de5049e0fa3f50ac012f4aaf284b119",
+        "path": "endpoints/49.json"
+      },
+      {
+        "hash": "bec76c7746bd774c7c628323d61788072a81504559e3d6bc93e26b846637a4b2",
+        "path": "endpoints/5.json"
+      },
+      {
+        "hash": "af8821583940f0e5f70e89361d5444dab7489086a8f713e4629c798cb2e7fb1e",
+        "path": "endpoints/50.json"
+      },
+      {
+        "hash": "b5a5179fa2b79b9773bd95db0800c27416400f9cf40a4fabdfa19db0c5f19e24",
+        "path": "endpoints/51.json"
+      },
+      {
+        "hash": "6121264d8e4272079ea9b29903e7adc0e9b41ef89956aff9c4d666a606cacd25",
+        "path": "endpoints/52.json"
+      },
+      {
+        "hash": "cb64fcdba090bd1228b30d8659c2a2a9f0a50e716fbee6cab86e8677a8394e46",
+        "path": "endpoints/53.json"
+      },
+      {
+        "hash": "2838c6d303819e2cddf9d37df25fb9d684de28e639e0dd3f8194b2ab6d586a8b",
+        "path": "endpoints/54.json"
+      },
+      {
+        "hash": "cdd388b027d2237b4101f461eb679bbea6f18988122ae0f4d410cf203d58f481",
+        "path": "endpoints/55.json"
+      },
+      {
+        "hash": "adf3270671a5bed2024cd40054902b70031a82ecd885d9bdb7d5cd847be0dd9d",
+        "path": "endpoints/56.json"
+      },
+      {
+        "hash": "16319e2fbe641c9858cf202a6e1ae87fd1e74cc9a540d5d07158f937a20ec77f",
+        "path": "endpoints/57.json"
+      },
+      {
+        "hash": "1e04ac3aeedf8c42513f3412d88a546537c55b8028b39f9296bd2f8bf17f9d14",
+        "path": "endpoints/58.json"
+      },
+      {
+        "hash": "7a8ba94c56391416e3ef23f6826b2e8ea20eede156e62e5b2fd01de3a7e4cfce",
+        "path": "endpoints/59.json"
+      },
+      {
+        "hash": "1ade41f2adcb8b9b0bce4efa0e530f79bda0738409b6521a7ff1c1d62ac2fb21",
+        "path": "endpoints/6.json"
+      },
+      {
+        "hash": "c325e0513c520bd1d78773b3739203a51d8982b672a9f7175b62bdd2f30b2c8a",
+        "path": "endpoints/60.json"
+      },
+      {
+        "hash": "456f2b259bc46e270e52aab8f0d7ce7d486f2c9e3570be97708345cbf6812ff7",
+        "path": "endpoints/61.json"
+      },
+      {
+        "hash": "6f70075413451361821672887faf0f2e0fd718fc9349aa60b0e28a635cc41319",
+        "path": "endpoints/62.json"
+      },
+      {
+        "hash": "6fff1d92ebc3a3dba62d5ce225e3f0aaf88bd898cfcde81a063b89e4edf1bbe9",
+        "path": "endpoints/63.json"
+      },
+      {
+        "hash": "54f757f795c49f5e641b7155fbf326d476e518a5539e512ff81848969a1ac444",
+        "path": "endpoints/64.json"
+      },
+      {
+        "hash": "252eccb6c8a4bd1c2b97b52aaf887b3d91dd31efa9a8239301910f6899179c94",
+        "path": "endpoints/65.json"
+      },
+      {
+        "hash": "b3aaef3fd25bcc6548fda6ca439b5c7dd10a147272a22c7557ba669a58bb8bc7",
+        "path": "endpoints/66.json"
+      },
+      {
+        "hash": "5e25afa37e58c505dc19741942eb16f85bbd1fa1cfa900e18bb26744d4629613",
+        "path": "endpoints/67.json"
+      },
+      {
+        "hash": "5aba5b8dc768131a2bd34b4340bdd0750e71c73b8dffba345ca3e2ec927fa5f2",
+        "path": "endpoints/68.json"
+      },
+      {
+        "hash": "2e5a555d88e043225e3cab1ca23d0a931937cf0c5fcfa9b53b19a43d4822a7d5",
+        "path": "endpoints/69.json"
+      },
+      {
+        "hash": "50141a8161e943bc30eeb4b8d99d3f0aa59ea1f7fb4c56d02bb5bf621bac2ff7",
+        "path": "endpoints/7.json"
+      },
+      {
+        "hash": "f61946e865a279cc1bdef35993564ea7b1a9d83f549fc2dda64910579fdbd99d",
+        "path": "endpoints/70.json"
+      },
+      {
+        "hash": "9e556cbf3478e05d7416190e6ccc530e45d0f4c6876f491baeb653adba6aab63",
+        "path": "endpoints/71.json"
+      },
+      {
+        "hash": "c6079af58e845595d9f00bc836f3e15321f30a6894756da200b2c038e8d0d055",
+        "path": "endpoints/72.json"
+      },
+      {
+        "hash": "41507b0788a89b98fb1be4a7eccc9f3360564986dbc5b89c8bd5e6a68c656953",
+        "path": "endpoints/73.json"
+      },
+      {
+        "hash": "ada7e24c97d62217da743fd40ad2e6178a5d073dcbc3254cf87d592e2b7f7775",
+        "path": "endpoints/74.json"
+      },
+      {
+        "hash": "8b9645536dd413d179c16b96cba4d957d1440ba14f913c4ea7d09a5e4af9e5d2",
+        "path": "endpoints/75.json"
+      },
+      {
+        "hash": "85249b7c1a3c002f1bd8a1d72829943b8dc2eedab117f174baac3da92b38d45d",
+        "path": "endpoints/76.json"
+      },
+      {
+        "hash": "af5e996d5a3d288f30e2d04f6720832cedf88d852a7f30eef8b8e2e127eff4e9",
+        "path": "endpoints/77.json"
+      },
+      {
+        "hash": "b8fcb74b920ccf03adb9cbbdb7d81b656f375a9b0bffafd23c7af4fb8ca4e029",
+        "path": "endpoints/78.json"
+      },
+      {
+        "hash": "a6682bfec2336680b520eb05d6591a3651baa4ffe3371dc3b84d23398e8c1c27",
+        "path": "endpoints/79.json"
+      },
+      {
+        "hash": "cd031d0fd51dcb149514bd4600e2970b245e9efe37743444ebdee3e2ca568ab0",
+        "path": "endpoints/8.json"
+      },
+      {
+        "hash": "a6fd2d669e47e440a90b6acecc9a698e39d97f46884c8d56805f4baf8983f826",
+        "path": "endpoints/80.json"
+      },
+      {
+        "hash": "627aa47dcce984b9e62f310e9e943abd400621b65a9c44bd22b9de9aa91d4306",
+        "path": "endpoints/81.json"
+      },
+      {
+        "hash": "ca00bb3e1c04b98da552eddef8953a5628742dea6a3ca273525c94f35d52b9d5",
+        "path": "endpoints/82.json"
+      },
+      {
+        "hash": "1656443e4b5bbad532cb4067d8c5d8f2d870a84c5ad6b3de175fddc682a7508c",
+        "path": "endpoints/83.json"
+      },
+      {
+        "hash": "f68f0343d75ceebcd406ae56dd6778d40c6401c755cb74cdff00b3340131f0ea",
+        "path": "endpoints/84.json"
+      },
+      {
+        "hash": "95f2e9701251b0237b8fad289024cd3c4c91d15164403252ba938858140356b8",
+        "path": "endpoints/85.json"
+      },
+      {
+        "hash": "1eb3ef474b4276f117ff9f7b3c116cb263b3a7cb4333dc0bafd6639c8ab7fd63",
+        "path": "endpoints/86.json"
+      },
+      {
+        "hash": "9f9ecbaac44cb078bda5d09d7e214865ef5687b41bad1d278ae3e681197d0b08",
+        "path": "endpoints/87.json"
+      },
+      {
+        "hash": "3baeb7e92ddb840ad2d322d139152b40ab8a0c6863cfa0ff2e1d53c8859dec45",
+        "path": "endpoints/88.json"
+      },
+      {
+        "hash": "e7e2e37f03c0289130352798489370dae1d067c752801a995cac8bc5ca4667eb",
+        "path": "endpoints/89.json"
+      },
+      {
+        "hash": "1249947b272562609424b618c4c76e1939b0f523a71c8a13367e4ccd1528cf75",
+        "path": "endpoints/9.json"
+      }
+    ],
+    "modified": [
+      {
+        "hash": "e4061fa8c3f111f1e5aa8c17652b92c72e7b21b11cb566c3f5c687cd234f2036",
+        "path": "api-index.json"
+      },
+      {
+        "hash": "1bcbbd5e15001b525d021024668b106f3693e3a3532b0e5235728699d5be744e",
+        "path": "contracts.json"
+      },
+      {
+        "hash": "ecab61764285c33e0ccae94228b816afd6af184026db88e3b8dc4c56436ec2ed",
+        "path": "openapi.json"
+      }
+    ],
     "removed": []
   },
   "contract_version": "2026-06-06.1",
@@ -18,8 +1032,8 @@
     "renamed": []
   },
   "summary": {
-    "artifact_added_count": 0,
-    "artifact_modified_count": 0,
+    "artifact_added_count": 936,
+    "artifact_modified_count": 3,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -6,7 +6,8 @@
       "description": "Public artifact contract metadata for metagraph.sh consumers.",
       "id": "contracts",
       "path": "/metagraph/contracts.json",
-      "schema_ref": "#/components/schemas/ContractsArtifact"
+      "schema_ref": "#/components/schemas/ContractsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -14,7 +15,8 @@
       "description": "Provider/source registry.",
       "id": "providers",
       "path": "/metagraph/providers.json",
-      "schema_ref": "#/components/schemas/ProvidersArtifact"
+      "schema_ref": "#/components/schemas/ProvidersArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -22,7 +24,8 @@
       "description": "Per-provider detail payload.",
       "id": "provider-detail",
       "path": "/metagraph/providers/{slug}.json",
-      "schema_ref": "#/components/schemas/ProviderArtifact"
+      "schema_ref": "#/components/schemas/ProviderArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -30,7 +33,8 @@
       "description": "Endpoint resources for one provider or operator.",
       "id": "provider-endpoints",
       "path": "/metagraph/providers/{slug}/endpoints.json",
-      "schema_ref": "#/components/schemas/ProviderEndpointsArtifact"
+      "schema_ref": "#/components/schemas/ProviderEndpointsArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -38,7 +42,8 @@
       "description": "Clean API route index for metagraph.sh consumers.",
       "id": "api-index",
       "path": "/metagraph/api-index.json",
-      "schema_ref": "#/components/schemas/ApiIndexArtifact"
+      "schema_ref": "#/components/schemas/ApiIndexArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -46,7 +51,8 @@
       "description": "OpenAPI 3.1 contract for the metagraph.sh backend API.",
       "id": "openapi",
       "path": "/metagraph/openapi.json",
-      "schema_ref": "#/components/schemas/OpenApiArtifact"
+      "schema_ref": "#/components/schemas/OpenApiArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "text/plain; charset=utf-8",
@@ -54,7 +60,8 @@
       "description": "Generated TypeScript definitions for metagraph.sh backend consumers.",
       "id": "type-definitions",
       "path": "/metagraph/types.d.ts",
-      "schema_ref": null
+      "schema_ref": null,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -62,7 +69,8 @@
       "description": "Reviewable generated artifact and subnet-change summary.",
       "id": "changelog",
       "path": "/metagraph/changelog.json",
-      "schema_ref": "#/components/schemas/ChangelogArtifact"
+      "schema_ref": "#/components/schemas/ChangelogArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -70,7 +78,8 @@
       "description": "All active Finney subnets with compact registry metadata.",
       "id": "subnets",
       "path": "/metagraph/subnets.json",
-      "schema_ref": "#/components/schemas/SubnetsArtifact"
+      "schema_ref": "#/components/schemas/SubnetsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -78,7 +87,8 @@
       "description": "Per-subnet detail payload.",
       "id": "subnet-detail",
       "path": "/metagraph/subnets/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetDetailArtifact"
+      "schema_ref": "#/components/schemas/SubnetDetailArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -86,7 +96,8 @@
       "description": "Curated public interface surfaces only.",
       "id": "surfaces",
       "path": "/metagraph/surfaces.json",
-      "schema_ref": "#/components/schemas/SurfacesArtifact"
+      "schema_ref": "#/components/schemas/SurfacesArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -94,7 +105,8 @@
       "description": "Curated public interface surfaces for one subnet.",
       "id": "surfaces-subnet",
       "path": "/metagraph/surfaces/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetSurfacesArtifact"
+      "schema_ref": "#/components/schemas/SubnetSurfacesArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -102,7 +114,8 @@
       "description": "Generalized endpoint/resource registry derived from curated surfaces and probe observations.",
       "id": "endpoints",
       "path": "/metagraph/endpoints.json",
-      "schema_ref": "#/components/schemas/EndpointsArtifact"
+      "schema_ref": "#/components/schemas/EndpointsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -110,7 +123,8 @@
       "description": "Generalized endpoint/resource registry for one subnet.",
       "id": "endpoints-subnet",
       "path": "/metagraph/endpoints/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetEndpointsArtifact"
+      "schema_ref": "#/components/schemas/SubnetEndpointsArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -118,7 +132,8 @@
       "description": "Unpromoted candidate surfaces from public discovery.",
       "id": "candidates",
       "path": "/metagraph/candidates.json",
-      "schema_ref": "#/components/schemas/CandidatesArtifact"
+      "schema_ref": "#/components/schemas/CandidatesArtifact",
+      "storage_tier": "git"
     },
     {
       "content_type": "application/json",
@@ -126,7 +141,8 @@
       "description": "Unpromoted candidate surfaces for one subnet.",
       "id": "candidates-subnet",
       "path": "/metagraph/candidates/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetCandidatesArtifact"
+      "schema_ref": "#/components/schemas/SubnetCandidatesArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -134,7 +150,8 @@
       "description": "Candidate surfaces queued for maintainer review.",
       "id": "review-queue",
       "path": "/metagraph/review-queue.json",
-      "schema_ref": "#/components/schemas/ReviewQueueArtifact"
+      "schema_ref": "#/components/schemas/ReviewQueueArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -142,7 +159,8 @@
       "description": "Compact search index for subnets, surfaces, and providers.",
       "id": "search",
       "path": "/metagraph/search.json",
-      "schema_ref": "#/components/schemas/SearchArtifact"
+      "schema_ref": "#/components/schemas/SearchArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -150,7 +168,8 @@
       "description": "Registry coverage counts and source precedence.",
       "id": "coverage",
       "path": "/metagraph/coverage.json",
-      "schema_ref": "#/components/schemas/CoverageArtifact"
+      "schema_ref": "#/components/schemas/CoverageArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -158,7 +177,8 @@
       "description": "Curation state and gaps for every active subnet.",
       "id": "curation",
       "path": "/metagraph/curation.json",
-      "schema_ref": "#/components/schemas/CurationArtifact"
+      "schema_ref": "#/components/schemas/CurationArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -166,7 +186,8 @@
       "description": "Missing public interface facets by subnet.",
       "id": "gaps",
       "path": "/metagraph/gaps.json",
-      "schema_ref": "#/components/schemas/GapsArtifact"
+      "schema_ref": "#/components/schemas/GapsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -174,7 +195,8 @@
       "description": "Latest candidate verification snapshot.",
       "id": "verification",
       "path": "/metagraph/verification/latest.json",
-      "schema_ref": "#/components/schemas/VerificationArtifact"
+      "schema_ref": "#/components/schemas/VerificationArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -182,7 +204,8 @@
       "description": "Latest candidate verification snapshot for one subnet.",
       "id": "verification-subnet",
       "path": "/metagraph/verification/subnets/{netuid}.json",
-      "schema_ref": "#/components/schemas/SubnetVerificationArtifact"
+      "schema_ref": "#/components/schemas/SubnetVerificationArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -190,7 +213,8 @@
       "description": "Freshness and staleness summary for generated backend data.",
       "id": "freshness",
       "path": "/metagraph/freshness.json",
-      "schema_ref": "#/components/schemas/FreshnessArtifact"
+      "schema_ref": "#/components/schemas/FreshnessArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -198,7 +222,8 @@
       "description": "Upstream source and provider health summary.",
       "id": "source-health",
       "path": "/metagraph/source-health.json",
-      "schema_ref": "#/components/schemas/SourceHealthArtifact"
+      "schema_ref": "#/components/schemas/SourceHealthArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -206,7 +231,8 @@
       "description": "Compact hashes and counts for canonical source inputs.",
       "id": "source-snapshots",
       "path": "/metagraph/source-snapshots.json",
-      "schema_ref": "#/components/schemas/SourceSnapshotsArtifact"
+      "schema_ref": "#/components/schemas/SourceSnapshotsArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -214,7 +240,8 @@
       "description": "Public evidence ledger for subnet and surface claims.",
       "id": "evidence-ledger",
       "path": "/metagraph/evidence-ledger.json",
-      "schema_ref": "#/components/schemas/EvidenceLedgerArtifact"
+      "schema_ref": "#/components/schemas/EvidenceLedgerArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -222,7 +249,8 @@
       "description": "Latest surface health snapshot.",
       "id": "health-latest",
       "path": "/metagraph/health/latest.json",
-      "schema_ref": "#/components/schemas/HealthLatestArtifact"
+      "schema_ref": "#/components/schemas/HealthLatestArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -230,7 +258,8 @@
       "description": "Global and per-subnet health rollup.",
       "id": "health-summary",
       "path": "/metagraph/health/summary.json",
-      "schema_ref": "#/components/schemas/HealthSummaryArtifact"
+      "schema_ref": "#/components/schemas/HealthSummaryArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -238,7 +267,8 @@
       "description": "Compact daily health-history snapshot.",
       "id": "health-history",
       "path": "/metagraph/health/history/{date}.json",
-      "schema_ref": "#/components/schemas/HealthHistoryArtifact"
+      "schema_ref": "#/components/schemas/HealthHistoryArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -246,7 +276,8 @@
       "description": "Per-subnet health payload for metagraph.sh consumers.",
       "id": "health-subnet",
       "path": "/metagraph/health/subnets/{netuid}.json",
-      "schema_ref": "#/components/schemas/HealthSubnetArtifact"
+      "schema_ref": "#/components/schemas/HealthSubnetArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -254,7 +285,8 @@
       "description": "Badge data contract for status rendering.",
       "id": "health-badge",
       "path": "/metagraph/health/badges/{netuid}.json",
-      "schema_ref": "#/components/schemas/HealthBadgeArtifact"
+      "schema_ref": "#/components/schemas/HealthBadgeArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -262,7 +294,8 @@
       "description": "Bittensor base-layer RPC endpoint registry and probe status.",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
-      "schema_ref": "#/components/schemas/RpcEndpointsArtifact"
+      "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -270,7 +303,8 @@
       "description": "Endpoint pool scoring for future read-only RPC routing.",
       "id": "rpc-pools",
       "path": "/metagraph/rpc/pools.json",
-      "schema_ref": "#/components/schemas/RpcPoolsArtifact"
+      "schema_ref": "#/components/schemas/RpcPoolsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -278,7 +312,8 @@
       "description": "Generalized endpoint pool scoring for future read-only routing.",
       "id": "endpoint-pools",
       "path": "/metagraph/endpoint-pools.json",
-      "schema_ref": "#/components/schemas/EndpointPoolsArtifact"
+      "schema_ref": "#/components/schemas/EndpointPoolsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -286,7 +321,8 @@
       "description": "Probe-derived endpoint incident summary and active endpoint failures.",
       "id": "endpoint-incidents",
       "path": "/metagraph/endpoint-incidents.json",
-      "schema_ref": "#/components/schemas/EndpointIncidentsArtifact"
+      "schema_ref": "#/components/schemas/EndpointIncidentsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -294,7 +330,8 @@
       "description": "OpenAPI schema snapshot/drift status.",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
-      "schema_ref": "#/components/schemas/SchemaDriftArtifact"
+      "schema_ref": "#/components/schemas/SchemaDriftArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -302,7 +339,8 @@
       "description": "Index of captured machine-readable schemas.",
       "id": "schema-index",
       "path": "/metagraph/schemas/index.json",
-      "schema_ref": "#/components/schemas/SchemaIndexArtifact"
+      "schema_ref": "#/components/schemas/SchemaIndexArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -310,7 +348,8 @@
       "description": "Adapter-backed public metrics by subnet slug.",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
-      "schema_ref": "#/components/schemas/AdapterArtifact"
+      "schema_ref": "#/components/schemas/AdapterArtifact",
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -318,7 +357,8 @@
       "description": "R2 upload manifest for generated artifact history.",
       "id": "r2-manifest",
       "path": "/metagraph/r2-manifest.json",
-      "schema_ref": "#/components/schemas/R2ManifestArtifact"
+      "schema_ref": "#/components/schemas/R2ManifestArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -326,7 +366,8 @@
       "description": "Maintainer curation and adapter candidate report.",
       "id": "review-curation",
       "path": "/metagraph/review/curation.json",
-      "schema_ref": "#/components/schemas/ReviewCurationArtifact"
+      "schema_ref": "#/components/schemas/ReviewCurationArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -334,7 +375,8 @@
       "description": "Subnet interface gap priorities.",
       "id": "review-gap-priorities",
       "path": "/metagraph/review/gap-priorities.json",
-      "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact"
+      "schema_ref": "#/components/schemas/ReviewGapPrioritiesArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -342,7 +384,8 @@
       "description": "Subnets worth deeper adapter work.",
       "id": "review-adapter-candidates",
       "path": "/metagraph/review/adapter-candidates.json",
-      "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact"
+      "schema_ref": "#/components/schemas/ReviewAdapterCandidatesArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -350,7 +393,8 @@
       "description": "Public-safe maintainer review decision ledger.",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
-      "schema_ref": "#/components/schemas/ReviewDecisionsArtifact"
+      "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -358,7 +402,8 @@
       "description": "Generated build summary.",
       "id": "build-summary",
       "path": "/metagraph/build-summary.json",
-      "schema_ref": "#/components/schemas/BuildSummaryArtifact"
+      "schema_ref": "#/components/schemas/BuildSummaryArtifact",
+      "storage_tier": "dual"
     }
   ],
   "base_path": "/metagraph",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -240,13 +240,21 @@
               "string",
               "null"
             ]
+          },
+          "storage_tier": {
+            "enum": [
+              "dual",
+              "git",
+              "r2"
+            ]
           }
         },
         "required": [
           "contract_version",
           "id",
           "path",
-          "schema_ref"
+          "schema_ref",
+          "storage_tier"
         ],
         "type": "object"
       },
@@ -2633,6 +2641,13 @@
           "size_bytes": {
             "minimum": 0,
             "type": "integer"
+          },
+          "storage_tier": {
+            "enum": [
+              "dual",
+              "git",
+              "r2"
+            ]
           }
         },
         "required": [
@@ -2641,7 +2656,8 @@
           "latest_key",
           "path",
           "sha256",
-          "size_bytes"
+          "size_bytes",
+          "storage_tier"
         ],
         "type": "object"
       },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
-  "artifact_count": 975,
-  "artifact_size_bytes": 30021471,
+  "artifact_count": 966,
+  "artifact_size_bytes": 29411702,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -8,7 +8,8 @@
       "latest_key": "latest/adapters/allways.json",
       "path": "/metagraph/adapters/allways.json",
       "sha256": "fbc29b60a44c5e68fb876a3c240173e43bfc76be29edac44676e00cfb8666503",
-      "size_bytes": 8275
+      "size_bytes": 8275,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -16,15 +17,17 @@
       "latest_key": "latest/adapters/gittensor.json",
       "path": "/metagraph/adapters/gittensor.json",
       "sha256": "80d3d747129a603b7a8cb6a75babe2f633f3a5d9f807b70056badd2cb6276c36",
-      "size_bytes": 11552
+      "size_bytes": 11552,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "e68f80af05042fd3d48379ed56d87bc88fd42392821dec2f98e25c2393007dfe",
-      "size_bytes": 57593
+      "sha256": "e4061fa8c3f111f1e5aa8c17652b92c72e7b21b11cb566c3f5c687cd234f2036",
+      "size_bytes": 58914,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -32,7 +35,8 @@
       "latest_key": "latest/candidates.json",
       "path": "/metagraph/candidates.json",
       "sha256": "5d81e7c3fafede9d998cbb6b5e93e49db6f7a5f07692a26f448a43eaf7a6c220",
-      "size_bytes": 3433657
+      "size_bytes": 3433657,
+      "storage_tier": "git"
     },
     {
       "content_type": "application/json",
@@ -40,7 +44,8 @@
       "latest_key": "latest/candidates/0.json",
       "path": "/metagraph/candidates/0.json",
       "sha256": "2abbc5809a19be7d12f4a8571e64aabff92b35ea82ad47f592daf0b88ebeb226",
-      "size_bytes": 4541
+      "size_bytes": 4541,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -48,7 +53,8 @@
       "latest_key": "latest/candidates/1.json",
       "path": "/metagraph/candidates/1.json",
       "sha256": "31cacd7416c1a3a68a101ff6fbed0b0e11c5111a816dbaaeaf0e5f0f996d251c",
-      "size_bytes": 53362
+      "size_bytes": 53362,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -56,7 +62,8 @@
       "latest_key": "latest/candidates/10.json",
       "path": "/metagraph/candidates/10.json",
       "sha256": "eb28b0947c92e63c04a3c2aa1d9b9c2f41f438d8ed87086f3b5e640ed9d789f5",
-      "size_bytes": 20882
+      "size_bytes": 20882,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -64,7 +71,8 @@
       "latest_key": "latest/candidates/100.json",
       "path": "/metagraph/candidates/100.json",
       "sha256": "cd2f9bb7cd4bdceb16d47c1c4bb4ea8c069a47c9c5a0de8dafbdd696449b09f5",
-      "size_bytes": 34343
+      "size_bytes": 34343,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -72,7 +80,8 @@
       "latest_key": "latest/candidates/101.json",
       "path": "/metagraph/candidates/101.json",
       "sha256": "da745222ac34520582390bcd9d8871644f955299757a4efb2113963ecd70843f",
-      "size_bytes": 4577
+      "size_bytes": 4577,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -80,7 +89,8 @@
       "latest_key": "latest/candidates/102.json",
       "path": "/metagraph/candidates/102.json",
       "sha256": "51a105b2fe80643a7e85fbeb88d0fc4aba6d0e40c3c7003e47e4438becb34836",
-      "size_bytes": 33205
+      "size_bytes": 33205,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -88,7 +98,8 @@
       "latest_key": "latest/candidates/103.json",
       "path": "/metagraph/candidates/103.json",
       "sha256": "9afd4aacc1d63c2c79d2c6cab3938b907243002fd638fd9580fc2678e1868c07",
-      "size_bytes": 40930
+      "size_bytes": 40930,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -96,7 +107,8 @@
       "latest_key": "latest/candidates/104.json",
       "path": "/metagraph/candidates/104.json",
       "sha256": "8b307c16febeeb69f459bd7195b46c918b142d037b35acfbc1925b6b33b1c312",
-      "size_bytes": 4717
+      "size_bytes": 4717,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -104,7 +116,8 @@
       "latest_key": "latest/candidates/105.json",
       "path": "/metagraph/candidates/105.json",
       "sha256": "14718a01b29f8de7f1f669f56840bf8824ccbe7943f3db1aafcee665ef1a35ef",
-      "size_bytes": 20652
+      "size_bytes": 20652,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -112,7 +125,8 @@
       "latest_key": "latest/candidates/106.json",
       "path": "/metagraph/candidates/106.json",
       "sha256": "5b6dcddc9955cb4bb5e42462ad8a1aae8cb077df2a1fe9e984906036ebe39215",
-      "size_bytes": 20759
+      "size_bytes": 20759,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -120,7 +134,8 @@
       "latest_key": "latest/candidates/107.json",
       "path": "/metagraph/candidates/107.json",
       "sha256": "fb49da3535540ec680383c28470d55dbbc669aa03826fc7d4fb5689811df4262",
-      "size_bytes": 42174
+      "size_bytes": 42174,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -128,7 +143,8 @@
       "latest_key": "latest/candidates/108.json",
       "path": "/metagraph/candidates/108.json",
       "sha256": "ce4eb5dcaa19ad2d6905d8e49c2405f5bd151bbea6b6618c13e0de76f747e944",
-      "size_bytes": 33281
+      "size_bytes": 33281,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -136,7 +152,8 @@
       "latest_key": "latest/candidates/109.json",
       "path": "/metagraph/candidates/109.json",
       "sha256": "60cfeda6cd6ace48102ce8ab275dadbd83ec43247a827b52ec323f900422a369",
-      "size_bytes": 6786
+      "size_bytes": 6786,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -144,7 +161,8 @@
       "latest_key": "latest/candidates/11.json",
       "path": "/metagraph/candidates/11.json",
       "sha256": "b408716af70c1e9bded689cbd38b33f23643012487b2a5718fe32dafe3fbb0b1",
-      "size_bytes": 28918
+      "size_bytes": 28918,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -152,7 +170,8 @@
       "latest_key": "latest/candidates/110.json",
       "path": "/metagraph/candidates/110.json",
       "sha256": "0656674dc6ca4efca4c4580d445a32c250c3ce7d3a69b5fdc1a0bac56c752930",
-      "size_bytes": 43312
+      "size_bytes": 43312,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -160,7 +179,8 @@
       "latest_key": "latest/candidates/111.json",
       "path": "/metagraph/candidates/111.json",
       "sha256": "045337d13e8bf261bb78eda53d66454fedc69c446a81e3d9c915f94baebe6fa6",
-      "size_bytes": 15690
+      "size_bytes": 15690,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -168,7 +188,8 @@
       "latest_key": "latest/candidates/112.json",
       "path": "/metagraph/candidates/112.json",
       "sha256": "767d01cdb38737cd93d68346c84773b4a522d0af23006b1143098d5c28f5cd41",
-      "size_bytes": 27209
+      "size_bytes": 27209,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -176,7 +197,8 @@
       "latest_key": "latest/candidates/113.json",
       "path": "/metagraph/candidates/113.json",
       "sha256": "8bae7faeb26b0be6c10d37b7ba8b5631900ab9975bedfbb414f7973587f2eb70",
-      "size_bytes": 35424
+      "size_bytes": 35424,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -184,7 +206,8 @@
       "latest_key": "latest/candidates/114.json",
       "path": "/metagraph/candidates/114.json",
       "sha256": "5ea263a826a94a9a7f6d70ae3138cd2181f68438fc294f060e4e8bb0d1d470ee",
-      "size_bytes": 36953
+      "size_bytes": 36953,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -192,7 +215,8 @@
       "latest_key": "latest/candidates/115.json",
       "path": "/metagraph/candidates/115.json",
       "sha256": "e778d1d329460262a3de73bb0bebccb427f162d8a027111686e029d8e2eb51ca",
-      "size_bytes": 6803
+      "size_bytes": 6803,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -200,7 +224,8 @@
       "latest_key": "latest/candidates/116.json",
       "path": "/metagraph/candidates/116.json",
       "sha256": "574fde4acd03c5dc835b3d0a1cb8c96862ef1c0f0087bc724ecf90ee1f27fbdc",
-      "size_bytes": 6947
+      "size_bytes": 6947,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -208,7 +233,8 @@
       "latest_key": "latest/candidates/117.json",
       "path": "/metagraph/candidates/117.json",
       "sha256": "498fab52845e06cd99b8dec75a0ed812b9b8e1688111515e789d5e6e9a375c78",
-      "size_bytes": 9187
+      "size_bytes": 9187,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -216,7 +242,8 @@
       "latest_key": "latest/candidates/118.json",
       "path": "/metagraph/candidates/118.json",
       "sha256": "7be98df4b819f140a612aac1b830d412049c1428b4d7590ad65c635e3b4e1137",
-      "size_bytes": 47827
+      "size_bytes": 47827,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -224,7 +251,8 @@
       "latest_key": "latest/candidates/119.json",
       "path": "/metagraph/candidates/119.json",
       "sha256": "117a9561e9ed424603bedd1aa1735f36514085cef203baf2e7a2e82ba6dd8fac",
-      "size_bytes": 6757
+      "size_bytes": 6757,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -232,7 +260,8 @@
       "latest_key": "latest/candidates/12.json",
       "path": "/metagraph/candidates/12.json",
       "sha256": "74eef8074118f3e168e473748b3e1865de32fcac55e8668bb9de35b1fba17d72",
-      "size_bytes": 11570
+      "size_bytes": 11570,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -240,7 +269,8 @@
       "latest_key": "latest/candidates/120.json",
       "path": "/metagraph/candidates/120.json",
       "sha256": "2e7951cc278db4a237e77c6859ef7807dfe217645df6a159181a993202b47c44",
-      "size_bytes": 23127
+      "size_bytes": 23127,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -248,7 +278,8 @@
       "latest_key": "latest/candidates/121.json",
       "path": "/metagraph/candidates/121.json",
       "sha256": "84c581f14195a3178ec380a4ae90833a8aec27d9179e5f9439204b1a9316b7c0",
-      "size_bytes": 41629
+      "size_bytes": 41629,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -256,7 +287,8 @@
       "latest_key": "latest/candidates/122.json",
       "path": "/metagraph/candidates/122.json",
       "sha256": "9985ac27d511f0cd3d586d6b76dede87d8ab0fed14155ef8c311c59e4fe57849",
-      "size_bytes": 9305
+      "size_bytes": 9305,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -264,7 +296,8 @@
       "latest_key": "latest/candidates/123.json",
       "path": "/metagraph/candidates/123.json",
       "sha256": "e934b312d78f2a691bbe6ca7c8357e5977387afe23f72b862204ead7c72a4080",
-      "size_bytes": 6763
+      "size_bytes": 6763,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -272,7 +305,8 @@
       "latest_key": "latest/candidates/124.json",
       "path": "/metagraph/candidates/124.json",
       "sha256": "c59e519d3ed69bf162463660c5441bea98d6c1bce9cde8354429dfae288162c6",
-      "size_bytes": 23344
+      "size_bytes": 23344,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -280,7 +314,8 @@
       "latest_key": "latest/candidates/125.json",
       "path": "/metagraph/candidates/125.json",
       "sha256": "215770a8c68a1c48ecb76368bd62526d74de422213834d66ea8bf571de4f62ef",
-      "size_bytes": 4598
+      "size_bytes": 4598,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -288,7 +323,8 @@
       "latest_key": "latest/candidates/126.json",
       "path": "/metagraph/candidates/126.json",
       "sha256": "4d4fb34eb40e77bb66ef3f89b511da903dc501e78f61266a19194ef4763e376e",
-      "size_bytes": 28863
+      "size_bytes": 28863,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -296,7 +332,8 @@
       "latest_key": "latest/candidates/127.json",
       "path": "/metagraph/candidates/127.json",
       "sha256": "b417d20718a6e0d11a30a876674d04cd3bf051daaba23225b49b090fce49c9c6",
-      "size_bytes": 29549
+      "size_bytes": 29549,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -304,7 +341,8 @@
       "latest_key": "latest/candidates/128.json",
       "path": "/metagraph/candidates/128.json",
       "sha256": "2dc38640505bdda60a3466aeac7c4433d5b2823bac49aa324fb27ff13d945940",
-      "size_bytes": 23171
+      "size_bytes": 23171,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -312,7 +350,8 @@
       "latest_key": "latest/candidates/13.json",
       "path": "/metagraph/candidates/13.json",
       "sha256": "dcf5f3ed57d76dcad00c406caa92d3a6e8a452a54812332758d390e681aaf1ad",
-      "size_bytes": 57230
+      "size_bytes": 57230,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -320,7 +359,8 @@
       "latest_key": "latest/candidates/14.json",
       "path": "/metagraph/candidates/14.json",
       "sha256": "f90a0f420168bd788bde0e1e2aff54e3f0595550669f34dad272547d82111420",
-      "size_bytes": 57350
+      "size_bytes": 57350,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -328,7 +368,8 @@
       "latest_key": "latest/candidates/15.json",
       "path": "/metagraph/candidates/15.json",
       "sha256": "4821f184abe8642f92b1aecf4ce1e57b1c600d05fbe8c90f385b712ca9f8794d",
-      "size_bytes": 49713
+      "size_bytes": 49713,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -336,7 +377,8 @@
       "latest_key": "latest/candidates/16.json",
       "path": "/metagraph/candidates/16.json",
       "sha256": "9a83606b75b62139721f70d9e91433cc563a8af48a8a83905f99a235357cec34",
-      "size_bytes": 20604
+      "size_bytes": 20604,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -344,7 +386,8 @@
       "latest_key": "latest/candidates/17.json",
       "path": "/metagraph/candidates/17.json",
       "sha256": "2f1944ecffe2216f5d3bfc3d727c611495b6da67df6abddf5872205785f9e816",
-      "size_bytes": 33536
+      "size_bytes": 33536,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -352,7 +395,8 @@
       "latest_key": "latest/candidates/18.json",
       "path": "/metagraph/candidates/18.json",
       "sha256": "e2984acf7d07dc121ab595a74bd589d85d29f2db14cdf6c32ff6edeeda617b35",
-      "size_bytes": 31167
+      "size_bytes": 31167,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -360,7 +404,8 @@
       "latest_key": "latest/candidates/19.json",
       "path": "/metagraph/candidates/19.json",
       "sha256": "ca9fd7e868fa16f048ecb30e26a4c72a9ce3f1f0ee0b78e51147ef7cf58acb0c",
-      "size_bytes": 41661
+      "size_bytes": 41661,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -368,7 +413,8 @@
       "latest_key": "latest/candidates/2.json",
       "path": "/metagraph/candidates/2.json",
       "sha256": "8b410044af4ffd4601edad2fa3ecf90b29f710675d35f5303fca069f47c01b6c",
-      "size_bytes": 32561
+      "size_bytes": 32561,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -376,7 +422,8 @@
       "latest_key": "latest/candidates/20.json",
       "path": "/metagraph/candidates/20.json",
       "sha256": "272fd57f5e59ef1710f976c840da162cfd426882167db3718f4001d9c111250f",
-      "size_bytes": 25447
+      "size_bytes": 25447,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -384,7 +431,8 @@
       "latest_key": "latest/candidates/21.json",
       "path": "/metagraph/candidates/21.json",
       "sha256": "b1d736c8296fbc9a392919928297d4492e0db6bef8dd43188fe9e0933e76b31f",
-      "size_bytes": 29087
+      "size_bytes": 29087,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -392,7 +440,8 @@
       "latest_key": "latest/candidates/22.json",
       "path": "/metagraph/candidates/22.json",
       "sha256": "48f0a9a18cef69b766c9dbe3e8065a747f0a72fecca8bcb1e18f3b4980f95416",
-      "size_bytes": 21094
+      "size_bytes": 21094,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -400,7 +449,8 @@
       "latest_key": "latest/candidates/23.json",
       "path": "/metagraph/candidates/23.json",
       "sha256": "8d671dcf14eb9cae642125f6536ba21a85b4f331af2b9ed7a28b44c10fc002a3",
-      "size_bytes": 35986
+      "size_bytes": 35986,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -408,7 +458,8 @@
       "latest_key": "latest/candidates/24.json",
       "path": "/metagraph/candidates/24.json",
       "sha256": "a2ed3408ef36ed954c544bbcc0ef6c640384e941bc659d4e667ead158ccb2dc0",
-      "size_bytes": 31280
+      "size_bytes": 31280,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -416,7 +467,8 @@
       "latest_key": "latest/candidates/25.json",
       "path": "/metagraph/candidates/25.json",
       "sha256": "8bd033d8085e26188f57f029487fbb6e5bb648dc90eec2730a0d7c7486004b14",
-      "size_bytes": 42459
+      "size_bytes": 42459,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -424,7 +476,8 @@
       "latest_key": "latest/candidates/26.json",
       "path": "/metagraph/candidates/26.json",
       "sha256": "19a8dccb72baee74f8fb817314e39987c5277fc31728d5c6a1c8295614c03393",
-      "size_bytes": 31514
+      "size_bytes": 31514,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -432,7 +485,8 @@
       "latest_key": "latest/candidates/27.json",
       "path": "/metagraph/candidates/27.json",
       "sha256": "5049597f443de3329099efb4522a64ab6acb0cd6c8331338e514e251eb3a10a3",
-      "size_bytes": 20458
+      "size_bytes": 20458,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -440,7 +494,8 @@
       "latest_key": "latest/candidates/28.json",
       "path": "/metagraph/candidates/28.json",
       "sha256": "1268a48865419c69c15cef80324033278d08e5339e658a286c2387963855cbb4",
-      "size_bytes": 4548
+      "size_bytes": 4548,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -448,7 +503,8 @@
       "latest_key": "latest/candidates/29.json",
       "path": "/metagraph/candidates/29.json",
       "sha256": "11a124ae1bd37d1fa5bfa61e495fc4b206373e4e79ebaa37fa8e795840eaeaea",
-      "size_bytes": 18064
+      "size_bytes": 18064,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -456,7 +512,8 @@
       "latest_key": "latest/candidates/3.json",
       "path": "/metagraph/candidates/3.json",
       "sha256": "f8258544f3a05df240ecb71d41bff4cf731cdabbb1462de9f38e99a38c34ae65",
-      "size_bytes": 6936
+      "size_bytes": 6936,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -464,7 +521,8 @@
       "latest_key": "latest/candidates/30.json",
       "path": "/metagraph/candidates/30.json",
       "sha256": "b4dbfb174ac3c56a0a7414d7749f0e6a393bd2e6005b7e28f8b05b244b070119",
-      "size_bytes": 22990
+      "size_bytes": 22990,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -472,7 +530,8 @@
       "latest_key": "latest/candidates/31.json",
       "path": "/metagraph/candidates/31.json",
       "sha256": "6625d051bf57f4f2499d383e4c4a2e0e1b5bfc92348ef3245dbb0205c71cadc4",
-      "size_bytes": 4576
+      "size_bytes": 4576,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -480,7 +539,8 @@
       "latest_key": "latest/candidates/32.json",
       "path": "/metagraph/candidates/32.json",
       "sha256": "b1915ea56fc7ae5e8823a0a339fc83f92347b67cd2fce2f0ed3840ef8d663470",
-      "size_bytes": 45136
+      "size_bytes": 45136,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -488,7 +548,8 @@
       "latest_key": "latest/candidates/33.json",
       "path": "/metagraph/candidates/33.json",
       "sha256": "dda5c718bed4482ac7854afe3e8bc546067c81ab0259d01ed6e472aa4c962b4b",
-      "size_bytes": 28361
+      "size_bytes": 28361,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -496,7 +557,8 @@
       "latest_key": "latest/candidates/34.json",
       "path": "/metagraph/candidates/34.json",
       "sha256": "d1e1394a2c1fa8256560b84f00101743cbe76a651a82d123f31d7d1bc86ba68f",
-      "size_bytes": 11267
+      "size_bytes": 11267,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -504,7 +566,8 @@
       "latest_key": "latest/candidates/35.json",
       "path": "/metagraph/candidates/35.json",
       "sha256": "b3cc14bcc89a7b644c4d275ef97144515b9fb4fb619e632748aa03c8c496a29d",
-      "size_bytes": 25733
+      "size_bytes": 25733,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -512,7 +575,8 @@
       "latest_key": "latest/candidates/36.json",
       "path": "/metagraph/candidates/36.json",
       "sha256": "c38b192b8597cc70c4f3d5cab21737aefbce1a3de81fc88ce6d3d5024894e4fe",
-      "size_bytes": 26541
+      "size_bytes": 26541,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -520,7 +584,8 @@
       "latest_key": "latest/candidates/37.json",
       "path": "/metagraph/candidates/37.json",
       "sha256": "f2828dad97a384303119edbc26b54de4fb9c5d59226c61cbe6c584032a808e37",
-      "size_bytes": 45382
+      "size_bytes": 45382,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -528,7 +593,8 @@
       "latest_key": "latest/candidates/38.json",
       "path": "/metagraph/candidates/38.json",
       "sha256": "06c6075e27016b6d5d1b9f451ce78ae8e793acec5c4c9ba3e6ffc16673b945d0",
-      "size_bytes": 21145
+      "size_bytes": 21145,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -536,7 +602,8 @@
       "latest_key": "latest/candidates/39.json",
       "path": "/metagraph/candidates/39.json",
       "sha256": "fff237f61b0691b35bab64fbc36935ba0fbeea4d569ea2d8278cbfbca3c35825",
-      "size_bytes": 9148
+      "size_bytes": 9148,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -544,7 +611,8 @@
       "latest_key": "latest/candidates/4.json",
       "path": "/metagraph/candidates/4.json",
       "sha256": "3531648cbe059dbbab63e20e95fdd03c4e8e6872bb7ca4b3980c9c341ab12441",
-      "size_bytes": 45150
+      "size_bytes": 45150,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -552,7 +620,8 @@
       "latest_key": "latest/candidates/40.json",
       "path": "/metagraph/candidates/40.json",
       "sha256": "3a941d2ddec9557bebd20e0af5ada2e8e1c031f0b75c19e9383361e747ddb2fd",
-      "size_bytes": 6777
+      "size_bytes": 6777,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -560,7 +629,8 @@
       "latest_key": "latest/candidates/41.json",
       "path": "/metagraph/candidates/41.json",
       "sha256": "8eed4708a396058007c72a01e9c22ef70e04f0b42accbbb01d232dad5b5f13ad",
-      "size_bytes": 27180
+      "size_bytes": 27180,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -568,7 +638,8 @@
       "latest_key": "latest/candidates/42.json",
       "path": "/metagraph/candidates/42.json",
       "sha256": "e94de14842a4bb423dbf621dd6c2a98fdd5e819a54202c28bd312137f726ce27",
-      "size_bytes": 4593
+      "size_bytes": 4593,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -576,7 +647,8 @@
       "latest_key": "latest/candidates/43.json",
       "path": "/metagraph/candidates/43.json",
       "sha256": "63a7dab739db38e11c0109024e72e7482563c18ab4fa0a0eba73c119b1d98a21",
-      "size_bytes": 9059
+      "size_bytes": 9059,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -584,7 +656,8 @@
       "latest_key": "latest/candidates/44.json",
       "path": "/metagraph/candidates/44.json",
       "sha256": "7d577f27c37bccc86854e9156b3508d19daa8018a8a04505d7cb80b867099987",
-      "size_bytes": 25429
+      "size_bytes": 25429,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -592,7 +665,8 @@
       "latest_key": "latest/candidates/45.json",
       "path": "/metagraph/candidates/45.json",
       "sha256": "414420440ed071a88febbc1013a47245d92d7af61db542012d428f49567c9175",
-      "size_bytes": 41502
+      "size_bytes": 41502,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -600,7 +674,8 @@
       "latest_key": "latest/candidates/46.json",
       "path": "/metagraph/candidates/46.json",
       "sha256": "6b32cbb619d7a0c75b913f0da2f62bd17e695416fb730ac3030cc411132146a9",
-      "size_bytes": 58130
+      "size_bytes": 58130,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -608,7 +683,8 @@
       "latest_key": "latest/candidates/47.json",
       "path": "/metagraph/candidates/47.json",
       "sha256": "e6bffddb71daed13740e822e594ceff50cccbb53ba5f317632dee485f4f40f83",
-      "size_bytes": 13535
+      "size_bytes": 13535,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -616,7 +692,8 @@
       "latest_key": "latest/candidates/48.json",
       "path": "/metagraph/candidates/48.json",
       "sha256": "a6e0c9ea2e60e0eda5739cc1fc19b5fc497ae2df1b2d69381f10e2fd9020677e",
-      "size_bytes": 42820
+      "size_bytes": 42820,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -624,7 +701,8 @@
       "latest_key": "latest/candidates/49.json",
       "path": "/metagraph/candidates/49.json",
       "sha256": "7cb710887e32f402db642185d71250aad8c6678172255502620514e3a2ef6990",
-      "size_bytes": 25236
+      "size_bytes": 25236,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -632,7 +710,8 @@
       "latest_key": "latest/candidates/5.json",
       "path": "/metagraph/candidates/5.json",
       "sha256": "f33edc11b115e64600e024a0c9d97f5dd07420b205e39ee7b7d97b9e2dea2fd6",
-      "size_bytes": 35704
+      "size_bytes": 35704,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -640,7 +719,8 @@
       "latest_key": "latest/candidates/50.json",
       "path": "/metagraph/candidates/50.json",
       "sha256": "e136d6fd36a06baa8d69b955cbc41365cf13cf15d45da7b97ad2a1a37f3afb3a",
-      "size_bytes": 23035
+      "size_bytes": 23035,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -648,7 +728,8 @@
       "latest_key": "latest/candidates/51.json",
       "path": "/metagraph/candidates/51.json",
       "sha256": "1e1be9fcb33e3b99ebd75ee43c7273dda33184b898c9c3e18ca11c0864230f68",
-      "size_bytes": 42442
+      "size_bytes": 42442,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -656,7 +737,8 @@
       "latest_key": "latest/candidates/52.json",
       "path": "/metagraph/candidates/52.json",
       "sha256": "f250303d9189c536664b56530e99e6e44e377ecd2977abaec3b2d08413525e75",
-      "size_bytes": 27256
+      "size_bytes": 27256,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -664,7 +746,8 @@
       "latest_key": "latest/candidates/53.json",
       "path": "/metagraph/candidates/53.json",
       "sha256": "d3c6427f6be160159c4078a0935feaf932cfd139ba296c3658cf3c80ded51b87",
-      "size_bytes": 6927
+      "size_bytes": 6927,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -672,7 +755,8 @@
       "latest_key": "latest/candidates/54.json",
       "path": "/metagraph/candidates/54.json",
       "sha256": "42c99d45c9ec79009b84962def2953aa87a4d1f7872368a2e90eafc358550825",
-      "size_bytes": 27216
+      "size_bytes": 27216,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -680,7 +764,8 @@
       "latest_key": "latest/candidates/55.json",
       "path": "/metagraph/candidates/55.json",
       "sha256": "7f780703d7fbc33a5fee70ab2d742c8f7e603af38f4705f09d8be1aaa13f2a64",
-      "size_bytes": 29058
+      "size_bytes": 29058,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -688,7 +773,8 @@
       "latest_key": "latest/candidates/56.json",
       "path": "/metagraph/candidates/56.json",
       "sha256": "104887df82ab439638d32976f6949e2c730881c6587132e69c9e009d8f0a1b6f",
-      "size_bytes": 43844
+      "size_bytes": 43844,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -696,7 +782,8 @@
       "latest_key": "latest/candidates/57.json",
       "path": "/metagraph/candidates/57.json",
       "sha256": "f55d7d3767566e0499fb5589956a977ec3ea8e987214fd9b8b166bfd05e71576",
-      "size_bytes": 6882
+      "size_bytes": 6882,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -704,7 +791,8 @@
       "latest_key": "latest/candidates/58.json",
       "path": "/metagraph/candidates/58.json",
       "sha256": "e65cfe96f814188a86585f53b8aaf3f3080d7d629ec8076235f34f5279d06ebc",
-      "size_bytes": 15690
+      "size_bytes": 15690,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -712,7 +800,8 @@
       "latest_key": "latest/candidates/59.json",
       "path": "/metagraph/candidates/59.json",
       "sha256": "c45ae4a90b16408ffc8cc52d48b800ee2d5c5fee815ac4e429a2c291b3c97973",
-      "size_bytes": 30992
+      "size_bytes": 30992,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -720,7 +809,8 @@
       "latest_key": "latest/candidates/6.json",
       "path": "/metagraph/candidates/6.json",
       "sha256": "d8fa8a3d979b7bfb7cd8fe8bf5951dce2300328de2ac1846e790a078c0083903",
-      "size_bytes": 35897
+      "size_bytes": 35897,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -728,7 +818,8 @@
       "latest_key": "latest/candidates/60.json",
       "path": "/metagraph/candidates/60.json",
       "sha256": "98e2530e43fefb141ccf80b1cc8fe99d56445b447b8ef382106680ebf0bd3587",
-      "size_bytes": 33855
+      "size_bytes": 33855,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -736,7 +827,8 @@
       "latest_key": "latest/candidates/61.json",
       "path": "/metagraph/candidates/61.json",
       "sha256": "112296b0a3c0cb620eda9d616577444c34217e11ae525be03d80e94c880692a3",
-      "size_bytes": 25331
+      "size_bytes": 25331,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -744,7 +836,8 @@
       "latest_key": "latest/candidates/62.json",
       "path": "/metagraph/candidates/62.json",
       "sha256": "b25eec2351630247f75efe06db53ab5a8bd389c8053e77c8b04b9f90621acbab",
-      "size_bytes": 20868
+      "size_bytes": 20868,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -752,7 +845,8 @@
       "latest_key": "latest/candidates/63.json",
       "path": "/metagraph/candidates/63.json",
       "sha256": "5a89ebdd0e25b8649b8913b3dd63a184fd2696fc99706008f724c6ea7b693cc4",
-      "size_bytes": 44418
+      "size_bytes": 44418,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -760,7 +854,8 @@
       "latest_key": "latest/candidates/64.json",
       "path": "/metagraph/candidates/64.json",
       "sha256": "cfaf326118d5bb43ea8c64eb4b144991fb575084cef7c301ed8cdf9d60577de7",
-      "size_bytes": 55875
+      "size_bytes": 55875,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -768,7 +863,8 @@
       "latest_key": "latest/candidates/65.json",
       "path": "/metagraph/candidates/65.json",
       "sha256": "3be521ae840d0082d5ef2573a8098b980f7bb1dca5904b29fea1d37881b8953e",
-      "size_bytes": 36048
+      "size_bytes": 36048,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -776,7 +872,8 @@
       "latest_key": "latest/candidates/66.json",
       "path": "/metagraph/candidates/66.json",
       "sha256": "ca8aae234af71f0f8e9402722b50e7ae3a8a21cf2649589da23dfd194c3e3845",
-      "size_bytes": 31114
+      "size_bytes": 31114,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -784,7 +881,8 @@
       "latest_key": "latest/candidates/67.json",
       "path": "/metagraph/candidates/67.json",
       "sha256": "d580e157968fe54426ae4118dfa721a63939e646826407784fa12153c03f1e77",
-      "size_bytes": 26812
+      "size_bytes": 26812,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -792,7 +890,8 @@
       "latest_key": "latest/candidates/68.json",
       "path": "/metagraph/candidates/68.json",
       "sha256": "35e03ddef018c0d46e5aa724d2ac7d8c9a2a5d3376b103f2571c9532ee1959a6",
-      "size_bytes": 31211
+      "size_bytes": 31211,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -800,7 +899,8 @@
       "latest_key": "latest/candidates/69.json",
       "path": "/metagraph/candidates/69.json",
       "sha256": "0f870dadbd682513acdb944b8c2610e26ec55cd7ab0386d213f19c4d137f9336",
-      "size_bytes": 4555
+      "size_bytes": 4555,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -808,7 +908,8 @@
       "latest_key": "latest/candidates/7.json",
       "path": "/metagraph/candidates/7.json",
       "sha256": "a3733ed2ec7023d5ede62d38d664f2a63e588a86f7513022d780879b2c8e6fc3",
-      "size_bytes": 23015
+      "size_bytes": 23015,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -816,7 +917,8 @@
       "latest_key": "latest/candidates/70.json",
       "path": "/metagraph/candidates/70.json",
       "sha256": "240cc63d812f48ee192691f9ad7ed347fedc31591179bd2d5a4abafb7ce2d319",
-      "size_bytes": 31257
+      "size_bytes": 31257,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -824,7 +926,8 @@
       "latest_key": "latest/candidates/71.json",
       "path": "/metagraph/candidates/71.json",
       "sha256": "6690e1356f13352d6e01a37eb1a145d278abb2fe685f694ca3495e31ac9b0703",
-      "size_bytes": 23018
+      "size_bytes": 23018,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -832,7 +935,8 @@
       "latest_key": "latest/candidates/72.json",
       "path": "/metagraph/candidates/72.json",
       "sha256": "67e610007702bb6c326463886b0b157a9be1aa3b1ad6211df3c7ac075d7d03bd",
-      "size_bytes": 48624
+      "size_bytes": 48624,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -840,7 +944,8 @@
       "latest_key": "latest/candidates/73.json",
       "path": "/metagraph/candidates/73.json",
       "sha256": "ece1190ecba48a33ace07b4287d2f11fcba6c38ddc4568f71d232258999f4694",
-      "size_bytes": 6902
+      "size_bytes": 6902,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -848,7 +953,8 @@
       "latest_key": "latest/candidates/74.json",
       "path": "/metagraph/candidates/74.json",
       "sha256": "332996079e6384423c24f95526705ea4a0af9c02031a5b855f27949f6d8c9268",
-      "size_bytes": 31713
+      "size_bytes": 31713,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -856,7 +962,8 @@
       "latest_key": "latest/candidates/75.json",
       "path": "/metagraph/candidates/75.json",
       "sha256": "0ba6f9d21d5e42228a087fc5489a53023b3c8f5666fae78b413a37f8e1d446f0",
-      "size_bytes": 45490
+      "size_bytes": 45490,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -864,7 +971,8 @@
       "latest_key": "latest/candidates/76.json",
       "path": "/metagraph/candidates/76.json",
       "sha256": "944e4abb9ac6100a4c0bba477e5f6db2ad2960e29f7ea9d3f1e56f02d965787c",
-      "size_bytes": 4597
+      "size_bytes": 4597,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -872,7 +980,8 @@
       "latest_key": "latest/candidates/77.json",
       "path": "/metagraph/candidates/77.json",
       "sha256": "5a999352f07816d1588a2a3e3cfaef03d9150042dd2c208e9287d351d92f273e",
-      "size_bytes": 25186
+      "size_bytes": 25186,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -880,7 +989,8 @@
       "latest_key": "latest/candidates/78.json",
       "path": "/metagraph/candidates/78.json",
       "sha256": "4af635ee35927086a6758c0f8275adf030b60789e4baf3ab3ad7425ca0b2e676",
-      "size_bytes": 25525
+      "size_bytes": 25525,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -888,7 +998,8 @@
       "latest_key": "latest/candidates/79.json",
       "path": "/metagraph/candidates/79.json",
       "sha256": "29133a8690300212f903d03f53f39695d923e0d330f4c946db924645f9248e16",
-      "size_bytes": 45000
+      "size_bytes": 45000,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -896,7 +1007,8 @@
       "latest_key": "latest/candidates/8.json",
       "path": "/metagraph/candidates/8.json",
       "sha256": "6567e7876e717d0e54f1f5e26a962d125b5aa5e8f4892915486ac23de34d81fe",
-      "size_bytes": 33807
+      "size_bytes": 33807,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -904,7 +1016,8 @@
       "latest_key": "latest/candidates/80.json",
       "path": "/metagraph/candidates/80.json",
       "sha256": "50a3a61226b6073584ed2eb704444b7c4149763c76e26f528c2af547f8d104c9",
-      "size_bytes": 42533
+      "size_bytes": 42533,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -912,7 +1025,8 @@
       "latest_key": "latest/candidates/81.json",
       "path": "/metagraph/candidates/81.json",
       "sha256": "1e0ef96661e57e3c8fdf087abc8677423212d7be3d76306c68a7041cffbe29ac",
-      "size_bytes": 9136
+      "size_bytes": 9136,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -920,7 +1034,8 @@
       "latest_key": "latest/candidates/82.json",
       "path": "/metagraph/candidates/82.json",
       "sha256": "4ee1f44c4370628fa20e34d608c9b8ca94b410dc3b29d28140020634d5d71228",
-      "size_bytes": 47752
+      "size_bytes": 47752,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -928,7 +1043,8 @@
       "latest_key": "latest/candidates/83.json",
       "path": "/metagraph/candidates/83.json",
       "sha256": "c496a076c7879ee920611c02def173514385d10b39cdf1132e9fcaea3afada50",
-      "size_bytes": 21104
+      "size_bytes": 21104,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -936,7 +1052,8 @@
       "latest_key": "latest/candidates/84.json",
       "path": "/metagraph/candidates/84.json",
       "sha256": "d1bb8e3750c383fee6f51de54df71d8960ce80d295563765f98c9269344fa8f9",
-      "size_bytes": 15000
+      "size_bytes": 15000,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -944,7 +1061,8 @@
       "latest_key": "latest/candidates/85.json",
       "path": "/metagraph/candidates/85.json",
       "sha256": "cb3ff1a4497e7ed5f33372e0b459af17ee1700c00996364a7075702e4d406213",
-      "size_bytes": 37190
+      "size_bytes": 37190,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -952,7 +1070,8 @@
       "latest_key": "latest/candidates/86.json",
       "path": "/metagraph/candidates/86.json",
       "sha256": "e9284dad91956424c20f175fb314f5d71af3223849c9b30dc3ec7e022c845219",
-      "size_bytes": 4555
+      "size_bytes": 4555,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -960,7 +1079,8 @@
       "latest_key": "latest/candidates/87.json",
       "path": "/metagraph/candidates/87.json",
       "sha256": "32f406474f6323f724076e7c30d6c3914355b70c5c79fbdcf12721b2fa710666",
-      "size_bytes": 4623
+      "size_bytes": 4623,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -968,7 +1088,8 @@
       "latest_key": "latest/candidates/88.json",
       "path": "/metagraph/candidates/88.json",
       "sha256": "18e73617386fa842d5dc967b82963c6f3380ab5438b5ccd868f906bb28c79fb8",
-      "size_bytes": 37772
+      "size_bytes": 37772,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -976,7 +1097,8 @@
       "latest_key": "latest/candidates/89.json",
       "path": "/metagraph/candidates/89.json",
       "sha256": "49c225a5bec3ae280286e5565203519d75cca963761f9d3397bfcda8af2562b5",
-      "size_bytes": 28069
+      "size_bytes": 28069,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -984,7 +1106,8 @@
       "latest_key": "latest/candidates/9.json",
       "path": "/metagraph/candidates/9.json",
       "sha256": "2e40143e66e05884ac6d917018641b017461d12d55f31be9cffb9469e9954188",
-      "size_bytes": 48574
+      "size_bytes": 48574,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -992,7 +1115,8 @@
       "latest_key": "latest/candidates/90.json",
       "path": "/metagraph/candidates/90.json",
       "sha256": "700c754a957f134232fc2905caa7fb8aa3d37b889e91b067f5c3c4a651da0f16",
-      "size_bytes": 4569
+      "size_bytes": 4569,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1000,7 +1124,8 @@
       "latest_key": "latest/candidates/91.json",
       "path": "/metagraph/candidates/91.json",
       "sha256": "1d0b5453b001e5bb2cf72aabc8bfadac501d8720fe938bdd87fc0ed651e7cecf",
-      "size_bytes": 29464
+      "size_bytes": 29464,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1008,7 +1133,8 @@
       "latest_key": "latest/candidates/92.json",
       "path": "/metagraph/candidates/92.json",
       "sha256": "e51d58455c84b52753820869d613ec63934685acdd9b5f9dac014faefdc50556",
-      "size_bytes": 18887
+      "size_bytes": 18887,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1016,7 +1142,8 @@
       "latest_key": "latest/candidates/93.json",
       "path": "/metagraph/candidates/93.json",
       "sha256": "effdae7d25ad516806b0271c3ceae825ae9a929131153425b905625f6e3c31a7",
-      "size_bytes": 35944
+      "size_bytes": 35944,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1024,7 +1151,8 @@
       "latest_key": "latest/candidates/94.json",
       "path": "/metagraph/candidates/94.json",
       "sha256": "6cddd9c2f7120d9590b52bfa8945dd83ae091bb28523a2d4f95d817b433b2c73",
-      "size_bytes": 26731
+      "size_bytes": 26731,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1032,7 +1160,8 @@
       "latest_key": "latest/candidates/95.json",
       "path": "/metagraph/candidates/95.json",
       "sha256": "8dd0ab5e93037c5ac5dcbe9481f7fbb62946a7704440790f7af842f75a2454bc",
-      "size_bytes": 8794
+      "size_bytes": 8794,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1040,7 +1169,8 @@
       "latest_key": "latest/candidates/96.json",
       "path": "/metagraph/candidates/96.json",
       "sha256": "6491c641ed26045fccf5139ef06e88222bb03378a34a44ea61cf07aa15054e2f",
-      "size_bytes": 27600
+      "size_bytes": 27600,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1048,7 +1178,8 @@
       "latest_key": "latest/candidates/97.json",
       "path": "/metagraph/candidates/97.json",
       "sha256": "c7f06edb1f22fdd317d5ff6be960e713ea65b29b1517dea24d9f32c00ea2a8e4",
-      "size_bytes": 39330
+      "size_bytes": 39330,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1056,7 +1187,8 @@
       "latest_key": "latest/candidates/98.json",
       "path": "/metagraph/candidates/98.json",
       "sha256": "aa33077833f5b96b39800c650b5ab49c09884cd9910cc3ced665f59d7f94d242",
-      "size_bytes": 37768
+      "size_bytes": 37768,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1064,23 +1196,26 @@
       "latest_key": "latest/candidates/99.json",
       "path": "/metagraph/candidates/99.json",
       "sha256": "33a50dcd524a79d9e378a46f8b744a7e1bae5709aeb99a59319c020e93c5b35e",
-      "size_bytes": 35720
+      "size_bytes": 35720,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "444aa1078bf9e3fd54f899df9c336eebdb15b99c3d56c594f3434fcf7805f5cc",
-      "size_bytes": 1209
+      "sha256": "9f943ac61e51f7d58aa680182107a4322bbbac4a60e969cad3a9b32e582b5975",
+      "size_bytes": 36046,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "534dde0d7d88bc13cb1407d49a1e928cdb9702d28a9f66ce052f70444a6f9dff",
-      "size_bytes": 14650
+      "sha256": "1bcbbd5e15001b525d021024668b106f3693e3a3532b0e5235728699d5be744e",
+      "size_bytes": 15971,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -1088,7 +1223,8 @@
       "latest_key": "latest/coverage.json",
       "path": "/metagraph/coverage.json",
       "sha256": "f1afda027d7a6aab9721c2056269b69a2168c99558813188f3a34de4daa773ff",
-      "size_bytes": 982
+      "size_bytes": 982,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -1096,7 +1232,8 @@
       "latest_key": "latest/curation.json",
       "path": "/metagraph/curation.json",
       "sha256": "034eb2f3c88286478bcedffcd3406bccc1b564238fa05682a3adf9f9ac272c75",
-      "size_bytes": 147849
+      "size_bytes": 147849,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -1104,7 +1241,8 @@
       "latest_key": "latest/endpoint-incidents.json",
       "path": "/metagraph/endpoint-incidents.json",
       "sha256": "dfb414fa01911fe9697d45f365c9a82d2d7209b689231dcdfcf6dc179378cdb0",
-      "size_bytes": 659
+      "size_bytes": 659,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -1112,7 +1250,8 @@
       "latest_key": "latest/endpoint-pools.json",
       "path": "/metagraph/endpoint-pools.json",
       "sha256": "7dac9d34860831eebf6fb11160e866a690460b9b7d0541c713248683ac498904",
-      "size_bytes": 7131
+      "size_bytes": 7131,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -1120,7 +1259,8 @@
       "latest_key": "latest/endpoints.json",
       "path": "/metagraph/endpoints.json",
       "sha256": "83d225d3d96472c124707d8e198e4aff4f97dbffe775e491c5493e6a5a0e315a",
-      "size_bytes": 1113597
+      "size_bytes": 1113597,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -1128,7 +1268,8 @@
       "latest_key": "latest/endpoints/0.json",
       "path": "/metagraph/endpoints/0.json",
       "sha256": "54843c7b258f884c66a9362cddc323778ca732ad4dfcedb3a486111c0ba67c8f",
-      "size_bytes": 17508
+      "size_bytes": 17508,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1136,7 +1277,8 @@
       "latest_key": "latest/endpoints/1.json",
       "path": "/metagraph/endpoints/1.json",
       "sha256": "46e509bfb052c8a308863121360db459517c51aba216f6c663b192da4bed3794",
-      "size_bytes": 11000
+      "size_bytes": 11000,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1144,7 +1286,8 @@
       "latest_key": "latest/endpoints/10.json",
       "path": "/metagraph/endpoints/10.json",
       "sha256": "cc44807741a528015ff25879b8ca8cb7d0b3f7b81d654d87c83c5fcae97f40fe",
-      "size_bytes": 6442
+      "size_bytes": 6442,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1152,7 +1295,8 @@
       "latest_key": "latest/endpoints/100.json",
       "path": "/metagraph/endpoints/100.json",
       "sha256": "a1127c69c8ae8cc05a919cd7db075c5cf5f1091b2c803d8ee385ea06362b6705",
-      "size_bytes": 10953
+      "size_bytes": 10953,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1160,7 +1304,8 @@
       "latest_key": "latest/endpoints/101.json",
       "path": "/metagraph/endpoints/101.json",
       "sha256": "26d5be80a5706d2e9e5da35dcb0da286b5dfce290c8150ec299feb3ab1dbc48b",
-      "size_bytes": 3499
+      "size_bytes": 3499,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1168,7 +1313,8 @@
       "latest_key": "latest/endpoints/102.json",
       "path": "/metagraph/endpoints/102.json",
       "sha256": "97850a8352fabfcb5b58ee67302eca0f8532d92b7c5b0d48407b17c7db1b5bc1",
-      "size_bytes": 10785
+      "size_bytes": 10785,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1176,7 +1322,8 @@
       "latest_key": "latest/endpoints/103.json",
       "path": "/metagraph/endpoints/103.json",
       "sha256": "088163d97a2fbe571d1757782429e46263df64b38e4d875507a4a2fb11a3e338",
-      "size_bytes": 10778
+      "size_bytes": 10778,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1184,7 +1331,8 @@
       "latest_key": "latest/endpoints/104.json",
       "path": "/metagraph/endpoints/104.json",
       "sha256": "a708dbc46482a6a3b3c10933f4fc1592d4a1ed344f5377c80277a1e5f30e376c",
-      "size_bytes": 3559
+      "size_bytes": 3559,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1192,7 +1340,8 @@
       "latest_key": "latest/endpoints/105.json",
       "path": "/metagraph/endpoints/105.json",
       "sha256": "77822f1dc5c379296cc6ac02b765968d52ed42c8a6838df867de683abecca2a1",
-      "size_bytes": 9287
+      "size_bytes": 9287,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1200,7 +1349,8 @@
       "latest_key": "latest/endpoints/106.json",
       "path": "/metagraph/endpoints/106.json",
       "sha256": "9b5a54950131bb92fa7e336a82750c6080fd34777edd5814e260c3339700ca03",
-      "size_bytes": 7867
+      "size_bytes": 7867,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1208,7 +1358,8 @@
       "latest_key": "latest/endpoints/107.json",
       "path": "/metagraph/endpoints/107.json",
       "sha256": "34b7df39b5ec1656dd23d96c2e5dca5c0218a16606aeb309c02549558b635d7a",
-      "size_bytes": 16930
+      "size_bytes": 16930,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1216,7 +1367,8 @@
       "latest_key": "latest/endpoints/108.json",
       "path": "/metagraph/endpoints/108.json",
       "sha256": "5f62b93c458fac12af6b0ad1faa4d647e5a32ef5a15faf3afe87fbd342ea6834",
-      "size_bytes": 6487
+      "size_bytes": 6487,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1224,7 +1376,8 @@
       "latest_key": "latest/endpoints/109.json",
       "path": "/metagraph/endpoints/109.json",
       "sha256": "7d23547cf65d54c5cf670b5772888d7fe31f9b2773d3aea2f48e4e1e6691a333",
-      "size_bytes": 5013
+      "size_bytes": 5013,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1232,7 +1385,8 @@
       "latest_key": "latest/endpoints/11.json",
       "path": "/metagraph/endpoints/11.json",
       "sha256": "7d5fa85016ff963085c34c4c90f0d8195b285ad292c0c66187348261b49dd08e",
-      "size_bytes": 9340
+      "size_bytes": 9340,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1240,7 +1394,8 @@
       "latest_key": "latest/endpoints/110.json",
       "path": "/metagraph/endpoints/110.json",
       "sha256": "5daade2bf923ba0bb875c7b0b6d2346217805ecd463812780b5bd5701dc31cf6",
-      "size_bytes": 11236
+      "size_bytes": 11236,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1248,7 +1403,8 @@
       "latest_key": "latest/endpoints/111.json",
       "path": "/metagraph/endpoints/111.json",
       "sha256": "69505e14628aef91441a91688d03c3194f31d7d5c1c23a6dc200f5a9da278aec",
-      "size_bytes": 5020
+      "size_bytes": 5020,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1256,7 +1412,8 @@
       "latest_key": "latest/endpoints/112.json",
       "path": "/metagraph/endpoints/112.json",
       "sha256": "97c1ed79fdcac44e76eb2193da3a722bbdd6b5007e31d6fd8771993a7ca20495",
-      "size_bytes": 8025
+      "size_bytes": 8025,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1264,7 +1421,8 @@
       "latest_key": "latest/endpoints/113.json",
       "path": "/metagraph/endpoints/113.json",
       "sha256": "e8dd5ea7a3c05c56040700fec6ef035fa83a95a4b91282ec18fc4430dd2dc737",
-      "size_bytes": 10918
+      "size_bytes": 10918,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1272,7 +1430,8 @@
       "latest_key": "latest/endpoints/114.json",
       "path": "/metagraph/endpoints/114.json",
       "sha256": "5d7888583dc358ef32c64c820b64991aae95f5acd4d8a9b3646422462faebcfa",
-      "size_bytes": 10926
+      "size_bytes": 10926,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1280,7 +1439,8 @@
       "latest_key": "latest/endpoints/115.json",
       "path": "/metagraph/endpoints/115.json",
       "sha256": "ab67194afe07bc223a7e021dec3f4c27900562799d320bd241aa10e8b746aded",
-      "size_bytes": 5020
+      "size_bytes": 5020,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1288,7 +1448,8 @@
       "latest_key": "latest/endpoints/116.json",
       "path": "/metagraph/endpoints/116.json",
       "sha256": "1913beea94e98640b9a2b9cb6cdec2f7c53ec33a20c014f4798e7d7d70dce8eb",
-      "size_bytes": 3517
+      "size_bytes": 3517,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1296,7 +1457,8 @@
       "latest_key": "latest/endpoints/117.json",
       "path": "/metagraph/endpoints/117.json",
       "sha256": "319dc14b2532c64f973209ffbfe0eb1c5485e4f5067ac67380710ea5e050279d",
-      "size_bytes": 6550
+      "size_bytes": 6550,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1304,7 +1466,8 @@
       "latest_key": "latest/endpoints/118.json",
       "path": "/metagraph/endpoints/118.json",
       "sha256": "03a63af75f2f165c4a3588c826b54e0d1de1df9d2d9314c4de859f5d483c3812",
-      "size_bytes": 12436
+      "size_bytes": 12436,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1312,7 +1475,8 @@
       "latest_key": "latest/endpoints/119.json",
       "path": "/metagraph/endpoints/119.json",
       "sha256": "2a4cd0bd8f6b87522a4b1417b56e7969be2b24df96e5c6b041ed6b5343a65f22",
-      "size_bytes": 3508
+      "size_bytes": 3508,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1320,7 +1484,8 @@
       "latest_key": "latest/endpoints/12.json",
       "path": "/metagraph/endpoints/12.json",
       "sha256": "0a93fe740c050c9ce7972b4a8b09656a7b689b1f4ca61ad5e29fdf95bc68ee34",
-      "size_bytes": 6591
+      "size_bytes": 6591,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1328,7 +1493,8 @@
       "latest_key": "latest/endpoints/120.json",
       "path": "/metagraph/endpoints/120.json",
       "sha256": "fa2c262fe95a12d39402e652e2238011218cbcc77f42d8930d3145ed68079f06",
-      "size_bytes": 7985
+      "size_bytes": 7985,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1336,7 +1502,8 @@
       "latest_key": "latest/endpoints/121.json",
       "path": "/metagraph/endpoints/121.json",
       "sha256": "c2c6de0aafb35cb6879b856c5c335f60d3e8f6445c2f8fd1541427e1f6716f02",
-      "size_bytes": 6499
+      "size_bytes": 6499,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1344,7 +1511,8 @@
       "latest_key": "latest/endpoints/122.json",
       "path": "/metagraph/endpoints/122.json",
       "sha256": "ab3cbfac03d7ea1dad20996f98cc800dd514ca01fef472d85cdede1ddf53fbd5",
-      "size_bytes": 5074
+      "size_bytes": 5074,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1352,7 +1520,8 @@
       "latest_key": "latest/endpoints/123.json",
       "path": "/metagraph/endpoints/123.json",
       "sha256": "35f7932d46b58a764c4a8e35733a0dfb628e50d4d466c94120a82158c4ab3af2",
-      "size_bytes": 5004
+      "size_bytes": 5004,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1360,7 +1529,8 @@
       "latest_key": "latest/endpoints/124.json",
       "path": "/metagraph/endpoints/124.json",
       "sha256": "7a22aa00cfba72ab242a611a7473f8e22db097a49854eb62e2757ed2886b40f9",
-      "size_bytes": 10837
+      "size_bytes": 10837,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1368,7 +1538,8 @@
       "latest_key": "latest/endpoints/125.json",
       "path": "/metagraph/endpoints/125.json",
       "sha256": "ca640fff98f8d14d54d70b366ed341d4f7e50adb88adac7c087d7705c863e3d2",
-      "size_bytes": 3508
+      "size_bytes": 3508,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1376,7 +1547,8 @@
       "latest_key": "latest/endpoints/126.json",
       "path": "/metagraph/endpoints/126.json",
       "sha256": "5da22ac45c32e5c6f0a17cc81d4ae3325f6ab36f55949da933de50ba32feeef0",
-      "size_bytes": 7927
+      "size_bytes": 7927,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1384,7 +1556,8 @@
       "latest_key": "latest/endpoints/127.json",
       "path": "/metagraph/endpoints/127.json",
       "sha256": "07f14f6c3a3c0eaf9dcd30dad820c5d98c301aa42e509caf48a4b2372c7fadee",
-      "size_bytes": 8029
+      "size_bytes": 8029,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1392,7 +1565,8 @@
       "latest_key": "latest/endpoints/128.json",
       "path": "/metagraph/endpoints/128.json",
       "sha256": "5e0399a2e14bcad5f87472bf370a799454e1127d7482a86ad5c2fcbe3b89853c",
-      "size_bytes": 10866
+      "size_bytes": 10866,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1400,7 +1574,8 @@
       "latest_key": "latest/endpoints/13.json",
       "path": "/metagraph/endpoints/13.json",
       "sha256": "5d5450fe262cbeaf283694243fda9491e4927deefa2f3b2b436a858fadfe4665",
-      "size_bytes": 11352
+      "size_bytes": 11352,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1408,7 +1583,8 @@
       "latest_key": "latest/endpoints/14.json",
       "path": "/metagraph/endpoints/14.json",
       "sha256": "ef495f3ee2bae6b4bd472edba320689838c23f3a2b3de85270dcb533035dbeb0",
-      "size_bytes": 15391
+      "size_bytes": 15391,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1416,7 +1592,8 @@
       "latest_key": "latest/endpoints/15.json",
       "path": "/metagraph/endpoints/15.json",
       "sha256": "00b0e8245360acbc657507f8ba07526581bfae8cd00c06289291056ab71379de",
-      "size_bytes": 13747
+      "size_bytes": 13747,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1424,7 +1601,8 @@
       "latest_key": "latest/endpoints/16.json",
       "path": "/metagraph/endpoints/16.json",
       "sha256": "24e6fdfbd161b0218156372658fb1105edc41fb67ed6f9f0cc6a5e5b3df3a198",
-      "size_bytes": 9276
+      "size_bytes": 9276,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1432,7 +1610,8 @@
       "latest_key": "latest/endpoints/17.json",
       "path": "/metagraph/endpoints/17.json",
       "sha256": "827e89d000c70b4b94c2687476244a8ff206d5cce5c4f02047ddf52fa4f7e48d",
-      "size_bytes": 9540
+      "size_bytes": 9540,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1440,7 +1619,8 @@
       "latest_key": "latest/endpoints/18.json",
       "path": "/metagraph/endpoints/18.json",
       "sha256": "aef8e1744815c523dc14b69c93c1c6258d354191368213c42d61c34043a3bfd1",
-      "size_bytes": 9380
+      "size_bytes": 9380,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1448,7 +1628,8 @@
       "latest_key": "latest/endpoints/19.json",
       "path": "/metagraph/endpoints/19.json",
       "sha256": "ca26d47823b0b47d2383f6c1a98eed1d28cd6d90b6f4f62c20945419f3aa4963",
-      "size_bytes": 10867
+      "size_bytes": 10867,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1456,7 +1637,8 @@
       "latest_key": "latest/endpoints/2.json",
       "path": "/metagraph/endpoints/2.json",
       "sha256": "04cc583749d49f26ef1015dce4e3d7e88cf225f1ab6f160bab607b9595efd95f",
-      "size_bytes": 15577
+      "size_bytes": 15577,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1464,7 +1646,8 @@
       "latest_key": "latest/endpoints/20.json",
       "path": "/metagraph/endpoints/20.json",
       "sha256": "e53655c423df87f82e0afeaadbd30abaa0e2dfaa2a395a4887b82c2df181077d",
-      "size_bytes": 4975
+      "size_bytes": 4975,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1472,7 +1655,8 @@
       "latest_key": "latest/endpoints/21.json",
       "path": "/metagraph/endpoints/21.json",
       "sha256": "fd49e26e8526b1abb2edb24d1a6beb03ab876ce41214ba07b05f19ae7d2c416d",
-      "size_bytes": 6434
+      "size_bytes": 6434,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1480,7 +1664,8 @@
       "latest_key": "latest/endpoints/22.json",
       "path": "/metagraph/endpoints/22.json",
       "sha256": "0ea7508edf89ca9cf9758a44c836b79cf35b98b1cafdfbca330e37b694369da6",
-      "size_bytes": 10727
+      "size_bytes": 10727,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1488,7 +1673,8 @@
       "latest_key": "latest/endpoints/23.json",
       "path": "/metagraph/endpoints/23.json",
       "sha256": "d9bad47057d572638ccb04404dd3109bbb9a43cb71ff87fc6045b7da5528befa",
-      "size_bytes": 17018
+      "size_bytes": 17018,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1496,7 +1682,8 @@
       "latest_key": "latest/endpoints/24.json",
       "path": "/metagraph/endpoints/24.json",
       "sha256": "bd535d35a64e1a1e63b25db7318c357aff3c344c98857318109a9ee89b904800",
-      "size_bytes": 11086
+      "size_bytes": 11086,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1504,7 +1691,8 @@
       "latest_key": "latest/endpoints/25.json",
       "path": "/metagraph/endpoints/25.json",
       "sha256": "175c4803c299252aa042c464d0bd283dd52383343ec5c58b49b1d065b904ee49",
-      "size_bytes": 10908
+      "size_bytes": 10908,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1512,7 +1700,8 @@
       "latest_key": "latest/endpoints/26.json",
       "path": "/metagraph/endpoints/26.json",
       "sha256": "f83f91ff38013089be0b7a978388714f09ba7089e0d351736e41f40d23cceebe",
-      "size_bytes": 9430
+      "size_bytes": 9430,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1520,7 +1709,8 @@
       "latest_key": "latest/endpoints/27.json",
       "path": "/metagraph/endpoints/27.json",
       "sha256": "e6c57d3b54a31b3ac2cd1a7eec51952977573ec55ff5279d8f7810e23ee1399c",
-      "size_bytes": 3494
+      "size_bytes": 3494,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1528,7 +1718,8 @@
       "latest_key": "latest/endpoints/28.json",
       "path": "/metagraph/endpoints/28.json",
       "sha256": "23015625018bb1e9c48e082b714d43a4561650d74d770fcaae9a2d4896613ecd",
-      "size_bytes": 3482
+      "size_bytes": 3482,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1536,7 +1727,8 @@
       "latest_key": "latest/endpoints/29.json",
       "path": "/metagraph/endpoints/29.json",
       "sha256": "96fcaf012c9d648f1f8c3baef40d556a47ea3179e54c585d058577aa4daa8422",
-      "size_bytes": 9660
+      "size_bytes": 9660,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1544,7 +1736,8 @@
       "latest_key": "latest/endpoints/3.json",
       "path": "/metagraph/endpoints/3.json",
       "sha256": "189afa8602c2bfef8831c79abc65af42634703d25ef16bdfccf37f3b4dc5c52a",
-      "size_bytes": 5025
+      "size_bytes": 5025,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1552,7 +1745,8 @@
       "latest_key": "latest/endpoints/30.json",
       "path": "/metagraph/endpoints/30.json",
       "sha256": "af3271cb9e83c66e14857e4f3fd1a91f8592028ec91517b307f0431525bb71da",
-      "size_bytes": 6438
+      "size_bytes": 6438,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1560,7 +1754,8 @@
       "latest_key": "latest/endpoints/31.json",
       "path": "/metagraph/endpoints/31.json",
       "sha256": "b73c04778d102c47c57b2f81b9bbb32778f55d5fabd0d0ab428299947e0ef907",
-      "size_bytes": 3494
+      "size_bytes": 3494,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1568,7 +1763,8 @@
       "latest_key": "latest/endpoints/32.json",
       "path": "/metagraph/endpoints/32.json",
       "sha256": "bddb6f0057c7efab30c97f69e63da8c3f1104196caeb942081c2994782b89b8a",
-      "size_bytes": 7940
+      "size_bytes": 7940,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1576,7 +1772,8 @@
       "latest_key": "latest/endpoints/33.json",
       "path": "/metagraph/endpoints/33.json",
       "sha256": "3289b9e736b40a293efc3374bdc514831a24cf754339c314c2efe9f6ecd12152",
-      "size_bytes": 14881
+      "size_bytes": 14881,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1584,7 +1781,8 @@
       "latest_key": "latest/endpoints/34.json",
       "path": "/metagraph/endpoints/34.json",
       "sha256": "62a530b9dba1f40e7a54651dc62f0df028a02a3d63286496e9d115d3e4c38797",
-      "size_bytes": 6589
+      "size_bytes": 6589,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1592,7 +1790,8 @@
       "latest_key": "latest/endpoints/35.json",
       "path": "/metagraph/endpoints/35.json",
       "sha256": "47dbd37b73502ee846209b27820c9dc1c9d77449b12913cf1dc317da4ec3d447",
-      "size_bytes": 9585
+      "size_bytes": 9585,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1600,7 +1799,8 @@
       "latest_key": "latest/endpoints/36.json",
       "path": "/metagraph/endpoints/36.json",
       "sha256": "e1aae66c62e17c0aa45bda3006a7f891d6408e71c460c70e3b5c407c0353b2ab",
-      "size_bytes": 9275
+      "size_bytes": 9275,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1608,7 +1808,8 @@
       "latest_key": "latest/endpoints/37.json",
       "path": "/metagraph/endpoints/37.json",
       "sha256": "cfad4724bb1ae014657e2243ba0873cdcb79e3177ab8afecf48bb85c76c8fe08",
-      "size_bytes": 11136
+      "size_bytes": 11136,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1616,7 +1817,8 @@
       "latest_key": "latest/endpoints/38.json",
       "path": "/metagraph/endpoints/38.json",
       "sha256": "f84fd63596959102df8e7eb950c7dab963873350ad26949266c8c53b7ced792b",
-      "size_bytes": 9364
+      "size_bytes": 9364,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1624,7 +1826,8 @@
       "latest_key": "latest/endpoints/39.json",
       "path": "/metagraph/endpoints/39.json",
       "sha256": "604e627686b1dd5b46f7f7a6c75764f61117341151af778946fe292cb46ed4cd",
-      "size_bytes": 5045
+      "size_bytes": 5045,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1632,7 +1835,8 @@
       "latest_key": "latest/endpoints/4.json",
       "path": "/metagraph/endpoints/4.json",
       "sha256": "ff09009878cfb6cedb646ff0bc775da1a30eba8f720184209ae882d11af1c60e",
-      "size_bytes": 12326
+      "size_bytes": 12326,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1640,7 +1844,8 @@
       "latest_key": "latest/endpoints/40.json",
       "path": "/metagraph/endpoints/40.json",
       "sha256": "37b2f5caa1bb517ca08d8e706d8b1d3c510694c290fa8fc53b88c7622f624cb1",
-      "size_bytes": 3500
+      "size_bytes": 3500,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1648,7 +1853,8 @@
       "latest_key": "latest/endpoints/41.json",
       "path": "/metagraph/endpoints/41.json",
       "sha256": "dfe6c4c8424f1cad8566bc3d5c4f316280c66bc2be9399e984e0f42934a0d125",
-      "size_bytes": 12301
+      "size_bytes": 12301,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1656,7 +1862,8 @@
       "latest_key": "latest/endpoints/42.json",
       "path": "/metagraph/endpoints/42.json",
       "sha256": "4eb5cb04b6b91d1e8d54ad38c70c4d13115c4375dda0095e0f023ab0fab70841",
-      "size_bytes": 3503
+      "size_bytes": 3503,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1664,7 +1871,8 @@
       "latest_key": "latest/endpoints/43.json",
       "path": "/metagraph/endpoints/43.json",
       "sha256": "0714ea9c3330664f6b0a1ba2a10e65438f9d682e9fd17547ab771f213128e724",
-      "size_bytes": 5000
+      "size_bytes": 5000,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1672,7 +1880,8 @@
       "latest_key": "latest/endpoints/44.json",
       "path": "/metagraph/endpoints/44.json",
       "sha256": "1baff931c192ce0c84cc1d2e112375d3ba9da605de192e625dff8ae0c3c1408f",
-      "size_bytes": 7980
+      "size_bytes": 7980,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1680,7 +1889,8 @@
       "latest_key": "latest/endpoints/45.json",
       "path": "/metagraph/endpoints/45.json",
       "sha256": "e6cce45531792d64f1701856afe77edd1ef1073e1081fd22d73dab848bb9f2bb",
-      "size_bytes": 10905
+      "size_bytes": 10905,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1688,7 +1898,8 @@
       "latest_key": "latest/endpoints/46.json",
       "path": "/metagraph/endpoints/46.json",
       "sha256": "b04e1cf6907819263fde882b1cd70949e33179a9dda234dbdcd822c26ed7fa8d",
-      "size_bytes": 16843
+      "size_bytes": 16843,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1696,7 +1907,8 @@
       "latest_key": "latest/endpoints/47.json",
       "path": "/metagraph/endpoints/47.json",
       "sha256": "615377a32a4884cde2f92c6480d9efd5257bbcd5057838321ab03cc384137373",
-      "size_bytes": 9639
+      "size_bytes": 9639,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1704,7 +1916,8 @@
       "latest_key": "latest/endpoints/48.json",
       "path": "/metagraph/endpoints/48.json",
       "sha256": "1586787b808a9a76c7ee3c40a83fa206a605b590f7f1d02237854f3ff7a8a1f1",
-      "size_bytes": 6510
+      "size_bytes": 6510,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1712,7 +1925,8 @@
       "latest_key": "latest/endpoints/49.json",
       "path": "/metagraph/endpoints/49.json",
       "sha256": "c558b75439f46290223281787ebc58745de5049e0fa3f50ac012f4aaf284b119",
-      "size_bytes": 6532
+      "size_bytes": 6532,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1720,7 +1934,8 @@
       "latest_key": "latest/endpoints/5.json",
       "path": "/metagraph/endpoints/5.json",
       "sha256": "bec76c7746bd774c7c628323d61788072a81504559e3d6bc93e26b846637a4b2",
-      "size_bytes": 10982
+      "size_bytes": 10982,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1728,7 +1943,8 @@
       "latest_key": "latest/endpoints/50.json",
       "path": "/metagraph/endpoints/50.json",
       "sha256": "af8821583940f0e5f70e89361d5444dab7489086a8f713e4629c798cb2e7fb1e",
-      "size_bytes": 9287
+      "size_bytes": 9287,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1736,7 +1952,8 @@
       "latest_key": "latest/endpoints/51.json",
       "path": "/metagraph/endpoints/51.json",
       "sha256": "b5a5179fa2b79b9773bd95db0800c27416400f9cf40a4fabdfa19db0c5f19e24",
-      "size_bytes": 10783
+      "size_bytes": 10783,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1744,7 +1961,8 @@
       "latest_key": "latest/endpoints/52.json",
       "path": "/metagraph/endpoints/52.json",
       "sha256": "6121264d8e4272079ea9b29903e7adc0e9b41ef89956aff9c4d666a606cacd25",
-      "size_bytes": 12653
+      "size_bytes": 12653,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1752,7 +1970,8 @@
       "latest_key": "latest/endpoints/53.json",
       "path": "/metagraph/endpoints/53.json",
       "sha256": "cb64fcdba090bd1228b30d8659c2a2a9f0a50e716fbee6cab86e8677a8394e46",
-      "size_bytes": 3527
+      "size_bytes": 3527,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1760,7 +1979,8 @@
       "latest_key": "latest/endpoints/54.json",
       "path": "/metagraph/endpoints/54.json",
       "sha256": "2838c6d303819e2cddf9d37df25fb9d684de28e639e0dd3f8194b2ab6d586a8b",
-      "size_bytes": 8012
+      "size_bytes": 8012,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1768,7 +1988,8 @@
       "latest_key": "latest/endpoints/55.json",
       "path": "/metagraph/endpoints/55.json",
       "sha256": "cdd388b027d2237b4101f461eb679bbea6f18988122ae0f4d410cf203d58f481",
-      "size_bytes": 6445
+      "size_bytes": 6445,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1776,7 +1997,8 @@
       "latest_key": "latest/endpoints/56.json",
       "path": "/metagraph/endpoints/56.json",
       "sha256": "adf3270671a5bed2024cd40054902b70031a82ecd885d9bdb7d5cd847be0dd9d",
-      "size_bytes": 12383
+      "size_bytes": 12383,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1784,7 +2006,8 @@
       "latest_key": "latest/endpoints/57.json",
       "path": "/metagraph/endpoints/57.json",
       "sha256": "16319e2fbe641c9858cf202a6e1ae87fd1e74cc9a540d5d07158f937a20ec77f",
-      "size_bytes": 5026
+      "size_bytes": 5026,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1792,7 +2015,8 @@
       "latest_key": "latest/endpoints/58.json",
       "path": "/metagraph/endpoints/58.json",
       "sha256": "1e04ac3aeedf8c42513f3412d88a546537c55b8028b39f9296bd2f8bf17f9d14",
-      "size_bytes": 11204
+      "size_bytes": 11204,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1800,7 +2024,8 @@
       "latest_key": "latest/endpoints/59.json",
       "path": "/metagraph/endpoints/59.json",
       "sha256": "7a8ba94c56391416e3ef23f6826b2e8ea20eede156e62e5b2fd01de3a7e4cfce",
-      "size_bytes": 9452
+      "size_bytes": 9452,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1808,7 +2033,8 @@
       "latest_key": "latest/endpoints/6.json",
       "path": "/metagraph/endpoints/6.json",
       "sha256": "1ade41f2adcb8b9b0bce4efa0e530f79bda0738409b6521a7ff1c1d62ac2fb21",
-      "size_bytes": 11072
+      "size_bytes": 11072,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1816,7 +2042,8 @@
       "latest_key": "latest/endpoints/60.json",
       "path": "/metagraph/endpoints/60.json",
       "sha256": "c325e0513c520bd1d78773b3739203a51d8982b672a9f7175b62bdd2f30b2c8a",
-      "size_bytes": 15381
+      "size_bytes": 15381,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1824,7 +2051,8 @@
       "latest_key": "latest/endpoints/61.json",
       "path": "/metagraph/endpoints/61.json",
       "sha256": "456f2b259bc46e270e52aab8f0d7ce7d486f2c9e3570be97708345cbf6812ff7",
-      "size_bytes": 9466
+      "size_bytes": 9466,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1832,7 +2060,8 @@
       "latest_key": "latest/endpoints/62.json",
       "path": "/metagraph/endpoints/62.json",
       "sha256": "6f70075413451361821672887faf0f2e0fd718fc9349aa60b0e28a635cc41319",
-      "size_bytes": 4981
+      "size_bytes": 4981,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1840,7 +2069,8 @@
       "latest_key": "latest/endpoints/63.json",
       "path": "/metagraph/endpoints/63.json",
       "sha256": "6fff1d92ebc3a3dba62d5ce225e3f0aaf88bd898cfcde81a063b89e4edf1bbe9",
-      "size_bytes": 7970
+      "size_bytes": 7970,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1848,7 +2078,8 @@
       "latest_key": "latest/endpoints/64.json",
       "path": "/metagraph/endpoints/64.json",
       "sha256": "54f757f795c49f5e641b7155fbf326d476e518a5539e512ff81848969a1ac444",
-      "size_bytes": 16897
+      "size_bytes": 16897,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1856,7 +2087,8 @@
       "latest_key": "latest/endpoints/65.json",
       "path": "/metagraph/endpoints/65.json",
       "sha256": "252eccb6c8a4bd1c2b97b52aaf887b3d91dd31efa9a8239301910f6899179c94",
-      "size_bytes": 13854
+      "size_bytes": 13854,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1864,7 +2096,8 @@
       "latest_key": "latest/endpoints/66.json",
       "path": "/metagraph/endpoints/66.json",
       "sha256": "b3aaef3fd25bcc6548fda6ca439b5c7dd10a147272a22c7557ba669a58bb8bc7",
-      "size_bytes": 13704
+      "size_bytes": 13704,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1872,7 +2105,8 @@
       "latest_key": "latest/endpoints/67.json",
       "path": "/metagraph/endpoints/67.json",
       "sha256": "5e25afa37e58c505dc19741942eb16f85bbd1fa1cfa900e18bb26744d4629613",
-      "size_bytes": 9436
+      "size_bytes": 9436,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1880,7 +2114,8 @@
       "latest_key": "latest/endpoints/68.json",
       "path": "/metagraph/endpoints/68.json",
       "sha256": "5aba5b8dc768131a2bd34b4340bdd0750e71c73b8dffba345ca3e2ec927fa5f2",
-      "size_bytes": 10940
+      "size_bytes": 10940,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1888,7 +2123,8 @@
       "latest_key": "latest/endpoints/69.json",
       "path": "/metagraph/endpoints/69.json",
       "sha256": "2e5a555d88e043225e3cab1ca23d0a931937cf0c5fcfa9b53b19a43d4822a7d5",
-      "size_bytes": 3485
+      "size_bytes": 3485,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1896,7 +2132,8 @@
       "latest_key": "latest/endpoints/7.json",
       "path": "/metagraph/endpoints/7.json",
       "sha256": "50141a8161e943bc30eeb4b8d99d3f0aa59ea1f7fb4c56d02bb5bf621bac2ff7",
-      "size_bytes": 19977
+      "size_bytes": 19977,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1904,7 +2141,8 @@
       "latest_key": "latest/endpoints/70.json",
       "path": "/metagraph/endpoints/70.json",
       "sha256": "f61946e865a279cc1bdef35993564ea7b1a9d83f549fc2dda64910579fdbd99d",
-      "size_bytes": 9382
+      "size_bytes": 9382,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1912,7 +2150,8 @@
       "latest_key": "latest/endpoints/71.json",
       "path": "/metagraph/endpoints/71.json",
       "sha256": "9e556cbf3478e05d7416190e6ccc530e45d0f4c6876f491baeb653adba6aab63",
-      "size_bytes": 9300
+      "size_bytes": 9300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1920,7 +2159,8 @@
       "latest_key": "latest/endpoints/72.json",
       "path": "/metagraph/endpoints/72.json",
       "sha256": "c6079af58e845595d9f00bc836f3e15321f30a6894756da200b2c038e8d0d055",
-      "size_bytes": 9693
+      "size_bytes": 9693,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1928,7 +2168,8 @@
       "latest_key": "latest/endpoints/73.json",
       "path": "/metagraph/endpoints/73.json",
       "sha256": "41507b0788a89b98fb1be4a7eccc9f3360564986dbc5b89c8bd5e6a68c656953",
-      "size_bytes": 3494
+      "size_bytes": 3494,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1936,7 +2177,8 @@
       "latest_key": "latest/endpoints/74.json",
       "path": "/metagraph/endpoints/74.json",
       "sha256": "ada7e24c97d62217da743fd40ad2e6178a5d073dcbc3254cf87d592e2b7f7775",
-      "size_bytes": 9997
+      "size_bytes": 9997,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1944,7 +2186,8 @@
       "latest_key": "latest/endpoints/75.json",
       "path": "/metagraph/endpoints/75.json",
       "sha256": "8b9645536dd413d179c16b96cba4d957d1440ba14f913c4ea7d09a5e4af9e5d2",
-      "size_bytes": 10935
+      "size_bytes": 10935,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1952,7 +2195,8 @@
       "latest_key": "latest/endpoints/76.json",
       "path": "/metagraph/endpoints/76.json",
       "sha256": "85249b7c1a3c002f1bd8a1d72829943b8dc2eedab117f174baac3da92b38d45d",
-      "size_bytes": 3503
+      "size_bytes": 3503,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1960,7 +2204,8 @@
       "latest_key": "latest/endpoints/77.json",
       "path": "/metagraph/endpoints/77.json",
       "sha256": "af5e996d5a3d288f30e2d04f6720832cedf88d852a7f30eef8b8e2e127eff4e9",
-      "size_bytes": 9289
+      "size_bytes": 9289,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1968,7 +2213,8 @@
       "latest_key": "latest/endpoints/78.json",
       "path": "/metagraph/endpoints/78.json",
       "sha256": "b8fcb74b920ccf03adb9cbbdb7d81b656f375a9b0bffafd23c7af4fb8ca4e029",
-      "size_bytes": 12339
+      "size_bytes": 12339,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1976,7 +2222,8 @@
       "latest_key": "latest/endpoints/79.json",
       "path": "/metagraph/endpoints/79.json",
       "sha256": "a6682bfec2336680b520eb05d6591a3651baa4ffe3371dc3b84d23398e8c1c27",
-      "size_bytes": 7976
+      "size_bytes": 7976,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1984,7 +2231,8 @@
       "latest_key": "latest/endpoints/8.json",
       "path": "/metagraph/endpoints/8.json",
       "sha256": "cd031d0fd51dcb149514bd4600e2970b245e9efe37743444ebdee3e2ca568ab0",
-      "size_bytes": 12452
+      "size_bytes": 12452,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -1992,7 +2240,8 @@
       "latest_key": "latest/endpoints/80.json",
       "path": "/metagraph/endpoints/80.json",
       "sha256": "a6fd2d669e47e440a90b6acecc9a698e39d97f46884c8d56805f4baf8983f826",
-      "size_bytes": 13915
+      "size_bytes": 13915,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2000,7 +2249,8 @@
       "latest_key": "latest/endpoints/81.json",
       "path": "/metagraph/endpoints/81.json",
       "sha256": "627aa47dcce984b9e62f310e9e943abd400621b65a9c44bd22b9de9aa91d4306",
-      "size_bytes": 5042
+      "size_bytes": 5042,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2008,7 +2258,8 @@
       "latest_key": "latest/endpoints/82.json",
       "path": "/metagraph/endpoints/82.json",
       "sha256": "ca00bb3e1c04b98da552eddef8953a5628742dea6a3ca273525c94f35d52b9d5",
-      "size_bytes": 11034
+      "size_bytes": 11034,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2016,7 +2267,8 @@
       "latest_key": "latest/endpoints/83.json",
       "path": "/metagraph/endpoints/83.json",
       "sha256": "1656443e4b5bbad532cb4067d8c5d8f2d870a84c5ad6b3de175fddc682a7508c",
-      "size_bytes": 9346
+      "size_bytes": 9346,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2024,7 +2276,8 @@
       "latest_key": "latest/endpoints/84.json",
       "path": "/metagraph/endpoints/84.json",
       "sha256": "f68f0343d75ceebcd406ae56dd6778d40c6401c755cb74cdff00b3340131f0ea",
-      "size_bytes": 8108
+      "size_bytes": 8108,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2032,7 +2285,8 @@
       "latest_key": "latest/endpoints/85.json",
       "path": "/metagraph/endpoints/85.json",
       "sha256": "95f2e9701251b0237b8fad289024cd3c4c91d15164403252ba938858140356b8",
-      "size_bytes": 13685
+      "size_bytes": 13685,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2040,7 +2294,8 @@
       "latest_key": "latest/endpoints/86.json",
       "path": "/metagraph/endpoints/86.json",
       "sha256": "1eb3ef474b4276f117ff9f7b3c116cb263b3a7cb4333dc0bafd6639c8ab7fd63",
-      "size_bytes": 3485
+      "size_bytes": 3485,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2048,7 +2303,8 @@
       "latest_key": "latest/endpoints/87.json",
       "path": "/metagraph/endpoints/87.json",
       "sha256": "9f9ecbaac44cb078bda5d09d7e214865ef5687b41bad1d278ae3e681197d0b08",
-      "size_bytes": 3521
+      "size_bytes": 3521,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2056,7 +2312,8 @@
       "latest_key": "latest/endpoints/88.json",
       "path": "/metagraph/endpoints/88.json",
       "sha256": "3baeb7e92ddb840ad2d322d139152b40ab8a0c6863cfa0ff2e1d53c8859dec45",
-      "size_bytes": 12527
+      "size_bytes": 12527,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2064,7 +2321,8 @@
       "latest_key": "latest/endpoints/89.json",
       "path": "/metagraph/endpoints/89.json",
       "sha256": "e7e2e37f03c0289130352798489370dae1d067c752801a995cac8bc5ca4667eb",
-      "size_bytes": 9733
+      "size_bytes": 9733,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2072,7 +2330,8 @@
       "latest_key": "latest/endpoints/9.json",
       "path": "/metagraph/endpoints/9.json",
       "sha256": "1249947b272562609424b618c4c76e1939b0f523a71c8a13367e4ccd1528cf75",
-      "size_bytes": 13830
+      "size_bytes": 13830,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2080,7 +2339,8 @@
       "latest_key": "latest/endpoints/90.json",
       "path": "/metagraph/endpoints/90.json",
       "sha256": "e89546158182a9f1c155faa8964b56ec07859ea292a6384a8ab3f5e037275e78",
-      "size_bytes": 3491
+      "size_bytes": 3491,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2088,7 +2348,8 @@
       "latest_key": "latest/endpoints/91.json",
       "path": "/metagraph/endpoints/91.json",
       "sha256": "c884e820407fd0982bc8d3732d82d82db2055f509018cd1ab379917953b3b9c4",
-      "size_bytes": 4981
+      "size_bytes": 4981,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2096,7 +2357,8 @@
       "latest_key": "latest/endpoints/92.json",
       "path": "/metagraph/endpoints/92.json",
       "sha256": "da8fb6be47ee89018045241a04113ac9b4f410ea6e8fdc5de16c391f5829cd9f",
-      "size_bytes": 7819
+      "size_bytes": 7819,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2104,7 +2366,8 @@
       "latest_key": "latest/endpoints/93.json",
       "path": "/metagraph/endpoints/93.json",
       "sha256": "86019d6bf30b0d0116065bb6704d6a99072f63fc83d5b5c4622431c6373c3871",
-      "size_bytes": 12353
+      "size_bytes": 12353,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2112,7 +2375,8 @@
       "latest_key": "latest/endpoints/94.json",
       "path": "/metagraph/endpoints/94.json",
       "sha256": "fa59df5ed0748589d2b0d289ac9e24054d6353ebd06bc39e708aec16af6e3a00",
-      "size_bytes": 9303
+      "size_bytes": 9303,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2120,7 +2384,8 @@
       "latest_key": "latest/endpoints/95.json",
       "path": "/metagraph/endpoints/95.json",
       "sha256": "fa937efd2079466e28504b93aef84a3ef99f24fc4433ad32a766dbd64080dc71",
-      "size_bytes": 4950
+      "size_bytes": 4950,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2128,7 +2393,8 @@
       "latest_key": "latest/endpoints/96.json",
       "path": "/metagraph/endpoints/96.json",
       "sha256": "566aaf330a52d09e62e57a5c1d92cd5af7b03e74fc08d9a698c474ab0e719d48",
-      "size_bytes": 13833
+      "size_bytes": 13833,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2136,7 +2402,8 @@
       "latest_key": "latest/endpoints/97.json",
       "path": "/metagraph/endpoints/97.json",
       "sha256": "82f5f128651f93bce87aa0f88bc3cac244ea5516bfa489c062f90787f546b24f",
-      "size_bytes": 18625
+      "size_bytes": 18625,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2144,7 +2411,8 @@
       "latest_key": "latest/endpoints/98.json",
       "path": "/metagraph/endpoints/98.json",
       "sha256": "7c07257a8e1473275d3e8cacfd44c20d22d4b6c974071a6b08a3be4d57da158b",
-      "size_bytes": 10949
+      "size_bytes": 10949,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2152,7 +2420,8 @@
       "latest_key": "latest/endpoints/99.json",
       "path": "/metagraph/endpoints/99.json",
       "sha256": "12e7de2cf1e3673ef39606ba3399a3afeb16d126a6f6c39b0a8e608c70dd6cea",
-      "size_bytes": 15405
+      "size_bytes": 15405,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2160,7 +2429,8 @@
       "latest_key": "latest/evidence-ledger.json",
       "path": "/metagraph/evidence-ledger.json",
       "sha256": "9301460eee6a1b8dbfe76652dd102bef2f6c317179a6414c7af70902698de1d3",
-      "size_bytes": 660658
+      "size_bytes": 660658,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -2168,7 +2438,8 @@
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
       "sha256": "76fad2344640e3dd1bbce78ec37ef6f341be9dadf5311d6fc2ec3ccdf1539d5e",
-      "size_bytes": 1573
+      "size_bytes": 1573,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -2176,7 +2447,8 @@
       "latest_key": "latest/gaps.json",
       "path": "/metagraph/gaps.json",
       "sha256": "e46ddea30398134993473a5f61fbf48cb6180af9bd18434a594f379921c8784c",
-      "size_bytes": 86031
+      "size_bytes": 86031,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -2184,7 +2456,8 @@
       "latest_key": "latest/health/badges/0.json",
       "path": "/metagraph/health/badges/0.json",
       "sha256": "cf24e5c86ae12adc471dcf3af02965060931803ca07155510f6c4840fda8118b",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2192,7 +2465,8 @@
       "latest_key": "latest/health/badges/1.json",
       "path": "/metagraph/health/badges/1.json",
       "sha256": "3cb5a8e03a24fd2c6f46c3a74e330452fc0eadd6cfae299d52c563657dc9c2b4",
-      "size_bytes": 296
+      "size_bytes": 296,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2200,7 +2474,8 @@
       "latest_key": "latest/health/badges/10.json",
       "path": "/metagraph/health/badges/10.json",
       "sha256": "2dad966595192761de73ebd26e1fbf2b3f465997da98aa7ef5f634912cc3a318",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2208,7 +2483,8 @@
       "latest_key": "latest/health/badges/100.json",
       "path": "/metagraph/health/badges/100.json",
       "sha256": "49112f3515c31ba9b0eb15a991e410e9bb96bcf16bc2fa83640f75fec2a041ca",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2216,7 +2492,8 @@
       "latest_key": "latest/health/badges/101.json",
       "path": "/metagraph/health/badges/101.json",
       "sha256": "8859d2e024b0159b37b911577dc5dfa01af4de7a91b01bb997539e183285feb9",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2224,7 +2501,8 @@
       "latest_key": "latest/health/badges/102.json",
       "path": "/metagraph/health/badges/102.json",
       "sha256": "dd39b81d121e0d6d60ea8d5dc08c788eaa5c14e9b9614df8bb35eac4219902b2",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2232,7 +2510,8 @@
       "latest_key": "latest/health/badges/103.json",
       "path": "/metagraph/health/badges/103.json",
       "sha256": "685b218a419266cacb07a6e70b311e787a55ff50afe30f881574db99e232bff2",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2240,7 +2519,8 @@
       "latest_key": "latest/health/badges/104.json",
       "path": "/metagraph/health/badges/104.json",
       "sha256": "b82943fa714b82646b655254a9d1a2aad358ff200bec3c21e0879e0d095a614d",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2248,7 +2528,8 @@
       "latest_key": "latest/health/badges/105.json",
       "path": "/metagraph/health/badges/105.json",
       "sha256": "81c17a92e756eb6d459d8eeb101fb21068c92fefb2add0777deca703f2594d17",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2256,7 +2537,8 @@
       "latest_key": "latest/health/badges/106.json",
       "path": "/metagraph/health/badges/106.json",
       "sha256": "2a288835141b65938fc7217fa061336601f508641f326901d7509081cc7366fc",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2264,7 +2546,8 @@
       "latest_key": "latest/health/badges/107.json",
       "path": "/metagraph/health/badges/107.json",
       "sha256": "d6ca598afb06138eedd54d58e71a1b162521a6e15fc23b3b2b542867212d9301",
-      "size_bytes": 302
+      "size_bytes": 302,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2272,7 +2555,8 @@
       "latest_key": "latest/health/badges/108.json",
       "path": "/metagraph/health/badges/108.json",
       "sha256": "e81e10faa651c7c548dc4f519378e1fd2556b08677ef4f975d623e1c8f62a1f0",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2280,7 +2564,8 @@
       "latest_key": "latest/health/badges/109.json",
       "path": "/metagraph/health/badges/109.json",
       "sha256": "c96e9d1a9b6a749f4a3d551400799cc4a774c3aba9b247ac3e8314e8eed3fd2b",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2288,7 +2573,8 @@
       "latest_key": "latest/health/badges/11.json",
       "path": "/metagraph/health/badges/11.json",
       "sha256": "0a238069e1df580b98bae8fdb5ad54bc907f81ce23a56a8f789667d602f09549",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2296,7 +2582,8 @@
       "latest_key": "latest/health/badges/110.json",
       "path": "/metagraph/health/badges/110.json",
       "sha256": "57d39e163d25bb646ff12b296da5151222ed5d67c9b2880ecec7e9e711b3a372",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2304,7 +2591,8 @@
       "latest_key": "latest/health/badges/111.json",
       "path": "/metagraph/health/badges/111.json",
       "sha256": "1063cb9ad2519c3656e56e2b5561c125ab742d4864f0f540f62c98b4c5c1a49e",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2312,7 +2600,8 @@
       "latest_key": "latest/health/badges/112.json",
       "path": "/metagraph/health/badges/112.json",
       "sha256": "196627218b3a47f66513bb65a74ba790f62f3f5c5fe6e11a0860e23f0d3922f4",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2320,7 +2609,8 @@
       "latest_key": "latest/health/badges/113.json",
       "path": "/metagraph/health/badges/113.json",
       "sha256": "5c955f91424a3b8b343beb756052106618b1ea61f2a29770b921bc030dba48eb",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2328,7 +2618,8 @@
       "latest_key": "latest/health/badges/114.json",
       "path": "/metagraph/health/badges/114.json",
       "sha256": "61f09684a11950cc81de5337dd25ca62450cd3683cabb332ef27ad6fd112f97b",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2336,7 +2627,8 @@
       "latest_key": "latest/health/badges/115.json",
       "path": "/metagraph/health/badges/115.json",
       "sha256": "ab42e233faa5cd3341a3f62125b656b23b5fccabb1e60e40c14365a01b860f6a",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2344,7 +2636,8 @@
       "latest_key": "latest/health/badges/116.json",
       "path": "/metagraph/health/badges/116.json",
       "sha256": "ea6726f9fb120ee8be93f1eaece6648b93782ebcc8161d92925c66c047af822b",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2352,7 +2645,8 @@
       "latest_key": "latest/health/badges/117.json",
       "path": "/metagraph/health/badges/117.json",
       "sha256": "6fcc1e6c6d89f21ca2c22487a070dc80aabbd2c58b33015c354ef05d9df2f4d9",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2360,7 +2654,8 @@
       "latest_key": "latest/health/badges/118.json",
       "path": "/metagraph/health/badges/118.json",
       "sha256": "834bea11e68ef5cad9144dbeb140c8f03d45674f21341516bb1c4d87d0c1daa7",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2368,7 +2663,8 @@
       "latest_key": "latest/health/badges/119.json",
       "path": "/metagraph/health/badges/119.json",
       "sha256": "00cc46cae461e35c83fc908c319fd652f9003e463ffb89fc4a6abfbd220a761f",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2376,7 +2672,8 @@
       "latest_key": "latest/health/badges/12.json",
       "path": "/metagraph/health/badges/12.json",
       "sha256": "579701c97e62b48d4a89fa6f0993ccf3c09975e9f5b312d8952a87d3d900a480",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2384,7 +2681,8 @@
       "latest_key": "latest/health/badges/120.json",
       "path": "/metagraph/health/badges/120.json",
       "sha256": "eb49d4b4df9533fc038f5c0a4a799de944d400930c8e98b392faf6b89f27a5ef",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2392,7 +2690,8 @@
       "latest_key": "latest/health/badges/121.json",
       "path": "/metagraph/health/badges/121.json",
       "sha256": "6c739fbbb604c35c7e25cb6e4500c392463239c0ad200c74539dadf3d7d75554",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2400,7 +2699,8 @@
       "latest_key": "latest/health/badges/122.json",
       "path": "/metagraph/health/badges/122.json",
       "sha256": "32bfeea404420be40b8bf0c98cd33992cfec3d86828f7da9d5f4c5fd06d15bd4",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2408,7 +2708,8 @@
       "latest_key": "latest/health/badges/123.json",
       "path": "/metagraph/health/badges/123.json",
       "sha256": "ac563819a32d5ce0813d9abc7ed802d01a86631c8bdc2f4fd1fa4bb8fae6b656",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2416,7 +2717,8 @@
       "latest_key": "latest/health/badges/124.json",
       "path": "/metagraph/health/badges/124.json",
       "sha256": "9063419744c7bf9d4e7908fdebac9b5f959159daa9ebe910d328a7f67cf5220e",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2424,7 +2726,8 @@
       "latest_key": "latest/health/badges/125.json",
       "path": "/metagraph/health/badges/125.json",
       "sha256": "7bd0377429df37f743d03fafba346172f1f9965d3bd57ac824753c0be59cbe7c",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2432,7 +2735,8 @@
       "latest_key": "latest/health/badges/126.json",
       "path": "/metagraph/health/badges/126.json",
       "sha256": "e46164e63302ba9f5111d34994f2f285e7484301c11d38082d4224c7ba5682eb",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2440,7 +2744,8 @@
       "latest_key": "latest/health/badges/127.json",
       "path": "/metagraph/health/badges/127.json",
       "sha256": "8b67292738f5119ba2e8498e3b885066677a109cd9e15803fe646dfc52fc1692",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2448,7 +2753,8 @@
       "latest_key": "latest/health/badges/128.json",
       "path": "/metagraph/health/badges/128.json",
       "sha256": "ee1c511afccd0f49c85b7a50140ada90785c3334b7d692585fa877b4ae4ff3d1",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2456,7 +2762,8 @@
       "latest_key": "latest/health/badges/13.json",
       "path": "/metagraph/health/badges/13.json",
       "sha256": "da80542b2bfa25a6f56df8914e9d2a027f5b4a4a84b0c993c910acfa26543880",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2464,7 +2771,8 @@
       "latest_key": "latest/health/badges/14.json",
       "path": "/metagraph/health/badges/14.json",
       "sha256": "2dc2ed474fc4ec7a2f18ecc8467e3f73e607308ce31603a04131dd644d908f81",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2472,7 +2780,8 @@
       "latest_key": "latest/health/badges/15.json",
       "path": "/metagraph/health/badges/15.json",
       "sha256": "8097ffcce03db58bf01c2040850e0d45d2bbb3f9bdc53f159c60ac36ae175735",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2480,7 +2789,8 @@
       "latest_key": "latest/health/badges/16.json",
       "path": "/metagraph/health/badges/16.json",
       "sha256": "e490befeb2cc94dd7c4d635f90ba0cbcdc1b974a7dd39bac2b37e4cc0d0dc7fa",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2488,7 +2798,8 @@
       "latest_key": "latest/health/badges/17.json",
       "path": "/metagraph/health/badges/17.json",
       "sha256": "0389a280fea81f7576326ab76be2e0b4f3349e854b599cf7ff68250b85ad4ab2",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2496,7 +2807,8 @@
       "latest_key": "latest/health/badges/18.json",
       "path": "/metagraph/health/badges/18.json",
       "sha256": "65f422f6257dfa9f1819806a99b7f585eec250ffaa50bd8872ba02212b6a5956",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2504,7 +2816,8 @@
       "latest_key": "latest/health/badges/19.json",
       "path": "/metagraph/health/badges/19.json",
       "sha256": "303172374b8719f4a89449a8d6c0b843f17eb288f965ea379e523ac0f9a32c18",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2512,7 +2825,8 @@
       "latest_key": "latest/health/badges/2.json",
       "path": "/metagraph/health/badges/2.json",
       "sha256": "0fcb2e9044fad2e80ad68a25974fffde3f9fbf6d35e1072b17ee53a2c6f27dd1",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2520,7 +2834,8 @@
       "latest_key": "latest/health/badges/20.json",
       "path": "/metagraph/health/badges/20.json",
       "sha256": "ec421653db2072fbed347b2ed8b3fb855016d1e6ff60b9bf6ea6224206140e38",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2528,7 +2843,8 @@
       "latest_key": "latest/health/badges/21.json",
       "path": "/metagraph/health/badges/21.json",
       "sha256": "59c442531237c294f74b08cc99f4764ba03b5e9a5f7c38e7f7e4369a6fe8df9d",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2536,7 +2852,8 @@
       "latest_key": "latest/health/badges/22.json",
       "path": "/metagraph/health/badges/22.json",
       "sha256": "33d7a1ca7fb7faf9705a8fdf9559ee73da7fa302ff283eb5e1e4a0d80c7f40c6",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2544,7 +2861,8 @@
       "latest_key": "latest/health/badges/23.json",
       "path": "/metagraph/health/badges/23.json",
       "sha256": "92a2811338ed3e3f98c7c9e7ace631cdda0dd5d103c2854070db1a6ea880b821",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2552,7 +2870,8 @@
       "latest_key": "latest/health/badges/24.json",
       "path": "/metagraph/health/badges/24.json",
       "sha256": "d9fa2423e7545928e9fcb4984e1d79a2b265838729f6b8f734c5280d651890ff",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2560,7 +2879,8 @@
       "latest_key": "latest/health/badges/25.json",
       "path": "/metagraph/health/badges/25.json",
       "sha256": "f6cdd83fd2b8ac4368488c655b6e880959b770f0993ca88b82e6e60d9ca8d570",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2568,7 +2888,8 @@
       "latest_key": "latest/health/badges/26.json",
       "path": "/metagraph/health/badges/26.json",
       "sha256": "d4ae97091c6273dc8512f2183c06fd0ccd9009aac399513ee5a434e4dfdc4d5f",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2576,7 +2897,8 @@
       "latest_key": "latest/health/badges/27.json",
       "path": "/metagraph/health/badges/27.json",
       "sha256": "922bead96b0fc552965573d40f308d9d7bc12f2dcf4df814996a347e458368b8",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2584,7 +2906,8 @@
       "latest_key": "latest/health/badges/28.json",
       "path": "/metagraph/health/badges/28.json",
       "sha256": "bfc12da7f876e64112f91fed380f92078830481dbb044dac8527274f6a306c09",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2592,7 +2915,8 @@
       "latest_key": "latest/health/badges/29.json",
       "path": "/metagraph/health/badges/29.json",
       "sha256": "771d1712019a5f88a6cee8f9ab29eab62396f0bcdc7ae9972bb752077b21a423",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2600,7 +2924,8 @@
       "latest_key": "latest/health/badges/3.json",
       "path": "/metagraph/health/badges/3.json",
       "sha256": "2e60d98ff669d6ffd7e5b3ba752ef85641152df284f88c8585cc8ec75ca850e5",
-      "size_bytes": 296
+      "size_bytes": 296,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2608,7 +2933,8 @@
       "latest_key": "latest/health/badges/30.json",
       "path": "/metagraph/health/badges/30.json",
       "sha256": "67fdccb7a7c4f66f1c0a396a3f9710361656774e9a375677ad3498f85005c5ab",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2616,7 +2942,8 @@
       "latest_key": "latest/health/badges/31.json",
       "path": "/metagraph/health/badges/31.json",
       "sha256": "840dbf4fedacb33c0de039a5b5333e07f603e92e5e6ae9694c79b5c2ed181913",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2624,7 +2951,8 @@
       "latest_key": "latest/health/badges/32.json",
       "path": "/metagraph/health/badges/32.json",
       "sha256": "dab611c37f559fe3f8f0aa8ba348e1a57876771faf72ee64987f30a6ea607e0e",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2632,7 +2960,8 @@
       "latest_key": "latest/health/badges/33.json",
       "path": "/metagraph/health/badges/33.json",
       "sha256": "e503f5777e8cba5ceff78cc9b3d296b3130ab25fb32598d376162e3464c8a9bf",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2640,7 +2969,8 @@
       "latest_key": "latest/health/badges/34.json",
       "path": "/metagraph/health/badges/34.json",
       "sha256": "d9a72de487a89e5913f0f0bfd89367419ed1c5edb2ba216b0f4a8b625f1533b1",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2648,7 +2978,8 @@
       "latest_key": "latest/health/badges/35.json",
       "path": "/metagraph/health/badges/35.json",
       "sha256": "f43e81bad3e548fd35f7f11291b980d9b046a62498ac6e54e9a3a82116a6b2ce",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2656,7 +2987,8 @@
       "latest_key": "latest/health/badges/36.json",
       "path": "/metagraph/health/badges/36.json",
       "sha256": "b0e8b90857bf2f6dfd34f6a01a9d9d84c6290b686ffd7f9f1e5c0aa69fbc193e",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2664,7 +2996,8 @@
       "latest_key": "latest/health/badges/37.json",
       "path": "/metagraph/health/badges/37.json",
       "sha256": "7d951bdb4098c740f74ec1b9fd37a0d73f2a194328ecb84a188d2186ae85e95e",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2672,7 +3005,8 @@
       "latest_key": "latest/health/badges/38.json",
       "path": "/metagraph/health/badges/38.json",
       "sha256": "2060a88de835596ee44329b9356ea2804fd4212b9815a5fb08cb01608e5f83de",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2680,7 +3014,8 @@
       "latest_key": "latest/health/badges/39.json",
       "path": "/metagraph/health/badges/39.json",
       "sha256": "aac598922ab17d7f8dd5741755d27cb202c835533f67b1bd8d3c176738299bce",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2688,7 +3023,8 @@
       "latest_key": "latest/health/badges/4.json",
       "path": "/metagraph/health/badges/4.json",
       "sha256": "e2edbdcf15e6d9adc96a0da4361da9ecc5e2558ced4c420b86a81d1c3dd96cbb",
-      "size_bytes": 296
+      "size_bytes": 296,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2696,7 +3032,8 @@
       "latest_key": "latest/health/badges/40.json",
       "path": "/metagraph/health/badges/40.json",
       "sha256": "1212ab505dac56cc7116fc64cd50b3ddf88c04651d0a692827586c8351a3785f",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2704,7 +3041,8 @@
       "latest_key": "latest/health/badges/41.json",
       "path": "/metagraph/health/badges/41.json",
       "sha256": "4b80f6c8d71fe17ae1fd368561c7a928261966901eb7d5f6692d33dd46a70448",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2712,7 +3050,8 @@
       "latest_key": "latest/health/badges/42.json",
       "path": "/metagraph/health/badges/42.json",
       "sha256": "24248cfc3bb05996efc3da2631a0d503d0c0157a237dafea229b924e4a545171",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2720,7 +3059,8 @@
       "latest_key": "latest/health/badges/43.json",
       "path": "/metagraph/health/badges/43.json",
       "sha256": "cd4b5c9d61a789148e33c47804c963ab97f8f2f189fa50f19ed15d28ca36709a",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2728,7 +3068,8 @@
       "latest_key": "latest/health/badges/44.json",
       "path": "/metagraph/health/badges/44.json",
       "sha256": "009c46741d2f27facbc9c7ad2da06a270ff858f6d130496f3b2c1e0e300d4019",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2736,7 +3077,8 @@
       "latest_key": "latest/health/badges/45.json",
       "path": "/metagraph/health/badges/45.json",
       "sha256": "445bc45ac1eccd7233a3357159a0b12feba5804623a616640068f68d9770f60d",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2744,7 +3086,8 @@
       "latest_key": "latest/health/badges/46.json",
       "path": "/metagraph/health/badges/46.json",
       "sha256": "dbb769ef191b5793d1021532619094fc10b7b02a60bd52b49f81bcc824a7b439",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2752,7 +3095,8 @@
       "latest_key": "latest/health/badges/47.json",
       "path": "/metagraph/health/badges/47.json",
       "sha256": "a580039ca6d225286a7a029540ec2f613e17059379d000f715834b6d5846d532",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2760,7 +3104,8 @@
       "latest_key": "latest/health/badges/48.json",
       "path": "/metagraph/health/badges/48.json",
       "sha256": "27b026e5f30e6c4190ff6be8b83ad7c2a37cccea7ae6364005a0dc5ef030dd5b",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2768,7 +3113,8 @@
       "latest_key": "latest/health/badges/49.json",
       "path": "/metagraph/health/badges/49.json",
       "sha256": "359fdfcddd6cfb7b765481d5b272ac2ce655793cc330028c03d144512182f4db",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2776,7 +3122,8 @@
       "latest_key": "latest/health/badges/5.json",
       "path": "/metagraph/health/badges/5.json",
       "sha256": "34de9f92d1e19bbefad60875ba8298be97bd04c7906112a70d856ba266b84337",
-      "size_bytes": 296
+      "size_bytes": 296,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2784,7 +3131,8 @@
       "latest_key": "latest/health/badges/50.json",
       "path": "/metagraph/health/badges/50.json",
       "sha256": "edac95476f590e704dd3bdc423f25c05833a40fd895a8fe58978d2f582110566",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2792,7 +3140,8 @@
       "latest_key": "latest/health/badges/51.json",
       "path": "/metagraph/health/badges/51.json",
       "sha256": "7ecbbfe5e21d320be4cf56e35df9e19bb423a1465de6447334538281362e3553",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2800,7 +3149,8 @@
       "latest_key": "latest/health/badges/52.json",
       "path": "/metagraph/health/badges/52.json",
       "sha256": "53ab9e40f0bee71e52569d2522e05cd91c3735bed013278cde0202d08569beec",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2808,7 +3158,8 @@
       "latest_key": "latest/health/badges/53.json",
       "path": "/metagraph/health/badges/53.json",
       "sha256": "03cab0855a3e5f5c2390d992af2e2ca015cb45b264df760d93730cecae755e77",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2816,7 +3167,8 @@
       "latest_key": "latest/health/badges/54.json",
       "path": "/metagraph/health/badges/54.json",
       "sha256": "214b54ecb6d4fdb64422ce7bbd88562d6118e67892bbc784e1353e04929543ec",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2824,7 +3176,8 @@
       "latest_key": "latest/health/badges/55.json",
       "path": "/metagraph/health/badges/55.json",
       "sha256": "91907368e1854d7a13d2f5d6e3aeca3e4567205da8463c3a54444434e9ddda9e",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2832,7 +3185,8 @@
       "latest_key": "latest/health/badges/56.json",
       "path": "/metagraph/health/badges/56.json",
       "sha256": "0ef97d3701ccb165124c3b22c6d1d896ab797bd41710875087dee8d939fc7b4a",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2840,7 +3194,8 @@
       "latest_key": "latest/health/badges/57.json",
       "path": "/metagraph/health/badges/57.json",
       "sha256": "a8d12118ed0ffce958f09082246011221cc1198492fcf297e1296cacc6943aca",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2848,7 +3203,8 @@
       "latest_key": "latest/health/badges/58.json",
       "path": "/metagraph/health/badges/58.json",
       "sha256": "dbde15d6470959b3d11422cfcb9000498be25c37f8cb50c3e7c60e1a52741396",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2856,7 +3212,8 @@
       "latest_key": "latest/health/badges/59.json",
       "path": "/metagraph/health/badges/59.json",
       "sha256": "f0128be05abecbf808175621cd55403b8cde371482a2dd098d95ca02ff4b83bd",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2864,7 +3221,8 @@
       "latest_key": "latest/health/badges/6.json",
       "path": "/metagraph/health/badges/6.json",
       "sha256": "cd85b2143cea9c9a0c8309f19c7ac1034811532594f241714ab4b3490fe56ec4",
-      "size_bytes": 296
+      "size_bytes": 296,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2872,7 +3230,8 @@
       "latest_key": "latest/health/badges/60.json",
       "path": "/metagraph/health/badges/60.json",
       "sha256": "7860fd9913da0dd7aa6cf312508a1203e666db47089f99849a1dfb6ed0ba71e1",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2880,7 +3239,8 @@
       "latest_key": "latest/health/badges/61.json",
       "path": "/metagraph/health/badges/61.json",
       "sha256": "30bd1706c3cf212c402a633f8b492fef156501951aaea548ff3499e990be29fd",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2888,7 +3248,8 @@
       "latest_key": "latest/health/badges/62.json",
       "path": "/metagraph/health/badges/62.json",
       "sha256": "8a42b5b18a00d09b30dcba6e79902ba6c32b9dc3844609fb242463cf437eccfd",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2896,7 +3257,8 @@
       "latest_key": "latest/health/badges/63.json",
       "path": "/metagraph/health/badges/63.json",
       "sha256": "c609e53b67492927e8bd1765a699fb6828b9f89507ab2367d1e17152ecf1c7bd",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2904,7 +3266,8 @@
       "latest_key": "latest/health/badges/64.json",
       "path": "/metagraph/health/badges/64.json",
       "sha256": "b04924081723a295e3cd423e3d6b45da9b6ebc7c0b617b15412f788c909b99a2",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2912,7 +3275,8 @@
       "latest_key": "latest/health/badges/65.json",
       "path": "/metagraph/health/badges/65.json",
       "sha256": "e47f7ebab3738889e2713e636d3461dbb9b0a67b4b804c068519bd212ab79dd3",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2920,7 +3284,8 @@
       "latest_key": "latest/health/badges/66.json",
       "path": "/metagraph/health/badges/66.json",
       "sha256": "c42e2244e25e47a11a40fbf897e7135c89fba05bba67588a16747ff65288513a",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2928,7 +3293,8 @@
       "latest_key": "latest/health/badges/67.json",
       "path": "/metagraph/health/badges/67.json",
       "sha256": "32fef2d8518b1b848c426df457630fc8e3a48d7ef600d707d2a1866bcbc24bf8",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2936,7 +3302,8 @@
       "latest_key": "latest/health/badges/68.json",
       "path": "/metagraph/health/badges/68.json",
       "sha256": "e75cdb97bf08dd1deb501788e2468ab5b2b66dae8e618d77a551bbb3353da07c",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2944,7 +3311,8 @@
       "latest_key": "latest/health/badges/69.json",
       "path": "/metagraph/health/badges/69.json",
       "sha256": "a503e9e9dfe934cfbaa9b374aea7da769bdde4b1a155c485d6b8b145fb10afba",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2952,7 +3320,8 @@
       "latest_key": "latest/health/badges/7.json",
       "path": "/metagraph/health/badges/7.json",
       "sha256": "3a7eccc15b1a466c5b09cbb2a1c5aadf1e5240a21c21da014ccd25688151ac49",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2960,7 +3329,8 @@
       "latest_key": "latest/health/badges/70.json",
       "path": "/metagraph/health/badges/70.json",
       "sha256": "0d0d7244d22cf928f1689e5a6ba33dcc9b0f99ebf5a7fe3e74323b573fe4dd47",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2968,7 +3338,8 @@
       "latest_key": "latest/health/badges/71.json",
       "path": "/metagraph/health/badges/71.json",
       "sha256": "8828c4ea8183ce0d89e07a36d27ee87268c76d61461d321b2a742264a48896c6",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2976,7 +3347,8 @@
       "latest_key": "latest/health/badges/72.json",
       "path": "/metagraph/health/badges/72.json",
       "sha256": "c5fa6f962b4481be9f4817c11e7ae911ba2b558a37ea857b6e88896c13176013",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2984,7 +3356,8 @@
       "latest_key": "latest/health/badges/73.json",
       "path": "/metagraph/health/badges/73.json",
       "sha256": "f1fa5aaa9c9f4b235b6159ab0bf92d3fdd6bd3631c257bc35bb4336c844d3bdd",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -2992,7 +3365,8 @@
       "latest_key": "latest/health/badges/74.json",
       "path": "/metagraph/health/badges/74.json",
       "sha256": "7deffe496b05a7ef5200f73d236f29a23e4c1014fd35f908288fac3825fb64a7",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3000,7 +3374,8 @@
       "latest_key": "latest/health/badges/75.json",
       "path": "/metagraph/health/badges/75.json",
       "sha256": "b1a31bd1744c9dc3d09f68e59694ed30eb22d7af4d39d8dcbcb57a033e7e4a44",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3008,7 +3383,8 @@
       "latest_key": "latest/health/badges/76.json",
       "path": "/metagraph/health/badges/76.json",
       "sha256": "77dbf5af705ef488f91b584e68d6304e69c5786995976cfb504940dd77c4828e",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3016,7 +3392,8 @@
       "latest_key": "latest/health/badges/77.json",
       "path": "/metagraph/health/badges/77.json",
       "sha256": "b5ac820fee5a0dbb05d4b6e8d7cbf77836206de4a14decf4458dba615d39931e",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3024,7 +3401,8 @@
       "latest_key": "latest/health/badges/78.json",
       "path": "/metagraph/health/badges/78.json",
       "sha256": "73c1b2ebedd7c1cf4146c5a7fd3996bd984418e9778bb8bf9db74762b3f9405c",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3032,7 +3410,8 @@
       "latest_key": "latest/health/badges/79.json",
       "path": "/metagraph/health/badges/79.json",
       "sha256": "50da575ce42343ee210fc4f213d54bfa1a90a81194f5fa0bd0e6552fcea630f6",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3040,7 +3419,8 @@
       "latest_key": "latest/health/badges/8.json",
       "path": "/metagraph/health/badges/8.json",
       "sha256": "332a9c7d660308894b369b0190ea6da996c275619277cdd2f4b7a53149f67274",
-      "size_bytes": 296
+      "size_bytes": 296,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3048,7 +3428,8 @@
       "latest_key": "latest/health/badges/80.json",
       "path": "/metagraph/health/badges/80.json",
       "sha256": "25d74af00abb871f492e3df7d50ff0567f332581d8441b81a4e21bfceec76aae",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3056,7 +3437,8 @@
       "latest_key": "latest/health/badges/81.json",
       "path": "/metagraph/health/badges/81.json",
       "sha256": "6fdc68abbf5ce3a7deb9985f51c04f9fc294afff6345935dbd6f356b668bf9bd",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3064,7 +3446,8 @@
       "latest_key": "latest/health/badges/82.json",
       "path": "/metagraph/health/badges/82.json",
       "sha256": "775be956fbf0fa7d200261d8fb4452895013179be8804177512b22c4a0345568",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3072,7 +3455,8 @@
       "latest_key": "latest/health/badges/83.json",
       "path": "/metagraph/health/badges/83.json",
       "sha256": "95e1e355e80057b562bdd7c6656c75bad04107c9c87c5eee383b6eca666ef879",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3080,7 +3464,8 @@
       "latest_key": "latest/health/badges/84.json",
       "path": "/metagraph/health/badges/84.json",
       "sha256": "49b7123a5e5a38fa68c8dba82dd7295a0d0bbcb3a90c77ac15feba12d9d7fa9e",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3088,7 +3473,8 @@
       "latest_key": "latest/health/badges/85.json",
       "path": "/metagraph/health/badges/85.json",
       "sha256": "51ce995ae854716609f51dc42739b6ffe38be2213f760341f2e0707d58da6cf5",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3096,7 +3482,8 @@
       "latest_key": "latest/health/badges/86.json",
       "path": "/metagraph/health/badges/86.json",
       "sha256": "e502c426747b5967bfaf5409484635e1b43fb1455af392a37a7ab4cab1bcf197",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3104,7 +3491,8 @@
       "latest_key": "latest/health/badges/87.json",
       "path": "/metagraph/health/badges/87.json",
       "sha256": "4d5f6a1c9df29a240b5368b2ed6a155b1df6aba12da14c773c6b37b3556d1ed3",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3112,7 +3500,8 @@
       "latest_key": "latest/health/badges/88.json",
       "path": "/metagraph/health/badges/88.json",
       "sha256": "8c598af677aea7e935609112662cd14d6ef11f2683ce0513c81dde946e9549f5",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3120,7 +3509,8 @@
       "latest_key": "latest/health/badges/89.json",
       "path": "/metagraph/health/badges/89.json",
       "sha256": "7bcd15260c92dee013fafcf086464ae58865e538f6eebc2e056abe5c916f4555",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3128,7 +3518,8 @@
       "latest_key": "latest/health/badges/9.json",
       "path": "/metagraph/health/badges/9.json",
       "sha256": "1deaaa150de94d18bd4562382d52601d30300fe48ee888ba4527fb60a497284c",
-      "size_bytes": 296
+      "size_bytes": 296,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3136,7 +3527,8 @@
       "latest_key": "latest/health/badges/90.json",
       "path": "/metagraph/health/badges/90.json",
       "sha256": "d4e03b851ffd24a8444d1e8fd7545d8c763b33ce65ed228b7c7960cb0685d596",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3144,7 +3536,8 @@
       "latest_key": "latest/health/badges/91.json",
       "path": "/metagraph/health/badges/91.json",
       "sha256": "de577768a865c897d285e068bb9356857b4652d0303b80bb19b458d9aac4fb80",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3152,7 +3545,8 @@
       "latest_key": "latest/health/badges/92.json",
       "path": "/metagraph/health/badges/92.json",
       "sha256": "342d9ced64252f776f9069219a4041c60645f875a25cb7131525644dd28bc070",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3160,7 +3554,8 @@
       "latest_key": "latest/health/badges/93.json",
       "path": "/metagraph/health/badges/93.json",
       "sha256": "f456fe55fb970b03283e209dfaa16457830b3ef3de14fff7a0cca41cfe391be7",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3168,7 +3563,8 @@
       "latest_key": "latest/health/badges/94.json",
       "path": "/metagraph/health/badges/94.json",
       "sha256": "9c25f3339e9928ee8380dd9508b2ef530565e146591797660b495f3832d09d23",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3176,7 +3572,8 @@
       "latest_key": "latest/health/badges/95.json",
       "path": "/metagraph/health/badges/95.json",
       "sha256": "497ceb49c628f98c69f2c79680da94cf6b0ad51d050a9ccf458b6846d50c0855",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3184,7 +3581,8 @@
       "latest_key": "latest/health/badges/96.json",
       "path": "/metagraph/health/badges/96.json",
       "sha256": "df5c89521fc1e311a37b19793b66393348dd2ff44e3b476f07ddb4bef8c4f636",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3192,7 +3590,8 @@
       "latest_key": "latest/health/badges/97.json",
       "path": "/metagraph/health/badges/97.json",
       "sha256": "86b6ecd4137a544da89273826e6af68ebd3166095965ef707b7be7316bd84b76",
-      "size_bytes": 300
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3200,7 +3599,8 @@
       "latest_key": "latest/health/badges/98.json",
       "path": "/metagraph/health/badges/98.json",
       "sha256": "661b77fed5a1486b4e78871e3d27be2dff2edba1ae32211bb267d08c4cc23722",
-      "size_bytes": 298
+      "size_bytes": 298,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3208,31 +3608,17 @@
       "latest_key": "latest/health/badges/99.json",
       "path": "/metagraph/health/badges/99.json",
       "sha256": "b87d8a7fb8f8456aa2f497fee6a25eb4301a85fdd56435841cbe040b3a92cb51",
-      "size_bytes": 300
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/health/history/2026-06-06.json",
-      "latest_key": "latest/health/history/2026-06-06.json",
-      "path": "/metagraph/health/history/2026-06-06.json",
-      "sha256": "90ca20a3b46ca9e8ad1b476bd50c42426de463f8cf2aabbeb8d204e374d66705",
-      "size_bytes": 321674
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/health/history/2026-06-07.json",
-      "latest_key": "latest/health/history/2026-06-07.json",
-      "path": "/metagraph/health/history/2026-06-07.json",
-      "sha256": "9b4c0b15a2e35e45f1db9ee14e6d6e96665828e6ab5033567eade0528f81ec1a",
-      "size_bytes": 321673
+      "size_bytes": 300,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/health/latest.json",
       "latest_key": "latest/health/latest.json",
       "path": "/metagraph/health/latest.json",
-      "sha256": "5413b260b9132631f788075eaee092208dee2c0825b0182ed481b1a6ae93cc4d",
-      "size_bytes": 421607
+      "sha256": "2a9450f3f8a15fdd763ce250e1cbf7dff41ba61164c280c8f614d9d54c358c51",
+      "size_bytes": 421638,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3240,7 +3626,8 @@
       "latest_key": "latest/health/subnets/0.json",
       "path": "/metagraph/health/subnets/0.json",
       "sha256": "c6573414a1b07f37b32f765bcebda96187e1932ff5737d2a7026ca0acbb15ee6",
-      "size_bytes": 7019
+      "size_bytes": 7019,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3248,7 +3635,8 @@
       "latest_key": "latest/health/subnets/1.json",
       "path": "/metagraph/health/subnets/1.json",
       "sha256": "3f4a960374d32487eb96a38b85c1e3b9e5e1244750010453c1377ba735c5e422",
-      "size_bytes": 4452
+      "size_bytes": 4452,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3256,7 +3644,8 @@
       "latest_key": "latest/health/subnets/10.json",
       "path": "/metagraph/health/subnets/10.json",
       "sha256": "f0dfb9eedffba12c2271d8d86c18b3964fc7ae1ba65192c5d55e3e6817ccacaa",
-      "size_bytes": 2681
+      "size_bytes": 2681,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3264,7 +3653,8 @@
       "latest_key": "latest/health/subnets/100.json",
       "path": "/metagraph/health/subnets/100.json",
       "sha256": "f2d09ab7e0ca8e5729cfd7e8927ec5d3d6db31ebdab3501cb2099446cf426142",
-      "size_bytes": 4402
+      "size_bytes": 4402,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3272,7 +3662,8 @@
       "latest_key": "latest/health/subnets/101.json",
       "path": "/metagraph/health/subnets/101.json",
       "sha256": "a04616708bf5e2a9495708a445db51e3a5a179f726308384ef12818ddc525bd1",
-      "size_bytes": 1601
+      "size_bytes": 1601,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3280,7 +3671,8 @@
       "latest_key": "latest/health/subnets/102.json",
       "path": "/metagraph/health/subnets/102.json",
       "sha256": "fe234e56746ec1f422e1cb9aee8cbf4d486185998c076ee19ec1698d990b8098",
-      "size_bytes": 4364
+      "size_bytes": 4364,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3288,7 +3680,8 @@
       "latest_key": "latest/health/subnets/103.json",
       "path": "/metagraph/health/subnets/103.json",
       "sha256": "ac456a24dab482ba817e93bd4e103706a9f9b326148230a1730a8195ef9d1cde",
-      "size_bytes": 4316
+      "size_bytes": 4316,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3296,7 +3689,8 @@
       "latest_key": "latest/health/subnets/104.json",
       "path": "/metagraph/health/subnets/104.json",
       "sha256": "586aa21466736d9f6bd4b9e4b470a72a5387678d31c4e7c86cadaa7e1929c36b",
-      "size_bytes": 1681
+      "size_bytes": 1681,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3304,7 +3698,8 @@
       "latest_key": "latest/health/subnets/105.json",
       "path": "/metagraph/health/subnets/105.json",
       "sha256": "34d54acf897d7456a87c49c927506d6a84e73646dedb2e8fc2b8f1b722a6a90b",
-      "size_bytes": 3751
+      "size_bytes": 3751,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3312,7 +3707,8 @@
       "latest_key": "latest/health/subnets/106.json",
       "path": "/metagraph/health/subnets/106.json",
       "sha256": "00b448925e839f8b8482053148825952673e265b72452923a6cad7302bcf50a4",
-      "size_bytes": 3223
+      "size_bytes": 3223,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3320,7 +3716,8 @@
       "latest_key": "latest/health/subnets/107.json",
       "path": "/metagraph/health/subnets/107.json",
       "sha256": "92ad1eeb4bbf32b32bb8bc86d33e5203b0754ebcc1316e638c1aabc319e089ac",
-      "size_bytes": 6640
+      "size_bytes": 6640,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3328,7 +3725,8 @@
       "latest_key": "latest/health/subnets/108.json",
       "path": "/metagraph/health/subnets/108.json",
       "sha256": "0241c2ac7678bec7c306dd31b4bb0aa8dffb4a175693716d9d67bd1f74cadb4c",
-      "size_bytes": 2724
+      "size_bytes": 2724,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3336,7 +3734,8 @@
       "latest_key": "latest/health/subnets/109.json",
       "path": "/metagraph/health/subnets/109.json",
       "sha256": "a7733c45c19b7a309cf53177194c0cf0a55d38aac08115b9539621f7802b0d4d",
-      "size_bytes": 2181
+      "size_bytes": 2181,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3344,7 +3743,8 @@
       "latest_key": "latest/health/subnets/11.json",
       "path": "/metagraph/health/subnets/11.json",
       "sha256": "75a70933661098bf8f5bb703356888285006c2b99327eb6726b6acda3534d6af",
-      "size_bytes": 3818
+      "size_bytes": 3818,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3352,7 +3752,8 @@
       "latest_key": "latest/health/subnets/110.json",
       "path": "/metagraph/health/subnets/110.json",
       "sha256": "1fb7ee7edafe73e5059ce3612bf9ba6977dd0e8c0b0b44d326d9d6aca89ec0c3",
-      "size_bytes": 4625
+      "size_bytes": 4625,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3360,7 +3761,8 @@
       "latest_key": "latest/health/subnets/111.json",
       "path": "/metagraph/health/subnets/111.json",
       "sha256": "5fb5bc41380ab86cadeddc0058648d8166c02861b11afe4429981480863dfbc7",
-      "size_bytes": 2189
+      "size_bytes": 2189,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3368,7 +3770,8 @@
       "latest_key": "latest/health/subnets/112.json",
       "path": "/metagraph/health/subnets/112.json",
       "sha256": "ae9f1f6a0441613a912b5da9f137c4c159d231f690ec0b45f744919522d59308",
-      "size_bytes": 3309
+      "size_bytes": 3309,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3376,7 +3779,8 @@
       "latest_key": "latest/health/subnets/113.json",
       "path": "/metagraph/health/subnets/113.json",
       "sha256": "54c7c23a7bc70ed08055ded4153f9cd1005552c53bfad356ff2da72acfedec18",
-      "size_bytes": 4394
+      "size_bytes": 4394,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3384,7 +3788,8 @@
       "latest_key": "latest/health/subnets/114.json",
       "path": "/metagraph/health/subnets/114.json",
       "sha256": "c3d936b5cf206e468497a4625282ae8e432959c6b02199c08b3badc7ee9e3c5a",
-      "size_bytes": 4364
+      "size_bytes": 4364,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3392,7 +3797,8 @@
       "latest_key": "latest/health/subnets/115.json",
       "path": "/metagraph/health/subnets/115.json",
       "sha256": "c51bd271e3d1e63339f36a51951c6cb09d6b407b2de135a3e61ff2a78a164a05",
-      "size_bytes": 2190
+      "size_bytes": 2190,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3400,7 +3806,8 @@
       "latest_key": "latest/health/subnets/116.json",
       "path": "/metagraph/health/subnets/116.json",
       "sha256": "e32a040fdd17d6c6b6daa6a6c8db5059db8a5900fb85ca1c1d81b8f13b8ec18b",
-      "size_bytes": 1625
+      "size_bytes": 1625,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3408,7 +3815,8 @@
       "latest_key": "latest/health/subnets/117.json",
       "path": "/metagraph/health/subnets/117.json",
       "sha256": "4e8b9837f60dea63f506300a942be21957180ff00792ee1447f929d78ac56b3b",
-      "size_bytes": 2768
+      "size_bytes": 2768,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3416,7 +3824,8 @@
       "latest_key": "latest/health/subnets/118.json",
       "path": "/metagraph/health/subnets/118.json",
       "sha256": "d30b3dbf2287a86c071ff57a6e77b0aa47b73fcf4fd3101c2c47c2ca72dffe05",
-      "size_bytes": 4960
+      "size_bytes": 4960,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3424,7 +3833,8 @@
       "latest_key": "latest/health/subnets/119.json",
       "path": "/metagraph/health/subnets/119.json",
       "sha256": "e213e6b4c6d56e2a1ab75350faa666616ad52422ca46dc151256315ceb9efb26",
-      "size_bytes": 1613
+      "size_bytes": 1613,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3432,7 +3842,8 @@
       "latest_key": "latest/health/subnets/12.json",
       "path": "/metagraph/health/subnets/12.json",
       "sha256": "19a107df5037cbc9532d22c4d04a9a7aeed3790b33dc0ae346e64782b0171180",
-      "size_bytes": 2794
+      "size_bytes": 2794,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3440,7 +3851,8 @@
       "latest_key": "latest/health/subnets/120.json",
       "path": "/metagraph/health/subnets/120.json",
       "sha256": "53e8cf0b5ca9f414f76d9f4c044ca62fbd29de6e0a809f8cc9de60501405b872",
-      "size_bytes": 3271
+      "size_bytes": 3271,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3448,7 +3860,8 @@
       "latest_key": "latest/health/subnets/121.json",
       "path": "/metagraph/health/subnets/121.json",
       "sha256": "53a4ec77629dcce5608edf2729ab73e0ad633d7cd0764988f8f4ebaa357f58fc",
-      "size_bytes": 2738
+      "size_bytes": 2738,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3456,7 +3869,8 @@
       "latest_key": "latest/health/subnets/122.json",
       "path": "/metagraph/health/subnets/122.json",
       "sha256": "ad22f7fb85c780adaf8bb96a0b032ddf65627e0e9f958fc215d0ecb65f9fb313",
-      "size_bytes": 2208
+      "size_bytes": 2208,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3464,7 +3878,8 @@
       "latest_key": "latest/health/subnets/123.json",
       "path": "/metagraph/health/subnets/123.json",
       "sha256": "15d02ffaab82171faea6152292e12a310858166ac73fdb6f1c0e21ad07148605",
-      "size_bytes": 2170
+      "size_bytes": 2170,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3472,7 +3887,8 @@
       "latest_key": "latest/health/subnets/124.json",
       "path": "/metagraph/health/subnets/124.json",
       "sha256": "dbd59309da5856c54d929e15803f603e9f43c386503ce961f29a37d689136fca",
-      "size_bytes": 4343
+      "size_bytes": 4343,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3480,7 +3896,8 @@
       "latest_key": "latest/health/subnets/125.json",
       "path": "/metagraph/health/subnets/125.json",
       "sha256": "2a7fb48555e7c9e14ed304c592c9e7fdc0b27d6f1e7d35df4297667facf395b6",
-      "size_bytes": 1613
+      "size_bytes": 1613,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3488,7 +3905,8 @@
       "latest_key": "latest/health/subnets/126.json",
       "path": "/metagraph/health/subnets/126.json",
       "sha256": "6e716dda5bc28a538071e8602ac20be3e53d332742f212dcf6abbef7d271225b",
-      "size_bytes": 3269
+      "size_bytes": 3269,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3496,7 +3914,8 @@
       "latest_key": "latest/health/subnets/127.json",
       "path": "/metagraph/health/subnets/127.json",
       "sha256": "af498e8b65114ff1df41d7673dbe771ea57e2e1444d67e7aaf8b9b1bf1515445",
-      "size_bytes": 3286
+      "size_bytes": 3286,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3504,7 +3923,8 @@
       "latest_key": "latest/health/subnets/128.json",
       "path": "/metagraph/health/subnets/128.json",
       "sha256": "a527da12196cd3a190eba90a5d8658a1719c72e65ffb1ecbe3fa0d806123c908",
-      "size_bytes": 4372
+      "size_bytes": 4372,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3512,7 +3932,8 @@
       "latest_key": "latest/health/subnets/13.json",
       "path": "/metagraph/health/subnets/13.json",
       "sha256": "345f3ee65e6a892ee6aa9461c27f785b34675f79159b273eb4f6732d3eb2767d",
-      "size_bytes": 4733
+      "size_bytes": 4733,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3520,7 +3941,8 @@
       "latest_key": "latest/health/subnets/14.json",
       "path": "/metagraph/health/subnets/14.json",
       "sha256": "66736244fe4858a3e465c26b69eca365abf7ac4d37c13bf17b9e39e2eb3d8275",
-      "size_bytes": 6048
+      "size_bytes": 6048,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3528,7 +3950,8 @@
       "latest_key": "latest/health/subnets/15.json",
       "path": "/metagraph/health/subnets/15.json",
       "sha256": "b28291cc842d0f44505a40e7a01ddea73ab20666bf734d594f427affb949fcca",
-      "size_bytes": 5426
+      "size_bytes": 5426,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3536,7 +3959,8 @@
       "latest_key": "latest/health/subnets/16.json",
       "path": "/metagraph/health/subnets/16.json",
       "sha256": "9608977d4332d494b1b8b19d51e3feff5b4f855fb884dbf704f9ac68b9e113da",
-      "size_bytes": 3744
+      "size_bytes": 3744,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3544,7 +3968,8 @@
       "latest_key": "latest/health/subnets/17.json",
       "path": "/metagraph/health/subnets/17.json",
       "sha256": "539032f8f23805b888696ec963d594929e6263d33811420f315c6c36984bdaf6",
-      "size_bytes": 3872
+      "size_bytes": 3872,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3552,7 +3977,8 @@
       "latest_key": "latest/health/subnets/18.json",
       "path": "/metagraph/health/subnets/18.json",
       "sha256": "65da00a0f6bbb3c8fb502243ce6255094b77c1de6c8cb1bf80ebde95ae0afa52",
-      "size_bytes": 3807
+      "size_bytes": 3807,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3560,7 +3986,8 @@
       "latest_key": "latest/health/subnets/19.json",
       "path": "/metagraph/health/subnets/19.json",
       "sha256": "ad4cae77afc7173199f73c32d963f4025e33238bd34b893e02dc7a9ca68eb010",
-      "size_bytes": 4392
+      "size_bytes": 4392,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3568,7 +3995,8 @@
       "latest_key": "latest/health/subnets/2.json",
       "path": "/metagraph/health/subnets/2.json",
       "sha256": "6494a30a20d4ad56420b76d51c48f18428394585f305720271492d1a057bb9cc",
-      "size_bytes": 6146
+      "size_bytes": 6146,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3576,7 +4004,8 @@
       "latest_key": "latest/health/subnets/20.json",
       "path": "/metagraph/health/subnets/20.json",
       "sha256": "9437b93e940fefbb51ca69805ccf47a3cbb790fbf2dedecdc5a181f5fe07780b",
-      "size_bytes": 2158
+      "size_bytes": 2158,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3584,7 +4013,8 @@
       "latest_key": "latest/health/subnets/21.json",
       "path": "/metagraph/health/subnets/21.json",
       "sha256": "3b125283a66a7670f87d5e5044e57827aaa25b687594025b7d1e60c36412d54d",
-      "size_bytes": 2674
+      "size_bytes": 2674,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3592,7 +4022,8 @@
       "latest_key": "latest/health/subnets/22.json",
       "path": "/metagraph/health/subnets/22.json",
       "sha256": "c51564b099c7bf35b3d706dfe59f6f2054ffe70c27a5abc45b084ee8566bdfa6",
-      "size_bytes": 4310
+      "size_bytes": 4310,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3600,7 +4031,8 @@
       "latest_key": "latest/health/subnets/23.json",
       "path": "/metagraph/health/subnets/23.json",
       "sha256": "c72190b3b62570a535ef3763f9ce119182cb05816056852a9d561b9763249fd4",
-      "size_bytes": 6680
+      "size_bytes": 6680,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3608,7 +4040,8 @@
       "latest_key": "latest/health/subnets/24.json",
       "path": "/metagraph/health/subnets/24.json",
       "sha256": "f53c59b5a8224e5bbc1402bedbd8cc94aa3fc2e561b4a4cbc38de91afcdca372",
-      "size_bytes": 4465
+      "size_bytes": 4465,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3616,7 +4049,8 @@
       "latest_key": "latest/health/subnets/25.json",
       "path": "/metagraph/health/subnets/25.json",
       "sha256": "43f3045304f90e70a7d5b0f63e79a48a580f215880a4a8ccdf66576526e14531",
-      "size_bytes": 4404
+      "size_bytes": 4404,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3624,7 +4058,8 @@
       "latest_key": "latest/health/subnets/26.json",
       "path": "/metagraph/health/subnets/26.json",
       "sha256": "2ea54c00731d0338c280c632cac6dfa8c6aef8d3d28acfc4bd602c5fe26eb47f",
-      "size_bytes": 3814
+      "size_bytes": 3814,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3632,7 +4067,8 @@
       "latest_key": "latest/health/subnets/27.json",
       "path": "/metagraph/health/subnets/27.json",
       "sha256": "c5f5b301749ca8323705a0a47950744fed4eb7adcc3a19f590a4ddedd660958a",
-      "size_bytes": 1601
+      "size_bytes": 1601,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3640,7 +4076,8 @@
       "latest_key": "latest/health/subnets/28.json",
       "path": "/metagraph/health/subnets/28.json",
       "sha256": "f3358c8f5d533b96efdfff6d55f011440bef69114f3218dfd0aa4aff899f3c1f",
-      "size_bytes": 1585
+      "size_bytes": 1585,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3648,7 +4085,8 @@
       "latest_key": "latest/health/subnets/29.json",
       "path": "/metagraph/health/subnets/29.json",
       "sha256": "ed5c8ac24be9bc9c7b2ed74912a72b34bd786ea6eefcafb0bb53404dc76f0638",
-      "size_bytes": 3918
+      "size_bytes": 3918,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3656,7 +4094,8 @@
       "latest_key": "latest/health/subnets/3.json",
       "path": "/metagraph/health/subnets/3.json",
       "sha256": "daa36e5a1272d1c2264526d2b769a7de4a6e7533175802de510d0e38f16d13ba",
-      "size_bytes": 2166
+      "size_bytes": 2166,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3664,7 +4103,8 @@
       "latest_key": "latest/health/subnets/30.json",
       "path": "/metagraph/health/subnets/30.json",
       "sha256": "2c80ebac8a631aa332c2038b4039ecabc30971a797814fea0b6c130d29e4b6bd",
-      "size_bytes": 2727
+      "size_bytes": 2727,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3672,7 +4112,8 @@
       "latest_key": "latest/health/subnets/31.json",
       "path": "/metagraph/health/subnets/31.json",
       "sha256": "015e3f334584e7c59ff252102ae74646a47cf726aad2e7ef46df989fc459a43c",
-      "size_bytes": 1601
+      "size_bytes": 1601,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3680,7 +4121,8 @@
       "latest_key": "latest/health/subnets/32.json",
       "path": "/metagraph/health/subnets/32.json",
       "sha256": "21e51017626bb6d17a5f665e4953208723e395a992f8218ad5b861a85c1ce3b8",
-      "size_bytes": 3238
+      "size_bytes": 3238,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3688,7 +4130,8 @@
       "latest_key": "latest/health/subnets/33.json",
       "path": "/metagraph/health/subnets/33.json",
       "sha256": "a591ea914c8bc002c51efe36e6544f5d2bcc35e07cc2e6d81d7d9a7db638344f",
-      "size_bytes": 5914
+      "size_bytes": 5914,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3696,7 +4139,8 @@
       "latest_key": "latest/health/subnets/34.json",
       "path": "/metagraph/health/subnets/34.json",
       "sha256": "f3c2591ed522d33365d504572373cca570a22c2072fa8f25d97299f96d30c584",
-      "size_bytes": 2749
+      "size_bytes": 2749,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3704,7 +4148,8 @@
       "latest_key": "latest/health/subnets/35.json",
       "path": "/metagraph/health/subnets/35.json",
       "sha256": "b22bb3d0091253694cd8eccd288d6319e5de33f4457207933e53dc428a193b96",
-      "size_bytes": 3907
+      "size_bytes": 3907,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3712,7 +4157,8 @@
       "latest_key": "latest/health/subnets/36.json",
       "path": "/metagraph/health/subnets/36.json",
       "sha256": "4333ceb402f4f35b19e471cf1009d035cb10574979ae50d5d6b0d2623cf90b71",
-      "size_bytes": 3752
+      "size_bytes": 3752,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3720,7 +4166,8 @@
       "latest_key": "latest/health/subnets/37.json",
       "path": "/metagraph/health/subnets/37.json",
       "sha256": "e05640510ed1e3547ef0e177b3decc6560a3df3abc880f9a18b719a789354a0c",
-      "size_bytes": 4464
+      "size_bytes": 4464,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3728,7 +4175,8 @@
       "latest_key": "latest/health/subnets/38.json",
       "path": "/metagraph/health/subnets/38.json",
       "sha256": "54c0bd0fa3bf589d0c9de881f149bbe0f1495f709e49cdb0a83cfd006e8c74c7",
-      "size_bytes": 3813
+      "size_bytes": 3813,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3736,7 +4184,8 @@
       "latest_key": "latest/health/subnets/39.json",
       "path": "/metagraph/health/subnets/39.json",
       "sha256": "6010932f6089b04ba462cd7ee62966d9b5b02ffec2ba26e76a98bf8c9c6f898b",
-      "size_bytes": 2182
+      "size_bytes": 2182,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3744,7 +4193,8 @@
       "latest_key": "latest/health/subnets/4.json",
       "path": "/metagraph/health/subnets/4.json",
       "sha256": "af15b27162a015fe13cab58deab2e34016e105147c510f297abf3a507f2cf950",
-      "size_bytes": 4897
+      "size_bytes": 4897,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3752,7 +4202,8 @@
       "latest_key": "latest/health/subnets/40.json",
       "path": "/metagraph/health/subnets/40.json",
       "sha256": "f99d43bcbf0a807411eef7e380fd27e5f4ff3105159ff0a5435466e65b7011a7",
-      "size_bytes": 1609
+      "size_bytes": 1609,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3760,7 +4211,8 @@
       "latest_key": "latest/health/subnets/41.json",
       "path": "/metagraph/health/subnets/41.json",
       "sha256": "c52b28106a228e557f0a882d0ade8a97378dfe7eeae4600f9f5eae55e75c4b9f",
-      "size_bytes": 4892
+      "size_bytes": 4892,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3768,7 +4220,8 @@
       "latest_key": "latest/health/subnets/42.json",
       "path": "/metagraph/health/subnets/42.json",
       "sha256": "2704bb37682359704aa80daf54a4695a2299bab386acaf8a4506342ec27526c2",
-      "size_bytes": 1613
+      "size_bytes": 1613,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3776,7 +4229,8 @@
       "latest_key": "latest/health/subnets/43.json",
       "path": "/metagraph/health/subnets/43.json",
       "sha256": "794976f643c93866c2da73faec3459aaeb94d7fd128cae84cf9b5ef285694836",
-      "size_bytes": 2172
+      "size_bytes": 2172,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3784,7 +4238,8 @@
       "latest_key": "latest/health/subnets/44.json",
       "path": "/metagraph/health/subnets/44.json",
       "sha256": "952ce34bc59b71b946606f60481a41cf9184a63a75aa70e87b9215f0f41987e6",
-      "size_bytes": 3270
+      "size_bytes": 3270,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3792,7 +4247,8 @@
       "latest_key": "latest/health/subnets/45.json",
       "path": "/metagraph/health/subnets/45.json",
       "sha256": "37033568bdd45c52c5067bf81c730ac128366d4f9a594552acd02a06c65c929a",
-      "size_bytes": 4453
+      "size_bytes": 4453,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3800,7 +4256,8 @@
       "latest_key": "latest/health/subnets/46.json",
       "path": "/metagraph/health/subnets/46.json",
       "sha256": "5998864741833af04be143e85e77eeab20db99bedda41a2628a37071632fbb94",
-      "size_bytes": 6614
+      "size_bytes": 6614,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3808,7 +4265,8 @@
       "latest_key": "latest/health/subnets/47.json",
       "path": "/metagraph/health/subnets/47.json",
       "sha256": "949a60cbe661393c71316016bb33a0aafd560d55e8d001154fa66c50f26f3b5c",
-      "size_bytes": 3904
+      "size_bytes": 3904,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3816,7 +4274,8 @@
       "latest_key": "latest/health/subnets/48.json",
       "path": "/metagraph/health/subnets/48.json",
       "sha256": "42d1624fa68b6266aedcbace5fa66b21ea033535c3fe3de8b7e0aec72f446b4d",
-      "size_bytes": 2760
+      "size_bytes": 2760,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3824,7 +4283,8 @@
       "latest_key": "latest/health/subnets/49.json",
       "path": "/metagraph/health/subnets/49.json",
       "sha256": "7aaf35a80ed1be6c6ba0775c46e03134b4f2dd049fdbe3cf197abe1feded0b4c",
-      "size_bytes": 2765
+      "size_bytes": 2765,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3832,7 +4292,8 @@
       "latest_key": "latest/health/subnets/5.json",
       "path": "/metagraph/health/subnets/5.json",
       "sha256": "64fb5284421180ca3e91d890cabd5cef01bfe146666c8f6aa7ad4061f6067a25",
-      "size_bytes": 4350
+      "size_bytes": 4350,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3840,7 +4301,8 @@
       "latest_key": "latest/health/subnets/50.json",
       "path": "/metagraph/health/subnets/50.json",
       "sha256": "e9ac64f47bed6c27dd85ec5b2a4cbdde4e79fbb3c0b6495249f2191799fa59fc",
-      "size_bytes": 3748
+      "size_bytes": 3748,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3848,7 +4310,8 @@
       "latest_key": "latest/health/subnets/51.json",
       "path": "/metagraph/health/subnets/51.json",
       "sha256": "e2ef54fefee1c2b70a0c9a63ef1aff08aac7c58193b71367c084acb7e0a17802",
-      "size_bytes": 4315
+      "size_bytes": 4315,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3856,7 +4319,8 @@
       "latest_key": "latest/health/subnets/52.json",
       "path": "/metagraph/health/subnets/52.json",
       "sha256": "d025f74920d74a03cb9d4dfb2d7cfaa15cd2f675bc55a8e82e6f8fb97cb154d2",
-      "size_bytes": 5054
+      "size_bytes": 5054,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3864,7 +4328,8 @@
       "latest_key": "latest/health/subnets/53.json",
       "path": "/metagraph/health/subnets/53.json",
       "sha256": "f9a832a842c408643ca995a8f79d0e3b9e0b8ebe7c77cd8e4dad89f1c38e7b42",
-      "size_bytes": 1645
+      "size_bytes": 1645,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3872,7 +4337,8 @@
       "latest_key": "latest/health/subnets/54.json",
       "path": "/metagraph/health/subnets/54.json",
       "sha256": "adf31977b73134d5dea59950dc4432f2e052e70f2335261bf48d60e373daf2be",
-      "size_bytes": 3299
+      "size_bytes": 3299,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3880,7 +4346,8 @@
       "latest_key": "latest/health/subnets/55.json",
       "path": "/metagraph/health/subnets/55.json",
       "sha256": "bf66d432a628e352eebfb8a7fd7c8097b7102929e5d1d9ff0940d8f4560ef7cd",
-      "size_bytes": 2685
+      "size_bytes": 2685,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3888,7 +4355,8 @@
       "latest_key": "latest/health/subnets/56.json",
       "path": "/metagraph/health/subnets/56.json",
       "sha256": "3ce7de02784af04b3ffd4e53e7b5826f340d5170a40827eca2d99e306029fd9d",
-      "size_bytes": 4928
+      "size_bytes": 4928,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3896,7 +4364,8 @@
       "latest_key": "latest/health/subnets/57.json",
       "path": "/metagraph/health/subnets/57.json",
       "sha256": "5f3fba7f5f8e53c6b85dcd90639c854010bab1b2db81e75d0fa1152d3d00efbd",
-      "size_bytes": 2157
+      "size_bytes": 2157,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3904,7 +4373,8 @@
       "latest_key": "latest/health/subnets/58.json",
       "path": "/metagraph/health/subnets/58.json",
       "sha256": "6d1f3637fdf0e5a9ffe705e51b6b5bbdd03ac5afc3f8d80772375d87c48fc3ac",
-      "size_bytes": 4541
+      "size_bytes": 4541,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3912,7 +4382,8 @@
       "latest_key": "latest/health/subnets/59.json",
       "path": "/metagraph/health/subnets/59.json",
       "sha256": "3410efa5abdb34fd0190c79b860d1afb752868d75ed4686a2d76e581ee2f0539",
-      "size_bytes": 3829
+      "size_bytes": 3829,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3920,7 +4391,8 @@
       "latest_key": "latest/health/subnets/6.json",
       "path": "/metagraph/health/subnets/6.json",
       "sha256": "53694e14cdfe8af8e53490f2d69286720470a73db4eb8d09eb4b6066c26067e3",
-      "size_bytes": 4485
+      "size_bytes": 4485,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3928,7 +4400,8 @@
       "latest_key": "latest/health/subnets/60.json",
       "path": "/metagraph/health/subnets/60.json",
       "sha256": "2aee13282b620f6f5727df9e78f8392c7f8a104b2681acde0f2d35da6de6f38c",
-      "size_bytes": 6031
+      "size_bytes": 6031,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3936,7 +4409,8 @@
       "latest_key": "latest/health/subnets/61.json",
       "path": "/metagraph/health/subnets/61.json",
       "sha256": "6a7d43237840d1f62c2e91664c6deee2b429fa439ba6a5832a2ef083762f282c",
-      "size_bytes": 3822
+      "size_bytes": 3822,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3944,7 +4418,8 @@
       "latest_key": "latest/health/subnets/62.json",
       "path": "/metagraph/health/subnets/62.json",
       "sha256": "b3c217b6bf8576af46820d505085cb49d6985fe52be68835ebf5fed4a25e639e",
-      "size_bytes": 2151
+      "size_bytes": 2151,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3952,7 +4427,8 @@
       "latest_key": "latest/health/subnets/63.json",
       "path": "/metagraph/health/subnets/63.json",
       "sha256": "9d3b25c5741ae21cf0012570dd0e710e5f1036702916a8373513d0cc443abac0",
-      "size_bytes": 3265
+      "size_bytes": 3265,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3960,7 +4436,8 @@
       "latest_key": "latest/health/subnets/64.json",
       "path": "/metagraph/health/subnets/64.json",
       "sha256": "1af17334fcd0fc9e2cbc8bcf08827059b8f8d993da167191c7d985d7220fae39",
-      "size_bytes": 6606
+      "size_bytes": 6606,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3968,7 +4445,8 @@
       "latest_key": "latest/health/subnets/65.json",
       "path": "/metagraph/health/subnets/65.json",
       "sha256": "1e4a1280175eb32b3e6f10d8ccf63d0c6493a693be62ea4f61026833bce54ba3",
-      "size_bytes": 5593
+      "size_bytes": 5593,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3976,7 +4454,8 @@
       "latest_key": "latest/health/subnets/66.json",
       "path": "/metagraph/health/subnets/66.json",
       "sha256": "dbaaa4487d0c6172d09b3cef60d952bab9a4cb8fb9bca441cde5c18275d3c090",
-      "size_bytes": 5425
+      "size_bytes": 5425,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3984,7 +4463,8 @@
       "latest_key": "latest/health/subnets/67.json",
       "path": "/metagraph/health/subnets/67.json",
       "sha256": "370f8db7c780d1c226e46942e4a395e2cb84cb41f343b650981180d7e00e9093",
-      "size_bytes": 3813
+      "size_bytes": 3813,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -3992,7 +4472,8 @@
       "latest_key": "latest/health/subnets/68.json",
       "path": "/metagraph/health/subnets/68.json",
       "sha256": "79d428e065fff86ad207fa1a2b945b65c6341fc9368ac92852b88afd45afcc73",
-      "size_bytes": 4389
+      "size_bytes": 4389,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4000,7 +4481,8 @@
       "latest_key": "latest/health/subnets/69.json",
       "path": "/metagraph/health/subnets/69.json",
       "sha256": "a50d40bb4dec5941e3778cdc08a9607b45ef56ecac1d30af6d2dc08ff27940f7",
-      "size_bytes": 1589
+      "size_bytes": 1589,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4008,7 +4490,8 @@
       "latest_key": "latest/health/subnets/7.json",
       "path": "/metagraph/health/subnets/7.json",
       "sha256": "99014fa496e0510cc1ea529a9d611aa1a7fe4d409aade384d7c74acf68a5b961",
-      "size_bytes": 7962
+      "size_bytes": 7962,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4016,7 +4499,8 @@
       "latest_key": "latest/health/subnets/70.json",
       "path": "/metagraph/health/subnets/70.json",
       "sha256": "5e5a66191608c1883f1728b01a86e308570c7758b792ac47a977ff53c09c5f3f",
-      "size_bytes": 3794
+      "size_bytes": 3794,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4024,7 +4508,8 @@
       "latest_key": "latest/health/subnets/71.json",
       "path": "/metagraph/health/subnets/71.json",
       "sha256": "0bb883234dca9d29891b15aec6a91ea7f61dcd767312b69a2cf9fbe12a5ac90a",
-      "size_bytes": 3764
+      "size_bytes": 3764,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4032,7 +4517,8 @@
       "latest_key": "latest/health/subnets/72.json",
       "path": "/metagraph/health/subnets/72.json",
       "sha256": "db72338aafbd1f61ce340dfebc878619436aad1c77cc569885c6e7b0869cce62",
-      "size_bytes": 3999
+      "size_bytes": 3999,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4040,7 +4526,8 @@
       "latest_key": "latest/health/subnets/73.json",
       "path": "/metagraph/health/subnets/73.json",
       "sha256": "cfbdc64b58fbbb01e5172d3cf633fc43d7e4f0d1b7f31ed19abd5b176eb62a0c",
-      "size_bytes": 1601
+      "size_bytes": 1601,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4048,7 +4535,8 @@
       "latest_key": "latest/health/subnets/74.json",
       "path": "/metagraph/health/subnets/74.json",
       "sha256": "dfec3e6783f646796a239ce9be074bbd6c47cfde8bc618a568aebdfaa3928deb",
-      "size_bytes": 4394
+      "size_bytes": 4394,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4056,7 +4544,8 @@
       "latest_key": "latest/health/subnets/75.json",
       "path": "/metagraph/health/subnets/75.json",
       "sha256": "b1f06e89d6ea5852f151aad45739b62a21f713d4f4890b03c87ba41e41140660",
-      "size_bytes": 4386
+      "size_bytes": 4386,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4064,7 +4553,8 @@
       "latest_key": "latest/health/subnets/76.json",
       "path": "/metagraph/health/subnets/76.json",
       "sha256": "c863c67b2060595f61e47e9bf7ae32dd70940a2ad782b54e862a0753b33b66dd",
-      "size_bytes": 1613
+      "size_bytes": 1613,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4072,7 +4562,8 @@
       "latest_key": "latest/health/subnets/77.json",
       "path": "/metagraph/health/subnets/77.json",
       "sha256": "68d50625f113fc3b1567bed266a28aaa19311c9100c5c207379cef8276f32d68",
-      "size_bytes": 3762
+      "size_bytes": 3762,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4080,7 +4571,8 @@
       "latest_key": "latest/health/subnets/78.json",
       "path": "/metagraph/health/subnets/78.json",
       "sha256": "79d4d02a1f733a3ba2433301d23ade6d175c497b3b8957fa9e62d5d243ef3d50",
-      "size_bytes": 4898
+      "size_bytes": 4898,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4088,7 +4580,8 @@
       "latest_key": "latest/health/subnets/79.json",
       "path": "/metagraph/health/subnets/79.json",
       "sha256": "5bb57e824674c4ad3ae6e9da3af6c03d4af519cabb6f99d9a8b534cf3ec52332",
-      "size_bytes": 3243
+      "size_bytes": 3243,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4096,7 +4589,8 @@
       "latest_key": "latest/health/subnets/8.json",
       "path": "/metagraph/health/subnets/8.json",
       "sha256": "68f0d15d7d13b91eeebf745cbdc78031b2bae924032fdbb2768fada2ca2493ae",
-      "size_bytes": 4948
+      "size_bytes": 4948,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4104,7 +4598,8 @@
       "latest_key": "latest/health/subnets/80.json",
       "path": "/metagraph/health/subnets/80.json",
       "sha256": "4c8a96f48bdb9a19773bd95c6ac77a1cdbbdf2d30c61c3f7612096d478f5a065",
-      "size_bytes": 5530
+      "size_bytes": 5530,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4112,7 +4607,8 @@
       "latest_key": "latest/health/subnets/81.json",
       "path": "/metagraph/health/subnets/81.json",
       "sha256": "d574a50d7d8cb3682f28b0b89c03621816c83d55e00c320dd23186c418c55c8f",
-      "size_bytes": 2179
+      "size_bytes": 2179,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4120,7 +4616,8 @@
       "latest_key": "latest/health/subnets/82.json",
       "path": "/metagraph/health/subnets/82.json",
       "sha256": "9e2ec8b3319bb842fa382020fa014dca24e7828c29cf48d5df12f575827447fb",
-      "size_bytes": 4413
+      "size_bytes": 4413,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4128,7 +4625,8 @@
       "latest_key": "latest/health/subnets/83.json",
       "path": "/metagraph/health/subnets/83.json",
       "sha256": "da3a2dbf37ac76b96c38fe36953201de4010452cd6ce8b4d880347a042c20b85",
-      "size_bytes": 3792
+      "size_bytes": 3792,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4136,7 +4634,8 @@
       "latest_key": "latest/health/subnets/84.json",
       "path": "/metagraph/health/subnets/84.json",
       "sha256": "5f1cee7827738c2e2e03a9ef8deb918ce81b8711f09137a6485fcf712faac71a",
-      "size_bytes": 3324
+      "size_bytes": 3324,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4144,7 +4643,8 @@
       "latest_key": "latest/health/subnets/85.json",
       "path": "/metagraph/health/subnets/85.json",
       "sha256": "c766cf7d64963e554c518845e2fc98dd5220bb7fca543f2fb491389394969092",
-      "size_bytes": 5421
+      "size_bytes": 5421,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4152,7 +4652,8 @@
       "latest_key": "latest/health/subnets/86.json",
       "path": "/metagraph/health/subnets/86.json",
       "sha256": "df309305139600d9ab4e5a3bb7c27a0955ff9961539e4911dd99628025ea0036",
-      "size_bytes": 1589
+      "size_bytes": 1589,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4160,7 +4661,8 @@
       "latest_key": "latest/health/subnets/87.json",
       "path": "/metagraph/health/subnets/87.json",
       "sha256": "3a6ff0a262b2bf21b7b675a3a2bd71c30b2eeb0b5bfadf3252bc8b07dca4c6ec",
-      "size_bytes": 1637
+      "size_bytes": 1637,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4168,7 +4670,8 @@
       "latest_key": "latest/health/subnets/88.json",
       "path": "/metagraph/health/subnets/88.json",
       "sha256": "360241950eaf1c924b4665a6fc26d129b2f451d4cd7f4f591abf560013b25029",
-      "size_bytes": 4984
+      "size_bytes": 4984,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4176,7 +4679,8 @@
       "latest_key": "latest/health/subnets/89.json",
       "path": "/metagraph/health/subnets/89.json",
       "sha256": "a9cabbaa83e94aa56ad865dec16d5cb6548f153cf16299ed29b89f53d4e78a13",
-      "size_bytes": 3993
+      "size_bytes": 3993,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4184,7 +4688,8 @@
       "latest_key": "latest/health/subnets/9.json",
       "path": "/metagraph/health/subnets/9.json",
       "sha256": "67078a6e5b42ae16484807c4ff0efe8576a57e56b8d9a4eb6670dcb26f0f0b53",
-      "size_bytes": 5463
+      "size_bytes": 5463,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4192,7 +4697,8 @@
       "latest_key": "latest/health/subnets/90.json",
       "path": "/metagraph/health/subnets/90.json",
       "sha256": "2ea3ac1c9d76bcf2a0c9eb423fa5513a9efdc1ead439989ddad51d26a68ebf16",
-      "size_bytes": 1597
+      "size_bytes": 1597,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4200,7 +4706,8 @@
       "latest_key": "latest/health/subnets/91.json",
       "path": "/metagraph/health/subnets/91.json",
       "sha256": "71c9d59e25322593bf4aed8e0a3a2d1936364c52753911e528946d5f48e9a856",
-      "size_bytes": 2166
+      "size_bytes": 2166,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4208,7 +4715,8 @@
       "latest_key": "latest/health/subnets/92.json",
       "path": "/metagraph/health/subnets/92.json",
       "sha256": "77af7071b6407989e6f7b67e29e5471b3a378532d62684cc1502b2692d01ab0d",
-      "size_bytes": 3230
+      "size_bytes": 3230,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4216,7 +4724,8 @@
       "latest_key": "latest/health/subnets/93.json",
       "path": "/metagraph/health/subnets/93.json",
       "sha256": "d2d3389cebc549864952b5da6d377b53312584d77d9bdae6b9a6fc99bd56627c",
-      "size_bytes": 4937
+      "size_bytes": 4937,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4224,7 +4733,8 @@
       "latest_key": "latest/health/subnets/94.json",
       "path": "/metagraph/health/subnets/94.json",
       "sha256": "298bc717144ccc7bcd16f6aabdb6d04d6e879938d3206d208d823c6fa97919a2",
-      "size_bytes": 3776
+      "size_bytes": 3776,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4232,7 +4742,8 @@
       "latest_key": "latest/health/subnets/95.json",
       "path": "/metagraph/health/subnets/95.json",
       "sha256": "8b4d10826fd0774e5e2fff0d1e274068c27f90a1d41f62a47f854e3dfe7a30e5",
-      "size_bytes": 2128
+      "size_bytes": 2128,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4240,7 +4751,8 @@
       "latest_key": "latest/health/subnets/96.json",
       "path": "/metagraph/health/subnets/96.json",
       "sha256": "110506e3491c3f62fc277c06ed68848aa3424eded0033b578a6fb82804ebf49d",
-      "size_bytes": 5465
+      "size_bytes": 5465,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4248,7 +4760,8 @@
       "latest_key": "latest/health/subnets/97.json",
       "path": "/metagraph/health/subnets/97.json",
       "sha256": "58b317bbbcb6774e9cee2b6f2afc8ffcfd26f53651a4b7d17c1b88902f8873b4",
-      "size_bytes": 7314
+      "size_bytes": 7314,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4256,7 +4769,8 @@
       "latest_key": "latest/health/subnets/98.json",
       "path": "/metagraph/health/subnets/98.json",
       "sha256": "32a32c7cae84d1ff6b08f6f6cd642b1a6c0068cf2097877397013ab0bdaa3ced",
-      "size_bytes": 4446
+      "size_bytes": 4446,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4264,7 +4778,8 @@
       "latest_key": "latest/health/subnets/99.json",
       "path": "/metagraph/health/subnets/99.json",
       "sha256": "023f49a23144049a502f079ff083c1d33a45c573bb53eec858b519ec61cbd577",
-      "size_bytes": 5985
+      "size_bytes": 5985,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4272,7 +4787,8 @@
       "latest_key": "latest/health/summary.json",
       "path": "/metagraph/health/summary.json",
       "sha256": "3d421a1832d48c01f3729103b1e3919b8aaceda2e034ca9e3330072ea17feb92",
-      "size_bytes": 40858
+      "size_bytes": 40858,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4280,15 +4796,17 @@
       "latest_key": "latest/metagraph/latest.json",
       "path": "/metagraph/metagraph/latest.json",
       "sha256": "ab32c06769d9840c72e2b82abc4cca4340fc7e7765698176cf5a44ae20a89fbd",
-      "size_bytes": 112329
+      "size_bytes": 112329,
+      "storage_tier": "git"
     },
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "62b83ac5331ff51871c97cc93bf444921441fa9e03132e22b8b0ab1fbdaca8e7",
-      "size_bytes": 253814
+      "sha256": "ecab61764285c33e0ccae94228b816afd6af184026db88e3b8dc4c56436ec2ed",
+      "size_bytes": 254144,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4296,7 +4814,8 @@
       "latest_key": "latest/providers.json",
       "path": "/metagraph/providers.json",
       "sha256": "2e79fce566b0f4f16ff83462c76d8544cd3ce88ede2e2d7c0f8901d5e31f7075",
-      "size_bytes": 5761
+      "size_bytes": 5761,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4304,7 +4823,8 @@
       "latest_key": "latest/providers/allways.json",
       "path": "/metagraph/providers/allways.json",
       "sha256": "70ab83576ac0aebee62ba0c367b9b04c7eb3cb72f9fc184ac16e2f5b49257488",
-      "size_bytes": 885
+      "size_bytes": 885,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4312,7 +4832,8 @@
       "latest_key": "latest/providers/allways/endpoints.json",
       "path": "/metagraph/providers/allways/endpoints.json",
       "sha256": "4fe6a7b5920cbc0d4449c966a7fe54ba9ad77e6d04740af57743efeac72c6940",
-      "size_bytes": 20048
+      "size_bytes": 20048,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4320,7 +4841,8 @@
       "latest_key": "latest/providers/blockmachine.json",
       "path": "/metagraph/providers/blockmachine.json",
       "sha256": "0c94d96e9ce7468538ec9cd600c185ca132355f5730b162042d85ed2d8f31ea9",
-      "size_bytes": 740
+      "size_bytes": 740,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4328,7 +4850,8 @@
       "latest_key": "latest/providers/blockmachine/endpoints.json",
       "path": "/metagraph/providers/blockmachine/endpoints.json",
       "sha256": "6208d1eec55b36fe3f6d399883b0c948dd876afafc48f6b10ed7fd1478dc70ff",
-      "size_bytes": 471
+      "size_bytes": 471,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4336,7 +4859,8 @@
       "latest_key": "latest/providers/dwellir.json",
       "path": "/metagraph/providers/dwellir.json",
       "sha256": "6811d3a543d32a4c5269b24e4801978466adc6bab63573db9ada518b7c3d4cb2",
-      "size_bytes": 715
+      "size_bytes": 715,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4344,7 +4868,8 @@
       "latest_key": "latest/providers/dwellir/endpoints.json",
       "path": "/metagraph/providers/dwellir/endpoints.json",
       "sha256": "909dcf7078126971bf8da777932771984476c43012e1a79862bd4ec9d7f1c061",
-      "size_bytes": 461
+      "size_bytes": 461,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4352,7 +4877,8 @@
       "latest_key": "latest/providers/flamewire.json",
       "path": "/metagraph/providers/flamewire.json",
       "sha256": "6939884e9447013b3ef9517608a4a2da3992302cef6ae9d8f70c515436ef7c6a",
-      "size_bytes": 745
+      "size_bytes": 745,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4360,7 +4886,8 @@
       "latest_key": "latest/providers/flamewire/endpoints.json",
       "path": "/metagraph/providers/flamewire/endpoints.json",
       "sha256": "f69f4ee0b0cb85120c22382a82cc500a5a26e598b7cc03241f10cea6d2f20548",
-      "size_bytes": 465
+      "size_bytes": 465,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4368,7 +4895,8 @@
       "latest_key": "latest/providers/getblock.json",
       "path": "/metagraph/providers/getblock.json",
       "sha256": "0116e2c5799be7a69be80cdc5c0ac1a986e20c9080323c9886fdad50834176ad",
-      "size_bytes": 702
+      "size_bytes": 702,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4376,7 +4904,8 @@
       "latest_key": "latest/providers/getblock/endpoints.json",
       "path": "/metagraph/providers/getblock/endpoints.json",
       "sha256": "7a3e044004b8ffcd0542c1cb8097c582147f19ab979b2ee22d75d134132b6c6b",
-      "size_bytes": 463
+      "size_bytes": 463,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4384,7 +4913,8 @@
       "latest_key": "latest/providers/gittensor.json",
       "path": "/metagraph/providers/gittensor.json",
       "sha256": "2d5d4a7f66b32cf4df63dca50d71fc595944c33d58fdf7dfcf806dedbda49ee4",
-      "size_bytes": 846
+      "size_bytes": 846,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4392,7 +4922,8 @@
       "latest_key": "latest/providers/gittensor/endpoints.json",
       "path": "/metagraph/providers/gittensor/endpoints.json",
       "sha256": "83f3db45c3ae992d18bf66a5afe92777ebb1285275e7c78bc51d1578e2dbc500",
-      "size_bytes": 10067
+      "size_bytes": 10067,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4400,7 +4931,8 @@
       "latest_key": "latest/providers/metagraphed.json",
       "path": "/metagraph/providers/metagraphed.json",
       "sha256": "325486d799b6d7bd37f15c80624c2d3cd810269ba2b8f22dbbd54f664d4c57ed",
-      "size_bytes": 649
+      "size_bytes": 649,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4408,7 +4940,8 @@
       "latest_key": "latest/providers/metagraphed/endpoints.json",
       "path": "/metagraph/providers/metagraphed/endpoints.json",
       "sha256": "89ce36acc3e98c2ca5ae5947b052b94b7596806a6a43d1309b46e832e3fd6c1a",
-      "size_bytes": 455
+      "size_bytes": 455,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4416,7 +4949,8 @@
       "latest_key": "latest/providers/nodies.json",
       "path": "/metagraph/providers/nodies.json",
       "sha256": "1443ef294b62a9453889798178ab946cc2005bfcff14eff76c6624024e1605bf",
-      "size_bytes": 847
+      "size_bytes": 847,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4424,7 +4958,8 @@
       "latest_key": "latest/providers/nodies/endpoints.json",
       "path": "/metagraph/providers/nodies/endpoints.json",
       "sha256": "f7e9113e01d51b46dba094cfb420e5fa79ce58a6ab75d42040d279b56625e585",
-      "size_bytes": 2066
+      "size_bytes": 2066,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4432,7 +4967,8 @@
       "latest_key": "latest/providers/onfinality.json",
       "path": "/metagraph/providers/onfinality.json",
       "sha256": "1ed453cce407b5ba7571764d1a8e6624037b031ceb42cb11a46681b6223f5445",
-      "size_bytes": 867
+      "size_bytes": 867,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4440,7 +4976,8 @@
       "latest_key": "latest/providers/onfinality/endpoints.json",
       "path": "/metagraph/providers/onfinality/endpoints.json",
       "sha256": "fa1be7147520de0d7050b88ed947efb227cec6f06a4203190f284bf4794e7910",
-      "size_bytes": 3469
+      "size_bytes": 3469,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4448,7 +4985,8 @@
       "latest_key": "latest/providers/opentensor.json",
       "path": "/metagraph/providers/opentensor.json",
       "sha256": "dd7133bbeb2cdb3c9669309587016644afe51aebf99264ee49f8921488a6ed4c",
-      "size_bytes": 883
+      "size_bytes": 883,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4456,7 +4994,8 @@
       "latest_key": "latest/providers/opentensor/endpoints.json",
       "path": "/metagraph/providers/opentensor/endpoints.json",
       "sha256": "14d6d95db349b7c03d2ce364d4d62625958f2c5da7578741e4785b5ee188abc0",
-      "size_bytes": 10360
+      "size_bytes": 10360,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4464,7 +5003,8 @@
       "latest_key": "latest/providers/taomarketcap.json",
       "path": "/metagraph/providers/taomarketcap.json",
       "sha256": "9efeb2be985b32475dc9e6c06d67bc78631eaa01ed1f332422e5afd0b8f12fa9",
-      "size_bytes": 1055
+      "size_bytes": 1055,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4472,7 +5012,8 @@
       "latest_key": "latest/providers/taomarketcap/endpoints.json",
       "path": "/metagraph/providers/taomarketcap/endpoints.json",
       "sha256": "e32a025c6aa7dae60dacb2db7115d0ae85bcb80cdbb69e925335e168b24ed5de",
-      "size_bytes": 775322
+      "size_bytes": 775322,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4480,7 +5021,8 @@
       "latest_key": "latest/providers/taopedia-articles.json",
       "path": "/metagraph/providers/taopedia-articles.json",
       "sha256": "53bfb0578c6e08bc67d4f61460da9a8425a466808f3e39e979f79c0958a5fb6e",
-      "size_bytes": 847
+      "size_bytes": 847,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4488,7 +5030,8 @@
       "latest_key": "latest/providers/taopedia-articles/endpoints.json",
       "path": "/metagraph/providers/taopedia-articles/endpoints.json",
       "sha256": "f1a401366bcf4c975058275ebd6d86217f6bbe60d0bf52774ced16c349ca5c67",
-      "size_bytes": 9823
+      "size_bytes": 9823,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4496,7 +5039,8 @@
       "latest_key": "latest/providers/taostats.json",
       "path": "/metagraph/providers/taostats.json",
       "sha256": "e586c720218d290c2edc07f938a80a49ba58b1967dd81af2ac4a11f7f466dd31",
-      "size_bytes": 696
+      "size_bytes": 696,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4504,7 +5048,8 @@
       "latest_key": "latest/providers/taostats/endpoints.json",
       "path": "/metagraph/providers/taostats/endpoints.json",
       "sha256": "3a83270ab59ea64ae22819bc75c567388e40cd9c2af80938f173817394b9c06e",
-      "size_bytes": 453
+      "size_bytes": 453,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4512,7 +5057,8 @@
       "latest_key": "latest/providers/tensorplex-subnet-docs.json",
       "path": "/metagraph/providers/tensorplex-subnet-docs.json",
       "sha256": "47d5d0eaf28dc4832a636c8538f4b5f5425be8abed77ff4aae92697a1da89fea",
-      "size_bytes": 970
+      "size_bytes": 970,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4520,7 +5066,8 @@
       "latest_key": "latest/providers/tensorplex-subnet-docs/endpoints.json",
       "path": "/metagraph/providers/tensorplex-subnet-docs/endpoints.json",
       "sha256": "d8590c0c33fbde3730ac0cbff62e064bb52e1848f2628a2631704425804e77e3",
-      "size_bytes": 286407
+      "size_bytes": 286407,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4528,7 +5075,8 @@
       "latest_key": "latest/review-queue.json",
       "path": "/metagraph/review-queue.json",
       "sha256": "9908d96ec9bf0f7bf8d4f5f36312abc8d9d59df154d8e98a0e19bb1d0349f833",
-      "size_bytes": 3433640
+      "size_bytes": 3433640,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4536,7 +5084,8 @@
       "latest_key": "latest/review/adapter-candidates.json",
       "path": "/metagraph/review/adapter-candidates.json",
       "sha256": "426cd6de0bdf0767e9bae03beadee33cfe21fd3f247a4402cb0b3b3dffc3f740",
-      "size_bytes": 27704
+      "size_bytes": 27704,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4544,7 +5093,8 @@
       "latest_key": "latest/review/curation.json",
       "path": "/metagraph/review/curation.json",
       "sha256": "64f0962c6693bc0105aa6f04fd081506e04e94aa87011db7ad0ef2205d5abe7f",
-      "size_bytes": 96515
+      "size_bytes": 96515,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4552,7 +5102,8 @@
       "latest_key": "latest/review/gap-priorities.json",
       "path": "/metagraph/review/gap-priorities.json",
       "sha256": "05fdce6fd4acf505a249795a315b4a320c0c16878e56036cb0f323fc2235ceab",
-      "size_bytes": 66938
+      "size_bytes": 66938,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4560,7 +5111,8 @@
       "latest_key": "latest/review/maintainer-decisions.json",
       "path": "/metagraph/review/maintainer-decisions.json",
       "sha256": "2e57a1b5a17d8212169056572adb6ea7e55e74d0cb2b73a5ba581c597eac371f",
-      "size_bytes": 1714
+      "size_bytes": 1714,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4568,7 +5120,8 @@
       "latest_key": "latest/rpc-endpoints.json",
       "path": "/metagraph/rpc-endpoints.json",
       "sha256": "8698e96c3e4717f32f47827051c153aecd7720e8b3b192220c43e46e55567b17",
-      "size_bytes": 6268
+      "size_bytes": 6268,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4576,7 +5129,8 @@
       "latest_key": "latest/rpc/pools.json",
       "path": "/metagraph/rpc/pools.json",
       "sha256": "d4ed1a414eeba78ffa64ff02b4758b831629bd47d0d69d8ac6950863e050786c",
-      "size_bytes": 5745
+      "size_bytes": 5745,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4584,15 +5138,8 @@
       "latest_key": "latest/schema-drift.json",
       "path": "/metagraph/schema-drift.json",
       "sha256": "5395a5fcc9ee4c4988ae9c17cce133ee1b99e94b74300c6a4badbc44b088389e",
-      "size_bytes": 9986
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/schemas/allways-swagger.json",
-      "latest_key": "latest/schemas/allways-swagger.json",
-      "path": "/metagraph/schemas/allways-swagger.json",
-      "sha256": "827b3e0927a76e7b589ae0a03f71584d81fe3506ea430e8334be6804e296b074",
-      "size_bytes": 618
+      "size_bytes": 9986,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4600,55 +5147,8 @@
       "latest_key": "latest/schemas/index.json",
       "path": "/metagraph/schemas/index.json",
       "sha256": "46c4c740de85f0a0e562f7f87181a4c0d4ede8eae93c5517fbc61cc1fc44df9f",
-      "size_bytes": 262
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/schemas/sn-22-website-common-openapi-json.json",
-      "latest_key": "latest/schemas/sn-22-website-common-openapi-json.json",
-      "path": "/metagraph/schemas/sn-22-website-common-openapi-json.json",
-      "sha256": "a6f47efe8ab9c3f23f6e1a4f4d4d3705f0d106c7c6ce89341fe6c0b80f2504bd",
-      "size_bytes": 637
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/schemas/sn-22-website-common-swagger.json",
-      "latest_key": "latest/schemas/sn-22-website-common-swagger.json",
-      "path": "/metagraph/schemas/sn-22-website-common-swagger.json",
-      "sha256": "ca0159b2951ddaac832ace1d3f0d34b0cc78fcc971e7baf5ec8b80ca7b407a00",
-      "size_bytes": 627
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/schemas/sn-46-website-common-openapi-json.json",
-      "latest_key": "latest/schemas/sn-46-website-common-openapi-json.json",
-      "path": "/metagraph/schemas/sn-46-website-common-openapi-json.json",
-      "sha256": "6ec9b0ddb2f3e64770c2c6548edbbf5513daa9ac218694a25960d846a8dfbe40",
-      "size_bytes": 640
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/schemas/sn-96-website-common-openapi-json.json",
-      "latest_key": "latest/schemas/sn-96-website-common-openapi-json.json",
-      "path": "/metagraph/schemas/sn-96-website-common-openapi-json.json",
-      "sha256": "a79d2098864e52de92c035067ddcf22a44f3b3eb8e6160f59d224fdea6271f03",
-      "size_bytes": 633
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/schemas/sn-96-website-common-swagger.json",
-      "latest_key": "latest/schemas/sn-96-website-common-swagger.json",
-      "path": "/metagraph/schemas/sn-96-website-common-swagger.json",
-      "sha256": "3bc0d56068416d6fe3b56b7c346d9b1a1eacb3a8c0762e590e4a09cb5d3f646d",
-      "size_bytes": 623
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/schemas/sn-97-website-common-openapi-json.json",
-      "latest_key": "latest/schemas/sn-97-website-common-openapi-json.json",
-      "path": "/metagraph/schemas/sn-97-website-common-openapi-json.json",
-      "sha256": "938e620924f2e8b56f0813bbdfab6405a5e2e034ac1f8636cc9a97c3ce241ef4",
-      "size_bytes": 652
+      "size_bytes": 262,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4656,7 +5156,8 @@
       "latest_key": "latest/search.json",
       "path": "/metagraph/search.json",
       "sha256": "a830b5592144c8b237912be764d4731f0e1d710158594eaf18dd1ec13711526b",
-      "size_bytes": 402094
+      "size_bytes": 402094,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4664,7 +5165,8 @@
       "latest_key": "latest/source-health.json",
       "path": "/metagraph/source-health.json",
       "sha256": "48f051b467e9af8f128f96eac4b128e5e9060a3208f7fd5ef36c0632d3fdf60d",
-      "size_bytes": 5297
+      "size_bytes": 5297,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4672,7 +5174,8 @@
       "latest_key": "latest/source-snapshots.json",
       "path": "/metagraph/source-snapshots.json",
       "sha256": "fe5751a8842d72e8fb817f8193f35b52b288871e35d89aba2c3e3b60d6fcfc38",
-      "size_bytes": 2743
+      "size_bytes": 2743,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4680,7 +5183,8 @@
       "latest_key": "latest/subnets.json",
       "path": "/metagraph/subnets.json",
       "sha256": "658381921f24412cf8fdab8308aefee0155d0dc00b63f000d999a64e4b664724",
-      "size_bytes": 112198
+      "size_bytes": 112198,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -4688,7 +5192,8 @@
       "latest_key": "latest/subnets/0.json",
       "path": "/metagraph/subnets/0.json",
       "sha256": "6aef034e87828f80df4f746b67c0a3fae0422e9bee1c1d246c29f84cf4cf2f1b",
-      "size_bytes": 39719
+      "size_bytes": 39719,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4696,7 +5201,8 @@
       "latest_key": "latest/subnets/1.json",
       "path": "/metagraph/subnets/1.json",
       "sha256": "c10325cdf6b8d02cd37d9c0386e3ef03a5b9f0b5ce4aa8dcfc81c1eca064f8e6",
-      "size_bytes": 79490
+      "size_bytes": 79490,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4704,7 +5210,8 @@
       "latest_key": "latest/subnets/10.json",
       "path": "/metagraph/subnets/10.json",
       "sha256": "0af77d9ec79c09afb39424ad49d0cd1ad863b423a6659ca9ac74eca6625f4dc1",
-      "size_bytes": 37889
+      "size_bytes": 37889,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4712,7 +5219,8 @@
       "latest_key": "latest/subnets/100.json",
       "path": "/metagraph/subnets/100.json",
       "sha256": "bc363e3792f4fee331f6d36a90f71ab26cd9aacf661bb51468d2dd0e87f02849",
-      "size_bytes": 62718
+      "size_bytes": 62718,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4720,7 +5228,8 @@
       "latest_key": "latest/subnets/101.json",
       "path": "/metagraph/subnets/101.json",
       "sha256": "1efa21a2614cd485f81706c6f71f439536f78269bd15639b3ed33b807223da47",
-      "size_bytes": 15726
+      "size_bytes": 15726,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4728,7 +5237,8 @@
       "latest_key": "latest/subnets/102.json",
       "path": "/metagraph/subnets/102.json",
       "sha256": "34b8ddd7afda66b8723ab48b83aa338db886d8789417339837e931bffebf1337",
-      "size_bytes": 61289
+      "size_bytes": 61289,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4736,7 +5246,8 @@
       "latest_key": "latest/subnets/103.json",
       "path": "/metagraph/subnets/103.json",
       "sha256": "482c8b7ffee7df41bed1a8cad64e0043e612d9f0ece4a40a44495420370683be",
-      "size_bytes": 67418
+      "size_bytes": 67418,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4744,7 +5255,8 @@
       "latest_key": "latest/subnets/104.json",
       "path": "/metagraph/subnets/104.json",
       "sha256": "3e79d883c4898417875d9c0553ec067fcc7aeaed9f9e390831dd771c30f50452",
-      "size_bytes": 16062
+      "size_bytes": 16062,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4752,7 +5264,8 @@
       "latest_key": "latest/subnets/105.json",
       "path": "/metagraph/subnets/105.json",
       "sha256": "81115fe1320f89437b877fcbd5d4d44d68a9d35307334d71b9eca71aa5163c0c",
-      "size_bytes": 46190
+      "size_bytes": 46190,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4760,7 +5273,8 @@
       "latest_key": "latest/subnets/106.json",
       "path": "/metagraph/subnets/106.json",
       "sha256": "cf8218324e4ab7f9d4cb52fe03ae0a21b8d58a7f7d0c327a720b1a2bcbfb4480",
-      "size_bytes": 41996
+      "size_bytes": 41996,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4768,7 +5282,8 @@
       "latest_key": "latest/subnets/107.json",
       "path": "/metagraph/subnets/107.json",
       "sha256": "76e9ef792da202e3647b15336b83b780a58cafd6c09e3ced91a600717122089f",
-      "size_bytes": 86924
+      "size_bytes": 86924,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4776,7 +5291,8 @@
       "latest_key": "latest/subnets/108.json",
       "path": "/metagraph/subnets/108.json",
       "sha256": "2164b6510eed5c120b66d58d2df66e52cf07c2e06abce834305192eaab92da3d",
-      "size_bytes": 48535
+      "size_bytes": 48535,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4784,7 +5300,8 @@
       "latest_key": "latest/subnets/109.json",
       "path": "/metagraph/subnets/109.json",
       "sha256": "f55fc2c8e714d786ed0f7d26ead0fc48e38a32f42c0e24b0db0403b7e567e235",
-      "size_bytes": 21872
+      "size_bytes": 21872,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4792,7 +5309,8 @@
       "latest_key": "latest/subnets/11.json",
       "path": "/metagraph/subnets/11.json",
       "sha256": "886c1f16fef394dcec7a5d0d937001c79e0dd3d7f666df10f2d650cbb8dd8c1d",
-      "size_bytes": 53316
+      "size_bytes": 53316,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4800,7 +5318,8 @@
       "latest_key": "latest/subnets/110.json",
       "path": "/metagraph/subnets/110.json",
       "sha256": "928ff0b83603be03ee31d8f0c14b55145fe7fb0a82341fc80315f5a9827160ee",
-      "size_bytes": 71233
+      "size_bytes": 71233,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4808,7 +5327,8 @@
       "latest_key": "latest/subnets/111.json",
       "path": "/metagraph/subnets/111.json",
       "sha256": "93e5602dba8f6e55ed157e5cc9b4c937435f67c66ec7654c98b55190f7571b5c",
-      "size_bytes": 29492
+      "size_bytes": 29492,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4816,7 +5336,8 @@
       "latest_key": "latest/subnets/112.json",
       "path": "/metagraph/subnets/112.json",
       "sha256": "edeea60f1922c31ef1a0eec133bd691db8537b84399d6cc403eadc05fe1549ef",
-      "size_bytes": 48400
+      "size_bytes": 48400,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4824,7 +5345,8 @@
       "latest_key": "latest/subnets/113.json",
       "path": "/metagraph/subnets/113.json",
       "sha256": "8783729f69d48d8544afecbdb55a2167e8dc6ea53c5dc0c90e65dfa1a807d7ec",
-      "size_bytes": 63359
+      "size_bytes": 63359,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4832,7 +5354,8 @@
       "latest_key": "latest/subnets/114.json",
       "path": "/metagraph/subnets/114.json",
       "sha256": "2953b628c8ff7c6e878959a8a19ebb6913593aa06f2c190204942d68ba032f85",
-      "size_bytes": 64512
+      "size_bytes": 64512,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4840,7 +5363,8 @@
       "latest_key": "latest/subnets/115.json",
       "path": "/metagraph/subnets/115.json",
       "sha256": "ddcf6068da3f50b6a78f0684d5b2e729b30119538ea87e89fc1049c6e3602024",
-      "size_bytes": 21912
+      "size_bytes": 21912,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4848,7 +5372,8 @@
       "latest_key": "latest/subnets/116.json",
       "path": "/metagraph/subnets/116.json",
       "sha256": "ba4d7c4d96515d92273bdceaa63496fb212c33b97ed042ac1563185368de6b15",
-      "size_bytes": 17782
+      "size_bytes": 17782,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4856,7 +5381,8 @@
       "latest_key": "latest/subnets/117.json",
       "path": "/metagraph/subnets/117.json",
       "sha256": "c7aa27352fa710f65a4a7f30b7fb65474e0260e269a96ffb5a66cccd2d0722db",
-      "size_bytes": 28624
+      "size_bytes": 28624,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4864,7 +5390,8 @@
       "latest_key": "latest/subnets/118.json",
       "path": "/metagraph/subnets/118.json",
       "sha256": "f823ae0f09a96b0ac88cb70e7e8077e3bc3f895624e4da2db1cd2f2ba64f03ad",
-      "size_bytes": 78313
+      "size_bytes": 78313,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4872,7 +5399,8 @@
       "latest_key": "latest/subnets/119.json",
       "path": "/metagraph/subnets/119.json",
       "sha256": "9855a8f46507ee411919464f457f4a85540be156ad5abc451ab5eb8a3fd5cea7",
-      "size_bytes": 17515
+      "size_bytes": 17515,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4880,7 +5408,8 @@
       "latest_key": "latest/subnets/12.json",
       "path": "/metagraph/subnets/12.json",
       "sha256": "152b5646d27eedfb7044148aa050962bb79f8b4e23b0251194ef300f1a1cc7bd",
-      "size_bytes": 30634
+      "size_bytes": 30634,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4888,7 +5417,8 @@
       "latest_key": "latest/subnets/120.json",
       "path": "/metagraph/subnets/120.json",
       "sha256": "4333660c43dce025b50c488d70cede38bfd4b4fc6a5f5a6973f2aa3ef9cda299",
-      "size_bytes": 44377
+      "size_bytes": 44377,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4896,7 +5426,8 @@
       "latest_key": "latest/subnets/121.json",
       "path": "/metagraph/subnets/121.json",
       "sha256": "a53c5d1039f243c0db01411964cec28d40ec400547c46175f7fb5c0a9034d7bc",
-      "size_bytes": 55668
+      "size_bytes": 55668,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4904,7 +5435,8 @@
       "latest_key": "latest/subnets/122.json",
       "path": "/metagraph/subnets/122.json",
       "sha256": "efec8a2e84fa6546f48556462dd0fc57e6a71e0e67d9b1296f6264e9b549a309",
-      "size_bytes": 24426
+      "size_bytes": 24426,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4912,7 +5444,8 @@
       "latest_key": "latest/subnets/123.json",
       "path": "/metagraph/subnets/123.json",
       "sha256": "bd3eea8fb22814b549eaf17fcd5e8872bb34e50bd97f7c4119b5e70bb96c13fe",
-      "size_bytes": 21818
+      "size_bytes": 21818,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4920,7 +5453,8 @@
       "latest_key": "latest/subnets/124.json",
       "path": "/metagraph/subnets/124.json",
       "sha256": "ced7c84800b0bc0654e786a5a49f7e710701091dd5ee5720eaa6b89efea38c08",
-      "size_bytes": 53084
+      "size_bytes": 53084,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4928,7 +5462,8 @@
       "latest_key": "latest/subnets/125.json",
       "path": "/metagraph/subnets/125.json",
       "sha256": "075bd9bdcc116ecfa1ed85d400f12e4883b4d6d584c99e4b01ebf20b6b43253b",
-      "size_bytes": 15778
+      "size_bytes": 15778,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4936,7 +5471,8 @@
       "latest_key": "latest/subnets/126.json",
       "path": "/metagraph/subnets/126.json",
       "sha256": "2bcf5fd4f8b89357b897b0d69f0803b7fa70566707febb4ff58103a2f11c8440",
-      "size_bytes": 49007
+      "size_bytes": 49007,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4944,7 +5480,8 @@
       "latest_key": "latest/subnets/127.json",
       "path": "/metagraph/subnets/127.json",
       "sha256": "9aecf6cfbeb4deaf26b12524e9a0909848e26aba87ddb37d855a700d7ede0de5",
-      "size_bytes": 49662
+      "size_bytes": 49662,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4952,7 +5489,8 @@
       "latest_key": "latest/subnets/128.json",
       "path": "/metagraph/subnets/128.json",
       "sha256": "fc51fa6ddbea058b80af07b737c9b6bb1d78bae1955a619e1a0c5e5f170ffcae",
-      "size_bytes": 53146
+      "size_bytes": 53146,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4960,7 +5498,8 @@
       "latest_key": "latest/subnets/13.json",
       "path": "/metagraph/subnets/13.json",
       "sha256": "4104015d7f1e22579a97c20dfe9eebe3412d26837ef394c06542b8acd595bf16",
-      "size_bytes": 83230
+      "size_bytes": 83230,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4968,7 +5507,8 @@
       "latest_key": "latest/subnets/14.json",
       "path": "/metagraph/subnets/14.json",
       "sha256": "67141144c6cd880e5cabb5fdb5458efe9a297d336bb7e7f9a41dbd380c2be88c",
-      "size_bytes": 95317
+      "size_bytes": 95317,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4976,7 +5516,8 @@
       "latest_key": "latest/subnets/15.json",
       "path": "/metagraph/subnets/15.json",
       "sha256": "c3f02c9cd5743694a2f1c0af3df240ab41ca23cdc999ea1e203c155aecb247dc",
-      "size_bytes": 83871
+      "size_bytes": 83871,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4984,7 +5525,8 @@
       "latest_key": "latest/subnets/16.json",
       "path": "/metagraph/subnets/16.json",
       "sha256": "ff88114c072b9e177224364ce6d63b4b6549b89b1c7d0d94df280ea3667da7bf",
-      "size_bytes": 46120
+      "size_bytes": 46120,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -4992,7 +5534,8 @@
       "latest_key": "latest/subnets/17.json",
       "path": "/metagraph/subnets/17.json",
       "sha256": "f90275186052b78edf63b3cb612be61869f0abb637ac14231a266db41bdfe865",
-      "size_bytes": 57740
+      "size_bytes": 57740,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5000,7 +5543,8 @@
       "latest_key": "latest/subnets/18.json",
       "path": "/metagraph/subnets/18.json",
       "sha256": "fca1c7aa326427691c181ea2edbc6a7aec53198daa46d0f5276d589d46a46066",
-      "size_bytes": 55264
+      "size_bytes": 55264,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5008,7 +5552,8 @@
       "latest_key": "latest/subnets/19.json",
       "path": "/metagraph/subnets/19.json",
       "sha256": "05c8a7d57928d555e1052cb0f58b17586afb70983d6816ebf0dbe0999b909d99",
-      "size_bytes": 68634
+      "size_bytes": 68634,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5016,7 +5561,8 @@
       "latest_key": "latest/subnets/2.json",
       "path": "/metagraph/subnets/2.json",
       "sha256": "79e484b84b89a7fa54d8ed11e9c849ffe5715a33c4461989547f609bd7f865d2",
-      "size_bytes": 75124
+      "size_bytes": 75124,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5024,7 +5570,8 @@
       "latest_key": "latest/subnets/20.json",
       "path": "/metagraph/subnets/20.json",
       "sha256": "3702a8c8b276558e96000431e80808a2263182a28d82d525e96defea599d5ccb",
-      "size_bytes": 37328
+      "size_bytes": 37328,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5032,7 +5579,8 @@
       "latest_key": "latest/subnets/21.json",
       "path": "/metagraph/subnets/21.json",
       "sha256": "0a7393333b19d2ed16e0d456ae6ed95120dc298be184e58877358f8fd52c9836",
-      "size_bytes": 44494
+      "size_bytes": 44494,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5040,7 +5588,8 @@
       "latest_key": "latest/subnets/22.json",
       "path": "/metagraph/subnets/22.json",
       "sha256": "2fad30b0085ed6327400124eeac8e70127757e600e5990244646f0fc2b068a95",
-      "size_bytes": 51261
+      "size_bytes": 51261,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5048,7 +5597,8 @@
       "latest_key": "latest/subnets/23.json",
       "path": "/metagraph/subnets/23.json",
       "sha256": "2922d2129e014782052209e65163ff0eb8f9ab38169b0513d011db0414a10a06",
-      "size_bytes": 81836
+      "size_bytes": 81836,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5056,7 +5606,8 @@
       "latest_key": "latest/subnets/24.json",
       "path": "/metagraph/subnets/24.json",
       "sha256": "f42afbde8e799d59516a9aea5a75d8f7b8a327fccf5f92ae743d8f252f238b3a",
-      "size_bytes": 60143
+      "size_bytes": 60143,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5064,7 +5615,8 @@
       "latest_key": "latest/subnets/25.json",
       "path": "/metagraph/subnets/25.json",
       "sha256": "ee2e56af6ab9c085c5b6624314b149d221c540bc497cd581446e00cfac7c7d0e",
-      "size_bytes": 69259
+      "size_bytes": 69259,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5072,7 +5624,8 @@
       "latest_key": "latest/subnets/26.json",
       "path": "/metagraph/subnets/26.json",
       "sha256": "79ab2f051924fccbc34bb2652810182bf7a06aa74cd62e8edbac322d1d5ca457",
-      "size_bytes": 55521
+      "size_bytes": 55521,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5080,7 +5633,8 @@
       "latest_key": "latest/subnets/27.json",
       "path": "/metagraph/subnets/27.json",
       "sha256": "697de1736d16ec14732ebd90d4e168df57d2f16fd0ac903b33d14fed0c04083a",
-      "size_bytes": 29343
+      "size_bytes": 29343,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5088,7 +5642,8 @@
       "latest_key": "latest/subnets/28.json",
       "path": "/metagraph/subnets/28.json",
       "sha256": "79298f06a6dede613dda4b57f495c00c77a0d949498df06a4fed457779f0afcb",
-      "size_bytes": 15652
+      "size_bytes": 15652,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5096,7 +5651,8 @@
       "latest_key": "latest/subnets/29.json",
       "path": "/metagraph/subnets/29.json",
       "sha256": "fdb793d11ade3c36514564feeb49929609e978857d1e42c5dd1a2ceed71d49b4",
-      "size_bytes": 45000
+      "size_bytes": 45000,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5104,7 +5660,8 @@
       "latest_key": "latest/subnets/3.json",
       "path": "/metagraph/subnets/3.json",
       "sha256": "c5e52aa76fb845b25856703b05f220b3636cb156265f562f0c59212a9fcf9a88",
-      "size_bytes": 22235
+      "size_bytes": 22235,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5112,7 +5669,8 @@
       "latest_key": "latest/subnets/30.json",
       "path": "/metagraph/subnets/30.json",
       "sha256": "266936ed39ef0658b281f9af78adec386757c2ae37e62825c8a514a834f697d9",
-      "size_bytes": 39860
+      "size_bytes": 39860,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5120,7 +5678,8 @@
       "latest_key": "latest/subnets/31.json",
       "path": "/metagraph/subnets/31.json",
       "sha256": "5e0124dd48d6fa39d596829652a126a1eb95025b0e3af48a3ab2a0fad317115e",
-      "size_bytes": 15720
+      "size_bytes": 15720,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5128,7 +5687,8 @@
       "latest_key": "latest/subnets/32.json",
       "path": "/metagraph/subnets/32.json",
       "sha256": "f9edbcba0c00f0db4dbb9e99e07f4b28fdeff65be2389b9bd2aaaeea7b47712e",
-      "size_bytes": 62706
+      "size_bytes": 62706,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5136,7 +5696,8 @@
       "latest_key": "latest/subnets/33.json",
       "path": "/metagraph/subnets/33.json",
       "sha256": "908853dc912bea0d0cef94599b387667be307f1b458b68a457cfe6881e55db31",
-      "size_bytes": 69159
+      "size_bytes": 69159,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5144,7 +5705,8 @@
       "latest_key": "latest/subnets/34.json",
       "path": "/metagraph/subnets/34.json",
       "sha256": "be9214da5b4b4799078a162f29fe8ba8abec2bdefc40afba8b6a0e35d2aa7f5f",
-      "size_bytes": 30045
+      "size_bytes": 30045,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5152,7 +5714,8 @@
       "latest_key": "latest/subnets/35.json",
       "path": "/metagraph/subnets/35.json",
       "sha256": "549331a3cbe4d2c48d8b5a3b14cbbd5d9c98baba82675cd8c75d96db9ad4e6af",
-      "size_bytes": 51427
+      "size_bytes": 51427,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5160,7 +5723,8 @@
       "latest_key": "latest/subnets/36.json",
       "path": "/metagraph/subnets/36.json",
       "sha256": "db5491cfaa2c2043f8035a43cdce97ff907134a2692be5b190a4ba2b7d93ef27",
-      "size_bytes": 51106
+      "size_bytes": 51106,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5168,7 +5732,8 @@
       "latest_key": "latest/subnets/37.json",
       "path": "/metagraph/subnets/37.json",
       "sha256": "a45e6b6c7f3317ba57d8fccfe7db7037b5b121021773ddd0370255ddd5108e77",
-      "size_bytes": 72425
+      "size_bytes": 72425,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5176,7 +5741,8 @@
       "latest_key": "latest/subnets/38.json",
       "path": "/metagraph/subnets/38.json",
       "sha256": "12d3503e6624ec074a54c65a6abcc3a44db5c9d7a988b494cfd900372ca0f054",
-      "size_bytes": 46965
+      "size_bytes": 46965,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5184,7 +5750,8 @@
       "latest_key": "latest/subnets/39.json",
       "path": "/metagraph/subnets/39.json",
       "sha256": "33b549c3a812a61aca9ec0592d4bc9c34f595b0d5935a042a604ddcb23084d86",
-      "size_bytes": 24070
+      "size_bytes": 24070,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5192,7 +5759,8 @@
       "latest_key": "latest/subnets/4.json",
       "path": "/metagraph/subnets/4.json",
       "sha256": "217524a55ccbbac6a399d66c419d753173eea8cf92060538da81836ab3df8709",
-      "size_bytes": 75921
+      "size_bytes": 75921,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5200,7 +5768,8 @@
       "latest_key": "latest/subnets/40.json",
       "path": "/metagraph/subnets/40.json",
       "sha256": "f9d3b7151efb08dbc51e6bf943767d8ce832bd1352d2b4d4ccefecef224c9e01",
-      "size_bytes": 17508
+      "size_bytes": 17508,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5208,7 +5777,8 @@
       "latest_key": "latest/subnets/41.json",
       "path": "/metagraph/subnets/41.json",
       "sha256": "a29d123b7d2872a99134e9185f26e2ce9f856c65c9a5887ddee347c8949f2e61",
-      "size_bytes": 60663
+      "size_bytes": 60663,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5216,7 +5786,8 @@
       "latest_key": "latest/subnets/42.json",
       "path": "/metagraph/subnets/42.json",
       "sha256": "89d15ac99c6a0ec81750c4d7ea67e3fd89ed6ed0276c3fca0958caf1ed144258",
-      "size_bytes": 15777
+      "size_bytes": 15777,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5224,7 +5795,8 @@
       "latest_key": "latest/subnets/43.json",
       "path": "/metagraph/subnets/43.json",
       "sha256": "6847babb2fec51af7d9893ca644d49d989b4b58994d9bc6570940337f19779e4",
-      "size_bytes": 23815
+      "size_bytes": 23815,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5232,7 +5804,8 @@
       "latest_key": "latest/subnets/44.json",
       "path": "/metagraph/subnets/44.json",
       "sha256": "00c4e8f79e26c0ce492b3eff01455610832456e4eb11640cb1248e5249e5bc4e",
-      "size_bytes": 46443
+      "size_bytes": 46443,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5240,7 +5813,8 @@
       "latest_key": "latest/subnets/45.json",
       "path": "/metagraph/subnets/45.json",
       "sha256": "341f426247881124224077f14df7b257ae670f70f8e495d7b2729ee4ae7730eb",
-      "size_bytes": 68545
+      "size_bytes": 68545,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5248,7 +5822,8 @@
       "latest_key": "latest/subnets/46.json",
       "path": "/metagraph/subnets/46.json",
       "sha256": "bf5fb15d822303811941cc48268184cfc1292d2bcb2dbd3654cf6b42767b7288",
-      "size_bytes": 102899
+      "size_bytes": 102899,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5256,7 +5831,8 @@
       "latest_key": "latest/subnets/47.json",
       "path": "/metagraph/subnets/47.json",
       "sha256": "7f8502f9e358ead1eb14e3becfa8a776e1174eea520e0713f35759e39ba76d5b",
-      "size_bytes": 41144
+      "size_bytes": 41144,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5264,7 +5840,8 @@
       "latest_key": "latest/subnets/48.json",
       "path": "/metagraph/subnets/48.json",
       "sha256": "998cb26999e0b9f53835aca73c002c583ac240b6265049a2ee7712d2855e9f8b",
-      "size_bytes": 56786
+      "size_bytes": 56786,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5272,7 +5849,8 @@
       "latest_key": "latest/subnets/49.json",
       "path": "/metagraph/subnets/49.json",
       "sha256": "9be5ef77bf8b74998b348dc90c73c98820efb7dfc9f2f5456e4cc5288714f3f8",
-      "size_bytes": 42256
+      "size_bytes": 42256,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5280,7 +5858,8 @@
       "latest_key": "latest/subnets/5.json",
       "path": "/metagraph/subnets/5.json",
       "sha256": "e56e4713a52008586254eefb095bd82f46b88be359097ca0e64e9b0abd66517b",
-      "size_bytes": 63723
+      "size_bytes": 63723,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5288,7 +5867,8 @@
       "latest_key": "latest/subnets/50.json",
       "path": "/metagraph/subnets/50.json",
       "sha256": "713c1e6eadce830b7d9aeae5060c95626a711362d74b3123efdacf534ffd7cb1",
-      "size_bytes": 48321
+      "size_bytes": 48321,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5296,7 +5876,8 @@
       "latest_key": "latest/subnets/51.json",
       "path": "/metagraph/subnets/51.json",
       "sha256": "cf07e086893441c90c182175a28e90ca5c5a1f151f692148647124696419720a",
-      "size_bytes": 68752
+      "size_bytes": 68752,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5304,7 +5885,8 @@
       "latest_key": "latest/subnets/52.json",
       "path": "/metagraph/subnets/52.json",
       "sha256": "71d1748cada9f22582ff06228bce5f6f7de090e235936fb293f6b124339f13af",
-      "size_bytes": 61973
+      "size_bytes": 61973,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5312,7 +5894,8 @@
       "latest_key": "latest/subnets/53.json",
       "path": "/metagraph/subnets/53.json",
       "sha256": "06850caf097323b494c3caddd3ae98add9e497c07eb05ac0d274f623f12eb7bc",
-      "size_bytes": 17719
+      "size_bytes": 17719,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5320,7 +5903,8 @@
       "latest_key": "latest/subnets/54.json",
       "path": "/metagraph/subnets/54.json",
       "sha256": "dfa368931452771cf099a99c8d676ca60a5603d4546bcb394eb4b9547e7a7174",
-      "size_bytes": 47864
+      "size_bytes": 47864,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5328,7 +5912,8 @@
       "latest_key": "latest/subnets/55.json",
       "path": "/metagraph/subnets/55.json",
       "sha256": "6ec7947cb500f034c19600ba0f0e1bda3c5c7d7790e64985e799d7cca070f4fe",
-      "size_bytes": 44822
+      "size_bytes": 44822,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5336,7 +5921,8 @@
       "latest_key": "latest/subnets/56.json",
       "path": "/metagraph/subnets/56.json",
       "sha256": "276c20ce02b59d2458c5a9d4b0377a701e305bfc83f33376e70b3d1ee8cee7c3",
-      "size_bytes": 74934
+      "size_bytes": 74934,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5344,7 +5930,8 @@
       "latest_key": "latest/subnets/57.json",
       "path": "/metagraph/subnets/57.json",
       "sha256": "9b3dc4b597387b48ecef8dd6a00a83ea001e0de74e3af4783bacfd1cbf220119",
-      "size_bytes": 22132
+      "size_bytes": 22132,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5352,7 +5939,8 @@
       "latest_key": "latest/subnets/58.json",
       "path": "/metagraph/subnets/58.json",
       "sha256": "38e804af70ae1729ba52fa8a59ef2826f62c0ecaa6160ced635efb83d81bb73e",
-      "size_bytes": 47617
+      "size_bytes": 47617,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5360,7 +5948,8 @@
       "latest_key": "latest/subnets/59.json",
       "path": "/metagraph/subnets/59.json",
       "sha256": "85305fb6db0591695273e1d5fae6a29e296cb6831f917d6307b745f1c54bd489",
-      "size_bytes": 55118
+      "size_bytes": 55118,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5368,7 +5957,8 @@
       "latest_key": "latest/subnets/6.json",
       "path": "/metagraph/subnets/6.json",
       "sha256": "d26696032ce9ec2c64e0b2347a121ac4021edb8173b45dbf139838a375d2d93d",
-      "size_bytes": 64592
+      "size_bytes": 64592,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5376,7 +5966,8 @@
       "latest_key": "latest/subnets/60.json",
       "path": "/metagraph/subnets/60.json",
       "sha256": "e6ecdcfe75ed25db0d17083cb9098c99a0add0c9d85fc37ad760937310f9e6a8",
-      "size_bytes": 75357
+      "size_bytes": 75357,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5384,7 +5975,8 @@
       "latest_key": "latest/subnets/61.json",
       "path": "/metagraph/subnets/61.json",
       "sha256": "fd2c10add96784270e2e3d612f9490941cc4823f12c68e1a9c41b64a4b4c73b4",
-      "size_bytes": 50565
+      "size_bytes": 50565,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5392,7 +5984,8 @@
       "latest_key": "latest/subnets/62.json",
       "path": "/metagraph/subnets/62.json",
       "sha256": "7872d5371200b1b26fc0f7cdb4091ffe80856249c9381f8811f8cd069601e34c",
-      "size_bytes": 33726
+      "size_bytes": 33726,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5400,7 +5993,8 @@
       "latest_key": "latest/subnets/63.json",
       "path": "/metagraph/subnets/63.json",
       "sha256": "90c90e33309db2c63adc52ccb2449b76d47c5dae27622e9c8cf0db12089cdad6",
-      "size_bytes": 62464
+      "size_bytes": 62464,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5408,7 +6002,8 @@
       "latest_key": "latest/subnets/64.json",
       "path": "/metagraph/subnets/64.json",
       "sha256": "61a51990c7ea820e825acbca4e51b8fec0ecc884412a1240760bdade54c17727",
-      "size_bytes": 98440
+      "size_bytes": 98440,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5416,7 +6011,8 @@
       "latest_key": "latest/subnets/65.json",
       "path": "/metagraph/subnets/65.json",
       "sha256": "cb7c81ef4ce1ba57e9928b3fcaa95c70bc90324bc4db7afe2d2398b36002a626",
-      "size_bytes": 72831
+      "size_bytes": 72831,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5424,7 +6020,8 @@
       "latest_key": "latest/subnets/66.json",
       "path": "/metagraph/subnets/66.json",
       "sha256": "81ccb9e599145afd6d555a04ebb3969f3dcf335a9576812f55b1bba6cb9012c2",
-      "size_bytes": 68052
+      "size_bytes": 68052,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5432,7 +6029,8 @@
       "latest_key": "latest/subnets/67.json",
       "path": "/metagraph/subnets/67.json",
       "sha256": "2426a2b31dad500566c69fbb4d7b9ffc6962ed352004891dd48c540e7909c4ba",
-      "size_bytes": 51915
+      "size_bytes": 51915,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5440,7 +6038,8 @@
       "latest_key": "latest/subnets/68.json",
       "path": "/metagraph/subnets/68.json",
       "sha256": "2f8653e9469db03277af7a086f5550ea6b3b6aa0f57471601e7ea74b546855ca",
-      "size_bytes": 59628
+      "size_bytes": 59628,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5448,7 +6047,8 @@
       "latest_key": "latest/subnets/69.json",
       "path": "/metagraph/subnets/69.json",
       "sha256": "abd2f453d389e13e59ac5fec52b0eb16522fddc62f4692959d85a24ec602e6e7",
-      "size_bytes": 15669
+      "size_bytes": 15669,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5456,7 +6056,8 @@
       "latest_key": "latest/subnets/7.json",
       "path": "/metagraph/subnets/7.json",
       "sha256": "4f983a818be5d7a24cc1be0d92b7e4a21477769f37c317b7e331236f3071c6cb",
-      "size_bytes": 56234
+      "size_bytes": 56234,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5464,7 +6065,8 @@
       "latest_key": "latest/subnets/70.json",
       "path": "/metagraph/subnets/70.json",
       "sha256": "f4ded09491552f9d650bec002c9a51e4dbb81c4e691e93a864c3e3674f3a119c",
-      "size_bytes": 54990
+      "size_bytes": 54990,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5472,7 +6074,8 @@
       "latest_key": "latest/subnets/71.json",
       "path": "/metagraph/subnets/71.json",
       "sha256": "ae5eaa89cacc4ffc6e08f84301f8661a499a43139b88c491a05606ab0c19dae2",
-      "size_bytes": 48281
+      "size_bytes": 48281,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5480,7 +6083,8 @@
       "latest_key": "latest/subnets/72.json",
       "path": "/metagraph/subnets/72.json",
       "sha256": "61774ad974167895d2782dceb622ec727ebc84afbb336a32f819e88715b53888",
-      "size_bytes": 70986
+      "size_bytes": 70986,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5488,7 +6092,8 @@
       "latest_key": "latest/subnets/73.json",
       "path": "/metagraph/subnets/73.json",
       "sha256": "13feca57160fac38c598192c34af6b5a0db94e387c29b013b01ef29d620d0c10",
-      "size_bytes": 17672
+      "size_bytes": 17672,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5496,7 +6101,8 @@
       "latest_key": "latest/subnets/74.json",
       "path": "/metagraph/subnets/74.json",
       "sha256": "c3a10ea645d619a1572aa0d39fd588da422fa9b244792a33c67e38808ae708eb",
-      "size_bytes": 47185
+      "size_bytes": 47185,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5504,7 +6110,8 @@
       "latest_key": "latest/subnets/75.json",
       "path": "/metagraph/subnets/75.json",
       "sha256": "6c74779e0224a23f164dd353a49a7e64c71e3a933989043d00d7dc0202d7ec2f",
-      "size_bytes": 72167
+      "size_bytes": 72167,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5512,7 +6119,8 @@
       "latest_key": "latest/subnets/76.json",
       "path": "/metagraph/subnets/76.json",
       "sha256": "b87911e7e79adec92be86d139ded1efac1b95246b070aed5a3b41bb1efbabfb4",
-      "size_bytes": 15770
+      "size_bytes": 15770,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5520,7 +6128,8 @@
       "latest_key": "latest/subnets/77.json",
       "path": "/metagraph/subnets/77.json",
       "sha256": "57ed293583cfda9ccc944dc257c8a7b6d9fea6a9d622c2a7cd843226818afaef",
-      "size_bytes": 50019
+      "size_bytes": 50019,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5528,7 +6137,8 @@
       "latest_key": "latest/subnets/78.json",
       "path": "/metagraph/subnets/78.json",
       "sha256": "20d11192f3c62b487e4cb5a889ff9e824055b35aaf92865b64bf90c9fa187162",
-      "size_bytes": 59546
+      "size_bytes": 59546,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5536,7 +6146,8 @@
       "latest_key": "latest/subnets/79.json",
       "path": "/metagraph/subnets/79.json",
       "sha256": "fb23fb7096c2fe5c96dc501a0c70a290d48e9aa32a8b48f0d68a92c2d97591a6",
-      "size_bytes": 62633
+      "size_bytes": 62633,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5544,7 +6155,8 @@
       "latest_key": "latest/subnets/8.json",
       "path": "/metagraph/subnets/8.json",
       "sha256": "9e6a5fdb461fd34e5dee9a99dafcab19070060d1fdc79f6ce2e8ab4965eb18f4",
-      "size_bytes": 66742
+      "size_bytes": 66742,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5552,7 +6164,8 @@
       "latest_key": "latest/subnets/80.json",
       "path": "/metagraph/subnets/80.json",
       "sha256": "43f812764f72da25a2b7f5d590eff48632bf244455f24f6f642daf3a699325c6",
-      "size_bytes": 78444
+      "size_bytes": 78444,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5560,7 +6173,8 @@
       "latest_key": "latest/subnets/81.json",
       "path": "/metagraph/subnets/81.json",
       "sha256": "9b3c9523035fefd6778aef4363aa30443963b3a34f19d0568f01bb29c63eb14e",
-      "size_bytes": 24043
+      "size_bytes": 24043,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5568,7 +6182,8 @@
       "latest_key": "latest/subnets/82.json",
       "path": "/metagraph/subnets/82.json",
       "sha256": "34a57886e353991ce99608a6ff366cce082999f4989a87521e637561cb14695c",
-      "size_bytes": 74266
+      "size_bytes": 74266,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5576,7 +6191,8 @@
       "latest_key": "latest/subnets/83.json",
       "path": "/metagraph/subnets/83.json",
       "sha256": "1909798b49abaf69d4785de56f9c21575698b6bd5e0ec702cdcf59e71636f81d",
-      "size_bytes": 46839
+      "size_bytes": 46839,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5584,7 +6200,8 @@
       "latest_key": "latest/subnets/84.json",
       "path": "/metagraph/subnets/84.json",
       "sha256": "c11db1b830e046f36881d12fed567b19fcd74be19fe187b7b9cbe9066774699a",
-      "size_bytes": 39087
+      "size_bytes": 39087,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5592,7 +6209,8 @@
       "latest_key": "latest/subnets/85.json",
       "path": "/metagraph/subnets/85.json",
       "sha256": "ef2c8c314b9e9b3c42560c48d022c9ccf0709653dd5b348db6314a40491a0519",
-      "size_bytes": 73088
+      "size_bytes": 73088,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5600,7 +6218,8 @@
       "latest_key": "latest/subnets/86.json",
       "path": "/metagraph/subnets/86.json",
       "sha256": "c53c1670f4669a8964fed4aa66bdaac1dc5e55c231a6db8361d4ae9ce734f22f",
-      "size_bytes": 15667
+      "size_bytes": 15667,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5608,7 +6227,8 @@
       "latest_key": "latest/subnets/87.json",
       "path": "/metagraph/subnets/87.json",
       "sha256": "0b3eb8da4165e70d7ff27e41b7640f6dcc4dcb48abf1d5ccf5343c966efb4a96",
-      "size_bytes": 15867
+      "size_bytes": 15867,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5616,7 +6236,8 @@
       "latest_key": "latest/subnets/88.json",
       "path": "/metagraph/subnets/88.json",
       "sha256": "af86eb67784ee2d4af613bcd3c9da1596c8b02bc491ad92d9d27df43619a0506",
-      "size_bytes": 70098
+      "size_bytes": 70098,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5624,7 +6245,8 @@
       "latest_key": "latest/subnets/89.json",
       "path": "/metagraph/subnets/89.json",
       "sha256": "b16ebc2db301e345ddf1e26f076ba07b96891e0f6e13ebcb5dfaa1dd7800aeba",
-      "size_bytes": 53966
+      "size_bytes": 53966,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5632,7 +6254,8 @@
       "latest_key": "latest/subnets/9.json",
       "path": "/metagraph/subnets/9.json",
       "sha256": "6fde98c175237e67c9f81f0f09b302ff832f21f61e94e344d9120bee01f754bc",
-      "size_bytes": 83402
+      "size_bytes": 83402,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5640,7 +6263,8 @@
       "latest_key": "latest/subnets/90.json",
       "path": "/metagraph/subnets/90.json",
       "sha256": "c45a8df7e7465ee2a63f7fad277daeab53c0c42db8304cc042e855f832e2db07",
-      "size_bytes": 15704
+      "size_bytes": 15704,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5648,7 +6272,8 @@
       "latest_key": "latest/subnets/91.json",
       "path": "/metagraph/subnets/91.json",
       "sha256": "da120d577bb9d4debe35b513a8669e910416200702f3eb105caf56c9d3f32b08",
-      "size_bytes": 40790
+      "size_bytes": 40790,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5656,7 +6281,8 @@
       "latest_key": "latest/subnets/92.json",
       "path": "/metagraph/subnets/92.json",
       "sha256": "88cc3e62b218407760fe303267216358d9b0818dbcaab2136e20b0165e26c801",
-      "size_bytes": 40974
+      "size_bytes": 40974,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5664,7 +6290,8 @@
       "latest_key": "latest/subnets/93.json",
       "path": "/metagraph/subnets/93.json",
       "sha256": "1248b4689f226719fa621e44faecacb8120f4837da6fb0f804935608aaa93e28",
-      "size_bytes": 68454
+      "size_bytes": 68454,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5672,7 +6299,8 @@
       "latest_key": "latest/subnets/94.json",
       "path": "/metagraph/subnets/94.json",
       "sha256": "13351b4ee203839967e82d24ed00e8cf19fb37b9f40238c2776a0ec819debbcb",
-      "size_bytes": 51338
+      "size_bytes": 51338,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5680,7 +6308,8 @@
       "latest_key": "latest/subnets/95.json",
       "path": "/metagraph/subnets/95.json",
       "sha256": "f3571243b411372f25ab35802be2acf105ad6f2a58f05666853455937d8d741c",
-      "size_bytes": 23190
+      "size_bytes": 23190,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5688,7 +6317,8 @@
       "latest_key": "latest/subnets/96.json",
       "path": "/metagraph/subnets/96.json",
       "sha256": "f3475ec03e8977e4c2fac54cab90fda293f180c48258b85fe857a0160ef30c9e",
-      "size_bytes": 65828
+      "size_bytes": 65828,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5696,7 +6326,8 @@
       "latest_key": "latest/subnets/97.json",
       "path": "/metagraph/subnets/97.json",
       "sha256": "1e0775b97e63e2d981e0e395119ed640fca8963e1f6a241183d3617a104e32e8",
-      "size_bytes": 89635
+      "size_bytes": 89635,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5704,7 +6335,8 @@
       "latest_key": "latest/subnets/98.json",
       "path": "/metagraph/subnets/98.json",
       "sha256": "a7ce7b089227c9275e4793355dde8077fa58a7863ca15d6ca7f8e75a0e0d48e7",
-      "size_bytes": 65671
+      "size_bytes": 65671,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5712,7 +6344,8 @@
       "latest_key": "latest/subnets/99.json",
       "path": "/metagraph/subnets/99.json",
       "sha256": "50c56abaeaf8d34523a39ef875ee246119e6944778261026b92622b36545c212",
-      "size_bytes": 76768
+      "size_bytes": 76768,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5720,7 +6353,8 @@
       "latest_key": "latest/surfaces.json",
       "path": "/metagraph/surfaces.json",
       "sha256": "88a2e62dcca66952f08e413869c233bb061449a1100b42d33d0a8932b43688de",
-      "size_bytes": 1075385
+      "size_bytes": 1075385,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -5728,7 +6362,8 @@
       "latest_key": "latest/surfaces/0.json",
       "path": "/metagraph/surfaces/0.json",
       "sha256": "091db78822cce579385197bd6def52b0ba85e7b6048de16a47e49998df758fae",
-      "size_bytes": 8165
+      "size_bytes": 8165,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5736,7 +6371,8 @@
       "latest_key": "latest/surfaces/1.json",
       "path": "/metagraph/surfaces/1.json",
       "sha256": "b28c2fc88d4fff5d3406cd3a1aa7cc8bec9b3096c4761eb4433eeb6a9c19a304",
-      "size_bytes": 10582
+      "size_bytes": 10582,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5744,7 +6380,8 @@
       "latest_key": "latest/surfaces/10.json",
       "path": "/metagraph/surfaces/10.json",
       "sha256": "20969ec8503c620481f2570b9639f529908038dfa335969de0acb25d23c19e55",
-      "size_bytes": 5942
+      "size_bytes": 5942,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5752,7 +6389,8 @@
       "latest_key": "latest/surfaces/100.json",
       "path": "/metagraph/surfaces/100.json",
       "sha256": "0fc5b4cfc9dc2cf04e1f29a5c5c535d4951535a951ca572f79f8b2e0ec70dd0f",
-      "size_bytes": 10588
+      "size_bytes": 10588,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5760,7 +6398,8 @@
       "latest_key": "latest/surfaces/101.json",
       "path": "/metagraph/surfaces/101.json",
       "sha256": "e05b8c75341076229b1ab8c7144b6f2c40a2410db0844337d9f7898248cd2681",
-      "size_bytes": 3119
+      "size_bytes": 3119,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5768,7 +6407,8 @@
       "latest_key": "latest/surfaces/102.json",
       "path": "/metagraph/surfaces/102.json",
       "sha256": "1dd24dfc8c2461b59c64cfe00e07fae07c90bf17af531ab4b5436b3f8740f140",
-      "size_bytes": 10294
+      "size_bytes": 10294,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5776,7 +6416,8 @@
       "latest_key": "latest/surfaces/103.json",
       "path": "/metagraph/surfaces/103.json",
       "sha256": "e2637ee1a32276c4b0b70f959e6e16599f9b4c44125058f3fb128f24352eb18e",
-      "size_bytes": 10323
+      "size_bytes": 10323,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5784,7 +6425,8 @@
       "latest_key": "latest/surfaces/104.json",
       "path": "/metagraph/surfaces/104.json",
       "sha256": "5c1cfd1f9602ba763cfbb32e645e182dba4d78830ff5563780b6344e9ff7e87c",
-      "size_bytes": 3219
+      "size_bytes": 3219,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5792,7 +6434,8 @@
       "latest_key": "latest/surfaces/105.json",
       "path": "/metagraph/surfaces/105.json",
       "sha256": "736994e63d2eeb09d481d3c75a97ecdc63e1536eeb8dd1fcf87929fe518695e3",
-      "size_bytes": 8908
+      "size_bytes": 8908,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5800,7 +6443,8 @@
       "latest_key": "latest/surfaces/106.json",
       "path": "/metagraph/surfaces/106.json",
       "sha256": "f71e88b94ffcd05b96e15767bfab0b080eb5d77b3bd368db4bfa54f175cb1fa5",
-      "size_bytes": 7363
+      "size_bytes": 7363,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5808,7 +6452,8 @@
       "latest_key": "latest/surfaces/107.json",
       "path": "/metagraph/surfaces/107.json",
       "sha256": "a9cc1931b38c1716f7a111a9bc74c8a124153e2bd5ba0b4ebeab584fedc6055e",
-      "size_bytes": 16237
+      "size_bytes": 16237,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5816,7 +6461,8 @@
       "latest_key": "latest/surfaces/108.json",
       "path": "/metagraph/surfaces/108.json",
       "sha256": "a29673cfb34a758da2125b566529aa19ec4efa5d95ed3285489c9453dd8bbd44",
-      "size_bytes": 6002
+      "size_bytes": 6002,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5824,7 +6470,8 @@
       "latest_key": "latest/surfaces/109.json",
       "path": "/metagraph/surfaces/109.json",
       "sha256": "180a8359c1485c3ecdba674d66bcd66ca9ddd724f98b239c2d995a43774cbebf",
-      "size_bytes": 4612
+      "size_bytes": 4612,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5832,7 +6479,8 @@
       "latest_key": "latest/surfaces/11.json",
       "path": "/metagraph/surfaces/11.json",
       "sha256": "bbe41092ebd4c4612c92387994e488c3de2b0c36930bba440df8de2ccd317c21",
-      "size_bytes": 8864
+      "size_bytes": 8864,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5840,7 +6488,8 @@
       "latest_key": "latest/surfaces/110.json",
       "path": "/metagraph/surfaces/110.json",
       "sha256": "9f7cf683d9b1dddce0dd71fba38666f1cb6c75cca07592991bed31ec69c4e222",
-      "size_bytes": 10927
+      "size_bytes": 10927,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5848,7 +6497,8 @@
       "latest_key": "latest/surfaces/111.json",
       "path": "/metagraph/surfaces/111.json",
       "sha256": "60f42adf95f0a2031ebe4b007dc37c22ec6a3085513e31571ae37ec3f8e55493",
-      "size_bytes": 4625
+      "size_bytes": 4625,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5856,7 +6506,8 @@
       "latest_key": "latest/surfaces/112.json",
       "path": "/metagraph/surfaces/112.json",
       "sha256": "6f341d24fa0d1abea65b6078ce71f6199d77f6918038e0166d4ec1bf703cc4e8",
-      "size_bytes": 7494
+      "size_bytes": 7494,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5864,7 +6515,8 @@
       "latest_key": "latest/surfaces/113.json",
       "path": "/metagraph/surfaces/113.json",
       "sha256": "bffbd1c561a8875a4dfd679070efcfdc9b33bfb52d10df7f5ccbe1b5e35bce53",
-      "size_bytes": 10349
+      "size_bytes": 10349,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5872,7 +6524,8 @@
       "latest_key": "latest/surfaces/114.json",
       "path": "/metagraph/surfaces/114.json",
       "sha256": "3cd2185b30a99f8ac8a83451479099c3725dc4fa0528a621dd1d259b8adc693e",
-      "size_bytes": 10329
+      "size_bytes": 10329,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5880,7 +6533,8 @@
       "latest_key": "latest/surfaces/115.json",
       "path": "/metagraph/surfaces/115.json",
       "sha256": "6a921ad08f4127a2c16ffd1dbd0de41f3dd0c110cd104fb78249713958f826ad",
-      "size_bytes": 4624
+      "size_bytes": 4624,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5888,7 +6542,8 @@
       "latest_key": "latest/surfaces/116.json",
       "path": "/metagraph/surfaces/116.json",
       "sha256": "1f2d1cb4dd4a85388dbee9c5ad8b87425fa118e736ea81d0676a43b112c753d2",
-      "size_bytes": 3149
+      "size_bytes": 3149,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5896,7 +6551,8 @@
       "latest_key": "latest/surfaces/117.json",
       "path": "/metagraph/surfaces/117.json",
       "sha256": "3f36677cc81013018a250a4c0ee6f8c04593b5a972e3b5fe1e0d56740a828892",
-      "size_bytes": 6228
+      "size_bytes": 6228,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5904,7 +6560,8 @@
       "latest_key": "latest/surfaces/118.json",
       "path": "/metagraph/surfaces/118.json",
       "sha256": "a74178fc8fe1fe854d8612a55241e005908feae1616532316d43b25574c6ab55",
-      "size_bytes": 11881
+      "size_bytes": 11881,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5912,7 +6569,8 @@
       "latest_key": "latest/surfaces/119.json",
       "path": "/metagraph/surfaces/119.json",
       "sha256": "a264492e8c7d5c38c84ae91fbf302e7053c6d445cb7cb4a179b094e222a3bb51",
-      "size_bytes": 3134
+      "size_bytes": 3134,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5920,7 +6578,8 @@
       "latest_key": "latest/surfaces/12.json",
       "path": "/metagraph/surfaces/12.json",
       "sha256": "b6d29263e397fd05be313df48311e060096c428a147b93b8a7b6b75d531232c9",
-      "size_bytes": 6174
+      "size_bytes": 6174,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5928,7 +6587,8 @@
       "latest_key": "latest/surfaces/120.json",
       "path": "/metagraph/surfaces/120.json",
       "sha256": "8747e3ffcf54aabff257af869ad9fe8b72aee32e209c5b20d1b248fd6ce5d11d",
-      "size_bytes": 7496
+      "size_bytes": 7496,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5936,7 +6596,8 @@
       "latest_key": "latest/surfaces/121.json",
       "path": "/metagraph/surfaces/121.json",
       "sha256": "bce5f4356892fa42b200b560cf44022ae8aea6068804ea6cbf366a694ede7e6c",
-      "size_bytes": 6023
+      "size_bytes": 6023,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5944,7 +6605,8 @@
       "latest_key": "latest/surfaces/122.json",
       "path": "/metagraph/surfaces/122.json",
       "sha256": "87ce50efc1abddc7a32bb751715b6bf27db9761d873fa08208ab3c349765e712",
-      "size_bytes": 4719
+      "size_bytes": 4719,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5952,7 +6614,8 @@
       "latest_key": "latest/surfaces/123.json",
       "path": "/metagraph/surfaces/123.json",
       "sha256": "4198dffcd2f302bb41140415fb0b75416033bdd9ce11d90f3a327725c1d455f2",
-      "size_bytes": 4596
+      "size_bytes": 4596,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5960,7 +6623,8 @@
       "latest_key": "latest/surfaces/124.json",
       "path": "/metagraph/surfaces/124.json",
       "sha256": "8a35b31c563a46686829b8878f155ae760b143cadefad85752e39778c42ab243",
-      "size_bytes": 10473
+      "size_bytes": 10473,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5968,7 +6632,8 @@
       "latest_key": "latest/surfaces/125.json",
       "path": "/metagraph/surfaces/125.json",
       "sha256": "4c0d7bb9f209652eb9788b838cf3f63cd5567334744abe327f6cbe811824d7af",
-      "size_bytes": 3134
+      "size_bytes": 3134,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5976,7 +6641,8 @@
       "latest_key": "latest/surfaces/126.json",
       "path": "/metagraph/surfaces/126.json",
       "sha256": "2caa486a855e01fb28495d5b2f511e9aff7a30020a316aaeea6e31d1826bb469",
-      "size_bytes": 7408
+      "size_bytes": 7408,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5984,7 +6650,8 @@
       "latest_key": "latest/surfaces/127.json",
       "path": "/metagraph/surfaces/127.json",
       "sha256": "7cfcf4584cf231b111231312465a91e91a0c68342952e86fc509b748cd550574",
-      "size_bytes": 7499
+      "size_bytes": 7499,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -5992,7 +6659,8 @@
       "latest_key": "latest/surfaces/128.json",
       "path": "/metagraph/surfaces/128.json",
       "sha256": "d1fc1ffda06e262d07a0adf5ac8b4e8ec7d74014342a44d9343c86063a2c5fca",
-      "size_bytes": 10475
+      "size_bytes": 10475,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6000,7 +6668,8 @@
       "latest_key": "latest/surfaces/13.json",
       "path": "/metagraph/surfaces/13.json",
       "sha256": "39f34324c22d512c1d40e21d3fb3ef0e3d78c5d379f83e8f8adc2e16c4517250",
-      "size_bytes": 10732
+      "size_bytes": 10732,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6008,7 +6677,8 @@
       "latest_key": "latest/surfaces/14.json",
       "path": "/metagraph/surfaces/14.json",
       "sha256": "a1e9701d7b8cc2a221aa652b056863c51cb514ea83296ce5ea9c7ce1194b4b6d",
-      "size_bytes": 14560
+      "size_bytes": 14560,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6016,7 +6686,8 @@
       "latest_key": "latest/surfaces/15.json",
       "path": "/metagraph/surfaces/15.json",
       "sha256": "8a868767e9fd7093799ad485ea6712ea9a93bf578a994aa72163c927f5bf6b17",
-      "size_bytes": 13001
+      "size_bytes": 13001,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6024,7 +6695,8 @@
       "latest_key": "latest/surfaces/16.json",
       "path": "/metagraph/surfaces/16.json",
       "sha256": "0fff62564d5d358f95480fc7250ba06016236aa93ad79408d3b409d2b5d6b29d",
-      "size_bytes": 8841
+      "size_bytes": 8841,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6032,7 +6704,8 @@
       "latest_key": "latest/surfaces/17.json",
       "path": "/metagraph/surfaces/17.json",
       "sha256": "58ccbd21a404f8f2eec14c1164f254971d6c73981c0ada5e0d86c8694462ecdd",
-      "size_bytes": 9042
+      "size_bytes": 9042,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6040,7 +6713,8 @@
       "latest_key": "latest/surfaces/18.json",
       "path": "/metagraph/surfaces/18.json",
       "sha256": "fe04867bf4a02e65419ce6126e08aa80f4624b81118dc73a14696cc94d3fc74a",
-      "size_bytes": 8797
+      "size_bytes": 8797,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6048,7 +6722,8 @@
       "latest_key": "latest/surfaces/19.json",
       "path": "/metagraph/surfaces/19.json",
       "sha256": "b44ea66958ba6e81e7b994b0773fa1cf2db97499d4d4f3c5066e8fed204a5d3c",
-      "size_bytes": 10340
+      "size_bytes": 10340,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6056,7 +6731,8 @@
       "latest_key": "latest/surfaces/2.json",
       "path": "/metagraph/surfaces/2.json",
       "sha256": "83c07d388f43d6fd632a4d95562e1c103dc800531ef8bb57515f03fb5e144fc4",
-      "size_bytes": 15067
+      "size_bytes": 15067,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6064,7 +6740,8 @@
       "latest_key": "latest/surfaces/20.json",
       "path": "/metagraph/surfaces/20.json",
       "sha256": "c212cba5a7cd3a2a8c8c6996af2bc4fe69153a1f401491db47b9f327abcd7329",
-      "size_bytes": 4558
+      "size_bytes": 4558,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6072,7 +6749,8 @@
       "latest_key": "latest/surfaces/21.json",
       "path": "/metagraph/surfaces/21.json",
       "sha256": "5b442392f3a206d62ba67bffd69f3b96845721cef46d0480ab773099c4acaf06",
-      "size_bytes": 5934
+      "size_bytes": 5934,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6080,7 +6758,8 @@
       "latest_key": "latest/surfaces/22.json",
       "path": "/metagraph/surfaces/22.json",
       "sha256": "0320c6537a442f5408bf7cf153d3b26df15fc06572167035044e1444b7da431c",
-      "size_bytes": 10633
+      "size_bytes": 10633,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6088,7 +6767,8 @@
       "latest_key": "latest/surfaces/23.json",
       "path": "/metagraph/surfaces/23.json",
       "sha256": "78fad3127afc0db149c13384a013c7bb7e19fe2f3da0ed5d4834aedc94bf24dd",
-      "size_bytes": 16325
+      "size_bytes": 16325,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6096,7 +6776,8 @@
       "latest_key": "latest/surfaces/24.json",
       "path": "/metagraph/surfaces/24.json",
       "sha256": "33405d65f8686f5b75d9420bce5428320730d3f65a13ee2b8f7b55433056bf95",
-      "size_bytes": 10418
+      "size_bytes": 10418,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6104,7 +6785,8 @@
       "latest_key": "latest/surfaces/25.json",
       "path": "/metagraph/surfaces/25.json",
       "sha256": "9c690c493c86cd18d5b6b0f1d6a49f58c67bb5820dcde914365c8eb7601d3205",
-      "size_bytes": 10433
+      "size_bytes": 10433,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6112,7 +6794,8 @@
       "latest_key": "latest/surfaces/26.json",
       "path": "/metagraph/surfaces/26.json",
       "sha256": "f045d55b9991ed94e5fce9def4ddc005c63f1d8bc442ac93ce745104e14a5e6e",
-      "size_bytes": 8851
+      "size_bytes": 8851,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6120,7 +6803,8 @@
       "latest_key": "latest/surfaces/27.json",
       "path": "/metagraph/surfaces/27.json",
       "sha256": "de351e19c19af2cd2ff8e86ac7183c9c774f102bcc4893cbae14f3e361790c37",
-      "size_bytes": 3122
+      "size_bytes": 3122,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6128,7 +6812,8 @@
       "latest_key": "latest/surfaces/28.json",
       "path": "/metagraph/surfaces/28.json",
       "sha256": "5283c6f49b215f7e056578fd5823356b3e47da516e6c5ec1e99bfa6b402b596f",
-      "size_bytes": 3102
+      "size_bytes": 3102,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6136,7 +6821,8 @@
       "latest_key": "latest/surfaces/29.json",
       "path": "/metagraph/surfaces/29.json",
       "sha256": "5b97e70451d99c2e1bc5610cc227dd745d96377d6dd67910dcf6150ccec2cb9d",
-      "size_bytes": 9139
+      "size_bytes": 9139,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6144,7 +6830,8 @@
       "latest_key": "latest/surfaces/3.json",
       "path": "/metagraph/surfaces/3.json",
       "sha256": "5a311ccbdc5cc1047252e00933ae2c4ea18fa784ef7e6c5e334c97b6dad665ed",
-      "size_bytes": 4708
+      "size_bytes": 4708,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6152,7 +6839,8 @@
       "latest_key": "latest/surfaces/30.json",
       "path": "/metagraph/surfaces/30.json",
       "sha256": "dd08fc00490f7a566a42a717f3d6402368725d4bc632a77c8421374c99bf482d",
-      "size_bytes": 5959
+      "size_bytes": 5959,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6160,7 +6848,8 @@
       "latest_key": "latest/surfaces/31.json",
       "path": "/metagraph/surfaces/31.json",
       "sha256": "9aadbd677c5e1ed7cd4ff8da53dac9f53427e6374ec36465017b69610f23de9d",
-      "size_bytes": 3122
+      "size_bytes": 3122,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6168,7 +6857,8 @@
       "latest_key": "latest/surfaces/32.json",
       "path": "/metagraph/surfaces/32.json",
       "sha256": "bc4d4fb3a44a73651a12f8a4984a6fdacaff37a7ced754462a459ce1e5fe7a5c",
-      "size_bytes": 7396
+      "size_bytes": 7396,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6176,7 +6866,8 @@
       "latest_key": "latest/surfaces/33.json",
       "path": "/metagraph/surfaces/33.json",
       "sha256": "6fd4ee93b920d736c5e7624c0ace2abfee1b312873ea27785d0d30c7ce5fe8f0",
-      "size_bytes": 14104
+      "size_bytes": 14104,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6184,7 +6875,8 @@
       "latest_key": "latest/surfaces/34.json",
       "path": "/metagraph/surfaces/34.json",
       "sha256": "2bf111a782b55132cf32c5933021d53f5cbf835785ba8d6a78e6b226558642ce",
-      "size_bytes": 6093
+      "size_bytes": 6093,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6192,7 +6884,8 @@
       "latest_key": "latest/surfaces/35.json",
       "path": "/metagraph/surfaces/35.json",
       "sha256": "eec833b107047eac011c09d22258dcad953fd808febb537aa49e45177654b8f1",
-      "size_bytes": 9097
+      "size_bytes": 9097,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6200,7 +6893,8 @@
       "latest_key": "latest/surfaces/36.json",
       "path": "/metagraph/surfaces/36.json",
       "sha256": "15ab17b85a14fb63ef3280b80ee54ffd5ef69ad5d50780a17354fa9ab26813b8",
-      "size_bytes": 8789
+      "size_bytes": 8789,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6208,7 +6902,8 @@
       "latest_key": "latest/surfaces/37.json",
       "path": "/metagraph/surfaces/37.json",
       "sha256": "7ce288419a24765464a84289a1387044ccd594836dcd4b4d907d2b8597e84b4f",
-      "size_bytes": 10515
+      "size_bytes": 10515,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6216,7 +6911,8 @@
       "latest_key": "latest/surfaces/38.json",
       "path": "/metagraph/surfaces/38.json",
       "sha256": "f13bc292eeb9945de0948f1db761b577b957f35f236a39fefe541cddf8229665",
-      "size_bytes": 8957
+      "size_bytes": 8957,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6224,7 +6920,8 @@
       "latest_key": "latest/surfaces/39.json",
       "path": "/metagraph/surfaces/39.json",
       "sha256": "7c5662177e85712da380a9cf2ce6feaa3c8cbe34a88b9e760320d98e472f6861",
-      "size_bytes": 4727
+      "size_bytes": 4727,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6232,7 +6929,8 @@
       "latest_key": "latest/surfaces/4.json",
       "path": "/metagraph/surfaces/4.json",
       "sha256": "f063c63f6108167cde9bddfbce89378b5d0291aef1d393041891777317d19c06",
-      "size_bytes": 11779
+      "size_bytes": 11779,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6240,7 +6938,8 @@
       "latest_key": "latest/surfaces/40.json",
       "path": "/metagraph/surfaces/40.json",
       "sha256": "f95be7b738cdb7bad00ab3d9f09fc32886f473918697f392e53403e584f935c4",
-      "size_bytes": 3132
+      "size_bytes": 3132,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6248,7 +6947,8 @@
       "latest_key": "latest/surfaces/41.json",
       "path": "/metagraph/surfaces/41.json",
       "sha256": "bdd2d4b974a53c6801f5ee6d0ebf0d8fc922471395fad5105159a71caffb18b6",
-      "size_bytes": 11828
+      "size_bytes": 11828,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6256,7 +6956,8 @@
       "latest_key": "latest/surfaces/42.json",
       "path": "/metagraph/surfaces/42.json",
       "sha256": "c13dc98c0510bc47a324b84dd0a91779dd6c35f4b0239373ea30c55b4d7df462",
-      "size_bytes": 3137
+      "size_bytes": 3137,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6264,7 +6965,8 @@
       "latest_key": "latest/surfaces/43.json",
       "path": "/metagraph/surfaces/43.json",
       "sha256": "e2c98f5e134773e8a47278d9ab5d8ff8dde42a63233e00179acf120456e18d98",
-      "size_bytes": 4608
+      "size_bytes": 4608,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6272,7 +6974,8 @@
       "latest_key": "latest/surfaces/44.json",
       "path": "/metagraph/surfaces/44.json",
       "sha256": "fb8c3adc1df5a801460e6fb7005e759ef1b65c094f0c87b9dd3df47198c5f2f9",
-      "size_bytes": 7528
+      "size_bytes": 7528,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6280,7 +6983,8 @@
       "latest_key": "latest/surfaces/45.json",
       "path": "/metagraph/surfaces/45.json",
       "sha256": "677ffe998a990e14f3ea4558e4a597c41fcebff2fb874b4f95ae6353aaa28d25",
-      "size_bytes": 10344
+      "size_bytes": 10344,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6288,7 +6992,8 @@
       "latest_key": "latest/surfaces/46.json",
       "path": "/metagraph/surfaces/46.json",
       "sha256": "b60316619a5bcc972807432422794b342099fd04f03f3f0aa0a15d420470fd4e",
-      "size_bytes": 16485
+      "size_bytes": 16485,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6296,7 +7001,8 @@
       "latest_key": "latest/surfaces/47.json",
       "path": "/metagraph/surfaces/47.json",
       "sha256": "84fca82c697227bea6abfc7919f1943f0372a9c1a29a563e4ffc1f6b5bfe89d8",
-      "size_bytes": 9154
+      "size_bytes": 9154,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6304,7 +7010,8 @@
       "latest_key": "latest/surfaces/48.json",
       "path": "/metagraph/surfaces/48.json",
       "sha256": "feb4e1096686ae6569008eaf10d39eba2a1570902d51b3311261ec7d0de54e9a",
-      "size_bytes": 6062
+      "size_bytes": 6062,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6312,7 +7019,8 @@
       "latest_key": "latest/surfaces/49.json",
       "path": "/metagraph/surfaces/49.json",
       "sha256": "9fc1776053dd73ffb7a48c9ac970f468ead37761d312e2511c0a1c885374ab1a",
-      "size_bytes": 6105
+      "size_bytes": 6105,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6320,7 +7028,8 @@
       "latest_key": "latest/surfaces/5.json",
       "path": "/metagraph/surfaces/5.json",
       "sha256": "d152108b720c454682513ec1652f1881f7fcd275e638764b668527d5e1eb25a8",
-      "size_bytes": 10378
+      "size_bytes": 10378,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6328,7 +7037,8 @@
       "latest_key": "latest/surfaces/50.json",
       "path": "/metagraph/surfaces/50.json",
       "sha256": "78cec7748ed49fc4c6f7ceb04d6d5043ff68a0c6d7725a58e610ec19a4652596",
-      "size_bytes": 8939
+      "size_bytes": 8939,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6336,7 +7046,8 @@
       "latest_key": "latest/surfaces/51.json",
       "path": "/metagraph/surfaces/51.json",
       "sha256": "9b26477a998187eb15cb3779337a6367e7bc40a5bf481a85433e6f158213d089",
-      "size_bytes": 10254
+      "size_bytes": 10254,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6344,7 +7055,8 @@
       "latest_key": "latest/surfaces/52.json",
       "path": "/metagraph/surfaces/52.json",
       "sha256": "4d36768aede7a4510aa81ed81c429a532fa813e70e607967fe54a7ea9680a3da",
-      "size_bytes": 12181
+      "size_bytes": 12181,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6352,7 +7064,8 @@
       "latest_key": "latest/surfaces/53.json",
       "path": "/metagraph/surfaces/53.json",
       "sha256": "5e3e849fc41eaaf395fc871ad19444578004fb8fc402f88a77d6c21e5bc4edee",
-      "size_bytes": 3177
+      "size_bytes": 3177,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6360,7 +7073,8 @@
       "latest_key": "latest/surfaces/54.json",
       "path": "/metagraph/surfaces/54.json",
       "sha256": "b3bd2ea4b7c7c24886bc80769b255fe843381ac64df10c9109d3163a4744e5e5",
-      "size_bytes": 7481
+      "size_bytes": 7481,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6368,7 +7082,8 @@
       "latest_key": "latest/surfaces/55.json",
       "path": "/metagraph/surfaces/55.json",
       "sha256": "a9eb00bfc30849aab1a6a5c2c65bd3ba2c2b098a570e0ff9596473d83da53843",
-      "size_bytes": 5948
+      "size_bytes": 5948,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6376,7 +7091,8 @@
       "latest_key": "latest/surfaces/56.json",
       "path": "/metagraph/surfaces/56.json",
       "sha256": "17849d5e67c633b0bdcd20b4fb29dddbd8703b9084c4ee1cffdba6fc44075231",
-      "size_bytes": 11993
+      "size_bytes": 11993,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6384,7 +7100,8 @@
       "latest_key": "latest/surfaces/57.json",
       "path": "/metagraph/surfaces/57.json",
       "sha256": "b9e3683196931604f0023d08f02822a8b4fcd983eda7eafd7ab4fd231c6e2ecf",
-      "size_bytes": 4652
+      "size_bytes": 4652,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6392,7 +7109,8 @@
       "latest_key": "latest/surfaces/58.json",
       "path": "/metagraph/surfaces/58.json",
       "sha256": "cc2c64f9cb4d3d166fab5265f802452617f815d0b4f3d31a44d0baba65088c12",
-      "size_bytes": 10611
+      "size_bytes": 10611,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6400,7 +7118,8 @@
       "latest_key": "latest/surfaces/59.json",
       "path": "/metagraph/surfaces/59.json",
       "sha256": "b46e6fc337f960d92f10da10c1764ce87692f7ddaa7393ec70c0255f8dab8ce3",
-      "size_bytes": 8871
+      "size_bytes": 8871,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6408,7 +7127,8 @@
       "latest_key": "latest/surfaces/6.json",
       "path": "/metagraph/surfaces/6.json",
       "sha256": "a770ae8e52681b9ee2cfb2b40508e9f33e832374a0c450ee8ddece9574f74e38",
-      "size_bytes": 10501
+      "size_bytes": 10501,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6416,7 +7136,8 @@
       "latest_key": "latest/surfaces/60.json",
       "path": "/metagraph/surfaces/60.json",
       "sha256": "c340dcb8675116d0bdb8cf65a2763572cc5b9e53972b90e0ec5cb199ab6a59a6",
-      "size_bytes": 14859
+      "size_bytes": 14859,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6424,7 +7145,8 @@
       "latest_key": "latest/surfaces/61.json",
       "path": "/metagraph/surfaces/61.json",
       "sha256": "383c9627f4a68d149e07953e729b918bff8b63012a2634c76653770cd6da78f9",
-      "size_bytes": 8891
+      "size_bytes": 8891,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6432,7 +7154,8 @@
       "latest_key": "latest/surfaces/62.json",
       "path": "/metagraph/surfaces/62.json",
       "sha256": "9c14937c70e9378a4e25dea8da82f36be95ce655f3ae69a76a50fb77d13306ff",
-      "size_bytes": 4572
+      "size_bytes": 4572,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6440,7 +7163,8 @@
       "latest_key": "latest/surfaces/63.json",
       "path": "/metagraph/surfaces/63.json",
       "sha256": "628d7ce617a83d98ef8817500663f9d5f9362cf87eefdaec9783481230bbfa4f",
-      "size_bytes": 7434
+      "size_bytes": 7434,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6448,7 +7172,8 @@
       "latest_key": "latest/surfaces/64.json",
       "path": "/metagraph/surfaces/64.json",
       "sha256": "24fcc61f69cd3d6158fe846c8149c084c7ab3e4ccbf7539b795759e8ee13ecb5",
-      "size_bytes": 16303
+      "size_bytes": 16303,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6456,7 +7181,8 @@
       "latest_key": "latest/surfaces/65.json",
       "path": "/metagraph/surfaces/65.json",
       "sha256": "ea81adf71b0082ce55d762c05dc2e263c29c79c8cab48adab92c4888d778b558",
-      "size_bytes": 13558
+      "size_bytes": 13558,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6464,7 +7190,8 @@
       "latest_key": "latest/surfaces/66.json",
       "path": "/metagraph/surfaces/66.json",
       "sha256": "82e783dcdba06dac528b348146c2cce542537fca9d2eb64062c540bb0fdb6db2",
-      "size_bytes": 13148
+      "size_bytes": 13148,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6472,7 +7199,8 @@
       "latest_key": "latest/surfaces/67.json",
       "path": "/metagraph/surfaces/67.json",
       "sha256": "8249b2bd52a82367b7f232341e6da0c624fe69f1ef8e8f4a08c1a36a5138b310",
-      "size_bytes": 8885
+      "size_bytes": 8885,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6480,7 +7208,8 @@
       "latest_key": "latest/surfaces/68.json",
       "path": "/metagraph/surfaces/68.json",
       "sha256": "d9d93f3af2af9a58f2306dced0291e7ba1f6eb19116f49a14dca1786b0c53f6e",
-      "size_bytes": 10201
+      "size_bytes": 10201,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6488,7 +7217,8 @@
       "latest_key": "latest/surfaces/69.json",
       "path": "/metagraph/surfaces/69.json",
       "sha256": "513f8c50bf706ec9f394078b97f121ae5cdd04b8ce1954fc54d8d419ef1b4302",
-      "size_bytes": 3107
+      "size_bytes": 3107,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6496,7 +7226,8 @@
       "latest_key": "latest/surfaces/7.json",
       "path": "/metagraph/surfaces/7.json",
       "sha256": "a3b56e2626350467310f377973c24e658f4cd12f2220cc9066eb3c6ae85a4a36",
-      "size_bytes": 7599
+      "size_bytes": 7599,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6504,7 +7235,8 @@
       "latest_key": "latest/surfaces/70.json",
       "path": "/metagraph/surfaces/70.json",
       "sha256": "a0189404eb15a6d5a448251eda386cfc9939430a0c1852489c8393578c0cba20",
-      "size_bytes": 8918
+      "size_bytes": 8918,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6512,7 +7244,8 @@
       "latest_key": "latest/surfaces/71.json",
       "path": "/metagraph/surfaces/71.json",
       "sha256": "534269ae4b648cf6abfc1d90c889ab5a54df633775fe97ee37c1656d03c4a77b",
-      "size_bytes": 8916
+      "size_bytes": 8916,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6520,7 +7253,8 @@
       "latest_key": "latest/surfaces/72.json",
       "path": "/metagraph/surfaces/72.json",
       "sha256": "578e9fcf2b8df8e1c6751623c8a14100760d44267efd722d1b5b209e2921b5d6",
-      "size_bytes": 9155
+      "size_bytes": 9155,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6528,7 +7262,8 @@
       "latest_key": "latest/surfaces/73.json",
       "path": "/metagraph/surfaces/73.json",
       "sha256": "513225525907c67de71b2e704dc61d63880af2f2602eb406250c60d1b1c4acd1",
-      "size_bytes": 3122
+      "size_bytes": 3122,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6536,7 +7271,8 @@
       "latest_key": "latest/surfaces/74.json",
       "path": "/metagraph/surfaces/74.json",
       "sha256": "bfd396c884d9270cd4bcbb4dd9435e56111c993ca57ce906724d40395062387f",
-      "size_bytes": 4047
+      "size_bytes": 4047,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6544,7 +7280,8 @@
       "latest_key": "latest/surfaces/75.json",
       "path": "/metagraph/surfaces/75.json",
       "sha256": "716f818ff90ba5608186d57dd2f88e830646234789efae618cd15cc75a4f4169",
-      "size_bytes": 10495
+      "size_bytes": 10495,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6552,7 +7289,8 @@
       "latest_key": "latest/surfaces/76.json",
       "path": "/metagraph/surfaces/76.json",
       "sha256": "2ca7d3281c4cdc57a30a06d670a2163213b33995aef478195c2cd2d36af14b18",
-      "size_bytes": 3137
+      "size_bytes": 3137,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6560,7 +7298,8 @@
       "latest_key": "latest/surfaces/77.json",
       "path": "/metagraph/surfaces/77.json",
       "sha256": "608ab7b0484e8ea6a00101a8b5139f5874d1917988d48bbfd11ca15355efcada",
-      "size_bytes": 8868
+      "size_bytes": 8868,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6568,7 +7307,8 @@
       "latest_key": "latest/surfaces/78.json",
       "path": "/metagraph/surfaces/78.json",
       "sha256": "dd2e1a1c5689f483bc96865aeb897edd0c1ccc626abba93b894e25d3246fcc3f",
-      "size_bytes": 11964
+      "size_bytes": 11964,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6576,7 +7316,8 @@
       "latest_key": "latest/surfaces/79.json",
       "path": "/metagraph/surfaces/79.json",
       "sha256": "c9ff1e5fed770dfb66944413ac34327c14d04d2b16b348f7d0b567210dacd575",
-      "size_bytes": 7512
+      "size_bytes": 7512,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6584,7 +7325,8 @@
       "latest_key": "latest/surfaces/8.json",
       "path": "/metagraph/surfaces/8.json",
       "sha256": "305d7bbc1cbcb34c9ef1fe885259097036e5209edc203504402f6722bfab779b",
-      "size_bytes": 11835
+      "size_bytes": 11835,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6592,7 +7334,8 @@
       "latest_key": "latest/surfaces/80.json",
       "path": "/metagraph/surfaces/80.json",
       "sha256": "1a7b3d67a594471eb872c951b7dbda08bac6fbcba5127682aacda72da77678de",
-      "size_bytes": 13399
+      "size_bytes": 13399,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6600,7 +7343,8 @@
       "latest_key": "latest/surfaces/81.json",
       "path": "/metagraph/surfaces/81.json",
       "sha256": "983b4dbe9b40f526613ee25be4f28ef42aa8ae3f56515fd806433e829eb9289b",
-      "size_bytes": 4719
+      "size_bytes": 4719,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6608,7 +7352,8 @@
       "latest_key": "latest/surfaces/82.json",
       "path": "/metagraph/surfaces/82.json",
       "sha256": "b8efc561c29ba22e6aba4b890ef023d032236b561f98e09cc4f259f911390d50",
-      "size_bytes": 10514
+      "size_bytes": 10514,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6616,7 +7361,8 @@
       "latest_key": "latest/surfaces/83.json",
       "path": "/metagraph/surfaces/83.json",
       "sha256": "86d00e4762a326e15b04f2dcbfcb318e49dee0bee75d6c79586bd0ff0faa9a12",
-      "size_bytes": 8917
+      "size_bytes": 8917,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6624,7 +7370,8 @@
       "latest_key": "latest/surfaces/84.json",
       "path": "/metagraph/surfaces/84.json",
       "sha256": "8cb1928d8fa7cd93bc6987aa28b3c3016d44cbc4c442e4d6da37ef226a6a877a",
-      "size_bytes": 7719
+      "size_bytes": 7719,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6632,7 +7379,8 @@
       "latest_key": "latest/surfaces/85.json",
       "path": "/metagraph/surfaces/85.json",
       "sha256": "b2607a0de355b18494ad24f95f0af8f3729a2a5e371da2aaf3cfef48b6a0cf09",
-      "size_bytes": 13326
+      "size_bytes": 13326,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6640,7 +7388,8 @@
       "latest_key": "latest/surfaces/86.json",
       "path": "/metagraph/surfaces/86.json",
       "sha256": "220e01127ecd37b74229f112ff3aa1f91b7798bc7c54a75e3b18ed34a80f868c",
-      "size_bytes": 3107
+      "size_bytes": 3107,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6648,7 +7397,8 @@
       "latest_key": "latest/surfaces/87.json",
       "path": "/metagraph/surfaces/87.json",
       "sha256": "fdbcf1a8dbbf35ac5459465dc6585ed0b7270377a9cebe64f710d548ea395810",
-      "size_bytes": 3167
+      "size_bytes": 3167,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6656,7 +7406,8 @@
       "latest_key": "latest/surfaces/88.json",
       "path": "/metagraph/surfaces/88.json",
       "sha256": "a84e7e39bcfec12bf509a72154fd2e844063e373266af2346dbd658b456190b3",
-      "size_bytes": 11853
+      "size_bytes": 11853,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6664,7 +7415,8 @@
       "latest_key": "latest/surfaces/89.json",
       "path": "/metagraph/surfaces/89.json",
       "sha256": "5c5a9d78b4c74f78f016140d7d96859521cf33640cfb418b8ac5cb5819d14ef3",
-      "size_bytes": 9216
+      "size_bytes": 9216,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6672,7 +7424,8 @@
       "latest_key": "latest/surfaces/9.json",
       "path": "/metagraph/surfaces/9.json",
       "sha256": "a9ece777a796b59be07146157fc7ca5af96c5988b6d01f02e7294f7b429e9443",
-      "size_bytes": 13274
+      "size_bytes": 13274,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6680,7 +7433,8 @@
       "latest_key": "latest/surfaces/90.json",
       "path": "/metagraph/surfaces/90.json",
       "sha256": "6a373c330393588834b341292aa218da580bc8a475c372e5bcc7802685440adf",
-      "size_bytes": 3117
+      "size_bytes": 3117,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6688,7 +7442,8 @@
       "latest_key": "latest/surfaces/91.json",
       "path": "/metagraph/surfaces/91.json",
       "sha256": "759a35dad2b67ae6fe15fa887b263d2427d5fedf4dedbb957052c77d90e1db8b",
-      "size_bytes": 4569
+      "size_bytes": 4569,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6696,7 +7451,8 @@
       "latest_key": "latest/surfaces/92.json",
       "path": "/metagraph/surfaces/92.json",
       "sha256": "1eb38770b902a64c9a046af2b5bbb79a221165ddc840f569be6f0662b5932984",
-      "size_bytes": 7529
+      "size_bytes": 7529,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6704,7 +7460,8 @@
       "latest_key": "latest/surfaces/93.json",
       "path": "/metagraph/surfaces/93.json",
       "sha256": "1f558f3ac3261136d1b8a7cbdfddce008d41f3d1f498555016bd11429c3947a3",
-      "size_bytes": 11931
+      "size_bytes": 11931,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6712,7 +7469,8 @@
       "latest_key": "latest/surfaces/94.json",
       "path": "/metagraph/surfaces/94.json",
       "sha256": "947d8679e0e07a4d4090d2b98aea38dd10d9ed952daef604b887ee1f20e20549",
-      "size_bytes": 8795
+      "size_bytes": 8795,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6720,7 +7478,8 @@
       "latest_key": "latest/surfaces/95.json",
       "path": "/metagraph/surfaces/95.json",
       "sha256": "86a5fdd669e3a2dee1a100fc14f88e8cd7c96a8f93f267774726b8f8e1b6afa2",
-      "size_bytes": 4485
+      "size_bytes": 4485,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6728,7 +7487,8 @@
       "latest_key": "latest/surfaces/96.json",
       "path": "/metagraph/surfaces/96.json",
       "sha256": "26e24843a7229b074c3ceefaf1086f1c42e869db73f0fd37f20b210353449abf",
-      "size_bytes": 13488
+      "size_bytes": 13488,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6736,7 +7496,8 @@
       "latest_key": "latest/surfaces/97.json",
       "path": "/metagraph/surfaces/97.json",
       "sha256": "061ac841f03f44f1ecf3b93e81aa8344c35e19db1edbf1dc2ede044bdf74974b",
-      "size_bytes": 17959
+      "size_bytes": 17959,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6744,7 +7505,8 @@
       "latest_key": "latest/surfaces/98.json",
       "path": "/metagraph/surfaces/98.json",
       "sha256": "bceae43349380bbbce250192d017b53385cd3a4b18fbad6e9dc739f15a210cb7",
-      "size_bytes": 10456
+      "size_bytes": 10456,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6752,15 +7514,17 @@
       "latest_key": "latest/surfaces/99.json",
       "path": "/metagraph/surfaces/99.json",
       "sha256": "2cdeb17284e5e91444fc65f115b6d8e1735917dbd9d26b1dba859da331b97783",
-      "size_bytes": 14786
+      "size_bytes": 14786,
+      "storage_tier": "r2"
     },
     {
       "content_type": "text/plain; charset=utf-8",
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "7e7eedbb5b3bfc7a2750c5e5c42e3781f5dc97a3a90ca1763c1dc71879c5a930",
-      "size_bytes": 150516
+      "sha256": "898931a57a6cb5d5ef3654114c772681b4810c51ee5858559b99903795d05dae",
+      "size_bytes": 150684,
+      "storage_tier": "dual"
     },
     {
       "content_type": "application/json",
@@ -6768,7 +7532,8 @@
       "latest_key": "latest/verification/latest.json",
       "path": "/metagraph/verification/latest.json",
       "sha256": "556a90ebe80f77063d34a47c08be290f063ea09d0ab88f3f7453c2bb1b5c4c16",
-      "size_bytes": 1789805
+      "size_bytes": 1789805,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6776,7 +7541,8 @@
       "latest_key": "latest/verification/subnets/0.json",
       "path": "/metagraph/verification/subnets/0.json",
       "sha256": "86ae19527dd7157f71d2b5d33999bb9ef72a79da527efea398487ae2bf0f1e0f",
-      "size_bytes": 2694
+      "size_bytes": 2694,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6784,7 +7550,8 @@
       "latest_key": "latest/verification/subnets/1.json",
       "path": "/metagraph/verification/subnets/1.json",
       "sha256": "84205a99cb7b4264c9acdb94864ca45501d7c36509d2b2fa47458b106f35aa25",
-      "size_bytes": 28353
+      "size_bytes": 28353,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6792,7 +7559,8 @@
       "latest_key": "latest/verification/subnets/10.json",
       "path": "/metagraph/verification/subnets/10.json",
       "sha256": "c070dfa0203d643df25aedc1429ee6275fb80bf29b7345afa16625d96267ff20",
-      "size_bytes": 11323
+      "size_bytes": 11323,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6800,7 +7568,8 @@
       "latest_key": "latest/verification/subnets/100.json",
       "path": "/metagraph/verification/subnets/100.json",
       "sha256": "9089ece848947e655b8df19290f49379c3a72fdb47ceb5ef2bb0b7f37ea416ab",
-      "size_bytes": 18546
+      "size_bytes": 18546,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6808,7 +7577,8 @@
       "latest_key": "latest/verification/subnets/101.json",
       "path": "/metagraph/verification/subnets/101.json",
       "sha256": "cfbfa9e9d96a64561fa817cff623b4ef1b408793627a8ec18773400f4d259749",
-      "size_bytes": 2714
+      "size_bytes": 2714,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6816,7 +7586,8 @@
       "latest_key": "latest/verification/subnets/102.json",
       "path": "/metagraph/verification/subnets/102.json",
       "sha256": "ed63800c1313ea555c584801d6af1643e6f6459f740ae00d89ab9c5e2b3e248f",
-      "size_bytes": 17741
+      "size_bytes": 17741,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6824,7 +7595,8 @@
       "latest_key": "latest/verification/subnets/103.json",
       "path": "/metagraph/verification/subnets/103.json",
       "sha256": "5e8ec2c600b720d370369915af9ec43b11b26fcd90e945c915d290375946c3c9",
-      "size_bytes": 22021
+      "size_bytes": 22021,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6832,7 +7604,8 @@
       "latest_key": "latest/verification/subnets/104.json",
       "path": "/metagraph/verification/subnets/104.json",
       "sha256": "cd460afefcd6bae317cd4e0b0b1652e26cf7d8a0f357241759b19b4c444bd836",
-      "size_bytes": 2774
+      "size_bytes": 2774,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6840,7 +7613,8 @@
       "latest_key": "latest/verification/subnets/105.json",
       "path": "/metagraph/verification/subnets/105.json",
       "sha256": "8cca028f033fbd8b420858f2933c2186f00228594752855e967bef9d414d6974",
-      "size_bytes": 11264
+      "size_bytes": 11264,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6848,7 +7622,8 @@
       "latest_key": "latest/verification/subnets/106.json",
       "path": "/metagraph/verification/subnets/106.json",
       "sha256": "cc6e967493c38723786eda2aa46271dcd02937fea9a8f6e4d96843190caafb1e",
-      "size_bytes": 11250
+      "size_bytes": 11250,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6856,7 +7631,8 @@
       "latest_key": "latest/verification/subnets/107.json",
       "path": "/metagraph/verification/subnets/107.json",
       "sha256": "d7eea2ef2d72dad1b49ae5c8c5249d627d5ec4a1b25b9f8baa3db35c96b5c83d",
-      "size_bytes": 22472
+      "size_bytes": 22472,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6864,7 +7640,8 @@
       "latest_key": "latest/verification/subnets/108.json",
       "path": "/metagraph/verification/subnets/108.json",
       "sha256": "f81f7111e361d96fcd2ad42e8952bce78e3d59040aad143f4bac7dc810d3b194",
-      "size_bytes": 17753
+      "size_bytes": 17753,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6872,7 +7649,8 @@
       "latest_key": "latest/verification/subnets/109.json",
       "path": "/metagraph/verification/subnets/109.json",
       "sha256": "f277af8ca568affb20728d9d440218f4a2b14fa2de9dc191a8f92ce345dfbbf3",
-      "size_bytes": 3935
+      "size_bytes": 3935,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6880,7 +7658,8 @@
       "latest_key": "latest/verification/subnets/11.json",
       "path": "/metagraph/verification/subnets/11.json",
       "sha256": "8c01a804f658af6b3039b3c30ff3da544579fa743b589c8470e0f21e97c011f5",
-      "size_bytes": 15459
+      "size_bytes": 15459,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6888,7 +7667,8 @@
       "latest_key": "latest/verification/subnets/110.json",
       "path": "/metagraph/verification/subnets/110.json",
       "sha256": "0efab6865b8cf40ec6c7147aead5e16b8a092ca5583a8b19f18f9a214a1df9e1",
-      "size_bytes": 23138
+      "size_bytes": 23138,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6896,7 +7676,8 @@
       "latest_key": "latest/verification/subnets/111.json",
       "path": "/metagraph/verification/subnets/111.json",
       "sha256": "f2e07b9f6b31ef5e4da7e2843780c01b30e7a2e037eb0d4e3bce656e9779c907",
-      "size_bytes": 8626
+      "size_bytes": 8626,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6904,7 +7685,8 @@
       "latest_key": "latest/verification/subnets/112.json",
       "path": "/metagraph/verification/subnets/112.json",
       "sha256": "51528dfa39addcaa92ce722d638e20d31e0d80c3c6b5340cb26c341fe75a4ae8",
-      "size_bytes": 14404
+      "size_bytes": 14404,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6912,7 +7694,8 @@
       "latest_key": "latest/verification/subnets/113.json",
       "path": "/metagraph/verification/subnets/113.json",
       "sha256": "743c28b4efd9f5dea105511bfa5a13774ce2d73795194522725e1fe38afb895b",
-      "size_bytes": 18920
+      "size_bytes": 18920,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6920,7 +7703,8 @@
       "latest_key": "latest/verification/subnets/114.json",
       "path": "/metagraph/verification/subnets/114.json",
       "sha256": "38dd93aeb379eff46408e81c15143afb05aa2af3762c942a35ea5fb8da114ca7",
-      "size_bytes": 19776
+      "size_bytes": 19776,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6928,7 +7712,8 @@
       "latest_key": "latest/verification/subnets/115.json",
       "path": "/metagraph/verification/subnets/115.json",
       "sha256": "5c626b8fde11d28daba8f54b4537b0626150f767f979059ed25e96f8d6f5ecce",
-      "size_bytes": 3941
+      "size_bytes": 3941,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6936,7 +7721,8 @@
       "latest_key": "latest/verification/subnets/116.json",
       "path": "/metagraph/verification/subnets/116.json",
       "sha256": "6eaae9a2a55ca921d7cff14625abc0f07a063fc1d8dc12a682809903048cfc9f",
-      "size_bytes": 4005
+      "size_bytes": 4005,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6944,7 +7730,8 @@
       "latest_key": "latest/verification/subnets/117.json",
       "path": "/metagraph/verification/subnets/117.json",
       "sha256": "36941df1951516a9b1edb6397cea7eed35354f9528b71832c16b4066dd2f5cee",
-      "size_bytes": 5254
+      "size_bytes": 5254,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6952,7 +7739,8 @@
       "latest_key": "latest/verification/subnets/118.json",
       "path": "/metagraph/verification/subnets/118.json",
       "sha256": "d71187bf0d2f7c16a02251f4490e3560b0df9f3c14a77de99084867657023981",
-      "size_bytes": 25536
+      "size_bytes": 25536,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6960,7 +7748,8 @@
       "latest_key": "latest/verification/subnets/119.json",
       "path": "/metagraph/verification/subnets/119.json",
       "sha256": "2912bf99edb38376fe0d239435d63f8a7c935d2b3f8dc8e3ddd98e94882fb257",
-      "size_bytes": 3939
+      "size_bytes": 3939,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6968,7 +7757,8 @@
       "latest_key": "latest/verification/subnets/12.json",
       "path": "/metagraph/verification/subnets/12.json",
       "sha256": "83b7e725da566de6ea0d3349174be27c59f928b290c5ddd02248220af346c896",
-      "size_bytes": 6486
+      "size_bytes": 6486,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6976,7 +7766,8 @@
       "latest_key": "latest/verification/subnets/120.json",
       "path": "/metagraph/verification/subnets/120.json",
       "sha256": "039a039205a2998b2dedf26e44d4c593fae5fd13afd7e69339c47113a744164c",
-      "size_bytes": 12531
+      "size_bytes": 12531,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6984,7 +7775,8 @@
       "latest_key": "latest/verification/subnets/121.json",
       "path": "/metagraph/verification/subnets/121.json",
       "sha256": "2e526376299a0ffd890b20a102d60fda71a10e3fec1bc86f63a99e764e8916c7",
-      "size_bytes": 22064
+      "size_bytes": 22064,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -6992,7 +7784,8 @@
       "latest_key": "latest/verification/subnets/122.json",
       "path": "/metagraph/verification/subnets/122.json",
       "sha256": "9439cae53f3e355d7a0e67940c80d9c49a5a46e87363cfe2809a8a8d1bee253f",
-      "size_bytes": 5240
+      "size_bytes": 5240,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7000,7 +7793,8 @@
       "latest_key": "latest/verification/subnets/123.json",
       "path": "/metagraph/verification/subnets/123.json",
       "sha256": "18ad777dd18a99f89609275b394241a3a7798099e124046b7008e824a20ada10",
-      "size_bytes": 3925
+      "size_bytes": 3925,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7008,7 +7802,8 @@
       "latest_key": "latest/verification/subnets/124.json",
       "path": "/metagraph/verification/subnets/124.json",
       "sha256": "68e65fe623e6fe58fbd5797a5b00bca2e9f7d808399d698b65586520b7484d71",
-      "size_bytes": 12737
+      "size_bytes": 12737,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7016,7 +7811,8 @@
       "latest_key": "latest/verification/subnets/125.json",
       "path": "/metagraph/verification/subnets/125.json",
       "sha256": "ecaab5dfd15960ec2c36752f270879ce7ab7cc0e447ceb7711c5c20001d2e1cd",
-      "size_bytes": 2723
+      "size_bytes": 2723,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7024,7 +7820,8 @@
       "latest_key": "latest/verification/subnets/126.json",
       "path": "/metagraph/verification/subnets/126.json",
       "sha256": "5f669de38342c7bae56f1a82b97fa5f9099aa48355d62751c66980240424e510",
-      "size_bytes": 15465
+      "size_bytes": 15465,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7032,7 +7829,8 @@
       "latest_key": "latest/verification/subnets/127.json",
       "path": "/metagraph/verification/subnets/127.json",
       "sha256": "5f8cefc32a4e0527b8b36e2f92a5d0fa13161f0b9b0ac046be536b358e47a9f7",
-      "size_bytes": 15926
+      "size_bytes": 15926,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7040,7 +7838,8 @@
       "latest_key": "latest/verification/subnets/128.json",
       "path": "/metagraph/verification/subnets/128.json",
       "sha256": "42f5a844c58b6239e377f8e633f1a38115aa3703d1cde650ed11728be0292f3b",
-      "size_bytes": 12494
+      "size_bytes": 12494,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7048,7 +7847,8 @@
       "latest_key": "latest/verification/subnets/13.json",
       "path": "/metagraph/verification/subnets/13.json",
       "sha256": "c39cfae2865d34a59f11a25c95fe4f6b5da59a5a7c9bf58007eaedc6f643d710",
-      "size_bytes": 30287
+      "size_bytes": 30287,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7056,7 +7856,8 @@
       "latest_key": "latest/verification/subnets/14.json",
       "path": "/metagraph/verification/subnets/14.json",
       "sha256": "948759da2d73cf4434321e3bc03b773465c3f37ccb256db18e6fa2f2e2fc311b",
-      "size_bytes": 30196
+      "size_bytes": 30196,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7064,7 +7865,8 @@
       "latest_key": "latest/verification/subnets/15.json",
       "path": "/metagraph/verification/subnets/15.json",
       "sha256": "fb49ac42f3ffa5d145eba71f19a5cc7d3dcba11a28e5a087500ae7b2ed308bc1",
-      "size_bytes": 26328
+      "size_bytes": 26328,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7072,7 +7874,8 @@
       "latest_key": "latest/verification/subnets/16.json",
       "path": "/metagraph/verification/subnets/16.json",
       "sha256": "fdc833c6cdcbf5661371d8c836cb53d4099176e3c54eba0a5b46d3b93cb17825",
-      "size_bytes": 11146
+      "size_bytes": 11146,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7080,7 +7883,8 @@
       "latest_key": "latest/verification/subnets/17.json",
       "path": "/metagraph/verification/subnets/17.json",
       "sha256": "a31d164ca58662c751fcbd5f31bea30f100dca30fa0e934fd79cdab97a8f4818",
-      "size_bytes": 17975
+      "size_bytes": 17975,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7088,7 +7892,8 @@
       "latest_key": "latest/verification/subnets/18.json",
       "path": "/metagraph/verification/subnets/18.json",
       "sha256": "59bdf9cf1f15b37b7cd4490302640146f914cf0805e1a737178e9eccb63f7cd8",
-      "size_bytes": 16710
+      "size_bytes": 16710,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7096,7 +7901,8 @@
       "latest_key": "latest/verification/subnets/19.json",
       "path": "/metagraph/verification/subnets/19.json",
       "sha256": "8b4300358bbc89aa99035270aa7a721f1cc3898c96fca78129294f9097bff1b2",
-      "size_bytes": 22054
+      "size_bytes": 22054,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7104,7 +7910,8 @@
       "latest_key": "latest/verification/subnets/2.json",
       "path": "/metagraph/verification/subnets/2.json",
       "sha256": "049c0112058d034d38512fb5914d9d0dd473d6ff212d23ef1a5701395ec5bf6c",
-      "size_bytes": 17450
+      "size_bytes": 17450,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7112,7 +7919,8 @@
       "latest_key": "latest/verification/subnets/20.json",
       "path": "/metagraph/verification/subnets/20.json",
       "sha256": "39e44e72876ebc45745e9c9e58c65faadf9967b4c446a7ee01e06c4c69e76d97",
-      "size_bytes": 13828
+      "size_bytes": 13828,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7120,7 +7928,8 @@
       "latest_key": "latest/verification/subnets/21.json",
       "path": "/metagraph/verification/subnets/21.json",
       "sha256": "058a77a734de58713a0455070874a7d717221ccafe662df19273631e98ba9cfb",
-      "size_bytes": 15773
+      "size_bytes": 15773,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7128,7 +7937,8 @@
       "latest_key": "latest/verification/subnets/22.json",
       "path": "/metagraph/verification/subnets/22.json",
       "sha256": "68b2c7712e62dac7845e179bad452f1f83b539468188f3479abcceaa339086a7",
-      "size_bytes": 11585
+      "size_bytes": 11585,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7136,7 +7946,8 @@
       "latest_key": "latest/verification/subnets/23.json",
       "path": "/metagraph/verification/subnets/23.json",
       "sha256": "02bb4f3f8386ee7130bbae626583e950a04ef6202b76510c09c96936d7abc44e",
-      "size_bytes": 19207
+      "size_bytes": 19207,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7144,7 +7955,8 @@
       "latest_key": "latest/verification/subnets/24.json",
       "path": "/metagraph/verification/subnets/24.json",
       "sha256": "9a0bdbe531b835ca3299017c46fd338491415cd03d3b16fa11becbd682df5b26",
-      "size_bytes": 16743
+      "size_bytes": 16743,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7152,7 +7964,8 @@
       "latest_key": "latest/verification/subnets/25.json",
       "path": "/metagraph/verification/subnets/25.json",
       "sha256": "7d0928d7bcbcf201c5c1a5c6258819f6458c55659d3d7bae3c2a1e0a2f1ab25e",
-      "size_bytes": 22756
+      "size_bytes": 22756,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7160,7 +7973,8 @@
       "latest_key": "latest/verification/subnets/26.json",
       "path": "/metagraph/verification/subnets/26.json",
       "sha256": "1b354ae0236efb3dce1720c31fc7ec854a8642035aed4777534779563f577cfc",
-      "size_bytes": 16856
+      "size_bytes": 16856,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7168,7 +7982,8 @@
       "latest_key": "latest/verification/subnets/27.json",
       "path": "/metagraph/verification/subnets/27.json",
       "sha256": "133ea7cb078c9ae0936678ff8a16c91a7c10e17fafa92a2dd81d6b5fb5ac03c7",
-      "size_bytes": 11019
+      "size_bytes": 11019,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7176,7 +7991,8 @@
       "latest_key": "latest/verification/subnets/28.json",
       "path": "/metagraph/verification/subnets/28.json",
       "sha256": "7c8d24682c379c9a096376bf29a9d2eb11eb290424a321a68732379be16d65f2",
-      "size_bytes": 2699
+      "size_bytes": 2699,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7184,7 +8000,8 @@
       "latest_key": "latest/verification/subnets/29.json",
       "path": "/metagraph/verification/subnets/29.json",
       "sha256": "f329068b5dca5ed5d05229d121cfe331a1d46cb97ca37db2d179c87af0ad7997",
-      "size_bytes": 9890
+      "size_bytes": 9890,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7192,7 +8009,8 @@
       "latest_key": "latest/verification/subnets/3.json",
       "path": "/metagraph/verification/subnets/3.json",
       "sha256": "a5de0d45c331f4fc4b5a7b278251c637625fbf3f8db24c2c07be221ca3ea1294",
-      "size_bytes": 4022
+      "size_bytes": 4022,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7200,7 +8018,8 @@
       "latest_key": "latest/verification/subnets/30.json",
       "path": "/metagraph/verification/subnets/30.json",
       "sha256": "a8f12056c0878918f1aca81e58dd081a4ad1f3e0a3e682379338e479ec59ec57",
-      "size_bytes": 12277
+      "size_bytes": 12277,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7208,7 +8027,8 @@
       "latest_key": "latest/verification/subnets/31.json",
       "path": "/metagraph/verification/subnets/31.json",
       "sha256": "babb680c2ed87c94a62a1749afe21b6479d5c2085a77aa05926e39bb991c7eda",
-      "size_bytes": 2711
+      "size_bytes": 2711,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7216,7 +8036,8 @@
       "latest_key": "latest/verification/subnets/32.json",
       "path": "/metagraph/verification/subnets/32.json",
       "sha256": "e6416733ed8d03c138dbeb0b3bdd7021359c91cb641478b4552080df4b9c672a",
-      "size_bytes": 24030
+      "size_bytes": 24030,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7224,7 +8045,8 @@
       "latest_key": "latest/verification/subnets/33.json",
       "path": "/metagraph/verification/subnets/33.json",
       "sha256": "bca5ded40766b106c8e6933ddef113a05097868cdf638cec49c2681401cb2ec0",
-      "size_bytes": 15304
+      "size_bytes": 15304,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7232,7 +8054,8 @@
       "latest_key": "latest/verification/subnets/34.json",
       "path": "/metagraph/verification/subnets/34.json",
       "sha256": "a65318f2cb83d88bbecd52222e0c8e12e70035a316c8073e2ef5ce48b97b5d21",
-      "size_bytes": 6332
+      "size_bytes": 6332,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7240,7 +8063,8 @@
       "latest_key": "latest/verification/subnets/35.json",
       "path": "/metagraph/verification/subnets/35.json",
       "sha256": "678a066cfe37d42db6aa7b128d0bfd1dad24ec618385c3634c762c4ac720bf4b",
-      "size_bytes": 13849
+      "size_bytes": 13849,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7248,7 +8072,8 @@
       "latest_key": "latest/verification/subnets/36.json",
       "path": "/metagraph/verification/subnets/36.json",
       "sha256": "b3efac33acd0378d948bf6544663f1c224264376dd29f33bd4278beccb03d8c8",
-      "size_bytes": 14310
+      "size_bytes": 14310,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7256,7 +8081,8 @@
       "latest_key": "latest/verification/subnets/37.json",
       "path": "/metagraph/verification/subnets/37.json",
       "sha256": "ede711a68f1f09f2a6c6f8486bf29f0908b9f3bb746d3bf811c1469b54140655",
-      "size_bytes": 24127
+      "size_bytes": 24127,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7264,7 +8090,8 @@
       "latest_key": "latest/verification/subnets/38.json",
       "path": "/metagraph/verification/subnets/38.json",
       "sha256": "67294ac2c8d30b46dd00fa4eefbdaccbd01d1b6e3ea0c4584557be43ffa3f5a1",
-      "size_bytes": 11406
+      "size_bytes": 11406,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7272,7 +8099,8 @@
       "latest_key": "latest/verification/subnets/39.json",
       "path": "/metagraph/verification/subnets/39.json",
       "sha256": "24ba03d8448cfbff90aef8c3f15b86e7ad5c187bc7ee6b32a6ad126eeaf33140",
-      "size_bytes": 5243
+      "size_bytes": 5243,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7280,7 +8108,8 @@
       "latest_key": "latest/verification/subnets/4.json",
       "path": "/metagraph/verification/subnets/4.json",
       "sha256": "d4a7c6b04e1aee7d8805e1891acbce6d06d45386c7fe1615599291781cbeca59",
-      "size_bytes": 24042
+      "size_bytes": 24042,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7288,7 +8117,8 @@
       "latest_key": "latest/verification/subnets/40.json",
       "path": "/metagraph/verification/subnets/40.json",
       "sha256": "0bca6b35e82e696607518fbf8ffcc0e808a4639748227b7e221c089cda2db950",
-      "size_bytes": 3951
+      "size_bytes": 3951,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7296,7 +8126,8 @@
       "latest_key": "latest/verification/subnets/41.json",
       "path": "/metagraph/verification/subnets/41.json",
       "sha256": "425f080ee9a818285fe7aaf5c5887f8b16326f864b162b427f664809a3e062ff",
-      "size_bytes": 14590
+      "size_bytes": 14590,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7304,7 +8135,8 @@
       "latest_key": "latest/verification/subnets/42.json",
       "path": "/metagraph/verification/subnets/42.json",
       "sha256": "050224922c88543e6c561961f004f9ff589097b8ac00cc15f83576b328dc8f4c",
-      "size_bytes": 2720
+      "size_bytes": 2720,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7312,7 +8144,8 @@
       "latest_key": "latest/verification/subnets/43.json",
       "path": "/metagraph/verification/subnets/43.json",
       "sha256": "695e625a7422b41ff2d8f48b7019740e061fe67c814fd9b6959450634b5313e6",
-      "size_bytes": 5138
+      "size_bytes": 5138,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7320,7 +8153,8 @@
       "latest_key": "latest/verification/subnets/44.json",
       "path": "/metagraph/verification/subnets/44.json",
       "sha256": "564b1afe81426a0937d04f5983bfa55d9d9120d807ccdf620388e6aed07bad11",
-      "size_bytes": 13717
+      "size_bytes": 13717,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7328,7 +8162,8 @@
       "latest_key": "latest/verification/subnets/45.json",
       "path": "/metagraph/verification/subnets/45.json",
       "sha256": "8760ac8f9b6012f25f911e09f19b5823161f7db64d97605c1f8ae206994b928e",
-      "size_bytes": 22022
+      "size_bytes": 22022,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7336,7 +8171,8 @@
       "latest_key": "latest/verification/subnets/46.json",
       "path": "/metagraph/verification/subnets/46.json",
       "sha256": "745f8e6178d1da51ff7ded880ca4b10a39cc8f8e445f1900d23427953c8d2769",
-      "size_bytes": 29957
+      "size_bytes": 29957,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7344,7 +8180,8 @@
       "latest_key": "latest/verification/subnets/47.json",
       "path": "/metagraph/verification/subnets/47.json",
       "sha256": "da4d1a7f7d5c484a8b515cb6dc28de76fe8bb9f15fe9fa8c7fc628d4123fef55",
-      "size_bytes": 7531
+      "size_bytes": 7531,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7352,7 +8189,8 @@
       "latest_key": "latest/verification/subnets/48.json",
       "path": "/metagraph/verification/subnets/48.json",
       "sha256": "1dc440647ec327388f8e375f9d3f7655ae1689d13e17e5096e8a9d4b9f933d5f",
-      "size_bytes": 22644
+      "size_bytes": 22644,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7360,7 +8198,8 @@
       "latest_key": "latest/verification/subnets/49.json",
       "path": "/metagraph/verification/subnets/49.json",
       "sha256": "636d7b4e270cc8ea33168dbd8d70a9b9c468146f7d81b6e0466c8ed4c628134f",
-      "size_bytes": 13429
+      "size_bytes": 13429,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7368,7 +8207,8 @@
       "latest_key": "latest/verification/subnets/5.json",
       "path": "/metagraph/verification/subnets/5.json",
       "sha256": "7691a662ab7a99d0a38d3af07d73322e19395026c05b230eaa6bdddbdaa0317a",
-      "size_bytes": 19129
+      "size_bytes": 19129,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7376,7 +8216,8 @@
       "latest_key": "latest/verification/subnets/50.json",
       "path": "/metagraph/verification/subnets/50.json",
       "sha256": "fcd3cfd6592d38020602c39304ca8462788aab3eebaab37362dc555c8c790216",
-      "size_bytes": 12505
+      "size_bytes": 12505,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7384,7 +8225,8 @@
       "latest_key": "latest/verification/subnets/51.json",
       "path": "/metagraph/verification/subnets/51.json",
       "sha256": "2115402fe2faeb87292114d499a31255393507505d6ed2880c8c9cd380ed342f",
-      "size_bytes": 22577
+      "size_bytes": 22577,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7392,7 +8234,8 @@
       "latest_key": "latest/verification/subnets/52.json",
       "path": "/metagraph/verification/subnets/52.json",
       "sha256": "2c9c97f40bf4dfb252f1f58d0868b30ddaa941aca96f1b4f15fff2af95829665",
-      "size_bytes": 14850
+      "size_bytes": 14850,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7400,7 +8243,8 @@
       "latest_key": "latest/verification/subnets/53.json",
       "path": "/metagraph/verification/subnets/53.json",
       "sha256": "38cf05e2b9b37158aa016a5ad5705b295dbabf4d53483d38e2e0873db8776cd1",
-      "size_bytes": 4027
+      "size_bytes": 4027,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7408,7 +8252,8 @@
       "latest_key": "latest/verification/subnets/54.json",
       "path": "/metagraph/verification/subnets/54.json",
       "sha256": "05e82711f54eba7b98cd28df485c286e88de8cbe074766ba2226e1cb017cc39a",
-      "size_bytes": 14607
+      "size_bytes": 14607,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7416,7 +8261,8 @@
       "latest_key": "latest/verification/subnets/55.json",
       "path": "/metagraph/verification/subnets/55.json",
       "sha256": "204d8e7b77acdd849cb9cda970200bdc315e17326e8e21a1f91970442c842d7a",
-      "size_bytes": 15608
+      "size_bytes": 15608,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7424,7 +8270,8 @@
       "latest_key": "latest/verification/subnets/56.json",
       "path": "/metagraph/verification/subnets/56.json",
       "sha256": "6a851a06931c84ca473337b92a01b49537d8f405dd312e3f81824a98e5c25da5",
-      "size_bytes": 23342
+      "size_bytes": 23342,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7432,7 +8279,8 @@
       "latest_key": "latest/verification/subnets/57.json",
       "path": "/metagraph/verification/subnets/57.json",
       "sha256": "3656ff2b9db9a9b00d0ae267fa7a8e3b6c4c12e1baf90c2075faa7771940092e",
-      "size_bytes": 3961
+      "size_bytes": 3961,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7440,7 +8288,8 @@
       "latest_key": "latest/verification/subnets/58.json",
       "path": "/metagraph/verification/subnets/58.json",
       "sha256": "c3c685a4cbe76fc873999b78248f31945aef0ba200a2b59019812f6289cc78ea",
-      "size_bytes": 8533
+      "size_bytes": 8533,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7448,7 +8297,8 @@
       "latest_key": "latest/verification/subnets/59.json",
       "path": "/metagraph/verification/subnets/59.json",
       "sha256": "f5355ef9944fe3d72218794d7848887a2cd32bd8f673b482b0543f3eb1ae2d48",
-      "size_bytes": 16555
+      "size_bytes": 16555,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7456,7 +8306,8 @@
       "latest_key": "latest/verification/subnets/6.json",
       "path": "/metagraph/verification/subnets/6.json",
       "sha256": "28ce30eeea68611b3e64a8642388892a65acbb4c035dffae3e8e122b7aeb3277",
-      "size_bytes": 19119
+      "size_bytes": 19119,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7464,7 +8315,8 @@
       "latest_key": "latest/verification/subnets/60.json",
       "path": "/metagraph/verification/subnets/60.json",
       "sha256": "d7090a1dd537be9efbea3144e5ab8e459b539eef431bff2cc3257af29ac7a1b0",
-      "size_bytes": 18113
+      "size_bytes": 18113,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7472,7 +8324,8 @@
       "latest_key": "latest/verification/subnets/61.json",
       "path": "/metagraph/verification/subnets/61.json",
       "sha256": "62e980e7fd1b6b5188f67f11bb1d75f7e7322af28c8a372181b1c4f07b6db2e6",
-      "size_bytes": 13617
+      "size_bytes": 13617,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7480,7 +8333,8 @@
       "latest_key": "latest/verification/subnets/62.json",
       "path": "/metagraph/verification/subnets/62.json",
       "sha256": "7247168696e0dff68c03ab02e5e0dc48752ce8abc604958e8fa902c2f032b58d",
-      "size_bytes": 11337
+      "size_bytes": 11337,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7488,7 +8342,8 @@
       "latest_key": "latest/verification/subnets/63.json",
       "path": "/metagraph/verification/subnets/63.json",
       "sha256": "55db404276fafc9c6b292fb8ed48317baa7fc78b25a0dfb5f6cc0f3e39a009d4",
-      "size_bytes": 23565
+      "size_bytes": 23565,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7496,7 +8351,8 @@
       "latest_key": "latest/verification/subnets/64.json",
       "path": "/metagraph/verification/subnets/64.json",
       "sha256": "d95b81b18807224a7be968576c949fe219c881127b9bdb09c630719eb590c78e",
-      "size_bytes": 29573
+      "size_bytes": 29573,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7504,7 +8360,8 @@
       "latest_key": "latest/verification/subnets/65.json",
       "path": "/metagraph/verification/subnets/65.json",
       "sha256": "d0c96510bed0dde0381002ea15dc0ef866f312547867790230dc7d8611aaa751",
-      "size_bytes": 19258
+      "size_bytes": 19258,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7512,7 +8369,8 @@
       "latest_key": "latest/verification/subnets/66.json",
       "path": "/metagraph/verification/subnets/66.json",
       "sha256": "9d2f0f9b23c7b58b1a596e3684d9a3356310b7c8053f07c67f51f5856038da4f",
-      "size_bytes": 16580
+      "size_bytes": 16580,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7520,7 +8378,8 @@
       "latest_key": "latest/verification/subnets/67.json",
       "path": "/metagraph/verification/subnets/67.json",
       "sha256": "f660831da7a727a75136286fba6da0c44a091df68ee263c51cd80681750c95c9",
-      "size_bytes": 14314
+      "size_bytes": 14314,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7528,7 +8387,8 @@
       "latest_key": "latest/verification/subnets/68.json",
       "path": "/metagraph/verification/subnets/68.json",
       "sha256": "74cbcec0b6f72ff526abae3e78a5c17637d990bd40e1591066e3f908d4864b15",
-      "size_bytes": 16673
+      "size_bytes": 16673,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7536,7 +8396,8 @@
       "latest_key": "latest/verification/subnets/69.json",
       "path": "/metagraph/verification/subnets/69.json",
       "sha256": "e46acf2053f279dc641ee03a6ba2ba2d75596cf5f88d4bcbbe74938b5e9e1859",
-      "size_bytes": 2702
+      "size_bytes": 2702,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7544,7 +8405,8 @@
       "latest_key": "latest/verification/subnets/7.json",
       "path": "/metagraph/verification/subnets/7.json",
       "sha256": "359cc9d5e71bd746784b89b217575e35c1fd96c4d89b7472c38d64c0431e6027",
-      "size_bytes": 12433
+      "size_bytes": 12433,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7552,7 +8414,8 @@
       "latest_key": "latest/verification/subnets/70.json",
       "path": "/metagraph/verification/subnets/70.json",
       "sha256": "338ef3b5a6ac967982b043179f0d2d9cc1c1b31b6bd89ad7c45e36aad623eade",
-      "size_bytes": 16937
+      "size_bytes": 16937,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7560,7 +8423,8 @@
       "latest_key": "latest/verification/subnets/71.json",
       "path": "/metagraph/verification/subnets/71.json",
       "sha256": "4f9468e6da0889ccb0318f3bedb8d290d1a589a7bb98073d91da7301f07104c3",
-      "size_bytes": 12432
+      "size_bytes": 12432,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7568,7 +8432,8 @@
       "latest_key": "latest/verification/subnets/72.json",
       "path": "/metagraph/verification/subnets/72.json",
       "sha256": "bb0e91e5399646d74725172eeb8f875696bec76a79fc58bca9dd20c17a0c9a6e",
-      "size_bytes": 25628
+      "size_bytes": 25628,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7576,7 +8441,8 @@
       "latest_key": "latest/verification/subnets/73.json",
       "path": "/metagraph/verification/subnets/73.json",
       "sha256": "e3ba0c01108b98572527186d46ec5dca522f8ba264ba7d5cb4d77681f9b4b013",
-      "size_bytes": 3987
+      "size_bytes": 3987,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7584,7 +8450,8 @@
       "latest_key": "latest/verification/subnets/74.json",
       "path": "/metagraph/verification/subnets/74.json",
       "sha256": "9205c3a2b02fff48b70305528848315b18e42f5d2a709610652fe7886356464e",
-      "size_bytes": 16915
+      "size_bytes": 16915,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7592,7 +8459,8 @@
       "latest_key": "latest/verification/subnets/75.json",
       "path": "/metagraph/verification/subnets/75.json",
       "sha256": "f7e4069134042e39b0d3cef9d0e3aeaa70fa53c73094022e806bf96531cbc29b",
-      "size_bytes": 24210
+      "size_bytes": 24210,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7600,7 +8468,8 @@
       "latest_key": "latest/verification/subnets/76.json",
       "path": "/metagraph/verification/subnets/76.json",
       "sha256": "19af319237baec137f0cb3c080c2d851264dee22a5720ec47d7f11631ad9ccd2",
-      "size_bytes": 2720
+      "size_bytes": 2720,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7608,7 +8477,8 @@
       "latest_key": "latest/verification/subnets/77.json",
       "path": "/metagraph/verification/subnets/77.json",
       "sha256": "0df96f128428a48b7ff35f7813f91728c268f2796bf7de256728a44a6001079c",
-      "size_bytes": 13560
+      "size_bytes": 13560,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7616,7 +8486,8 @@
       "latest_key": "latest/verification/subnets/78.json",
       "path": "/metagraph/verification/subnets/78.json",
       "sha256": "3639c2136af8cb80f0c97faca90d8453da93e7175c6bd1e7b85092ec50fb7e1b",
-      "size_bytes": 13770
+      "size_bytes": 13770,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7624,7 +8495,8 @@
       "latest_key": "latest/verification/subnets/79.json",
       "path": "/metagraph/verification/subnets/79.json",
       "sha256": "ffcd3550c2fe3d71cc7e6a300a67bccfafaef0d79e5aa6c0d58430ab5e93925e",
-      "size_bytes": 24081
+      "size_bytes": 24081,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7632,7 +8504,8 @@
       "latest_key": "latest/verification/subnets/8.json",
       "path": "/metagraph/verification/subnets/8.json",
       "sha256": "641d35cac2f6aead42a85b885f867cff276268ea839f9487addd8f364f413e8a",
-      "size_bytes": 18052
+      "size_bytes": 18052,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7640,7 +8513,8 @@
       "latest_key": "latest/verification/subnets/80.json",
       "path": "/metagraph/verification/subnets/80.json",
       "sha256": "aa61909039df7ad3669e6b28e1c79838e0ec10a4b1465cc541661df52a0fda81",
-      "size_bytes": 22638
+      "size_bytes": 22638,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7648,7 +8522,8 @@
       "latest_key": "latest/verification/subnets/81.json",
       "path": "/metagraph/verification/subnets/81.json",
       "sha256": "ee8b2a7de4f082f912d90c5e11885d99a2e92eb595b4b1d0e1d38c152a5dcea7",
-      "size_bytes": 5234
+      "size_bytes": 5234,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7656,7 +8531,8 @@
       "latest_key": "latest/verification/subnets/82.json",
       "path": "/metagraph/verification/subnets/82.json",
       "sha256": "6cbe2b445243306b1d509e349190255b4da178f1aaa42495661f1d7b701f7057",
-      "size_bytes": 25335
+      "size_bytes": 25335,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7664,7 +8540,8 @@
       "latest_key": "latest/verification/subnets/83.json",
       "path": "/metagraph/verification/subnets/83.json",
       "sha256": "0c8956d89143d92d8cb495a4424c9d2ca06cba439ed2fa5cc7e2559fd7475aac",
-      "size_bytes": 11382
+      "size_bytes": 11382,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7672,7 +8549,8 @@
       "latest_key": "latest/verification/subnets/84.json",
       "path": "/metagraph/verification/subnets/84.json",
       "sha256": "305c90fef41222029fbead7951237af708b3a678384dbff32d482038870fd067",
-      "size_bytes": 7848
+      "size_bytes": 7848,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7680,7 +8558,8 @@
       "latest_key": "latest/verification/subnets/85.json",
       "path": "/metagraph/verification/subnets/85.json",
       "sha256": "cd63c8e934a0341bcb394fe630a0a26643979e47c7d1180e3476c7f4ebb2c5b7",
-      "size_bytes": 20042
+      "size_bytes": 20042,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7688,7 +8567,8 @@
       "latest_key": "latest/verification/subnets/86.json",
       "path": "/metagraph/verification/subnets/86.json",
       "sha256": "2ab96c7016aab4909524474fe1cfa42c027b3ce67cd1071babc84de21155c2ab",
-      "size_bytes": 2702
+      "size_bytes": 2702,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7696,7 +8576,8 @@
       "latest_key": "latest/verification/subnets/87.json",
       "path": "/metagraph/verification/subnets/87.json",
       "sha256": "9094d5a4ce3942729398871feaad9433596e888aa6be4118143f096a91528e1c",
-      "size_bytes": 2738
+      "size_bytes": 2738,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7704,7 +8585,8 @@
       "latest_key": "latest/verification/subnets/88.json",
       "path": "/metagraph/verification/subnets/88.json",
       "sha256": "41cfd3dad2d75c1766c397b7f5f3da746317872be1578555c83b536b577ccc8b",
-      "size_bytes": 19985
+      "size_bytes": 19985,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7712,7 +8594,8 @@
       "latest_key": "latest/verification/subnets/89.json",
       "path": "/metagraph/verification/subnets/89.json",
       "sha256": "86630528dfdd13e47ea314b034a95c76f98e2c8d66ba2ef34fbcc357396647ac",
-      "size_bytes": 15045
+      "size_bytes": 15045,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7720,7 +8603,8 @@
       "latest_key": "latest/verification/subnets/9.json",
       "path": "/metagraph/verification/subnets/9.json",
       "sha256": "040bcd9c8604880d047137fc41ce7470188dba02b4327edd50891c9a1be61349",
-      "size_bytes": 25882
+      "size_bytes": 25882,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7728,7 +8612,8 @@
       "latest_key": "latest/verification/subnets/90.json",
       "path": "/metagraph/verification/subnets/90.json",
       "sha256": "191c054ae436ac949040d1b56d8ab9b39f7fd4880af5b14cc6b9f90dd25c7698",
-      "size_bytes": 2708
+      "size_bytes": 2708,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7736,7 +8621,8 @@
       "latest_key": "latest/verification/subnets/91.json",
       "path": "/metagraph/verification/subnets/91.json",
       "sha256": "be05f6109929dc316d239dca5b89601438900cca7cc49a944162c5e6ef15f1cd",
-      "size_bytes": 15841
+      "size_bytes": 15841,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7744,7 +8630,8 @@
       "latest_key": "latest/verification/subnets/92.json",
       "path": "/metagraph/verification/subnets/92.json",
       "sha256": "8c9d6748dafce0478df92feea3dc1dc7add75eca77f9fff9dbe976e54af6ffb6",
-      "size_bytes": 10176
+      "size_bytes": 10176,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7752,7 +8639,8 @@
       "latest_key": "latest/verification/subnets/93.json",
       "path": "/metagraph/verification/subnets/93.json",
       "sha256": "72d418e4f4fa3beed45b95965dd946f26871a4f5861f77edda92aedd98bc559a",
-      "size_bytes": 19197
+      "size_bytes": 19197,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7760,7 +8648,8 @@
       "latest_key": "latest/verification/subnets/94.json",
       "path": "/metagraph/verification/subnets/94.json",
       "sha256": "175b0ba53eb3f11a5c28b248822f7f2b707b373179a1d83b7c4bf87f66e208d8",
-      "size_bytes": 14357
+      "size_bytes": 14357,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7768,7 +8657,8 @@
       "latest_key": "latest/verification/subnets/95.json",
       "path": "/metagraph/verification/subnets/95.json",
       "sha256": "f32222564d950722273031e97217847aaaf07cc9ef13cb538f2e106bfd2ca0ea",
-      "size_bytes": 5052
+      "size_bytes": 5052,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7776,7 +8666,8 @@
       "latest_key": "latest/verification/subnets/96.json",
       "path": "/metagraph/verification/subnets/96.json",
       "sha256": "d35eca5e4edc3e563843b36c053fc01184f4476558cef1af121dc3b0c5617bb9",
-      "size_bytes": 14846
+      "size_bytes": 14846,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7784,7 +8675,8 @@
       "latest_key": "latest/verification/subnets/97.json",
       "path": "/metagraph/verification/subnets/97.json",
       "sha256": "551c6dd40c1b9493fc12479dd47de7a9f0dc167c540e3b6ef98eea69007dece8",
-      "size_bytes": 20963
+      "size_bytes": 20963,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7792,7 +8684,8 @@
       "latest_key": "latest/verification/subnets/98.json",
       "path": "/metagraph/verification/subnets/98.json",
       "sha256": "82f0f0dc25ef3d35021b5cde1c39e79f9a44ce4b34d6e35229941ed7909f672e",
-      "size_bytes": 20057
+      "size_bytes": 20057,
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",
@@ -7800,7 +8693,8 @@
       "latest_key": "latest/verification/subnets/99.json",
       "path": "/metagraph/verification/subnets/99.json",
       "sha256": "c7df29a00e6f54f7be598e09e78541a821f1de1d48211c58aa153fb412ef3e96",
-      "size_bytes": 19110
+      "size_bytes": 19110,
+      "storage_tier": "r2"
     }
   ],
   "bucket_binding": "METAGRAPH_ARCHIVE",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -633,6 +633,8 @@ export interface components {
             id: string;
             path: string;
             schema_ref: string | null;
+            /** @enum {unknown} */
+            storage_tier: "dual" | "git" | "r2";
         };
         ArtifactDiffEntry: string | {
             hash?: string;
@@ -1218,6 +1220,8 @@ export interface components {
             path: string;
             sha256: string;
             size_bytes: number;
+            /** @enum {unknown} */
+            storage_tier: "dual" | "git" | "r2";
         };
         ResponseEnvelopeContract: {
             /** @constant */

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -226,13 +226,21 @@
               "string",
               "null"
             ]
+          },
+          "storage_tier": {
+            "enum": [
+              "dual",
+              "git",
+              "r2"
+            ]
           }
         },
         "required": [
           "contract_version",
           "id",
           "path",
-          "schema_ref"
+          "schema_ref",
+          "storage_tier"
         ],
         "type": "object"
       },
@@ -2611,6 +2619,13 @@
           "size_bytes": {
             "minimum": 0,
             "type": "integer"
+          },
+          "storage_tier": {
+            "enum": [
+              "dual",
+              "git",
+              "r2"
+            ]
           }
         },
         "required": [
@@ -2619,7 +2634,8 @@
           "latest_key",
           "path",
           "sha256",
-          "size_bytes"
+          "size_bytes",
+          "storage_tier"
         ],
         "type": "object"
       },

--- a/schemas/components/09-schemas-adapters-r2.schema.json
+++ b/schemas/components/09-schemas-adapters-r2.schema.json
@@ -129,7 +129,8 @@
           "latest_key",
           "path",
           "sha256",
-          "size_bytes"
+          "size_bytes",
+          "storage_tier"
         ],
         "properties": {
           "content_type": {
@@ -152,6 +153,9 @@
           "size_bytes": {
             "type": "integer",
             "minimum": 0
+          },
+          "storage_tier": {
+            "enum": ["dual", "git", "r2"]
           }
         },
         "additionalProperties": false

--- a/schemas/components/10-contracts-build.schema.json
+++ b/schemas/components/10-contracts-build.schema.json
@@ -7,7 +7,13 @@
     "schemas": {
       "ArtifactContractEntry": {
         "type": "object",
-        "required": ["contract_version", "id", "path", "schema_ref"],
+        "required": [
+          "contract_version",
+          "id",
+          "path",
+          "schema_ref",
+          "storage_tier"
+        ],
         "properties": {
           "content_type": {
             "type": "string"
@@ -28,6 +34,9 @@
           "schema_ref": {
             "type": ["string", "null"],
             "pattern": "^#/components/schemas/[A-Za-z0-9]+$"
+          },
+          "storage_tier": {
+            "enum": ["dual", "git", "r2"]
           }
         },
         "additionalProperties": false

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -33,6 +33,10 @@ import {
   summarizeArtifactBudgets,
 } from "./artifact-budgets.mjs";
 import { buildCanonicalOpenApiArtifact } from "./openapi-components.mjs";
+import {
+  R2_STAGING_RELATIVE_ROOT,
+  artifactStorageTierForRelativePath,
+} from "../src/artifact-storage.mjs";
 
 const providers = await loadProviders();
 const overlays = await loadSubnets();
@@ -64,9 +68,19 @@ const activeOverlays = overlays.filter((overlay) =>
 );
 const surfaces = flattenSurfaces(activeOverlays);
 const outputRoot = path.join(repoRoot, "public/metagraph");
+const r2OutputRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 const generatedAt = buildTimestamp();
 const contractVersion = CONTRACT_VERSION;
-const previousArtifactDigests = await collectArtifactDigests(outputRoot);
+const previousR2ManifestArtifact = await readOptionalJson(
+  path.join(outputRoot, "r2-manifest.json"),
+);
+await fs.rm(r2OutputRoot, { recursive: true, force: true });
+
+const previousArtifactDigests = await collectArtifactDigests({
+  previousManifest: previousR2ManifestArtifact,
+  publicRoot: outputRoot,
+  r2Root: r2OutputRoot,
+});
 const previousSubnetsArtifact = await readOptionalJson(
   path.join(outputRoot, "subnets.json"),
 );
@@ -260,12 +274,12 @@ const gapsIndex = mergedSubnets.map((subnet) => ({
   slug: subnet.slug,
 }));
 
-await writeJson(path.join(outputRoot, "providers.json"), {
+await writeJson(artifactFile("providers.json"), {
   schema_version: 1,
   generated_at: generatedAt,
   providers,
 });
-await fs.rm(path.join(outputRoot, "providers"), {
+await fs.rm(r2ArtifactDir("providers"), {
   recursive: true,
   force: true,
 });
@@ -273,7 +287,7 @@ for (const provider of providers) {
   const providerEndpoints = endpointResources.endpoints.filter(
     (endpoint) => endpoint.provider === provider.id,
   );
-  await writeJson(path.join(outputRoot, `providers/${provider.id}.json`), {
+  await writeJson(artifactFile(`providers/${provider.id}.json`), {
     schema_version: 1,
     contract_version: contractVersion,
     generated_at: generatedAt,
@@ -282,7 +296,7 @@ for (const provider of providers) {
   });
 }
 
-await writeJson(path.join(outputRoot, "subnets.json"), {
+await writeJson(artifactFile("subnets.json"), {
   schema_version: 1,
   generated_at: generatedAt,
   network: nativeSnapshot.network,
@@ -291,7 +305,7 @@ await writeJson(path.join(outputRoot, "subnets.json"), {
   subnets: subnetIndex,
 });
 
-await fs.rm(path.join(outputRoot, "subnets"), { recursive: true, force: true });
+await fs.rm(r2ArtifactDir("subnets"), { recursive: true, force: true });
 for (const subnet of mergedSubnets) {
   const subnetCandidates = candidatesByNetuid.get(subnet.netuid) || [];
   const subnetSurfaces = surfaces.filter(
@@ -300,7 +314,7 @@ for (const subnet of mergedSubnets) {
   const subnetEndpoints = endpointResources.endpoints.filter(
     (endpoint) => endpoint.netuid === subnet.netuid,
   );
-  await writeJson(path.join(outputRoot, `subnets/${subnet.netuid}.json`), {
+  await writeJson(artifactFile(`subnets/${subnet.netuid}.json`), {
     schema_version: 1,
     generated_at: generatedAt,
     subnet,
@@ -313,19 +327,19 @@ for (const subnet of mergedSubnets) {
   });
 }
 
-await writeJson(path.join(outputRoot, "surfaces.json"), {
+await writeJson(artifactFile("surfaces.json"), {
   schema_version: 1,
   generated_at: generatedAt,
   notes:
     "Curated and verified public interface surfaces only. Native-only subnet stubs do not invent surfaces.",
   surfaces,
 });
-await fs.rm(path.join(outputRoot, "surfaces"), {
+await fs.rm(r2ArtifactDir("surfaces"), {
   recursive: true,
   force: true,
 });
 for (const subnet of mergedSubnets) {
-  await writeJson(path.join(outputRoot, `surfaces/${subnet.netuid}.json`), {
+  await writeJson(artifactFile(`surfaces/${subnet.netuid}.json`), {
     schema_version: 1,
     contract_version: contractVersion,
     generated_at: generatedAt,
@@ -336,19 +350,19 @@ for (const subnet of mergedSubnets) {
   });
 }
 
-await writeJson(path.join(outputRoot, "candidates.json"), {
+await writeJson(artifactFile("candidates.json"), {
   schema_version: 1,
   generated_at: generatedAt,
   notes:
     "Unverified candidate surfaces from public source discovery and community intake. Candidates are not verified registry surfaces.",
   candidates: candidateIndex,
 });
-await fs.rm(path.join(outputRoot, "candidates"), {
+await fs.rm(r2ArtifactDir("candidates"), {
   recursive: true,
   force: true,
 });
 for (const subnet of mergedSubnets) {
-  await writeJson(path.join(outputRoot, `candidates/${subnet.netuid}.json`), {
+  await writeJson(artifactFile(`candidates/${subnet.netuid}.json`), {
     schema_version: 1,
     contract_version: contractVersion,
     generated_at: generatedAt,
@@ -361,7 +375,7 @@ for (const subnet of mergedSubnets) {
   });
 }
 
-await writeJson(path.join(outputRoot, "review-queue.json"), {
+await writeJson(artifactFile("review-queue.json"), {
   schema_version: 1,
   generated_at: generatedAt,
   notes:
@@ -370,14 +384,14 @@ await writeJson(path.join(outputRoot, "review-queue.json"), {
   candidates: reviewQueue,
 });
 
-await writeJson(path.join(outputRoot, "curation.json"), {
+await writeJson(artifactFile("curation.json"), {
   schema_version: 1,
   generated_at: generatedAt,
   notes: "Curation status for every active Finney subnet.",
   curation: curationIndex,
 });
 
-await writeJson(path.join(outputRoot, "gaps.json"), {
+await writeJson(artifactFile("gaps.json"), {
   schema_version: 1,
   generated_at: generatedAt,
   notes:
@@ -385,11 +399,11 @@ await writeJson(path.join(outputRoot, "gaps.json"), {
   gaps: gapsIndex,
 });
 
-await writeJson(path.join(outputRoot, "verification/latest.json"), {
+await writeJson(artifactFile("verification/latest.json"), {
   ...verification,
   generated_at: verification.generated_at || generatedAt,
 });
-await fs.rm(path.join(outputRoot, "verification/subnets"), {
+await fs.rm(r2ArtifactDir("verification/subnets"), {
   recursive: true,
   force: true,
 });
@@ -397,52 +411,40 @@ for (const subnet of mergedSubnets) {
   const results = (verification.results || []).filter(
     (result) => result.netuid === subnet.netuid,
   );
-  await writeJson(
-    path.join(outputRoot, `verification/subnets/${subnet.netuid}.json`),
-    {
-      schema_version: 1,
-      contract_version: contractVersion,
-      generated_at: verification.generated_at || generatedAt,
-      candidate_count: results.length,
-      netuid: subnet.netuid,
-      slug: subnet.slug,
-      name: subnet.name,
-      summary: {
-        by_classification: countBy(
-          results,
-          (result) => result.classification || "unknown",
-        ),
-        by_kind: countBy(results, (result) => result.kind || "unknown"),
-        by_provider: countBy(results, (result) => result.provider || "unknown"),
-      },
-      results,
+  await writeJson(artifactFile(`verification/subnets/${subnet.netuid}.json`), {
+    schema_version: 1,
+    contract_version: contractVersion,
+    generated_at: verification.generated_at || generatedAt,
+    candidate_count: results.length,
+    netuid: subnet.netuid,
+    slug: subnet.slug,
+    name: subnet.name,
+    summary: {
+      by_classification: countBy(
+        results,
+        (result) => result.classification || "unknown",
+      ),
+      by_kind: countBy(results, (result) => result.kind || "unknown"),
+      by_provider: countBy(results, (result) => result.provider || "unknown"),
     },
-  );
+    results,
+  });
 }
 
-await writeJson(
-  path.join(outputRoot, "metagraph/latest.json"),
-  metagraphLatest,
-);
-await fs.rm(path.join(outputRoot, "health/subnets"), {
+await writeJson(artifactFile("metagraph/latest.json"), metagraphLatest);
+await fs.rm(r2ArtifactDir("health/subnets"), {
   recursive: true,
   force: true,
 });
-await fs.rm(path.join(outputRoot, "health/badges"), {
+await fs.rm(r2ArtifactDir("health/badges"), {
   recursive: true,
   force: true,
 });
-await writeJson(
-  path.join(outputRoot, "health/latest.json"),
-  healthArtifacts.latest,
-);
-await writeJson(
-  path.join(outputRoot, "health/summary.json"),
-  healthArtifacts.summary,
-);
-await writeJson(path.join(outputRoot, "rpc-endpoints.json"), rpcEndpoints);
-await writeJson(path.join(outputRoot, "endpoints.json"), endpointResources);
-await fs.rm(path.join(outputRoot, "endpoints"), {
+await writeJson(artifactFile("health/latest.json"), healthArtifacts.latest);
+await writeJson(artifactFile("health/summary.json"), healthArtifacts.summary);
+await writeJson(artifactFile("rpc-endpoints.json"), rpcEndpoints);
+await writeJson(artifactFile("endpoints.json"), endpointResources);
+await fs.rm(r2ArtifactDir("endpoints"), {
   recursive: true,
   force: true,
 });
@@ -450,7 +452,7 @@ for (const subnet of mergedSubnets) {
   const subnetEndpoints = endpointResources.endpoints.filter(
     (endpoint) => endpoint.netuid === subnet.netuid,
   );
-  await writeJson(path.join(outputRoot, `endpoints/${subnet.netuid}.json`), {
+  await writeJson(artifactFile(`endpoints/${subnet.netuid}.json`), {
     schema_version: 1,
     contract_version: contractVersion,
     generated_at: generatedAt,
@@ -465,45 +467,39 @@ for (const provider of providers) {
   const providerEndpoints = endpointResources.endpoints.filter(
     (endpoint) => endpoint.provider === provider.id,
   );
-  await writeJson(
-    path.join(outputRoot, `providers/${provider.id}/endpoints.json`),
-    {
-      schema_version: 1,
-      contract_version: contractVersion,
-      generated_at: generatedAt,
-      provider: {
-        id: provider.id,
-        name: provider.name,
-        kind: provider.kind,
-        authority: provider.authority,
-      },
-      summary: endpointSummary(providerEndpoints),
-      endpoints: providerEndpoints,
+  await writeJson(artifactFile(`providers/${provider.id}/endpoints.json`), {
+    schema_version: 1,
+    contract_version: contractVersion,
+    generated_at: generatedAt,
+    provider: {
+      id: provider.id,
+      name: provider.name,
+      kind: provider.kind,
+      authority: provider.authority,
     },
-  );
+    summary: endpointSummary(providerEndpoints),
+    endpoints: providerEndpoints,
+  });
 }
 for (const [netuid, subnetHealth] of healthArtifacts.subnets) {
-  await writeJson(
-    path.join(outputRoot, `health/subnets/${netuid}.json`),
-    subnetHealth,
-  );
+  await writeJson(artifactFile(`health/subnets/${netuid}.json`), subnetHealth);
 }
 for (const [netuid, badge] of healthArtifacts.badges) {
-  await writeJson(path.join(outputRoot, `health/badges/${netuid}.json`), badge);
+  await writeJson(artifactFile(`health/badges/${netuid}.json`), badge);
 }
-await writeJson(path.join(outputRoot, "coverage.json"), coverage);
-await writeJson(path.join(outputRoot, "contracts.json"), contracts);
+await writeJson(artifactFile("coverage.json"), coverage);
+await writeJson(artifactFile("contracts.json"), contracts);
 await writeJson(
-  path.join(outputRoot, "api-index.json"),
+  artifactFile("api-index.json"),
   buildApiIndexArtifact(generatedAt, contracts),
 );
-await writeJson(path.join(outputRoot, "openapi.json"), openApi);
+await writeJson(artifactFile("openapi.json"), openApi);
 await writeJson(
-  path.join(outputRoot, "search.json"),
+  artifactFile("search.json"),
   buildSearchIndex(mergedSubnets, surfaces, providers),
 );
 await writeJson(
-  path.join(outputRoot, "freshness.json"),
+  artifactFile("freshness.json"),
   buildFreshnessArtifact({
     adapterSnapshots,
     generatedAt,
@@ -514,7 +510,7 @@ await writeJson(
   }),
 );
 await writeJson(
-  path.join(outputRoot, "source-health.json"),
+  artifactFile("source-health.json"),
   buildSourceHealthArtifact({
     candidates,
     endpointResources,
@@ -524,7 +520,7 @@ await writeJson(
   }),
 );
 await writeJson(
-  path.join(outputRoot, "evidence-ledger.json"),
+  artifactFile("evidence-ledger.json"),
   buildEvidenceLedger({
     candidates,
     generatedAt,
@@ -533,7 +529,7 @@ await writeJson(
   }),
 );
 await writeJson(
-  path.join(outputRoot, "rpc/pools.json"),
+  artifactFile("rpc/pools.json"),
   buildEndpointPoolArtifact({
     generatedAt,
     contractVersion,
@@ -541,19 +537,16 @@ await writeJson(
   }),
 );
 await writeJson(
-  path.join(outputRoot, "endpoint-pools.json"),
+  artifactFile("endpoint-pools.json"),
   buildEndpointPoolArtifact({
     generatedAt,
     contractVersion,
     endpointArtifact: endpointResources,
   }),
 );
+await writeJson(artifactFile("endpoint-incidents.json"), endpointIncidents);
 await writeJson(
-  path.join(outputRoot, "endpoint-incidents.json"),
-  endpointIncidents,
-);
-await writeJson(
-  path.join(outputRoot, "source-snapshots.json"),
+  artifactFile("source-snapshots.json"),
   await buildSourceSnapshots({
     adapterSnapshots,
     candidates,
@@ -565,11 +558,8 @@ await writeJson(
     verification,
   }),
 );
-await writeJson(
-  path.join(outputRoot, "schema-drift.json"),
-  schemaDriftPlaceholder,
-);
-await writeJson(path.join(outputRoot, "schemas/index.json"), {
+await writeJson(artifactFile("schema-drift.json"), schemaDriftPlaceholder);
+await writeJson(artifactFile("schemas/index.json"), {
   schema_version: 1,
   contract_version: contractVersion,
   generated_at: generatedAt,
@@ -578,20 +568,20 @@ await writeJson(path.join(outputRoot, "schemas/index.json"), {
     "Run npm run schemas:snapshot to capture machine-readable OpenAPI/Swagger schema snapshots.",
   schemas: [],
 });
-await writeJson(path.join(outputRoot, "review/curation.json"), curationReview);
-await writeJson(path.join(outputRoot, "review/gap-priorities.json"), {
+await writeJson(artifactFile("review/curation.json"), curationReview);
+await writeJson(artifactFile("review/gap-priorities.json"), {
   schema_version: 1,
   contract_version: contractVersion,
   generated_at: generatedAt,
   priorities: curationReview.gap_priorities,
 });
-await writeJson(path.join(outputRoot, "review/adapter-candidates.json"), {
+await writeJson(artifactFile("review/adapter-candidates.json"), {
   schema_version: 1,
   contract_version: contractVersion,
   generated_at: generatedAt,
   candidates: curationReview.adapter_candidates,
 });
-await writeJson(path.join(outputRoot, "review/maintainer-decisions.json"), {
+await writeJson(artifactFile("review/maintainer-decisions.json"), {
   schema_version: 1,
   contract_version: contractVersion,
   generated_at: generatedAt,
@@ -601,12 +591,15 @@ await writeJson(path.join(outputRoot, "review/maintainer-decisions.json"), {
 });
 
 for (const [slug, artifact] of Object.entries(adapterArtifacts)) {
-  await writeJson(path.join(outputRoot, `adapters/${slug}.json`), artifact);
+  await writeJson(artifactFile(`adapters/${slug}.json`), artifact);
 }
 
-const currentArtifactDigests = await collectArtifactDigests(outputRoot);
+const currentArtifactDigests = await collectArtifactDigests({
+  publicRoot: outputRoot,
+  r2Root: r2OutputRoot,
+});
 await writeJson(
-  path.join(outputRoot, "changelog.json"),
+  artifactFile("changelog.json"),
   buildChangelog({
     currentArtifacts: currentArtifactDigests,
     currentCoverage: coverage,
@@ -618,18 +611,24 @@ await writeJson(
   }),
 );
 
-const artifactSizesBeforeR2 = await collectArtifactSizes(outputRoot);
+const artifactSizesBeforeR2 = await collectArtifactSizes({
+  publicRoot: outputRoot,
+  r2Root: r2OutputRoot,
+});
 await writeJson(
-  path.join(outputRoot, "r2-manifest.json"),
+  artifactFile("r2-manifest.json"),
   buildR2Manifest({
     artifactSizes: artifactSizesBeforeR2,
     generatedAt,
   }),
 );
 
-const artifactSizes = await collectArtifactSizes(outputRoot);
+const artifactSizes = await collectArtifactSizes({
+  publicRoot: outputRoot,
+  r2Root: r2OutputRoot,
+});
 const artifactBudgets = evaluateArtifactBudgets(artifactSizes);
-await writeJson(path.join(outputRoot, "build-summary.json"), {
+await writeJson(artifactFile("build-summary.json"), {
   schema_version: 1,
   contract_version: contractVersion,
   generated_at: generatedAt,
@@ -1484,6 +1483,7 @@ function buildR2Manifest({ artifactSizes, generatedAt: timestamp }) {
     path: `/metagraph/${artifact.path}`,
     sha256: artifact.sha256,
     size_bytes: artifact.size_bytes,
+    storage_tier: artifact.storage_tier,
   }));
   return {
     schema_version: 1,
@@ -1734,32 +1734,56 @@ function delta(before, after) {
   };
 }
 
-async function collectArtifactDigests(root) {
+function artifactFile(relativePath) {
+  const tier = artifactStorageTierForRelativePath(relativePath);
+  return path.join(tier === "r2" ? r2OutputRoot : outputRoot, relativePath);
+}
+
+function r2ArtifactDir(relativePath) {
+  return path.join(r2OutputRoot, relativePath);
+}
+
+async function collectArtifactDigests({
+  previousManifest,
+  publicRoot,
+  r2Root,
+}) {
   const files = [];
-  try {
-    await walk(root, async (filePath) => {
-      if (!filePath.endsWith(".json")) {
-        return;
-      }
-      const relativePath = path.relative(root, filePath).replace(/\\/g, "/");
-      if (
-        ["build-summary.json", "changelog.json", "r2-manifest.json"].includes(
-          relativePath,
-        )
-      ) {
-        return;
-      }
-      const value = await readJson(filePath);
-      files.push({
-        path: relativePath,
-        hash: hashJson(value),
-      });
-    });
-  } catch (error) {
-    if (error.code !== "ENOENT") {
-      throw error;
+  await collectArtifactFiles({ publicRoot, r2Root }, async (filePath, root) => {
+    if (!filePath.endsWith(".json")) {
+      return;
     }
+    const relativePath = path.relative(root, filePath).replace(/\\/g, "/");
+    if (
+      ["build-summary.json", "changelog.json", "r2-manifest.json"].includes(
+        relativePath,
+      )
+    ) {
+      return;
+    }
+    const raw = await fs.readFile(filePath);
+    files.push({
+      path: relativePath,
+      hash: sha256Hex(raw),
+    });
+  });
+
+  for (const artifact of previousManifest?.artifacts || []) {
+    const relativePath = artifact.path?.replace(/^\/metagraph\//, "");
+    if (
+      artifact.storage_tier !== "r2" ||
+      !relativePath ||
+      !artifact.sha256 ||
+      files.some((file) => file.path === relativePath)
+    ) {
+      continue;
+    }
+    files.push({
+      path: relativePath,
+      hash: artifact.sha256,
+    });
   }
+
   return files.sort((a, b) => a.path.localeCompare(b.path));
 }
 
@@ -1774,9 +1798,9 @@ async function readOptionalJson(filePath) {
   }
 }
 
-async function collectArtifactSizes(root) {
+async function collectArtifactSizes({ publicRoot, r2Root }) {
   const files = [];
-  await walk(root, async (filePath) => {
+  await collectArtifactFiles({ publicRoot, r2Root }, async (filePath, root) => {
     if (!filePath.endsWith(".json")) {
       return;
     }
@@ -1790,9 +1814,23 @@ async function collectArtifactSizes(root) {
       path: relativePath,
       sha256: sha256Hex(raw),
       size_bytes: stat.size,
+      storage_tier: artifactStorageTierForRelativePath(relativePath),
     });
   });
   return files.sort((a, b) => a.path.localeCompare(b.path));
+}
+
+async function collectArtifactFiles({ publicRoot, r2Root }, onFile) {
+  await walkIfExists(publicRoot, async (filePath) => {
+    const relativePath = path
+      .relative(publicRoot, filePath)
+      .replace(/\\/g, "/");
+    if (artifactStorageTierForRelativePath(relativePath) === "r2") {
+      return;
+    }
+    await onFile(filePath, publicRoot);
+  });
+  await walkIfExists(r2Root, async (filePath) => onFile(filePath, r2Root));
 }
 
 async function loadAdapterSnapshots() {
@@ -1820,12 +1858,20 @@ async function loadReviewDecisions() {
   }
 }
 
-async function walk(dirPath, onFile) {
-  const entries = await fs.readdir(dirPath, { withFileTypes: true });
+async function walkIfExists(dirPath, onFile) {
+  let entries;
+  try {
+    entries = await fs.readdir(dirPath, { withFileTypes: true });
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      return;
+    }
+    throw error;
+  }
   for (const entry of entries) {
     const entryPath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
-      await walk(entryPath, onFile);
+      await walkIfExists(entryPath, onFile);
     } else if (entry.isFile()) {
       await onFile(entryPath);
     }

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1,10 +1,19 @@
 import { promises as fs } from "node:fs";
+import { existsSync } from "node:fs";
 import { createHash } from "node:crypto";
 import { lookup } from "node:dns/promises";
 import { BlockList, isIP } from "node:net";
 import path from "node:path";
+import {
+  ARTIFACT_STORAGE_TIERS,
+  R2_STAGING_RELATIVE_ROOT,
+  artifactRelativePath,
+  artifactStorageTierForRelativePath,
+} from "../src/artifact-storage.mjs";
 
 export const repoRoot = new URL("..", import.meta.url).pathname;
+export const publicMetagraphRoot = path.join(repoRoot, "public/metagraph");
+export const r2StagingRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 
 const credentialedUrlParams = new Set([
   "x-amz-credential",
@@ -44,9 +53,96 @@ export async function readJson(filePath) {
   return JSON.parse(raw);
 }
 
+export async function readArtifactJson(relativePath) {
+  return readJson(artifactFilePath(relativePath));
+}
+
 export async function writeJson(filePath, value) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, `${stableStringify(value)}\n`, "utf8");
+}
+
+export function artifactFilePath(relativePath, options = {}) {
+  const normalized = artifactRelativePath(relativePath);
+  const tier = artifactStorageTierForRelativePath(normalized);
+  if (tier !== ARTIFACT_STORAGE_TIERS.r2) {
+    return path.join(publicMetagraphRoot, normalized);
+  }
+
+  const stagedPath = path.join(r2StagingRoot, normalized);
+  const publicPath = path.join(publicMetagraphRoot, normalized);
+  const allowPublicFallback = options.allowPublicFallback !== false;
+  if (existsSync(stagedPath) || !allowPublicFallback) {
+    return stagedPath;
+  }
+  return publicPath;
+}
+
+export function artifactOutputPath(relativePath) {
+  const normalized = artifactRelativePath(relativePath);
+  const tier = artifactStorageTierForRelativePath(normalized);
+  return path.join(
+    tier === ARTIFACT_STORAGE_TIERS.r2 ? r2StagingRoot : publicMetagraphRoot,
+    normalized,
+  );
+}
+
+export function artifactDirectoryPath(relativePath) {
+  const normalized = artifactRelativePath(relativePath).replace(/\/+$/, "");
+  const stagedPath = path.join(r2StagingRoot, normalized);
+  if (existsSync(stagedPath)) {
+    return stagedPath;
+  }
+  return path.join(publicMetagraphRoot, normalized);
+}
+
+export function createLocalArtifactEnv(overrides = {}) {
+  return {
+    ASSETS: {
+      async fetch(request) {
+        const url = new URL(request.url);
+        const filePath = path.join(
+          repoRoot,
+          "public",
+          url.pathname.replace(/^\/+/, ""),
+        );
+        try {
+          const body = await fs.readFile(filePath);
+          return new Response(body, {
+            status: 200,
+            headers: {
+              "content-type": filePath.endsWith(".json")
+                ? "application/json"
+                : "application/octet-stream",
+            },
+          });
+        } catch {
+          return new Response("not found", { status: 404 });
+        }
+      },
+    },
+    METAGRAPH_R2_LATEST_PREFIX: "latest/",
+    METAGRAPH_ARCHIVE: {
+      async get(key) {
+        const relativePath = String(key).replace(/^latest\//, "");
+        const filePath = artifactFilePath(relativePath);
+        try {
+          const body = await fs.readFile(filePath, "utf8");
+          return {
+            async json() {
+              return JSON.parse(body);
+            },
+            async text() {
+              return body;
+            },
+          };
+        } catch {
+          return null;
+        }
+      },
+    },
+    ...overrides,
+  };
 }
 
 export async function listJsonFiles(dirPath) {

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -8,10 +8,11 @@ import {
   buildTimestamp,
   flattenSurfaces,
   isJsonContentType,
+  artifactDirectoryPath,
+  artifactOutputPath,
   loadProviders,
   isUnsafeResolvedUrl,
   loadSubnets,
-  repoRoot,
   writeJson,
 } from "./lib.mjs";
 
@@ -23,7 +24,6 @@ const surfaces = allSurfaces.filter(
   (surface) => surface.probe?.enabled && surface.public_safe,
 );
 const startedAt = Date.now();
-const outputRoot = path.join(repoRoot, "public/metagraph");
 const priorHistory = await loadPriorHistory();
 const subtensorProbeCalls = [
   { key: "chain_getHeader", method: "chain_getHeader", params: [] },
@@ -671,21 +671,18 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
     contractVersion,
     source: "live-smoke-probe",
   });
-  await writeJson(path.join(outputRoot, "health/latest.json"), artifact.latest);
+  await writeJson(artifactOutputPath("health/latest.json"), artifact.latest);
+  await writeJson(artifactOutputPath("health/summary.json"), artifact.summary);
   await writeJson(
-    path.join(outputRoot, "health/summary.json"),
-    artifact.summary,
-  );
-  await writeJson(
-    path.join(outputRoot, "rpc-endpoints.json"),
+    artifactOutputPath("rpc-endpoints.json"),
     rpcEndpointArtifact,
   );
   await writeJson(
-    path.join(outputRoot, "endpoints.json"),
+    artifactOutputPath("endpoints.json"),
     endpointResourceArtifact,
   );
   await writeJson(
-    path.join(outputRoot, "endpoint-incidents.json"),
+    artifactOutputPath("endpoint-incidents.json"),
     buildEndpointIncidentArtifact({
       endpointArtifact: endpointResourceArtifact,
       generatedAt: buildTimestamp(),
@@ -693,7 +690,7 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
     }),
   );
   await writeJson(
-    path.join(outputRoot, "rpc/pools.json"),
+    artifactOutputPath("rpc/pools.json"),
     buildEndpointPoolArtifact({
       generatedAt: buildTimestamp(),
       contractVersion,
@@ -701,22 +698,25 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
     }),
   );
   await writeJson(
-    path.join(outputRoot, "endpoint-pools.json"),
+    artifactOutputPath("endpoint-pools.json"),
     buildEndpointPoolArtifact({
       generatedAt: buildTimestamp(),
       contractVersion,
       endpointArtifact: endpointResourceArtifact,
     }),
   );
-  await fs.rm(path.join(outputRoot, "endpoints"), {
-    recursive: true,
-    force: true,
-  });
+  await fs.rm(
+    artifactOutputPath("endpoints/0.json").replace(/\/0\.json$/, ""),
+    {
+      recursive: true,
+      force: true,
+    },
+  );
   for (const subnet of subnets) {
     const subnetEndpoints = endpointResourceArtifact.endpoints.filter(
       (endpoint) => endpoint.netuid === subnet.netuid,
     );
-    await writeJson(path.join(outputRoot, `endpoints/${subnet.netuid}.json`), {
+    await writeJson(artifactOutputPath(`endpoints/${subnet.netuid}.json`), {
       schema_version: 1,
       contract_version: contractVersion,
       generated_at: buildTimestamp(),
@@ -732,7 +732,7 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
       (endpoint) => endpoint.provider === provider.id,
     );
     await writeJson(
-      path.join(outputRoot, `providers/${provider.id}/endpoints.json`),
+      artifactOutputPath(`providers/${provider.id}/endpoints.json`),
       {
         schema_version: 1,
         contract_version: contractVersion,
@@ -750,28 +750,31 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
   }
   const day = artifact.latest.probe_finished_at.slice(0, 10);
   await writeJson(
-    path.join(outputRoot, `health/history/${day}.json`),
+    artifactOutputPath(`health/history/${day}.json`),
     buildHealthHistoryArtifact(artifact.latest, day),
   );
-  await fs.rm(path.join(outputRoot, "health/subnets"), {
-    recursive: true,
-    force: true,
-  });
-  await fs.rm(path.join(outputRoot, "health/badges"), {
-    recursive: true,
-    force: true,
-  });
+  await fs.rm(
+    artifactOutputPath("health/subnets/0.json").replace(/\/0\.json$/, ""),
+    {
+      recursive: true,
+      force: true,
+    },
+  );
+  await fs.rm(
+    artifactOutputPath("health/badges/0.json").replace(/\/0\.json$/, ""),
+    {
+      recursive: true,
+      force: true,
+    },
+  );
   for (const [netuid, subnetHealth] of artifact.subnets) {
     await writeJson(
-      path.join(outputRoot, `health/subnets/${netuid}.json`),
+      artifactOutputPath(`health/subnets/${netuid}.json`),
       subnetHealth,
     );
   }
   for (const [netuid, badge] of artifact.badges) {
-    await writeJson(
-      path.join(outputRoot, `health/badges/${netuid}.json`),
-      badge,
-    );
+    await writeJson(artifactOutputPath(`health/badges/${netuid}.json`), badge);
   }
 }
 
@@ -977,7 +980,7 @@ function classifySubnetStatus({
 }
 
 async function loadPriorHistory() {
-  const historyRoot = path.join(outputRoot, "health/history");
+  const historyRoot = artifactDirectoryPath("health/history");
   let entries;
   try {
     entries = await fs.readdir(historyRoot, { withFileTypes: true });

--- a/scripts/r2-download.mjs
+++ b/scripts/r2-download.mjs
@@ -2,6 +2,10 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { mkdir, readFile } from "node:fs/promises";
 import { readJson, repoRoot, sha256Hex, stableStringify } from "./lib.mjs";
+import {
+  R2_STAGING_RELATIVE_ROOT,
+  artifactStorageTierForPath,
+} from "../src/artifact-storage.mjs";
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
@@ -18,7 +22,7 @@ const outputDir = outputDirArg
   : "tmp/r2-download";
 const planned = manifest.artifacts.map((artifact) => ({
   key: `${prefix}${artifact.path.replace(/^\/metagraph\//, "")}`,
-  local_path: path.join(outputDir, artifact.path.replace(/^\/metagraph\//, "")),
+  local_path: localArtifactPath(outputDir, artifact.path),
   sha256: artifact.sha256,
   size_bytes: artifact.size_bytes,
 }));
@@ -83,4 +87,13 @@ function getObject(key, localPath, bucketName) {
     console.error(result.stderr);
     throw new Error(`wrangler r2 object get failed for ${key}`);
   }
+}
+
+function localArtifactPath(baseDir, artifactPath) {
+  const relativePath = artifactPath.replace(/^\/metagraph\//, "");
+  const tier = artifactStorageTierForPath(artifactPath);
+  if (tier === "r2") {
+    return path.join(repoRoot, R2_STAGING_RELATIVE_ROOT, relativePath);
+  }
+  return path.join(baseDir, relativePath);
 }

--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -8,6 +8,10 @@ import {
   stableStringify,
   writeJson,
 } from "./lib.mjs";
+import {
+  R2_STAGING_RELATIVE_ROOT,
+  artifactStorageTierForRelativePath,
+} from "../src/artifact-storage.mjs";
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
@@ -47,14 +51,12 @@ console.log(stableStringify(summary));
 async function buildManifest() {
   const generatedAt = buildTimestamp();
   const version = generatedAt.replace(/[:.]/g, "-");
-  const files = await listPublicArtifactFiles(
-    path.join(repoRoot, "public/metagraph"),
-  );
+  const publicRoot = path.join(repoRoot, "public/metagraph");
+  const r2Root = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
+  const files = await listManifestArtifactFiles({ publicRoot, r2Root });
   const artifacts = [];
-  for (const file of files) {
-    const relative = path
-      .relative(path.join(repoRoot, "public/metagraph"), file)
-      .replace(/\\/g, "/");
+  for (const { file, root } of files) {
+    const relative = path.relative(root, file).replace(/\\/g, "/");
     if (["build-summary.json", "r2-manifest.json"].includes(relative)) {
       continue;
     }
@@ -67,6 +69,7 @@ async function buildManifest() {
       path: `/metagraph/${relative}`,
       sha256: sha256Hex(raw),
       size_bytes: fileStat.size,
+      storage_tier: artifactStorageTierForRelativePath(relative),
     });
   }
   artifacts.sort((a, b) => a.path.localeCompare(b.path));
@@ -87,7 +90,25 @@ async function buildManifest() {
   };
 }
 
-async function listPublicArtifactFiles(dirPath) {
+async function listManifestArtifactFiles({ publicRoot, r2Root }) {
+  const publicFiles = (await listArtifactFiles(publicRoot))
+    .filter((file) => {
+      const relative = path.relative(publicRoot, file).replace(/\\/g, "/");
+      return artifactStorageTierForRelativePath(relative) !== "r2";
+    })
+    .map((file) => ({ file, root: publicRoot }));
+  const r2Files = (await listArtifactFiles(r2Root)).map((file) => ({
+    file,
+    root: r2Root,
+  }));
+  return [...publicFiles, ...r2Files].sort((a, b) => {
+    const left = path.relative(a.root, a.file).replace(/\\/g, "/");
+    const right = path.relative(b.root, b.file).replace(/\\/g, "/");
+    return left.localeCompare(right);
+  });
+}
+
+async function listArtifactFiles(dirPath) {
   let entries;
   try {
     entries = await readdir(dirPath, { withFileTypes: true });
@@ -102,7 +123,7 @@ async function listPublicArtifactFiles(dirPath) {
   for (const entry of entries) {
     const entryPath = path.join(dirPath, entry.name);
     if (entry.isDirectory()) {
-      files.push(...(await listPublicArtifactFiles(entryPath)));
+      files.push(...(await listArtifactFiles(entryPath)));
     } else if (entry.isFile() && isManifestedArtifact(entry.name)) {
       files.push(entryPath);
     }

--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -2,6 +2,10 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { readJson, repoRoot, sha256Hex, stableStringify } from "./lib.mjs";
+import {
+  R2_STAGING_RELATIVE_ROOT,
+  artifactStorageTierForPath,
+} from "../src/artifact-storage.mjs";
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
@@ -68,11 +72,7 @@ let uploadedHistoryCount = 0;
 let uploadedControlCount = 0;
 
 for (const artifact of plannedArtifacts) {
-  const localPath = path.join(
-    repoRoot,
-    "public/metagraph",
-    artifact.path.replace(/^\/metagraph\//, ""),
-  );
+  const localPath = artifactLocalPath(artifact.path);
   verifyLocalArtifact(localPath, artifact);
   const changed =
     forceUpload ||
@@ -164,6 +164,16 @@ function verifyLocalArtifact(localPath, artifact) {
       `local artifact hash mismatch for ${artifact.path}: expected ${artifact.sha256}, got ${actual}`,
     );
   }
+}
+
+function artifactLocalPath(artifactPath) {
+  const relativePath = artifactPath.replace(/^\/metagraph\//, "");
+  const tier = artifactStorageTierForPath(artifactPath);
+  return path.join(
+    repoRoot,
+    tier === "r2" ? R2_STAGING_RELATIVE_ROOT : "public/metagraph",
+    relativePath,
+  );
 }
 
 function buildControlArtifacts(manifest) {

--- a/scripts/refresh-build-summary.mjs
+++ b/scripts/refresh-build-summary.mjs
@@ -11,11 +11,19 @@ import {
   stableStringify,
   writeJson,
 } from "./lib.mjs";
+import {
+  R2_STAGING_RELATIVE_ROOT,
+  artifactStorageTierForRelativePath,
+} from "../src/artifact-storage.mjs";
 
 const outputRoot = path.join(repoRoot, "public/metagraph");
+const r2OutputRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 const summaryPath = path.join(outputRoot, "build-summary.json");
 const existing = JSON.parse(await fs.readFile(summaryPath, "utf8"));
-const artifacts = await collectArtifactSizes(outputRoot);
+const artifacts = await collectArtifactSizes({
+  publicRoot: outputRoot,
+  r2Root: r2OutputRoot,
+});
 const artifactBudgets = evaluateArtifactBudgets(artifacts);
 
 await writeJson(summaryPath, {
@@ -42,16 +50,34 @@ console.log(
   }),
 );
 
-async function collectArtifactSizes(root) {
+async function collectArtifactSizes({ publicRoot, r2Root }) {
   const files = [];
-  await walk(root, async (filePath) => {
+  await walk(publicRoot, async (filePath) => {
     if (!filePath.endsWith(".json")) {
       return;
     }
-    const relativePath = path.relative(root, filePath).replace(/\\/g, "/");
+    const relativePath = path
+      .relative(publicRoot, filePath)
+      .replace(/\\/g, "/");
+    if (artifactStorageTierForRelativePath(relativePath) === "r2") {
+      return;
+    }
     if (["build-summary.json", "r2-manifest.json"].includes(relativePath)) {
       return;
     }
+    const raw = await fs.readFile(filePath);
+    const stat = await fs.stat(filePath);
+    files.push({
+      path: relativePath,
+      sha256: sha256Hex(raw),
+      size_bytes: stat.size,
+    });
+  });
+  await walk(r2Root, async (filePath) => {
+    if (!filePath.endsWith(".json")) {
+      return;
+    }
+    const relativePath = path.relative(r2Root, filePath).replace(/\\/g, "/");
     const raw = await fs.readFile(filePath);
     const stat = await fs.stat(filePath);
     files.push({

--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -8,6 +8,7 @@ const targetRoots = [
   "registry",
   "schemas",
   "public",
+  "dist/metagraph-r2",
   ".github",
   "workers",
   "wrangler.jsonc",

--- a/scripts/snapshot-openapi.mjs
+++ b/scripts/snapshot-openapi.mjs
@@ -1,6 +1,7 @@
 import { promises as fs } from "node:fs";
-import path from "node:path";
 import {
+  artifactFilePath,
+  artifactOutputPath,
   buildTimestamp,
   flattenSurfaces,
   hashJson,
@@ -8,7 +9,6 @@ import {
   isUnsafeResolvedUrl,
   isUnsafeUrl,
   loadSubnets,
-  repoRoot,
   stableStringify,
   writeJson,
 } from "./lib.mjs";
@@ -22,7 +22,6 @@ const subnets = await loadSubnets();
 const surfaces = flattenSurfaces(subnets).filter(
   (surface) => surface.kind === "openapi" && surface.public_safe,
 );
-const schemaRoot = path.join(repoRoot, "public/metagraph/schemas");
 const existingBySurface = await loadExistingSchemaIndex();
 const results = [];
 
@@ -79,21 +78,17 @@ const drift = {
 };
 
 if (!dryRun) {
-  await fs.mkdir(schemaRoot, { recursive: true });
   for (const result of results) {
     if (result.status !== "captured") {
       continue;
     }
     await writeJson(
-      path.join(schemaRoot, `${result.surface_id}.json`),
+      artifactOutputPath(`schemas/${result.surface_id}.json`),
       result.snapshot,
     );
   }
-  await writeJson(path.join(schemaRoot, "index.json"), index);
-  await writeJson(
-    path.join(repoRoot, "public/metagraph/schema-drift.json"),
-    drift,
-  );
+  await writeJson(artifactOutputPath("schemas/index.json"), index);
+  await writeJson(artifactOutputPath("schema-drift.json"), drift);
 }
 
 console.log(
@@ -321,7 +316,7 @@ function normalizeSchema(value) {
 async function loadExistingSchemaIndex() {
   try {
     const index = JSON.parse(
-      await fs.readFile(path.join(schemaRoot, "index.json"), "utf8"),
+      await fs.readFile(artifactFilePath("schemas/index.json"), "utf8"),
     );
     return new Map(
       (index.schemas || [])

--- a/scripts/sync-summary.mjs
+++ b/scripts/sync-summary.mjs
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { artifactFilePath } from "./lib.mjs";
 
 const files = {
   subnets: "public/metagraph/subnets.json",
@@ -157,10 +158,17 @@ console.log(lines.join("\n"));
 
 function readWorktreeJson(file) {
   try {
-    return JSON.parse(readFileSync(file, "utf8"));
+    return JSON.parse(readFileSync(worktreePath(file), "utf8"));
   } catch {
     return null;
   }
+}
+
+function worktreePath(file) {
+  if (file.startsWith("public/metagraph/")) {
+    return artifactFilePath(file.replace(/^public\/metagraph\//, ""));
+  }
+  return file;
 }
 
 function readHeadJson(file) {

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -1,11 +1,10 @@
 import assert from "node:assert/strict";
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
-import { promises as fs } from "node:fs";
 import path from "node:path";
 import { API_ROUTES, compileRoutePattern } from "../src/contracts.mjs";
 import { handleRequest } from "../workers/api.mjs";
-import { readJson, repoRoot } from "./lib.mjs";
+import { createLocalArtifactEnv, readJson, repoRoot } from "./lib.mjs";
 
 const openapi = await readJson(
   path.join(repoRoot, "public/metagraph/openapi.json"),
@@ -18,31 +17,7 @@ const ajv = new Ajv2020({
 });
 addFormats(ajv);
 
-const env = {
-  ASSETS: {
-    async fetch(request) {
-      const url = new URL(request.url);
-      const filePath = path.join(
-        repoRoot,
-        "public",
-        url.pathname.replace(/^\/+/, ""),
-      );
-      try {
-        const body = await fs.readFile(filePath);
-        return new Response(body, {
-          status: 200,
-          headers: {
-            "content-type": filePath.endsWith(".json")
-              ? "application/json"
-              : "application/octet-stream",
-          },
-        });
-      } catch {
-        return new Response("not found", { status: 404 });
-      }
-    },
-  },
-};
+const env = createLocalArtifactEnv();
 
 const checks = [
   ["/api/v1", (body) => assert.equal(Array.isArray(body.data.routes), true)],

--- a/scripts/validate-artifact-budgets.mjs
+++ b/scripts/validate-artifact-budgets.mjs
@@ -2,8 +2,13 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import { evaluateArtifactBudgets } from "./artifact-budgets.mjs";
 import { repoRoot, sha256Hex } from "./lib.mjs";
+import {
+  R2_STAGING_RELATIVE_ROOT,
+  artifactStorageTierForRelativePath,
+} from "../src/artifact-storage.mjs";
 
 const artifactRoot = path.join(repoRoot, "public/metagraph");
+const r2ArtifactRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 const artifacts = [];
 
 await walk(artifactRoot, async (filePath) => {
@@ -13,9 +18,26 @@ await walk(artifactRoot, async (filePath) => {
   const relativePath = path
     .relative(artifactRoot, filePath)
     .replace(/\\/g, "/");
+  if (artifactStorageTierForRelativePath(relativePath) === "r2") {
+    return;
+  }
   if (["build-summary.json", "r2-manifest.json"].includes(relativePath)) {
     return;
   }
+  const raw = await fs.readFile(filePath);
+  artifacts.push({
+    path: relativePath,
+    sha256: sha256Hex(raw),
+    size_bytes: raw.byteLength,
+  });
+});
+await walk(r2ArtifactRoot, async (filePath) => {
+  if (!filePath.endsWith(".json")) {
+    return;
+  }
+  const relativePath = path
+    .relative(r2ArtifactRoot, filePath)
+    .replace(/\\/g, "/");
   const raw = await fs.readFile(filePath);
   artifacts.push({
     path: relativePath,

--- a/scripts/validate-openapi-examples.mjs
+++ b/scripts/validate-openapi-examples.mjs
@@ -7,7 +7,12 @@ import {
   artifactPathFromTemplate,
   CONTRACT_VERSION,
 } from "../src/contracts.mjs";
-import { readJson, repoRoot } from "./lib.mjs";
+import {
+  artifactDirectoryPath,
+  artifactFilePath,
+  readJson,
+  repoRoot,
+} from "./lib.mjs";
 
 const openapi = await readJson(
   path.join(repoRoot, "public/metagraph/openapi.json"),
@@ -25,7 +30,7 @@ const errors = [];
 for (const route of API_ROUTES) {
   const artifactPath = await exampleArtifactPath(route.artifact_path);
   const artifact = await readJson(
-    path.join(repoRoot, "public", artifactPath.replace(/^\/+/, "")),
+    artifactFilePath(artifactPath.replace(/^\/metagraph\//, "")),
   );
   const body = {
     ok: true,
@@ -75,9 +80,7 @@ console.log(
 
 async function exampleArtifactPath(template) {
   if (template.includes("{date}")) {
-    const files = await fs.readdir(
-      path.join(repoRoot, "public/metagraph/health/history"),
-    );
+    const files = await fs.readdir(artifactDirectoryPath("health/history"));
     const latest = files
       .filter((file) => /^\d{4}-\d{2}-\d{2}\.json$/.test(file))
       .sort()
@@ -100,12 +103,9 @@ async function exampleArtifactPath(template) {
 
 async function firstProviderSlug(template) {
   if (template.endsWith("/endpoints.json")) {
-    const providers = await fs.readdir(
-      path.join(repoRoot, "public/metagraph/providers"),
-      {
-        withFileTypes: true,
-      },
-    );
+    const providers = await fs.readdir(artifactDirectoryPath("providers"), {
+      withFileTypes: true,
+    });
     return providers
       .filter((entry) => entry.isDirectory())
       .map((entry) => entry.name)

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -1,5 +1,6 @@
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { PUBLIC_ARTIFACTS } from "../src/contracts.mjs";
 import {
@@ -11,6 +12,10 @@ import {
   readJson,
   repoRoot,
 } from "./lib.mjs";
+import {
+  R2_STAGING_RELATIVE_ROOT,
+  artifactStorageTierForPath,
+} from "../src/artifact-storage.mjs";
 
 const ajv = new Ajv2020({
   allErrors: true,
@@ -128,16 +133,22 @@ async function artifactValidationTargets() {
     }
 
     targets.push({
-      file_path: path.join(
-        repoRoot,
-        "public",
-        artifact.path.replace(/^\/+/, ""),
-      ),
+      file_path: artifactFilePath(artifact.path),
       label: artifact.id,
       schema_ref: artifact.schema_ref,
     });
   }
   return targets.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+function artifactFilePath(artifactPath) {
+  const relativePath = artifactPath.replace(/^\/metagraph\//, "");
+  const tier = artifactStorageTierForPath(artifactPath);
+  const r2Path = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT, relativePath);
+  if (tier === "r2" && existsSync(r2Path)) {
+    return r2Path;
+  }
+  return path.join(repoRoot, "public/metagraph", relativePath);
 }
 
 function templatedArtifactDirectory(artifactId) {
@@ -146,7 +157,16 @@ function templatedArtifactDirectory(artifactId) {
     ...slugArtifactDirectories(),
     "health-history": "health/history",
   };
-  return path.join(repoRoot, "public/metagraph", directories[artifactId]);
+  const relativeDir = directories[artifactId];
+  const template = PUBLIC_ARTIFACTS.find(
+    (artifact) => artifact.id === artifactId,
+  )?.path;
+  const tier = artifactStorageTierForPath(template || "");
+  const r2Dir = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT, relativeDir);
+  if (tier === "r2" && existsSync(r2Dir)) {
+    return r2Dir;
+  }
+  return path.join(repoRoot, "public/metagraph", relativeDir);
 }
 
 function netuidArtifactDirectories() {

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import {
@@ -16,6 +17,10 @@ import {
   slugify,
   stableStringify,
 } from "./lib.mjs";
+import {
+  R2_STAGING_RELATIVE_ROOT,
+  artifactStorageTierForRelativePath,
+} from "../src/artifact-storage.mjs";
 
 const providerKinds = new Set([
   "subnet-team",
@@ -682,97 +687,66 @@ function buildExpectedGeneratedSubnet(nativeSnapshot, overlay, candidateCount) {
   };
 }
 
+async function readArtifactJson(relativePath) {
+  return readJson(artifactPathForRelative(relativePath));
+}
+
+function artifactPath(relativePath) {
+  return artifactPathForRelative(relativePath);
+}
+
+function artifactPathForRelative(relativePath) {
+  const tier = artifactStorageTierForRelativePath(relativePath);
+  const r2Path = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT, relativePath);
+  if (tier === "r2" && existsSync(r2Path)) {
+    return r2Path;
+  }
+  return path.join(repoRoot, "public/metagraph", relativePath);
+}
+
 async function validateGeneratedArtifacts(
   nativeSnapshot,
   overlays,
   candidates,
 ) {
-  const providersArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/providers.json"),
+  const providersArtifact = await readArtifactJson("providers.json");
+  const subnetsArtifact = await readArtifactJson("subnets.json");
+  const surfacesArtifact = await readArtifactJson("surfaces.json");
+  const candidatesArtifact = await readArtifactJson("candidates.json");
+  const curationArtifact = await readArtifactJson("curation.json");
+  const gapsArtifact = await readArtifactJson("gaps.json");
+  const reviewQueueArtifact = await readArtifactJson("review-queue.json");
+  const verificationArtifact = await readArtifactJson(
+    "verification/latest.json",
   );
-  const subnetsArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/subnets.json"),
+  const coverageArtifact = await readArtifactJson("coverage.json");
+  const contractsArtifact = await readArtifactJson("contracts.json");
+  const apiIndexArtifact = await readArtifactJson("api-index.json");
+  const changelogArtifact = await readArtifactJson("changelog.json");
+  const searchArtifact = await readArtifactJson("search.json");
+  const freshnessArtifact = await readArtifactJson("freshness.json");
+  const sourceHealthArtifact = await readArtifactJson("source-health.json");
+  const sourceSnapshotsArtifact = await readArtifactJson(
+    "source-snapshots.json",
   );
-  const surfacesArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/surfaces.json"),
+  const evidenceLedgerArtifact = await readArtifactJson("evidence-ledger.json");
+  const healthArtifact = await readArtifactJson("health/latest.json");
+  const healthSummaryArtifact = await readArtifactJson("health/summary.json");
+  const rpcEndpointsArtifact = await readArtifactJson("rpc-endpoints.json");
+  const endpointsArtifact = await readArtifactJson("endpoints.json");
+  const endpointPoolsArtifact = await readArtifactJson("rpc/pools.json");
+  const r2ManifestArtifact = await readArtifactJson("r2-manifest.json");
+  const schemaDriftArtifact = await readArtifactJson("schema-drift.json");
+  const schemaIndexArtifact = await readArtifactJson("schemas/index.json");
+  const reviewCurationArtifact = await readArtifactJson("review/curation.json");
+  const reviewGapPrioritiesArtifact = await readArtifactJson(
+    "review/gap-priorities.json",
   );
-  const candidatesArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/candidates.json"),
+  const reviewAdapterCandidatesArtifact = await readArtifactJson(
+    "review/adapter-candidates.json",
   );
-  const curationArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/curation.json"),
-  );
-  const gapsArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/gaps.json"),
-  );
-  const reviewQueueArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/review-queue.json"),
-  );
-  const verificationArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/verification/latest.json"),
-  );
-  const coverageArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/coverage.json"),
-  );
-  const contractsArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/contracts.json"),
-  );
-  const apiIndexArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/api-index.json"),
-  );
-  const changelogArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/changelog.json"),
-  );
-  const searchArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/search.json"),
-  );
-  const freshnessArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/freshness.json"),
-  );
-  const sourceHealthArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/source-health.json"),
-  );
-  const sourceSnapshotsArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/source-snapshots.json"),
-  );
-  const evidenceLedgerArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/evidence-ledger.json"),
-  );
-  const healthArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/health/latest.json"),
-  );
-  const healthSummaryArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/health/summary.json"),
-  );
-  const rpcEndpointsArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/rpc-endpoints.json"),
-  );
-  const endpointsArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/endpoints.json"),
-  );
-  const endpointPoolsArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/rpc/pools.json"),
-  );
-  const r2ManifestArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/r2-manifest.json"),
-  );
-  const schemaDriftArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/schema-drift.json"),
-  );
-  const schemaIndexArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/schemas/index.json"),
-  );
-  const reviewCurationArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/review/curation.json"),
-  );
-  const reviewGapPrioritiesArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/review/gap-priorities.json"),
-  );
-  const reviewAdapterCandidatesArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/review/adapter-candidates.json"),
-  );
-  const reviewDecisionsArtifact = await readJson(
-    path.join(repoRoot, "public/metagraph/review/maintainer-decisions.json"),
+  const reviewDecisionsArtifact = await readArtifactJson(
+    "review/maintainer-decisions.json",
   );
 
   for (const [artifactName, artifact] of [
@@ -833,10 +807,7 @@ async function validateGeneratedArtifacts(
       subnet.coverage_level !== "native-only",
       `generated:${subnet.netuid}: active subnet must be curated`,
     );
-    const detailPath = path.join(
-      repoRoot,
-      `public/metagraph/subnets/${subnet.netuid}.json`,
-    );
+    const detailPath = artifactPath(`subnets/${subnet.netuid}.json`);
     try {
       const detailArtifact = await readJson(detailPath);
       const subnetCandidates = candidatesByNetuid.get(subnet.netuid) || [];
@@ -1128,11 +1099,11 @@ async function validateGeneratedArtifacts(
 
   for (const netuid of nativeNetuids) {
     for (const artifactPath of [
-      `public/metagraph/health/subnets/${netuid}.json`,
-      `public/metagraph/health/badges/${netuid}.json`,
+      `health/subnets/${netuid}.json`,
+      `health/badges/${netuid}.json`,
     ]) {
       try {
-        await fs.access(path.join(repoRoot, artifactPath));
+        await fs.access(artifactPathForRelative(artifactPath));
       } catch {
         assert(false, `${artifactPath}: missing health artifact`);
       }

--- a/scripts/worker-test.mjs
+++ b/scripts/worker-test.mjs
@@ -1,34 +1,8 @@
 import assert from "node:assert/strict";
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import { handleRequest } from "../workers/api.mjs";
-import { repoRoot } from "./lib.mjs";
+import { createLocalArtifactEnv } from "./lib.mjs";
 
-const env = {
-  ASSETS: {
-    async fetch(request) {
-      const url = new URL(request.url);
-      const filePath = path.join(
-        repoRoot,
-        "public",
-        url.pathname.replace(/^\/+/, ""),
-      );
-      try {
-        const body = await fs.readFile(filePath);
-        return new Response(body, {
-          status: 200,
-          headers: {
-            "content-type": filePath.endsWith(".json")
-              ? "application/json"
-              : "application/octet-stream",
-          },
-        });
-      } catch {
-        return new Response("not found", { status: 404 });
-      }
-    },
-  },
-};
+const env = createLocalArtifactEnv();
 
 const head = await handleRequest(
   new Request("https://metagraph.sh/api/v1/subnets", { method: "HEAD" }),

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -1,0 +1,84 @@
+export const ARTIFACT_STORAGE_TIERS = {
+  dual: "dual",
+  git: "git",
+  r2: "r2",
+};
+
+export const R2_STAGING_RELATIVE_ROOT = "dist/metagraph-r2/metagraph";
+
+const R2_ONLY_PATTERNS = [
+  /^adapters\/[^/]+\.json$/,
+  /^candidates\/(?:\d+|\{netuid\})\.json$/,
+  /^endpoints\/(?:\d+|\{netuid\})\.json$/,
+  /^health\/badges\/(?:\d+|\{netuid\})\.json$/,
+  /^health\/history\/(?:\d{4}-\d{2}-\d{2}|\{date\})\.json$/,
+  /^health\/latest\.json$/,
+  /^health\/subnets\/(?:\d+|\{netuid\})\.json$/,
+  /^metagraph\/latest\.json$/,
+  /^providers\/[^/]+\.json$/,
+  /^providers\/[^/]+\/endpoints\.json$/,
+  /^schemas\/(?!index\.json$).+\.json$/,
+  /^source-snapshots\.json$/,
+  /^subnets\/(?:\d+|\{netuid\})\.json$/,
+  /^surfaces\/(?:\d+|\{netuid\})\.json$/,
+  /^verification\/latest\.json$/,
+  /^verification\/subnets\/(?:\d+|\{netuid\})\.json$/,
+];
+
+const DUAL_PATTERNS = [
+  /^api-index\.json$/,
+  /^build-summary\.json$/,
+  /^changelog\.json$/,
+  /^contracts\.json$/,
+  /^coverage\.json$/,
+  /^curation\.json$/,
+  /^endpoint-incidents\.json$/,
+  /^endpoint-pools\.json$/,
+  /^endpoints\.json$/,
+  /^evidence-ledger\.json$/,
+  /^freshness\.json$/,
+  /^gaps\.json$/,
+  /^health\/summary\.json$/,
+  /^openapi\.json$/,
+  /^providers\.json$/,
+  /^r2-manifest\.json$/,
+  /^review\/adapter-candidates\.json$/,
+  /^review\/curation\.json$/,
+  /^review\/gap-priorities\.json$/,
+  /^review\/maintainer-decisions\.json$/,
+  /^review-queue\.json$/,
+  /^rpc\/pools\.json$/,
+  /^rpc-endpoints\.json$/,
+  /^schema-drift\.json$/,
+  /^schemas\/index\.json$/,
+  /^search\.json$/,
+  /^source-health\.json$/,
+  /^subnets\.json$/,
+  /^surfaces\.json$/,
+  /^types\.d\.ts$/,
+];
+
+export function artifactRelativePath(artifactPath = "") {
+  return String(artifactPath)
+    .replace(/^\/+/, "")
+    .replace(/^metagraph\//, "");
+}
+
+export function artifactStorageTierForRelativePath(relativePath = "") {
+  const normalized = artifactRelativePath(relativePath);
+  if (R2_ONLY_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return ARTIFACT_STORAGE_TIERS.r2;
+  }
+  if (DUAL_PATTERNS.some((pattern) => pattern.test(normalized))) {
+    return ARTIFACT_STORAGE_TIERS.dual;
+  }
+  return ARTIFACT_STORAGE_TIERS.git;
+}
+
+export function artifactStorageTierForPath(artifactPath = "") {
+  return artifactStorageTierForRelativePath(artifactRelativePath(artifactPath));
+}
+
+export function isR2OnlyArtifactPath(artifactPath = "") {
+  return artifactStorageTierForPath(artifactPath) === ARTIFACT_STORAGE_TIERS.r2;
+}

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1,3 +1,5 @@
+import { artifactStorageTierForPath } from "./artifact-storage.mjs";
+
 export const CONTRACT_VERSION = "2026-06-06.1";
 export const SCHEMA_VERSION = 1;
 export const PRIMARY_DOMAIN = "metagraph.sh";
@@ -907,6 +909,7 @@ export function buildContractsArtifact(generatedAt) {
         ? `#/components/schemas/${entry.schema_ref}`
         : null,
       contract_version: CONTRACT_VERSION,
+      storage_tier: entry.storage_tier,
     })),
   };
 }
@@ -945,6 +948,7 @@ export function buildApiIndexArtifact(generatedAt, contractsArtifact) {
       path: entry.path,
       contract_version: entry.contract_version,
       schema_ref: entry.schema_ref,
+      storage_tier: entry.storage_tier,
     })),
   };
 }
@@ -1111,6 +1115,7 @@ function artifact(id, pathValue, description, schemaRef) {
     path: pathValue,
     description,
     schema_ref: schemaRef,
+    storage_tier: artifactStorageTierForPath(pathValue),
   };
 }
 

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { test } from "vitest";
+import { artifactFilePath, createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
 function runNode(script) {
@@ -17,7 +18,7 @@ test("registry validates", () => {
 });
 
 test("registry validation rejects tampered per-subnet artifacts", () => {
-  const artifactPath = "public/metagraph/subnets/0.json";
+  const artifactPath = artifactFilePath("subnets/0.json");
   const original = readFileSync(artifactPath, "utf8");
   const tampered = JSON.parse(original);
   tampered.phishing_url = "https://example.invalid/phish";
@@ -43,103 +44,39 @@ test("public artifacts are internally consistent", () => {
   const native = JSON.parse(
     readFileSync("registry/native/finney-subnets.json", "utf8"),
   );
-  const subnets = JSON.parse(
-    readFileSync("public/metagraph/subnets.json", "utf8"),
-  );
-  const surfaces = JSON.parse(
-    readFileSync("public/metagraph/surfaces.json", "utf8"),
-  );
-  const candidates = JSON.parse(
-    readFileSync("public/metagraph/candidates.json", "utf8"),
-  );
-  const curation = JSON.parse(
-    readFileSync("public/metagraph/curation.json", "utf8"),
-  );
-  const gaps = JSON.parse(readFileSync("public/metagraph/gaps.json", "utf8"));
-  const reviewQueue = JSON.parse(
-    readFileSync("public/metagraph/review-queue.json", "utf8"),
-  );
-  const verification = JSON.parse(
-    readFileSync("public/metagraph/verification/latest.json", "utf8"),
-  );
-  const health = JSON.parse(
-    readFileSync("public/metagraph/health/latest.json", "utf8"),
-  );
-  const healthSummary = JSON.parse(
-    readFileSync("public/metagraph/health/summary.json", "utf8"),
-  );
-  const healthHistory = JSON.parse(
-    readFileSync("public/metagraph/health/history/2026-06-06.json", "utf8"),
-  );
-  const rpcEndpoints = JSON.parse(
-    readFileSync("public/metagraph/rpc-endpoints.json", "utf8"),
-  );
-  const endpoints = JSON.parse(
-    readFileSync("public/metagraph/endpoints.json", "utf8"),
-  );
-  const subnetEndpoints = JSON.parse(
-    readFileSync("public/metagraph/endpoints/7.json", "utf8"),
-  );
-  const coverage = JSON.parse(
-    readFileSync("public/metagraph/coverage.json", "utf8"),
-  );
-  const contracts = JSON.parse(
-    readFileSync("public/metagraph/contracts.json", "utf8"),
-  );
-  const apiIndex = JSON.parse(
-    readFileSync("public/metagraph/api-index.json", "utf8"),
-  );
-  const changelog = JSON.parse(
-    readFileSync("public/metagraph/changelog.json", "utf8"),
-  );
-  const search = JSON.parse(
-    readFileSync("public/metagraph/search.json", "utf8"),
-  );
-  const freshness = JSON.parse(
-    readFileSync("public/metagraph/freshness.json", "utf8"),
-  );
-  const sourceHealth = JSON.parse(
-    readFileSync("public/metagraph/source-health.json", "utf8"),
-  );
-  const sourceSnapshots = JSON.parse(
-    readFileSync("public/metagraph/source-snapshots.json", "utf8"),
-  );
-  const evidenceLedger = JSON.parse(
-    readFileSync("public/metagraph/evidence-ledger.json", "utf8"),
-  );
-  const endpointPools = JSON.parse(
-    readFileSync("public/metagraph/endpoint-pools.json", "utf8"),
-  );
-  const endpointIncidents = JSON.parse(
-    readFileSync("public/metagraph/endpoint-incidents.json", "utf8"),
-  );
-  const rpcEndpointPools = JSON.parse(
-    readFileSync("public/metagraph/rpc/pools.json", "utf8"),
-  );
-  const providerEndpoints = JSON.parse(
-    readFileSync("public/metagraph/providers/allways/endpoints.json", "utf8"),
-  );
-  const r2Manifest = JSON.parse(
-    readFileSync("public/metagraph/r2-manifest.json", "utf8"),
-  );
-  const schemaDrift = JSON.parse(
-    readFileSync("public/metagraph/schema-drift.json", "utf8"),
-  );
-  const schemaIndex = JSON.parse(
-    readFileSync("public/metagraph/schemas/index.json", "utf8"),
-  );
-  const reviewCuration = JSON.parse(
-    readFileSync("public/metagraph/review/curation.json", "utf8"),
-  );
-  const gapPriorities = JSON.parse(
-    readFileSync("public/metagraph/review/gap-priorities.json", "utf8"),
-  );
-  const adapterCandidates = JSON.parse(
-    readFileSync("public/metagraph/review/adapter-candidates.json", "utf8"),
-  );
-  const reviewDecisions = JSON.parse(
-    readFileSync("public/metagraph/review/maintainer-decisions.json", "utf8"),
-  );
+  const subnets = readArtifact("subnets.json");
+  const surfaces = readArtifact("surfaces.json");
+  const candidates = readArtifact("candidates.json");
+  const curation = readArtifact("curation.json");
+  const gaps = readArtifact("gaps.json");
+  const reviewQueue = readArtifact("review-queue.json");
+  const verification = readArtifact("verification/latest.json");
+  const health = readArtifact("health/latest.json");
+  const healthSummary = readArtifact("health/summary.json");
+  const healthHistory = readArtifact("health/history/2026-06-06.json");
+  const rpcEndpoints = readArtifact("rpc-endpoints.json");
+  const endpoints = readArtifact("endpoints.json");
+  const subnetEndpoints = readArtifact("endpoints/7.json");
+  const coverage = readArtifact("coverage.json");
+  const contracts = readArtifact("contracts.json");
+  const apiIndex = readArtifact("api-index.json");
+  const changelog = readArtifact("changelog.json");
+  const search = readArtifact("search.json");
+  const freshness = readArtifact("freshness.json");
+  const sourceHealth = readArtifact("source-health.json");
+  const sourceSnapshots = readArtifact("source-snapshots.json");
+  const evidenceLedger = readArtifact("evidence-ledger.json");
+  const endpointPools = readArtifact("endpoint-pools.json");
+  const endpointIncidents = readArtifact("endpoint-incidents.json");
+  const rpcEndpointPools = readArtifact("rpc/pools.json");
+  const providerEndpoints = readArtifact("providers/allways/endpoints.json");
+  const r2Manifest = readArtifact("r2-manifest.json");
+  const schemaDrift = readArtifact("schema-drift.json");
+  const schemaIndex = readArtifact("schemas/index.json");
+  const reviewCuration = readArtifact("review/curation.json");
+  const gapPriorities = readArtifact("review/gap-priorities.json");
+  const adapterCandidates = readArtifact("review/adapter-candidates.json");
+  const reviewDecisions = readArtifact("review/maintainer-decisions.json");
 
   assert.equal(subnets.subnets.length, native.subnets.length);
   assert.equal(surfaces.surfaces.length, coverage.surface_count);
@@ -326,19 +263,19 @@ test("public artifacts are internally consistent", () => {
 
   for (const subnet of native.subnets) {
     assert.equal(
-      existsSync(`public/metagraph/subnets/${subnet.netuid}.json`),
+      existsSync(artifactFilePath(`subnets/${subnet.netuid}.json`)),
       true,
     );
     assert.equal(
-      existsSync(`public/metagraph/health/subnets/${subnet.netuid}.json`),
+      existsSync(artifactFilePath(`health/subnets/${subnet.netuid}.json`)),
       true,
     );
     assert.equal(
-      existsSync(`public/metagraph/health/badges/${subnet.netuid}.json`),
+      existsSync(artifactFilePath(`health/badges/${subnet.netuid}.json`)),
       true,
     );
     assert.equal(
-      existsSync(`public/metagraph/endpoints/${subnet.netuid}.json`),
+      existsSync(artifactFilePath(`endpoints/${subnet.netuid}.json`)),
       true,
     );
   }
@@ -367,23 +304,7 @@ test("limited R2 upload dry run skips control manifests", () => {
 });
 
 test("Worker API serves public artifact envelopes", async () => {
-  const env = {
-    ASSETS: {
-      async fetch(request) {
-        const url = new URL(request.url);
-        const path = `public${url.pathname}`;
-        if (!existsSync(path)) {
-          return new Response("not found", { status: 404 });
-        }
-        return new Response(readFileSync(path), {
-          status: 200,
-          headers: {
-            "content-type": "application/json",
-          },
-        });
-      },
-    },
-  };
+  const env = createLocalArtifactEnv();
 
   const response = await handleRequest(
     new Request("https://metagraph.sh/api/v1/subnets/7"),
@@ -400,3 +321,7 @@ test("Worker API serves public artifact envelopes", async () => {
   assert.equal(body.ok, true);
   assert.equal(body.data.subnet.netuid, 7);
 });
+
+function readArtifact(relativePath) {
+  return JSON.parse(readFileSync(artifactFilePath(relativePath), "utf8"));
+}

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { mkdtemp, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { describe, test } from "vitest";
@@ -14,6 +15,9 @@ import {
   buildRpcEndpointArtifact,
   buildTimestamp,
   classifyNativeName,
+  artifactFilePath,
+  artifactOutputPath,
+  createLocalArtifactEnv,
   flattenSurfaces,
   hashJson,
   isCredentialedUrl,
@@ -39,6 +43,13 @@ import {
   stableStringify,
   writeJson,
 } from "../scripts/lib.mjs";
+import {
+  ARTIFACT_STORAGE_TIERS,
+  artifactRelativePath,
+  artifactStorageTierForPath,
+  artifactStorageTierForRelativePath,
+  isR2OnlyArtifactPath,
+} from "../src/artifact-storage.mjs";
 import { buildCanonicalOpenApiArtifact } from "../scripts/openapi-components.mjs";
 import {
   buildIssueIntakeReport,
@@ -95,6 +106,85 @@ describe("script utility contracts", () => {
       );
     } finally {
       await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("classifies artifact storage tiers for files and route templates", async () => {
+    assert.equal(
+      artifactRelativePath("/metagraph/subnets/7.json"),
+      "subnets/7.json",
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("subnets/{netuid}.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForPath("/metagraph/health/history/{date}.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("schemas/index.json"),
+      ARTIFACT_STORAGE_TIERS.dual,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("schemas/allways-swagger.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForRelativePath("robots.txt"),
+      ARTIFACT_STORAGE_TIERS.git,
+    );
+    assert.equal(
+      isR2OnlyArtifactPath("/metagraph/verification/latest.json"),
+      true,
+    );
+    assert.equal(isR2OnlyArtifactPath("/metagraph/contracts.json"), false);
+
+    const stagedPath = artifactOutputPath("health/history/2099-01-01.json");
+    try {
+      await writeJson(stagedPath, {
+        schema_version: 1,
+        generated_at: "1970-01-01T00:00:00.000Z",
+        date: "2099-01-01",
+        surfaces: [],
+      });
+      assert.equal(existsSync(stagedPath), true);
+      assert.equal(
+        artifactFilePath("health/history/2099-01-01.json"),
+        stagedPath,
+      );
+      const env = createLocalArtifactEnv();
+      const object = await env.METAGRAPH_ARCHIVE.get(
+        "latest/health/history/2099-01-01.json",
+      );
+      assert.deepEqual(await object.json(), {
+        schema_version: 1,
+        generated_at: "1970-01-01T00:00:00.000Z",
+        date: "2099-01-01",
+        surfaces: [],
+      });
+      assert.equal(
+        await env.METAGRAPH_ARCHIVE.get(
+          "latest/health/history/2099-01-02.json",
+        ),
+        null,
+      );
+      assert.equal(
+        (
+          await env.ASSETS.fetch(
+            new Request("https://assets.local/metagraph/contracts.json"),
+          )
+        ).status,
+        200,
+      );
+      assert.equal(
+        (await readFile(artifactFilePath("contracts.json"), "utf8")).includes(
+          "metagraph.sh",
+        ),
+        true,
+      );
+    } finally {
+      await rm(path.dirname(stagedPath), { recursive: true, force: true });
     }
   });
 
@@ -283,6 +373,25 @@ describe("script utility contracts", () => {
             public_safe: true,
             probe: { enabled: true, method: "chain_getHeader" },
           },
+          {
+            id: "root-degraded-rpc",
+            kind: "subtensor-rpc",
+            url: "https://degraded.example.com",
+            provider: "degraded",
+            authority: "provider-claimed",
+            auth_required: false,
+            public_safe: true,
+            probe: { enabled: true, method: "chain_getHeader" },
+          },
+          {
+            id: "root-private-api",
+            kind: "subnet-api",
+            url: "https://private.example.com",
+            provider: "private",
+            authority: "provider-claimed",
+            auth_required: false,
+            public_safe: false,
+          },
         ],
       },
     ]);
@@ -313,13 +422,20 @@ describe("script utility contracts", () => {
           classification: "dead",
           latency_ms: null,
         },
+        {
+          surface_id: "root-degraded-rpc",
+          status: "degraded",
+          classification: "rate-limited",
+          latency_ms: 1500,
+          methods_supported: ["chain_getHeader"],
+        },
       ],
       generatedAt: "1970-01-01T00:00:00.000Z",
       contractVersion: "test",
       source: "fixture",
     });
 
-    assert.equal(rpc.summary.endpoint_count, 3);
+    assert.equal(rpc.summary.endpoint_count, 4);
     assert.equal(rpc.summary.archive_supported_count, 1);
     assert.equal(rpc.endpoints[0].method_tested, "chain_getHeader");
 
@@ -344,12 +460,20 @@ describe("script utility contracts", () => {
           error: "connection refused",
           verified_at: "1970-01-01T00:00:00.000Z",
         },
+        {
+          surface_id: "root-degraded-rpc",
+          status: "degraded",
+          classification: "rate-limited",
+          latency_ms: 1500,
+          methods_supported: ["chain_getHeader"],
+          verified_at: "1970-01-01T00:00:00.000Z",
+        },
       ],
       generatedAt: "1970-01-01T00:00:00.000Z",
       contractVersion: "test",
       source: "fixture",
     });
-    assert.equal(endpointResources.summary.endpoint_count, 5);
+    assert.equal(endpointResources.summary.endpoint_count, 7);
     assert.equal(
       endpointResources.endpoints.find(
         (endpoint) => endpoint.surface_id === "root-docs",
@@ -378,6 +502,18 @@ describe("script utility contracts", () => {
       endpointResources.endpoints.find(
         (endpoint) => endpoint.surface_id === "root-rpc",
       ).score_reasons.length > 0,
+      true,
+    );
+    assert.equal(
+      endpointResources.endpoints.find(
+        (endpoint) => endpoint.surface_id === "root-private-api",
+      ).publication_state,
+      "disabled",
+    );
+    assert.equal(
+      endpointResources.endpoints
+        .find((endpoint) => endpoint.surface_id === "root-private-api")
+        .pool_eligibility_reasons.includes("not-public-safe"),
       true,
     );
 
@@ -413,18 +549,36 @@ describe("script utility contracts", () => {
         ),
       true,
     );
+    const generalizedPools = buildEndpointPoolArtifact({
+      generatedAt: "1970-01-01T00:00:00.000Z",
+      contractVersion: "test",
+      endpointArtifact: endpointResources,
+    });
+    assert.equal(generalizedPools.source, "endpoint-resource-probes");
+    assert.equal(
+      generalizedPools.provider_scores.some(
+        (provider) => provider.provider === "degraded",
+      ),
+      true,
+    );
 
     const incidents = buildEndpointIncidentArtifact({
       endpointArtifact: endpointResources,
       generatedAt: "1970-01-01T00:00:00.000Z",
       contractVersion: "test",
     });
-    assert.equal(incidents.summary.incident_count, 1);
+    assert.equal(incidents.summary.incident_count, 2);
     assert.equal(
       incidents.incidents[0].endpoint_id,
       "endpoint-root-failed-rpc",
     );
     assert.equal(incidents.incidents[0].severity, "critical");
+    assert.equal(
+      incidents.incidents.find(
+        (incident) => incident.endpoint_id === "endpoint-root-degraded-rpc",
+      ).severity,
+      "warning",
+    );
     assert.equal(incidents.incidents[0].user_reported, false);
     assert.equal(incidents.incidents[0].source, "probe-derived");
   });

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1,34 +1,9 @@
 import assert from "node:assert/strict";
-import { promises as fs } from "node:fs";
-import path from "node:path";
 import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import worker, { handleRequest } from "../workers/api.mjs";
 
-const env = {
-  ASSETS: {
-    async fetch(request) {
-      const url = new URL(request.url);
-      const filePath = path.join(
-        process.cwd(),
-        "public",
-        url.pathname.replace(/^\/+/, ""),
-      );
-      try {
-        const body = await fs.readFile(filePath);
-        return new Response(body, {
-          status: 200,
-          headers: {
-            "content-type": filePath.endsWith(".json")
-              ? "application/json"
-              : "application/octet-stream",
-          },
-        });
-      } catch {
-        return new Response("not found", { status: 404 });
-      }
-    },
-  },
-};
+const env = createLocalArtifactEnv();
 
 describe("Worker runtime", () => {
   test("default export delegates to handleRequest", async () => {
@@ -55,6 +30,36 @@ describe("Worker runtime", () => {
     const body = await response.json();
     assert.equal(body.ok, true);
     assert.equal(body.data.subnet.netuid, 7);
+  });
+
+  test("serves raw R2-tier artifacts from archive storage", async () => {
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/subnets/7.json"),
+      env,
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-metagraph-artifact-source"), "r2");
+    assert.equal(response.headers.get("x-metagraph-storage-tier"), "r2");
+    assert.equal((await response.json()).subnet.netuid, 7);
+
+    const missingArchive = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/subnets/7.json"),
+      {
+        ASSETS: env.ASSETS,
+      },
+      {},
+    );
+    assert.equal(missingArchive.status, 404);
+    assert.equal(
+      (await missingArchive.json()).error.code,
+      "r2_binding_missing",
+    );
+
+    const assetMissing = await env.ASSETS.fetch(
+      new Request("https://assets.local/metagraph/nope.json"),
+    );
+    assert.equal(assetMissing.status, 404);
   });
 
   test("supports HEAD, ETag revalidation, and CORS preflight", async () => {
@@ -474,6 +479,8 @@ describe("Worker runtime", () => {
 
     try {
       const unsafeOnlyCases = [
+        null,
+        "http://bittensor-finney.api.onfinality.io/public",
         "https://localhost/internal",
         "https://metadata.localhost/internal",
         "https://bittensor-finney.api.onfinality.io.evil.example/public",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -6,6 +6,10 @@ import {
   artifactPathFromTemplate,
   compileRoutePattern,
 } from "../src/contracts.mjs";
+import {
+  artifactStorageTierForPath,
+  ARTIFACT_STORAGE_TIERS,
+} from "../src/artifact-storage.mjs";
 
 const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
 
@@ -74,6 +78,13 @@ export async function handleRequest(request, env = {}, _ctx = {}) {
     return handleApiRequest(request, env, url);
   }
 
+  if (
+    url.pathname.startsWith("/metagraph/") &&
+    url.pathname.endsWith(".json")
+  ) {
+    return handleRawArtifactRequest(request, env, url);
+  }
+
   if (env.ASSETS?.fetch) {
     return env.ASSETS.fetch(request);
   }
@@ -83,6 +94,28 @@ export async function handleRequest(request, env = {}, _ctx = {}) {
     "No static asset binding is configured for this route.",
     404,
   );
+}
+
+async function handleRawArtifactRequest(request, env, url) {
+  const artifact = await readArtifact(env, url.pathname);
+  if (!artifact.ok) {
+    return errorResponse(artifact.code, artifact.message, artifact.status, {
+      artifact_path: url.pathname,
+    });
+  }
+  const body = JSON.stringify(artifact.data);
+  const headers = apiHeaders("standard");
+  headers.set("content-type", JSON_CONTENT_TYPE);
+  headers.set("x-metagraph-artifact-source", artifact.source);
+  headers.set("x-metagraph-storage-tier", artifact.storage_tier);
+  headers.set("etag", await weakEtag(body));
+  if (request.headers.get("if-none-match") === headers.get("etag")) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
 }
 
 async function handleApiRequest(request, env, url) {
@@ -278,12 +311,22 @@ function matchRoute(pathname) {
 }
 
 async function readArtifact(env, artifactPath) {
-  const asset = await readAsset(env, artifactPath);
+  const storageTier = artifactStorageTierForPath(artifactPath);
+
+  if (storageTier === ARTIFACT_STORAGE_TIERS.r2) {
+    const r2 = await readR2(env, artifactPath, storageTier);
+    if (r2.ok || env.METAGRAPH_ALLOW_R2_STATIC_FALLBACK !== "true") {
+      return r2;
+    }
+    return readAsset(env, artifactPath, storageTier);
+  }
+
+  const asset = await readAsset(env, artifactPath, storageTier);
   if (asset.ok) {
     return asset;
   }
 
-  const r2 = await readR2(env, artifactPath);
+  const r2 = await readR2(env, artifactPath, storageTier);
   if (r2.ok) {
     return r2;
   }
@@ -291,7 +334,7 @@ async function readArtifact(env, artifactPath) {
   return asset.status !== 404 ? asset : r2;
 }
 
-async function readAsset(env, artifactPath) {
+async function readAsset(env, artifactPath, storageTier) {
   if (!env.ASSETS?.fetch) {
     return {
       ok: false,
@@ -318,10 +361,11 @@ async function readAsset(env, artifactPath) {
     ok: true,
     data: await response.json(),
     source: "static-assets",
+    storage_tier: storageTier,
   };
 }
 
-async function readR2(env, artifactPath) {
+async function readR2(env, artifactPath, storageTier) {
   if (!env.METAGRAPH_ARCHIVE?.get) {
     return {
       ok: false,
@@ -346,6 +390,7 @@ async function readR2(env, artifactPath) {
     ok: true,
     data: await object.json(),
     source: "r2",
+    storage_tier: storageTier,
   };
 }
 


### PR DESCRIPTION
## Summary
- split generated artifacts into compact Git-reviewed outputs and volatile R2-staged detail outputs
- add storage-tier metadata to artifact contracts, manifests, OpenAPI handoff data, and Worker artifact loading
- update validators, tests, smoke probes, docs, and R2 upload/download tooling to resolve artifacts through the shared storage-tier map

## What changed
- added a shared artifact storage-tier resolver for `dual`, `git`, and `r2` artifacts
- writes high-churn per-subnet/detail artifacts to ignored R2 staging instead of tracked `public/metagraph` detail paths
- keeps existing `/metagraph/*` and `/api/v1/*` public route contracts stable
- makes Worker read R2-tier artifacts from R2 first, with static fallback only behind an explicit migration/test flag
- updates schema contracts and generated OpenAPI/types with `storage_tier` metadata
- adds test coverage for storage-tier classification, local R2-backed Worker reads, and endpoint pool edge cases

## Why
- registry refreshes were producing hundreds of generated detail-file changes, which made PRs hard to review
- R2 should carry volatile operational detail while Git keeps reviewed inputs, compact indexes, and release manifests

## Validation
- `npm run check`
- `npm run test:coverage`
- `npm run r2:upload:dry-run`
- `npm run scan:public-safety`
- `git diff --check`

## Notes
- No public API paths are removed or renamed.
- The branch stages 936 R2 detail files locally during build, but they are ignored and not committed.
- Follow-up registry refresh work should happen in a separate data PR after this storage split lands.