### PR TITLE
test(intake): exercise submission gate smoke path

### DIFF
--- a/registry/candidates/community/community-sn-7-example-docs-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-example-docs-all-ways-io.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-example-docs-all-ways-io",
+      "kind": "example",
+      "name": "Allways example submission gate smoke",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://docs.all-ways.io/how-it-works.html",
+      "source_urls": [
+        "https://docs.all-ways.io/how-it-works.html"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.all-ways.io/how-it-works.html"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
## Summary
- disposable UGC smoke PR for the private Metagraphed submission gate
- adds one schema-valid community candidate file only

## Validation
- npm run validate:intake

## Notes
- This PR is expected to route through the private submission gate and be closed after verifying labels/comments/D1 state.