### PR TITLE
feat(intake): add provider profile submissions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,9 +10,9 @@
 
 - [ ] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
 - [ ] Generated artifacts came from repo scripts, not hand-edited public JSON.
-- [ ] Direct community submissions change exactly one `registry/candidates/community/*.json` file and no generated artifacts.
+- [ ] Direct community submissions change exactly one `registry/candidates/community/*.json` or `registry/providers/community/*.json` file and no generated artifacts.
 - [ ] Community-submitted interfaces pass public preflight before private gate review.
-- [ ] Direct community submission files were generated with `npm run candidate:new` or match `docs/examples/submissions/direct-candidate.json`.
+- [ ] Direct community submission files were generated with `npm run candidate:new` / `npm run provider:new` or match `docs/examples/submissions/direct-candidate.json` / `docs/examples/submissions/direct-provider-profile.json`.
 
 ## Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,8 @@ Community submissions can become candidates, not direct registry truth. There ar
 two supported paths:
 
 - PR-first: add exactly one `registry/candidates/community/*.json` candidate
-  document and no other files.
+  document or exactly one `registry/providers/community/*.json` provider
+  profile document and no other files.
 - Issue-first: submit an `interface-submission` issue and let the import
   workflow create the candidate PR after approval.
 - Endpoint/provider/status issues: submit endpoint resources, provider profiles,
@@ -56,6 +57,12 @@ You can generate a direct candidate PR file locally:
 
 ```bash
 npm run candidate:new -- --netuid 7 --kind docs --url https://docs.all-ways.io/community-submission-example --source-url https://docs.all-ways.io/how-it-works.html --provider allways --submitted-by <github-login> --write
+```
+
+You can generate a direct provider profile review file locally:
+
+```bash
+npm run provider:new -- --id example-operator --name "Example Operator" --kind infrastructure-provider --website-url https://example.com --docs-url https://docs.example.com --github-url https://github.com/example --contact-url https://example.com/contact --submitted-by <github-login> --write
 ```
 
 Example payloads live under `docs/examples/submissions`.
@@ -71,9 +78,14 @@ The public submission gate performs deterministic checks first:
 - registered provider;
 - public-safe interface and source URLs;
 - one candidate per submission;
+- one provider profile per provider submission;
 - no duplicate curated surface or candidate;
 - submitter provenance for direct PRs;
 - no generated artifact edits.
+
+Provider profile submissions are review inputs only. They cannot claim official
+authority, cannot make endpoints pool-eligible, and cannot directly edit
+canonical `registry/providers/*.json` entries.
 
 Passing public preflight routes the submission into private gate review. The
 private reviewer may merge/import clean submissions, close hard failures, or

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -129,6 +129,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `npm run validate:docs`: validate public docs against current artifact and API contracts.
 - `npm run validate:intake`: validate GitHub issue intake templates.
 - `npm run candidate:new`: generate a one-candidate community PR file.
+- `npm run provider:new`: generate a one-provider-profile community PR file.
 - `npm run submission:comment`: render a deterministic Markdown submission report.
 - `npm run validate:workflows`: validate workflow hardening rules.
 - `npm run worker:deploy:dry-run`: validate Worker/Wrangler deployment shape without contacting Cloudflare.

--- a/docs/examples/submissions/direct-provider-profile.json
+++ b/docs/examples/submissions/direct-provider-profile.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "example-contributor",
+    "submitted_by_url": "https://github.com/example-contributor"
+  },
+  "provider": {
+    "schema_version": 1,
+    "id": "example-operator",
+    "name": "Example Operator",
+    "kind": "infrastructure-provider",
+    "website_url": "https://example.com",
+    "docs_url": "https://docs.example.com",
+    "github_url": "https://github.com/example",
+    "contact_url": "https://example.com/contact",
+    "authority": "community",
+    "public_notes": "Example public-safe provider profile submission."
+  }
+}

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -33,10 +33,11 @@ The stable marker comment is:
 
 ## Direct PR Shape
 
-Direct UGC PRs must change exactly one file:
+Direct UGC PRs must change exactly one candidate or provider review file:
 
 ```text
 registry/candidates/community/<slug>.json
+registry/providers/community/<slug>.json
 ```
 
 The file must contain exactly one candidate:
@@ -72,8 +73,35 @@ The file must contain exactly one candidate:
 }
 ```
 
+Provider profile review files must contain exactly one provider profile:
+
+```json
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "github-login",
+    "submitted_by_url": "https://github.com/github-login"
+  },
+  "provider": {
+    "schema_version": 1,
+    "id": "example-operator",
+    "name": "Example Operator",
+    "kind": "infrastructure-provider",
+    "website_url": "https://example.com",
+    "docs_url": "https://docs.example.com",
+    "github_url": "https://github.com/example",
+    "contact_url": "https://example.com/contact",
+    "authority": "community",
+    "public_notes": "Public-safe provider profile submission."
+  }
+}
+```
+
 Generated artifacts, scripts, workflows, package metadata, native snapshots,
 private URLs, secrets, wallet/PAT data, and validator-local data are rejected.
+Provider profile submissions are review inputs only; they cannot claim official
+authority, directly modify canonical provider manifests, set endpoint health, or
+make any endpoint pool-eligible.
 
 ## Supported UGC Types
 

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "submission:pr": "node scripts/submission-pr.mjs",
     "submission:comment": "node scripts/submission-comment.mjs",
     "candidate:new": "node scripts/candidate-new.mjs",
+    "provider:new": "node scripts/provider-new.mjs",
     "r2:manifest": "node scripts/r2-manifest.mjs --write",
     "r2:manifest:dry-run": "node scripts/r2-manifest.mjs",
     "build-summary:refresh": "node scripts/refresh-build-summary.mjs",

--- a/schemas/provider-submission.schema.json
+++ b/schemas/provider-submission.schema.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://metagraph.sh/schemas/provider-submission.schema.json",
+  "title": "Metagraphed Provider Profile Submission",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "submission", "provider"],
+  "properties": {
+    "schema_version": {
+      "const": 1
+    },
+    "submission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["submitted_by", "submitted_by_url"],
+      "properties": {
+        "submitted_by": {
+          "type": "string",
+          "pattern": "^[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"
+        },
+        "submitted_by_url": {
+          "type": "string",
+          "pattern": "^https://github\\.com/[A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?$"
+        }
+      }
+    },
+    "provider": {
+      "$ref": "https://metagraph.sh/schemas/provider.schema.json"
+    }
+  }
+}

--- a/scripts/provider-new.mjs
+++ b/scripts/provider-new.mjs
@@ -1,0 +1,129 @@
+import path from "node:path";
+import {
+  loadCandidates,
+  loadNativeSnapshot,
+  loadProviders,
+  loadSubnets,
+  normalizePublicUrl,
+  repoRoot,
+  slugify,
+  stableStringify,
+  writeJson,
+} from "./lib.mjs";
+import {
+  buildPrSubmissionReport,
+  normalizeGitHubLogin,
+} from "./submission-policy.mjs";
+
+const args = process.argv.slice(2);
+const write = args.includes("--write");
+const id = slugify(valueAfter("--id") || valueAfter("--slug") || "");
+const name = valueAfter("--name");
+const kind = valueAfter("--kind");
+const websiteUrl = normalizePublicUrl(valueAfter("--website-url"));
+const docsUrl = normalizeOptionalUrl(valueAfter("--docs-url"));
+const githubUrl = normalizeOptionalUrl(valueAfter("--github-url"));
+const teamUrl = normalizeOptionalUrl(valueAfter("--team-url"));
+const contactUrl = normalizeOptionalUrl(valueAfter("--contact-url"));
+const publicNotes = valueAfter("--public-notes") || "";
+const authority = valueAfter("--authority") || "community";
+const submittedBy = normalizeGitHubLogin(
+  valueAfter("--submitted-by") || process.env.GITHUB_ACTOR || process.env.USER,
+);
+const outArg = valueAfter("--out");
+
+if (!id) {
+  fail("--id or --slug is required");
+}
+if (!name) {
+  fail("--name is required");
+}
+if (!kind) {
+  fail("--kind is required");
+}
+if (!websiteUrl) {
+  fail("--website-url must be a public http(s), wss, or ws URL");
+}
+if (!submittedBy) {
+  fail("--submitted-by or GITHUB_ACTOR is required");
+}
+for (const [flag, value] of [
+  ["--docs-url", docsUrl],
+  ["--github-url", githubUrl],
+  ["--team-url", teamUrl],
+  ["--contact-url", contactUrl],
+]) {
+  if (valueAfter(flag) && !value) {
+    fail(`${flag} must be a public http(s), wss, or ws URL`);
+  }
+}
+
+const outPath =
+  outArg || path.join(repoRoot, "registry/providers/community", `${id}.json`);
+const outputPath = path.resolve(outPath);
+const submissionFile = path.join("registry/providers/community", `${id}.json`);
+const document = {
+  schema_version: 1,
+  submission: {
+    submitted_by: submittedBy,
+    submitted_by_url: `https://github.com/${submittedBy}`,
+  },
+  provider: {
+    schema_version: 1,
+    id,
+    name,
+    kind,
+    website_url: websiteUrl,
+    ...(docsUrl ? { docs_url: docsUrl } : {}),
+    ...(githubUrl ? { github_url: githubUrl } : {}),
+    ...(teamUrl ? { team_url: teamUrl } : {}),
+    ...(contactUrl ? { contact_url: contactUrl } : {}),
+    authority,
+    public_notes: publicNotes,
+  },
+};
+
+const report = buildPrSubmissionReport({
+  changedFiles: [submissionFile],
+  providerDocument: document,
+  submitter: submittedBy,
+  native: await loadNativeSnapshot(),
+  providers: await loadProviders(),
+  existingCandidates: await loadCandidates(),
+  existingSubnets: await loadSubnets(),
+});
+
+if (report.blocking) {
+  console.error(stableStringify(report));
+  process.exit(1);
+}
+
+if (write) {
+  await writeJson(outputPath, document);
+}
+
+console.log(
+  stableStringify({
+    mode: write ? "write" : "dry-run",
+    output_path: path.relative(repoRoot, outputPath),
+    public_state: report.public_state,
+    next_action: report.next_action,
+    manual_reasons: report.manual_reasons,
+    warnings: report.warnings,
+    provider: document.provider,
+  }),
+);
+
+function valueAfter(flag) {
+  const index = args.indexOf(flag);
+  return index === -1 ? null : args[index + 1] || null;
+}
+
+function normalizeOptionalUrl(value) {
+  return value ? normalizePublicUrl(value) : null;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/submission-comment.mjs
+++ b/scripts/submission-comment.mjs
@@ -22,6 +22,11 @@ export function buildSubmissionMarkdown(report) {
       `Candidate file: ${formatMarkdownValue(report.direct_candidate_file)}`,
     );
   }
+  if (report.direct_provider_file) {
+    lines.push(
+      `Provider file: ${formatMarkdownValue(report.direct_provider_file)}`,
+    );
+  }
 
   lines.push("");
   appendList(lines, "Errors", report.errors);

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -47,6 +47,8 @@ export const PUBLIC_PREFLIGHT_STATES = new Set([
 
 export const DIRECT_CANDIDATE_PATTERN =
   /^registry\/candidates\/community\/[a-z0-9][a-z0-9-]*\.json$/;
+export const DIRECT_PROVIDER_PATTERN =
+  /^registry\/providers\/community\/[a-z0-9][a-z0-9-]*\.json$/;
 
 export const SUPPORTED_INTERFACE_KINDS = new Set([
   "archive",
@@ -430,6 +432,7 @@ function issueSummary(issue) {
 export function buildPrSubmissionReport({
   changedFiles,
   candidateDocument = null,
+  providerDocument = null,
   submitter = null,
   native,
   providers,
@@ -443,6 +446,7 @@ export function buildPrSubmissionReport({
   const manual_reasons = [];
   const warnings = [];
   let candidate = null;
+  let provider = null;
 
   if (scope.scope === "normal-pr") {
     return {
@@ -456,6 +460,7 @@ export function buildPrSubmissionReport({
       warnings: [],
       manual_reasons: [],
       candidate: null,
+      provider: null,
       publish_allowed: false,
       auto_merge_eligible: false,
       blocking: false,
@@ -464,10 +469,16 @@ export function buildPrSubmissionReport({
     };
   }
 
-  if (errors.length === 0) {
+  if (errors.length === 0 && scope.scope === "direct-candidate") {
     const extracted = extractSingleCandidate(candidateDocument);
     errors.push(...extracted.errors);
     candidate = extracted.candidate;
+  }
+
+  if (errors.length === 0 && scope.scope === "direct-provider") {
+    const extracted = extractSingleProvider(providerDocument);
+    errors.push(...extracted.errors);
+    provider = extracted.provider;
   }
 
   if (candidate) {
@@ -479,6 +490,18 @@ export function buildPrSubmissionReport({
       providers,
       existingCandidates,
       existingSubnets,
+    });
+    errors.push(...deterministic.errors);
+    manual_reasons.push(...deterministic.manual_reasons);
+    warnings.push(...deterministic.warnings);
+  }
+
+  if (provider) {
+    const deterministic = validateProviderForSubmission({
+      provider,
+      document: providerDocument,
+      submitter,
+      providers,
     });
     errors.push(...deterministic.errors);
     manual_reasons.push(...deterministic.manual_reasons);
@@ -505,11 +528,13 @@ export function buildPrSubmissionReport({
     public_state: publicState,
     changed_files: normalizedFiles,
     direct_candidate_file: scope.candidateFiles[0] || null,
+    direct_provider_file: scope.providerFiles[0] || null,
     errors: errors.map((error) => error.message),
     error_categories: errors.map((error) => error.category),
     warnings,
     manual_reasons,
     candidate,
+    provider,
     publish_allowed: false,
     auto_merge_eligible: false,
     private_review_required:
@@ -537,29 +562,44 @@ export function classifyPrScope(changedFiles) {
   const candidateFiles = files.filter((file) =>
     DIRECT_CANDIDATE_PATTERN.test(file),
   );
+  const providerFiles = files.filter((file) =>
+    DIRECT_PROVIDER_PATTERN.test(file),
+  );
   const touchedCommunityCandidate = files.filter((file) =>
     file.startsWith("registry/candidates/community/"),
   );
+  const touchedCommunityProvider = files.filter((file) =>
+    file.startsWith("registry/providers/community/"),
+  );
   const errors = [];
 
-  if (candidateFiles.length === 0 && touchedCommunityCandidate.length === 0) {
+  if (
+    candidateFiles.length === 0 &&
+    providerFiles.length === 0 &&
+    touchedCommunityCandidate.length === 0 &&
+    touchedCommunityProvider.length === 0
+  ) {
     return {
       scope: "normal-pr",
       candidateFiles,
+      providerFiles,
       errors,
     };
   }
 
-  if (candidateFiles.length !== 1) {
+  const submissionFileCount = candidateFiles.length + providerFiles.length;
+  if (submissionFileCount !== 1) {
     errors.push({
       category: "unsupported-shape",
       message:
-        "direct submissions must change exactly one registry/candidates/community/*.json file",
+        "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file",
     });
   }
 
   const unrelated = files.filter(
-    (file) => !DIRECT_CANDIDATE_PATTERN.test(file),
+    (file) =>
+      !DIRECT_CANDIDATE_PATTERN.test(file) &&
+      !DIRECT_PROVIDER_PATTERN.test(file),
   );
   if (unrelated.length > 0) {
     errors.push({
@@ -569,8 +609,9 @@ export function classifyPrScope(changedFiles) {
   }
 
   return {
-    scope: "direct-candidate",
+    scope: providerFiles.length === 1 ? "direct-provider" : "direct-candidate",
     candidateFiles,
+    providerFiles,
     errors,
   };
 }
@@ -604,6 +645,39 @@ export function extractSingleCandidate(document) {
 
   return {
     candidate: document.candidates?.[0] || null,
+    errors,
+  };
+}
+
+export function extractSingleProvider(document) {
+  const errors = [];
+  if (!document || typeof document !== "object") {
+    return {
+      provider: null,
+      errors: [
+        {
+          category: "unsupported-shape",
+          message: "provider submission document must be a JSON object",
+        },
+      ],
+    };
+  }
+
+  if (document.schema_version !== 1) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "provider submission document schema_version must be 1",
+    });
+  }
+  if (!document.provider || typeof document.provider !== "object") {
+    errors.push({
+      category: "unsupported-shape",
+      message: "provider submission document must include provider",
+    });
+  }
+
+  return {
+    provider: document.provider || null,
     errors,
   };
 }
@@ -788,6 +862,109 @@ export function validateCandidateForSubmission({
       });
     }
   }
+
+  return { errors, warnings, manual_reasons };
+}
+
+export function validateProviderForSubmission({
+  provider,
+  document = {},
+  submitter = null,
+  providers,
+}) {
+  const errors = [];
+  const warnings = [];
+  const manual_reasons = ["provider profile submissions require review"];
+  const providerIds = new Set(providers.map((entry) => entry.id));
+  const websiteUrl = normalizePublicUrl(provider?.website_url);
+  const docsUrl = normalizePublicUrl(provider?.docs_url);
+  const githubUrl = normalizePublicUrl(provider?.github_url);
+  const teamUrl = normalizePublicUrl(provider?.team_url);
+  const contactUrl = normalizePublicUrl(provider?.contact_url);
+
+  if (!provider || typeof provider !== "object") {
+    return {
+      errors: [
+        {
+          category: "unsupported-shape",
+          message: "provider is required",
+        },
+      ],
+      warnings,
+      manual_reasons,
+    };
+  }
+
+  if (provider.schema_version !== 1) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "provider schema_version must be 1",
+    });
+  }
+  if (!/^[a-z0-9][a-z0-9-]*$/.test(provider.id || "")) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "provider id must be a lowercase slug",
+    });
+  }
+  if (!String(provider.name || "").trim()) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "provider name is required",
+    });
+  }
+  if (!PROVIDER_KINDS.has(provider.kind)) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "provider kind is unsupported",
+    });
+  }
+  if (!websiteUrl) {
+    errors.push({
+      category: "private-or-unsafe-url",
+      message: "provider website_url is missing, invalid, or unsafe",
+    });
+  }
+  for (const [field, normalized] of [
+    ["docs_url", docsUrl],
+    ["github_url", githubUrl],
+    ["team_url", teamUrl],
+    ["contact_url", contactUrl],
+  ]) {
+    if (provider[field] && !normalized) {
+      errors.push({
+        category: "private-or-unsafe-url",
+        message: `provider ${field} is invalid or unsafe`,
+      });
+    } else if (provider[field] && provider[field] !== normalized) {
+      warnings.push(`provider ${field} will be normalized by registry tooling`);
+    }
+  }
+  if (!["community", "provider-claimed"].includes(provider.authority)) {
+    errors.push({
+      category: "unsupported-shape",
+      message:
+        "community provider submissions can only use community or provider-claimed authority",
+    });
+  }
+  if (provider.notes !== undefined) {
+    errors.push({
+      category: "unsupported-shape",
+      message:
+        "community provider submissions must use public_notes, not notes",
+    });
+  }
+  if (provider.id && providerIds.has(provider.id)) {
+    manual_reasons.push("existing provider profile updates require review");
+  }
+
+  errors.push(...unsafeTextReasons(JSON.stringify(provider)));
+  errors.push(
+    ...validateSubmissionProvenance({
+      document,
+      submitter,
+    }),
+  );
 
   return { errors, warnings, manual_reasons };
 }

--- a/scripts/submission-pr.mjs
+++ b/scripts/submission-pr.mjs
@@ -11,6 +11,7 @@ import {
 } from "./lib.mjs";
 import {
   DIRECT_CANDIDATE_PATTERN,
+  DIRECT_PROVIDER_PATTERN,
   buildPrSubmissionReport,
   normalizeChangedFiles,
 } from "./submission-policy.mjs";
@@ -33,8 +34,14 @@ const changedFiles = normalizeChangedFiles(
 const directCandidateFile = changedFiles.find((file) =>
   DIRECT_CANDIDATE_PATTERN.test(file),
 );
+const directProviderFile = changedFiles.find((file) =>
+  DIRECT_PROVIDER_PATTERN.test(file),
+);
 const candidateDocument = directCandidateFile
   ? await readJson(path.resolve(directCandidateFile))
+  : null;
+const providerDocument = directProviderFile
+  ? await readJson(path.resolve(directProviderFile))
   : null;
 const existingCandidates = directCandidateFile
   ? (await loadCandidates()).filter(
@@ -44,13 +51,19 @@ const existingCandidates = directCandidateFile
         ),
     )
   : await loadCandidates();
+const existingProviders = directProviderFile
+  ? (await loadProviders()).filter(
+      (provider) => provider.id !== providerDocument?.provider?.id,
+    )
+  : await loadProviders();
 
 const report = buildPrSubmissionReport({
   changedFiles,
   candidateDocument,
+  providerDocument,
   submitter,
   native: await loadNativeSnapshot(),
-  providers: await loadProviders(),
+  providers: existingProviders,
   existingCandidates,
   existingSubnets: await loadSubnets(),
 });

--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -33,6 +33,9 @@ const candidateExample = await readJson(
 const providerExample = await readJson(
   path.join(repoRoot, "docs/examples/submissions/provider-profile.json"),
 );
+const directProviderExample = await readJson(
+  path.join(repoRoot, "docs/examples/submissions/direct-provider-profile.json"),
+);
 const statusReportExample = await readJson(
   path.join(repoRoot, "docs/examples/submissions/status-report.json"),
 );
@@ -115,6 +118,7 @@ checkIncludes(providerTemplate, "provider profile template", [
 
 checkIncludes(pullRequestTemplate, "pull request template", [
   "registry/candidates/community/*.json",
+  "registry/providers/community/*.json",
   "npm run submission:pr",
 ]);
 
@@ -141,6 +145,7 @@ checkIncludes(submissionGateDocs, "submission gate docs", [
 
 checkExampleCandidate(candidateExample);
 checkExampleProvider(providerExample);
+checkExampleProviderSubmission(directProviderExample);
 checkExampleStatusReport(statusReportExample);
 
 if (errors.length > 0) {
@@ -196,6 +201,31 @@ function checkExampleProvider(provider) {
     if (provider?.[field] === undefined || provider?.[field] === "") {
       errors.push(`provider example: missing ${field}`);
     }
+  }
+}
+
+function checkExampleProviderSubmission(document) {
+  if (document?.schema_version !== 1 || !document?.provider) {
+    errors.push(
+      "direct provider profile example: missing schema_version or provider",
+    );
+    return;
+  }
+  if (
+    document?.submission?.submitted_by_url !==
+    `https://github.com/${document?.submission?.submitted_by}`
+  ) {
+    errors.push(
+      "direct provider profile example: submitted_by_url must match submitted_by",
+    );
+  }
+  checkExampleProvider(document.provider);
+  if (
+    !["community", "provider-claimed"].includes(document.provider.authority)
+  ) {
+    errors.push(
+      "direct provider profile example: authority must be community or provider-claimed",
+    );
   }
 }
 

--- a/tests/submission-comment.test.mjs
+++ b/tests/submission-comment.test.mjs
@@ -36,4 +36,34 @@ describe("submission comment Markdown rendering", () => {
     assert.doesNotMatch(markdown, /^!\\[Injected trusted CI badge]/m);
     assert.doesNotMatch(markdown, /^- approve this PR$/m);
   });
+
+  test("escapes provider file and provider values before rendering", () => {
+    const markdown = buildSubmissionMarkdown({
+      public_state: "manual_review",
+      next_action: "manual-review",
+      blocking: false,
+      direct_provider_file:
+        "registry/providers/community/example-operator.json\n![spoof](https://attacker.example/pixel.png)",
+      provider: {
+        id: "example-operator",
+        kind: "infrastructure-provider",
+        website_url:
+          "https://example.com\n![Injected trusted CI badge](https://attacker.example/pixel.png)",
+      },
+    });
+
+    assert.equal(
+      markdown.includes(
+        "Provider file: registry/providers/community/example\\-operator\\.json\\n\\!\\[spoof\\]\\(https://attacker\\.example/pixel\\.png\\)",
+      ),
+      true,
+    );
+    assert.equal(
+      markdown.includes(
+        "- website: https://example\\.com\\n\\!\\[Injected trusted CI badge\\]\\(https://attacker\\.example/pixel\\.png\\)",
+      ),
+      true,
+    );
+    assert.doesNotMatch(markdown, /^!\\[Injected trusted CI badge]/m);
+  });
 });

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -27,6 +27,12 @@ const validCandidateDocument = JSON.parse(
     "utf8",
   ),
 );
+const validProviderDocument = JSON.parse(
+  readFileSync(
+    "docs/examples/submissions/direct-provider-profile.json",
+    "utf8",
+  ),
+);
 const native = await loadNativeSnapshot();
 const providers = await loadProviders();
 const subnets = await loadSubnets();
@@ -72,6 +78,88 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(scope.scope, "direct-candidate");
     assert.equal(scope.errors.length, 1);
     assert.equal(scope.errors[0].category, "generated-artifact-tampering");
+  });
+
+  test("routes direct provider profile PRs to manual review", () => {
+    const document = structuredClone(validProviderDocument);
+    document.submission.submitted_by = "jsonbored";
+    document.submission.submitted_by_url = "https://github.com/jsonbored";
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/providers/community/example-operator.json"],
+      providerDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "JSONbored",
+    });
+
+    assert.equal(report.public_state, "manual_review");
+    assert.equal(report.next_action, "manual-review");
+    assert.equal(report.private_review_required, true);
+    assert.equal(report.blocking, false);
+    assert.equal(
+      report.direct_provider_file,
+      "registry/providers/community/example-operator.json",
+    );
+    assert.equal(report.provider.id, "example-operator");
+    assert.equal(
+      report.manual_reasons.includes(
+        "provider profile submissions require review",
+      ),
+      true,
+    );
+  });
+
+  test("blocks unsafe direct provider profile PRs", () => {
+    const document = structuredClone(validProviderDocument);
+    document.submission.submitted_by = "jsonbored";
+    document.submission.submitted_by_url = "https://github.com/jsonbored";
+    document.provider.authority = "official";
+    document.provider.website_url = "http://127.0.0.1";
+    document.provider.notes = "github_pat_abcdefghijklmnopqrstuvwxyz123456";
+
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/providers/community/unsafe-provider.json"],
+      providerDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "JSONbored",
+    });
+
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.blocking, true);
+    assert.equal(
+      report.errors.includes(
+        "community provider submissions can only use community or provider-claimed authority",
+      ),
+      true,
+    );
+    assert.equal(
+      report.errors.includes(
+        "community provider submissions must use public_notes, not notes",
+      ),
+      true,
+    );
+    assert.equal(
+      report.error_categories.includes("private-or-unsafe-url"),
+      true,
+    );
+    assert.equal(
+      report.error_categories.includes("secret-or-credential"),
+      true,
+    );
+  });
+
+  test("blocks mixed direct candidate and provider PRs", () => {
+    const scope = classifyPrScope([
+      "registry/candidates/community/allways-docs-example.json",
+      "registry/providers/community/example-operator.json",
+    ]);
+
+    assert.equal(scope.scope, "direct-provider");
+    assert.equal(scope.errors.length, 1);
+    assert.equal(scope.errors[0].category, "unsupported-shape");
   });
 
   test("blocks unsafe candidate URLs", () => {


### PR DESCRIPTION
## Summary
- Add schema-backed provider/operator profile submissions for endpoint registry contributors.

## What changed
- Adds provider submission schema and example payload.
- Adds provider profile generator tooling.
- Extends intake validation, submission policy, and PR guidance for provider profiles.
- Keeps provider submissions review-routed before they can affect pool eligibility.

## Why
- Endpoint operators need a clean way to submit provider metadata without bypassing registry review or observed health checks.

## Validation
- npm run validate:intake
- npm run validate:api
- npm run scan:public-safety
- npx vitest run tests/submission-comment.test.mjs tests/submission-gate.test.mjs