### PR TITLE
fix(intake): update submission marker comments in place

### DIFF
--- a/.github/workflows/intake-validation.yml
+++ b/.github/workflows/intake-validation.yml
@@ -50,9 +50,26 @@ jobs:
             const { execFileSync } = require('child_process');
             execFileSync('npm', ['run', 'submission:comment', '--', '--report', 'intake-report.json', '--out', 'intake-comment.md'], { stdio: 'inherit' });
             const body = fs.readFileSync('intake-comment.md', 'utf8');
-            await github.rest.issues.createComment({
+            const marker = '<!-- metagraphed-submission-gate -->';
+            const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.issue.number,
-              body
+              per_page: 100
             });
+            const existing = comments.find((comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.issue.number,
+                body
+              });
+            }

--- a/scripts/submission-comment.mjs
+++ b/scripts/submission-comment.mjs
@@ -1,5 +1,6 @@
 import { promises as fs } from "node:fs";
 import { pathToFileURL } from "node:url";
+import { SUBMISSION_REVIEW_MARKER } from "./submission-policy.mjs";
 
 if (
   process.argv[1] &&
@@ -10,6 +11,8 @@ if (
 
 export function buildSubmissionMarkdown(report) {
   const lines = [
+    report.review_marker || SUBMISSION_REVIEW_MARKER,
+    "",
     "## Metagraphed Submission Preflight",
     "",
     `State: ${formatMarkdownValue(report.public_state || report.state || "unknown")}`,

--- a/tests/submission-comment.test.mjs
+++ b/tests/submission-comment.test.mjs
@@ -7,6 +7,7 @@ describe("submission comment Markdown rendering", () => {
     const markdown = buildSubmissionMarkdown({
       public_state: "submit_pr",
       next_action: "private-review",
+      review_marker: "<!-- metagraphed-submission-gate -->",
       blocking: false,
       warnings: ["review\n![spoof](https://attacker.example/pixel.png)"],
       manual_reasons: ["- approve this PR"],
@@ -20,6 +21,7 @@ describe("submission comment Markdown rendering", () => {
       },
     });
 
+    assert.match(markdown, /^<!-- metagraphed-submission-gate -->\n\n## /);
     assert.equal(
       markdown.includes(
         "- url: https://example\\.com/path\\n\\!\\[Injected trusted CI badge\\]\\(https://attacker\\.example/pixel\\.png\\)",


### PR DESCRIPTION
## Summary
- Make public intake comments update the existing gate marker comment instead of posting repeated comments.

## What changed
- Adds the stable Metagraphed submission marker to workflow comments.
- Updates comment logic to edit the existing marker comment when present.
- Adds test coverage for the marker-comment behavior.

## Why
- Contributor PRs should get one clear gate comment, not noisy repeated bot comments on every validation pass.

## Validation
- npm run validate:intake
- npm run validate:workflows
- npx vitest run tests/submission-comment.test.mjs
- git diff --check