### PR TITLE
Fix raw artifact route R2 exposure

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -62,6 +62,39 @@ describe("Worker runtime", () => {
     assert.equal(assetMissing.status, 404);
   });
 
+  test("rejects raw artifact paths outside public contracts before R2 lookup", async () => {
+    const r2KeysRequested = [];
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/internal/control.json"),
+      {
+        ASSETS: {
+          async fetch() {
+            return new Response("not found", { status: 404 });
+          },
+        },
+        METAGRAPH_ARCHIVE: {
+          async get(key) {
+            r2KeysRequested.push(key);
+            return {
+              async json() {
+                return { secret_token: "should-not-be-public" };
+              },
+            };
+          },
+        },
+      },
+      {},
+    );
+
+    assert.equal(response.status, 404);
+    assert.equal(response.headers.get("x-metagraph-error-code"), "not_found");
+    assert.deepEqual(r2KeysRequested, []);
+    assert.equal(
+      (await response.json()).meta.artifact_path,
+      "/metagraph/internal/control.json",
+    );
+  });
+
   test("supports HEAD, ETag revalidation, and CORS preflight", async () => {
     const head = await handleRequest(
       new Request("https://metagraph.sh/api/v1/subnets", { method: "HEAD" }),

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1,6 +1,7 @@
 import {
   API_QUERY_COLLECTIONS,
   API_ROUTES,
+  PUBLIC_ARTIFACTS,
   CACHE_SECONDS,
   CONTRACT_VERSION,
   artifactPathFromTemplate,
@@ -12,6 +13,13 @@ import {
 } from "../src/artifact-storage.mjs";
 
 const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
+
+const RAW_ARTIFACT_ROUTES = PUBLIC_ARTIFACTS.filter((entry) =>
+  entry.path.endsWith(".json"),
+).map((entry) => ({
+  ...entry,
+  pattern: compileRoutePattern(entry.path),
+}));
 
 const ROUTES = API_ROUTES.map((entry) => ({
   ...entry,
@@ -97,6 +105,17 @@ export async function handleRequest(request, env = {}, _ctx = {}) {
 }
 
 async function handleRawArtifactRequest(request, env, url) {
+  if (!matchRawArtifact(url.pathname)) {
+    return errorResponse(
+      "not_found",
+      "No public artifact contract matched this path.",
+      404,
+      {
+        artifact_path: url.pathname,
+      },
+    );
+  }
+
   const artifact = await readArtifact(env, url.pathname);
   if (!artifact.ok) {
     return errorResponse(artifact.code, artifact.message, artifact.status, {
@@ -290,6 +309,12 @@ async function handleRpcProxyRequest(request, env, url) {
     status: upstream.status,
     headers,
   });
+}
+
+function matchRawArtifact(pathname) {
+  return RAW_ARTIFACT_ROUTES.some((candidate) =>
+    candidate.pattern.test(pathname),
+  );
 }
 
 function matchRoute(pathname) {


### PR DESCRIPTION
### Motivation
- Prevent the raw `/metagraph/*.json` Worker route from accepting arbitrary paths that can fall back to R2 and expose non-public objects under the `latest/` prefix.
- Enforce that only declared `PUBLIC_ARTIFACTS` contract paths reach artifact reads so the storage-tier contract is respected.

### Description
- Import `PUBLIC_ARTIFACTS` and derive `RAW_ARTIFACT_ROUTES` by compiling contract path templates with `compileRoutePattern` so raw artifact matching uses the declared contracts.
- Add a `matchRawArtifact` helper and an early guard in `handleRawArtifactRequest` that returns a `404` with `meta.artifact_path` when the requested path does not match a declared public artifact.
- Preserve the existing `readArtifact`/`readR2` behavior for matched artifacts so public R2/git/dual logic remains unchanged.
- Add a regression test in `tests/worker-runtime.test.mjs` asserting that `/metagraph/internal/control.json` is rejected before any R2 lookup is attempted.

### Testing
- Ran the targeted regression test with `npm test -- --run tests/worker-runtime.test.mjs -t "rejects raw artifact paths"`, which passed.
- Ran the full worker runtime test file with `npm test -- --run tests/worker-runtime.test.mjs`, which still fails for some cases due to missing staged R2 fixture artifacts under `dist/metagraph-r2/metagraph` in this checkout and not because of the introduced guard.
- Ran `npm run lint` and `npm run format:check`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2550ffee04832c81f8c52929431ef3)