### PR TITLE
fix(probes): import repo root for health cache writes

### DIFF
--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -13,6 +13,7 @@ import {
   loadProviders,
   isUnsafeResolvedUrl,
   loadSubnets,
+  repoRoot,
   writeJson,
 } from "./lib.mjs";
 

--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -85,40 +85,48 @@ for (const artifact of plannedArtifacts) {
     continue;
   }
   changedArtifactCount += 1;
-  uploadJobs.push(uploadJob(
-    localPath,
-    artifact.latest_key,
-    manifest.bucket_name,
-    artifact.content_type,
-    "latest",
-  ));
-  if (uploadHistory) {
-    uploadJobs.push(uploadJob(
+  uploadJobs.push(
+    uploadJob(
       localPath,
-      artifact.key,
+      artifact.latest_key,
       manifest.bucket_name,
       artifact.content_type,
-      "history",
-    ));
+      "latest",
+    ),
+  );
+  if (uploadHistory) {
+    uploadJobs.push(
+      uploadJob(
+        localPath,
+        artifact.key,
+        manifest.bucket_name,
+        artifact.content_type,
+        "history",
+      ),
+    );
   }
 }
 
 for (const controlArtifact of plannedControlArtifacts) {
-  uploadJobs.push(uploadJob(
-    controlArtifact.local_path,
-    controlArtifact.latest_key,
-    manifest.bucket_name,
-    controlArtifact.content_type,
-    "control",
-  ));
-  if (uploadHistory) {
-    uploadJobs.push(uploadJob(
+  uploadJobs.push(
+    uploadJob(
       controlArtifact.local_path,
-      controlArtifact.key,
+      controlArtifact.latest_key,
       manifest.bucket_name,
       controlArtifact.content_type,
-      "history",
-    ));
+      "control",
+    ),
+  );
+  if (uploadHistory) {
+    uploadJobs.push(
+      uploadJob(
+        controlArtifact.local_path,
+        controlArtifact.key,
+        manifest.bucket_name,
+        controlArtifact.content_type,
+        "history",
+      ),
+    );
   }
 }
 
@@ -127,12 +135,15 @@ await putObjects(uploadJobs, {
   progressInterval,
 });
 
-const uploadedLatestCount = uploadJobs.filter((job) => job.kind === "latest")
-  .length;
-const uploadedHistoryCount = uploadJobs.filter((job) => job.kind === "history")
-  .length;
-const uploadedControlCount = uploadJobs.filter((job) => job.kind === "control")
-  .length;
+const uploadedLatestCount = uploadJobs.filter(
+  (job) => job.kind === "latest",
+).length;
+const uploadedHistoryCount = uploadJobs.filter(
+  (job) => job.kind === "history",
+).length;
+const uploadedControlCount = uploadJobs.filter(
+  (job) => job.kind === "control",
+).length;
 
 console.log(
   stableStringify({

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -59,7 +59,9 @@ test("artifact build ignores forged committed health observations by default", (
     : null;
   rmSync(cachePath, { force: true });
   const tampered = JSON.parse(original);
-  const target = tampered.surfaces.find((surface) => surface.public_safe === true);
+  const target = tampered.surfaces.find(
+    (surface) => surface.public_safe === true,
+  );
   assert(target, "expected a public-safe health row to tamper");
 
   tampered.source = "live-smoke-probe";


### PR DESCRIPTION
## Summary
- import repoRoot in the smoke probe script so trusted health cache writes work
- apply Prettier cleanup to recent R2 upload and artifact test changes

## Why
- npm run check failed on main because scripts/probes-smoke.mjs referenced repoRoot without importing it
- recent merged files also had formatting drift that blocked format:check

## Validation
- npm run build
- npm run check
- npx vitest run tests/artifacts.test.mjs tests/worker-runtime.test.mjs
- npm run worker:test
- npm run validate:api
- npm run validate:openapi
- npm run scan:public-safety
- git diff --check

## Notes
- Generated tracked artifact changes from the local build were restored before commit; this PR only changes source/test formatting.