### PR TITLE
fix(sync): classify symbol-only native names as placeholders

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 966,
-  "artifact_size_bytes": 30833346,
+  "artifact_size_bytes": 30833375,
   "artifacts": [
     {
       "path": "adapters/allways.json",

--- a/public/metagraph/metagraph/latest.json
+++ b/public/metagraph/metagraph/latest.json
@@ -2440,7 +2440,7 @@
       "mechanism_count": 1,
       "name": "⚒",
       "native_name": "⚒",
-      "native_name_quality": "chain",
+      "native_name_quality": "placeholder",
       "netuid": 86,
       "participant_count": 256,
       "probed_surface_count": 2,

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 967,
-  "artifact_size_bytes": 30984030,
+  "artifact_size_bytes": 30984059,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -4804,8 +4804,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/metagraph/latest.json",
       "latest_key": "latest/metagraph/latest.json",
       "path": "/metagraph/metagraph/latest.json",
-      "sha256": "687da15bd0f8a630f2f2ce06e46cee428d32d25f5c954f635b6dca826c0156e1",
-      "size_bytes": 112301,
+      "sha256": "9d9cf63be2398fb9373546f64ea345ea5240237c53fb0904979bdfe87cbee6ed",
+      "size_bytes": 112307,
       "storage_tier": "git"
     },
     {
@@ -5191,8 +5191,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/subnets.json",
       "latest_key": "latest/subnets.json",
       "path": "/metagraph/subnets.json",
-      "sha256": "f1bc2eba16a205c2b6500b3aea275c6f8a95050785166150a1e5e4ab53ff4a8e",
-      "size_bytes": 112170,
+      "sha256": "23690ddf5e9133bf644d073cc68038397659883f61d08e0080b096192c5bff9d",
+      "size_bytes": 112176,
       "storage_tier": "dual"
     },
     {
@@ -6226,8 +6226,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/subnets/86.json",
       "latest_key": "latest/subnets/86.json",
       "path": "/metagraph/subnets/86.json",
-      "sha256": "c98f9ceaa4c557b90bbb45096d650d4386cc4ca97d3bdc795fb730a632e76519",
-      "size_bytes": 15707,
+      "sha256": "701e00951b75af1aa0261797f936acc07eed29f21e7ded6080ab5f7e1296ba6b",
+      "size_bytes": 15724,
       "storage_tier": "r2"
     },
     {

--- a/public/metagraph/subnets.json
+++ b/public/metagraph/subnets.json
@@ -2439,7 +2439,7 @@
       "mechanism_count": 1,
       "name": "⚒",
       "native_name": "⚒",
-      "native_name_quality": "chain",
+      "native_name_quality": "placeholder",
       "netuid": 86,
       "participant_count": 256,
       "probed_surface_count": 2,

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -282,7 +282,8 @@ export function classifyNativeName(value, netuid) {
     Number.isInteger(netuid) && normalized === `subnet ${netuid}`.toLowerCase();
   if (
     genericName ||
-    ["unknown", "none", "null", "n/a", "na", "unnamed"].includes(normalized)
+    ["unknown", "none", "null", "n/a", "na", "unnamed"].includes(normalized) ||
+    !/[\p{L}\p{N}]/u.test(raw)
   ) {
     return { raw_name: raw, quality: "placeholder" };
   }

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -237,9 +237,14 @@ describe("script utility contracts", () => {
     });
     assert.equal(classifyNativeName("", 1).quality, "empty");
     assert.equal(classifyNativeName("Luminar Network", 87).quality, "chain");
+    assert.equal(classifyNativeName("›", 76).quality, "placeholder");
     assert.equal(
       nativeNameQuality({ raw_name: "Subnet 42", netuid: 42 }),
       "placeholder",
+    );
+    assert.equal(
+      nativeDisplayName({ raw_name: "›", netuid: 76 }, "Byzantium"),
+      "Byzantium",
     );
     assert.equal(
       nativeDisplayName({ raw_name: "unknown", netuid: 87 }, "Luminar Network"),


### PR DESCRIPTION
## Summary
- Treat symbol-only native subnet names as degraded placeholder identity instead of real renames.

## What changed
- Adds placeholder-name classification for symbol-like native values.
- Keeps public display names stable when chain identity degrades.
- Moves the current SN76 drift into identity warnings instead of renamed netuids.

## Why
- Live chain metadata can temporarily degrade to placeholder-like values. Those should be reviewed as identity warnings, not published as subnet renames.

## Validation
- npm run sync:subnets:dry-run
- npm run validate
- npx vitest run tests/script-utils.test.mjs
- git diff --check

## Notes
- The dry run reports 129 native Finney subnets and one identity warning for SN76.