### PR TITLE
test(intake): exercise submission gate retry path

### DIFF
--- a/registry/candidates/community/smoke-sn-7-docs-all-ways-io.json
+++ b/registry/candidates/community/smoke-sn-7-docs-all-ways-io.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-docs-docs-all-ways-io",
+      "kind": "docs",
+      "name": "Allways community docs smoke",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://docs.all-ways.io/how-it-works.html",
+      "source_urls": [
+        "https://docs.all-ways.io/how-it-works.html"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.all-ways.io/community-submission-example"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
## Summary
- Opens a disposable one-file community candidate PR to smoke-test the public preflight and private submission gate.

## What changed
- Adds one schema-backed community candidate under `registry/candidates/community`.

## Why
- Verifies that valid UGC PRs are classified by the private gate instead of being ignored when GitHub file inspection is unavailable.

## Validation
- `npm run validate:intake`

## Notes
- This PR is intended to be closed after gate verification; it is not meant to publish a real registry change.