### PR TITLE
fix(health): avoid trusting committed probe artifacts

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -85,9 +85,7 @@ const previousSubnetsArtifact = await readOptionalJson(
 const previousCoverageArtifact = await readOptionalJson(
   path.join(outputRoot, "coverage.json"),
 );
-const previousHealthArtifact =
-  (await readOptionalJson(path.join(r2OutputRoot, "health/latest.json"))) ||
-  (await readOptionalJson(path.join(outputRoot, "health/latest.json")));
+const previousHealthArtifact = await loadPreviousHealthArtifact();
 
 await fs.rm(r2OutputRoot, { recursive: true, force: true });
 
@@ -139,14 +137,12 @@ const healthArtifacts = buildHealthArtifacts(
   mergedSubnets,
   {
     generatedAt,
-    notes:
-      "Health rows preserve matching live probe results when available. Run npm run probes:smoke with METAGRAPH_WRITE_PROBE_RESULTS=1 to refresh observed status.",
+    notes: previousHealthArtifact
+      ? "Health rows preserve matching live probe results from the local probe-result cache. Run npm run probes:smoke with METAGRAPH_WRITE_PROBE_RESULTS=1 to refresh observed status."
+      : "Run npm run probes:smoke with METAGRAPH_WRITE_PROBE_RESULTS=1 to replace unknown build-time health with live probe results.",
     probeFinishedAt: previousHealthArtifact?.probe_finished_at || null,
     probeStartedAt: previousHealthArtifact?.probe_started_at || null,
-    source:
-      previousHealthArtifact?.source === "live-smoke-probe"
-        ? "live-smoke-probe"
-        : "artifact-build",
+    source: previousHealthArtifact ? "live-smoke-probe" : "artifact-build",
   },
 );
 const rpcEndpoints = buildRpcEndpointArtifact({
@@ -826,6 +822,13 @@ function groupByNetuid(items) {
     groups.set(item.netuid, group);
   }
   return groups;
+}
+
+async function loadPreviousHealthArtifact() {
+  const artifact = await readOptionalJson(
+    path.join(repoRoot, ".cache/metagraphed/health/latest.json"),
+  );
+  return artifact?.source === "live-smoke-probe" ? artifact : null;
 }
 
 function buildSurfaceHealthRows({ surfaces, previousHealthArtifact }) {

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -671,6 +671,10 @@ if (process.env.METAGRAPH_WRITE_PROBE_RESULTS === "1") {
     contractVersion,
     source: "live-smoke-probe",
   });
+  await writeJson(
+    path.join(repoRoot, ".cache/metagraphed/health/latest.json"),
+    artifact.latest,
+  );
   await writeJson(artifactOutputPath("health/latest.json"), artifact.latest);
   await writeJson(artifactOutputPath("health/summary.json"), artifact.summary);
   await writeJson(

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1,6 +1,12 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { test } from "vitest";
 import {
   artifactDirectoryPath,
@@ -43,6 +49,63 @@ test("registry validation rejects tampered per-subnet artifacts", () => {
     /per-subnet detail artifact is not reproducible from registry inputs/,
   );
 });
+
+test("artifact build ignores forged committed health observations by default", () => {
+  const artifactPath = artifactFilePath("health/latest.json");
+  const cachePath = ".cache/metagraphed/health/latest.json";
+  const original = readFileSync(artifactPath, "utf8");
+  const originalCache = existsSync(cachePath)
+    ? readFileSync(cachePath, "utf8")
+    : null;
+  rmSync(cachePath, { force: true });
+  const tampered = JSON.parse(original);
+  const target = tampered.surfaces.find((surface) => surface.public_safe === true);
+  assert(target, "expected a public-safe health row to tamper");
+
+  tampered.source = "live-smoke-probe";
+  tampered.generated_at = "2999-01-01T00:00:00.000Z";
+  target.status = "ok";
+  target.classification = "live";
+  target.last_checked = "2999-01-01T00:00:00.000Z";
+  target.last_ok = "2999-01-01T00:00:00.000Z";
+  target.verified_at = "2999-01-01T00:00:00.000Z";
+  target.latency_ms = 7;
+  target.status_code = 200;
+  target.method_results = { forged_probe: { status: "ok" } };
+
+  try {
+    writeFileSync(artifactPath, `${JSON.stringify(tampered, null, 2)}\n`);
+    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+
+    const rebuilt = JSON.parse(readFileSync(artifactPath, "utf8"));
+    const rebuiltTarget = rebuilt.surfaces.find(
+      (surface) => surface.surface_id === target.surface_id,
+    );
+    assert.equal(rebuilt.source, "artifact-build");
+    assert.equal(rebuiltTarget.status, "unknown");
+    assert.equal(rebuiltTarget.classification, "unknown");
+    assert.equal(rebuiltTarget.last_checked, null);
+    assert.equal(rebuiltTarget.latency_ms, null);
+    assert.equal(rebuiltTarget.status_code, undefined);
+    assert.equal(rebuilt.summary.status_counts.ok || 0, 0);
+  } finally {
+    writeFileSync(artifactPath, original);
+    if (originalCache === null) {
+      rmSync(cachePath, { force: true });
+    } else {
+      writeFileSync(cachePath, originalCache);
+    }
+    execFileSync("git", ["checkout", "--", "public/metagraph"], {
+      cwd: process.cwd(),
+      stdio: "pipe",
+    });
+  }
+}, 30_000);
 
 test("public artifacts are internally consistent", () => {
   const native = JSON.parse(


### PR DESCRIPTION
### Motivation

- The artifact build was reading the committed `public/metagraph/health/latest.json` as trusted live probe input, which allowed forged or stale probe rows in the repo to be carried into regenerated artifacts and affect endpoint/pool eligibility.

### Description

- Stop reading the committed public health artifact in `scripts/build-artifacts.mjs` and instead optionally load a trusted local probe cache via `loadPreviousHealthArtifact()` so only explicitly persisted probe runs are reused.
- Persist live probe output from `scripts/probes-smoke.mjs` into a local ignored cache at `.cache/metagraphed/health/latest.json` when probe results are written so a "probe then rebuild" workflow remains possible without trusting committed artifacts.
- Update artifact metadata `notes` and `source` to reflect whether a trusted local cache was present (`"live-smoke-probe"`) or the build produced the snapshot (`"artifact-build"`).
- Add a regression test in `tests/artifacts.test.mjs` that forges a committed health row and asserts `npm run build:artifacts` resets the forged row to `unknown` when no trusted local cache exists, and adjust test harness to manage the cache file and timeout.

### Testing

- Ran the new targeted test: `npm test -- --run tests/artifacts.test.mjs -t "artifact build ignores forged"` and iterated until it passed; the final run passed.
- Ran `npm run build:artifacts` successfully to verify artifact generation with the new cache behavior.
- Ran `npm run lint`, `npm run format:check -- scripts/build-artifacts.mjs scripts/probes-smoke.mjs tests/artifacts.test.mjs`, and `npm run validate`, all of which completed successfully.
- Ran the full test file `tests/artifacts.test.mjs` and observed all tests pass (6/6).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2547d4dfb0832ca35d75ba334535c7)