### PR TITLE
ci(cloudflare): smoke Worker-backed artifact routes

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -106,3 +106,9 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Smoke deployed API
+        if: steps.cloudflare-secrets.outputs.publish == 'true'
+        run: npm run smoke:live
+        env:
+          METAGRAPH_LIVE_BASE_URL: https://metagraph.sh

--- a/docs/cloudflare-backend.md
+++ b/docs/cloudflare-backend.md
@@ -4,7 +4,7 @@ Metagraphed uses Cloudflare as the serving, cache, and artifact-history layer. G
 
 ## Runtime Shape
 
-- Workers serve `metagraph.sh/api/v1/*` routes over canonical `/metagraph/*` artifact paths.
+- Workers serve `metagraph.sh/api/v1/*` and `metagraph.sh/metagraph/*.json` routes over canonical artifact paths so API consumers get consistent CORS, cache headers, storage-tier headers, and R2 fallback.
 - Workers Static Assets serve compact checked-in artifacts from `public/metagraph`.
 - R2 stores high-churn/detail artifacts staged under `dist/metagraph-r2/metagraph`, plus current artifact copies under `latest/`; versioned artifact history under `runs/{generated_at}/` is opt-in for publish jobs that set `METAGRAPH_R2_UPLOAD_HISTORY=1`.
 - KV stores small latest pointers, feature flags, endpoint-pool summaries, and source-freshness summaries when configured.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -53,6 +53,14 @@ Actual writes require explicit environment gates:
 
 Normal R2 publishes are delta-based. The uploader reads `latest/r2-manifest.json`, compares artifact SHA-256 values, reads R2-tier files from the staging tree, skips unchanged artifact files, and refreshes `latest/r2-manifest.json` plus `latest/build-summary.json` on full uploads so Worker fallback and operator summaries stay current.
 
+After the Worker is deployed, run the live smoke gate:
+
+```bash
+npm run smoke:live
+```
+
+The live smoke checks `metagraph.sh` API envelopes, Worker-mediated raw artifact routes, CORS/cache headers, R2-backed detail routes, invalid-query errors, and verifies the v1 RPC proxy still returns `rpc_proxy_disabled`.
+
 ## Restore From R2
 
 Dry-run:

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "cloudflare:verify:dry-run": "node scripts/cloudflare-verify.mjs",
     "worker:test": "node scripts/worker-test.mjs",
     "worker:deploy:dry-run": "node scripts/worker-deploy-dry-run.mjs",
+    "smoke:live": "node scripts/smoke-live-api.mjs",
     "lint": "eslint .",
     "format:check": "prettier --check .",
     "check": "npm run lint && npm run format:check && npm run pipeline:check && npm run validate:docs",

--- a/scripts/cloudflare-verify.mjs
+++ b/scripts/cloudflare-verify.mjs
@@ -54,6 +54,11 @@ check(
   "RPC routes must run Worker first",
 );
 check(
+  Array.isArray(config.assets?.run_worker_first) &&
+    config.assets.run_worker_first.includes("/metagraph/*"),
+  "Metagraph artifact routes must run Worker first for CORS, cache headers, and R2 fallback",
+);
+check(
   assetsIgnore.includes(".DS_Store") && assetsIgnore.includes("Thumbs.db"),
   "public/.assetsignore must block OS metadata uploads",
 );

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { API_ROUTES } from "../src/contracts.mjs";
+
+const DEFAULT_BASE_URL = "https://metagraph.sh";
+const baseUrl = normalizeBaseUrl(
+  process.env.METAGRAPH_LIVE_BASE_URL || DEFAULT_BASE_URL,
+);
+const timeoutMs = Number(process.env.METAGRAPH_LIVE_SMOKE_TIMEOUT_MS || 15000);
+const healthDate = await discoverHealthHistoryDate();
+const apiChecks = API_ROUTES.map((route) => ({
+  route: route.path,
+  url: apiRouteUrl(route.path, healthDate),
+}));
+const rawArtifactChecks = [
+  "/metagraph/openapi.json",
+  "/metagraph/r2-manifest.json",
+  "/metagraph/subnets/7.json",
+  "/metagraph/health/latest.json",
+  "/metagraph/candidates.json",
+  "/metagraph/review-queue.json",
+];
+const results = [];
+
+for (const check of apiChecks) {
+  const result = await fetchJson(check.url);
+  assert.equal(result.status, 200, `${check.route}: expected HTTP 200`);
+  assertHeader(result, "access-control-allow-origin", "*", check.route);
+  assert.ok(result.headers.get("etag"), `${check.route}: missing ETag`);
+  assert.ok(
+    result.headers.get("x-metagraph-contract-version"),
+    `${check.route}: missing contract version header`,
+  );
+  assert.equal(result.body?.ok, true, `${check.route}: expected ok envelope`);
+  assert.equal(
+    result.body?.schema_version,
+    1,
+    `${check.route}: expected schema_version 1`,
+  );
+  assert.ok(result.body?.data, `${check.route}: expected data payload`);
+  assert.ok(result.body?.meta, `${check.route}: expected meta payload`);
+  results.push({
+    path: new URL(check.url).pathname,
+    route: check.route,
+    status: result.status,
+    source: result.body.meta.source || null,
+  });
+}
+
+for (const artifactPath of rawArtifactChecks) {
+  const result = await fetchJson(`${baseUrl}${artifactPath}`);
+  assert.equal(result.status, 200, `${artifactPath}: expected HTTP 200`);
+  assertHeader(result, "access-control-allow-origin", "*", artifactPath);
+  assert.ok(result.headers.get("etag"), `${artifactPath}: missing ETag`);
+  assert.ok(
+    result.headers.get("x-metagraph-artifact-source"),
+    `${artifactPath}: missing artifact source header`,
+  );
+  assert.ok(
+    result.headers.get("x-metagraph-storage-tier"),
+    `${artifactPath}: missing storage tier header`,
+  );
+  assert.equal(
+    typeof result.body,
+    "object",
+    `${artifactPath}: expected JSON artifact body`,
+  );
+  results.push({
+    path: artifactPath,
+    route: artifactPath,
+    status: result.status,
+    source: result.headers.get("x-metagraph-artifact-source"),
+    storage_tier: result.headers.get("x-metagraph-storage-tier"),
+  });
+}
+
+const invalidQuery = await fetchJson(`${baseUrl}/api/v1/subnets?limit=0`);
+assert.equal(invalidQuery.status, 400, "invalid query should return HTTP 400");
+assert.equal(
+  invalidQuery.body?.error?.code,
+  "invalid_query",
+  "invalid query should return invalid_query error",
+);
+
+const disabledRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "chain_getHeader",
+    params: [],
+  }),
+});
+assert.equal(
+  disabledRpcProxy.status,
+  501,
+  "RPC proxy should remain disabled in v1 production",
+);
+assert.equal(
+  disabledRpcProxy.body?.error?.code,
+  "rpc_proxy_disabled",
+  "disabled RPC proxy should return rpc_proxy_disabled",
+);
+
+console.log(
+  JSON.stringify(
+    {
+      base_url: baseUrl,
+      status: "passed",
+      api_route_count: apiChecks.length,
+      raw_artifact_count: rawArtifactChecks.length,
+      health_history_date: healthDate,
+      checked_paths: results,
+    },
+    null,
+    2,
+  ),
+);
+
+async function discoverHealthHistoryDate() {
+  const result = await fetchJson(`${baseUrl}/metagraph/health/latest.json`);
+  assert.equal(
+    result.status,
+    200,
+    "/metagraph/health/latest.json: expected HTTP 200",
+  );
+  const generatedAt =
+    result.body?.probe_finished_at ||
+    result.body?.probe_started_at ||
+    result.body?.generated_at;
+  assert.match(
+    String(generatedAt || ""),
+    /^\d{4}-\d{2}-\d{2}T/,
+    "/metagraph/health/latest.json: probe timestamp must be an ISO timestamp",
+  );
+  return generatedAt.slice(0, 10);
+}
+
+function apiRouteUrl(routePath, date) {
+  const route = routePath
+    .replace("{netuid}", "7")
+    .replace("{slug}", "allways")
+    .replace("{date}", date);
+  const url = new URL(route, baseUrl);
+  if (routePath === "/api/v1/subnets") {
+    url.searchParams.set("limit", "3");
+    url.searchParams.set("sort", "netuid");
+  } else if (
+    [
+      "/api/v1/surfaces",
+      "/api/v1/endpoints",
+      "/api/v1/candidates",
+      "/api/v1/health/history/{date}",
+      "/api/v1/search",
+    ].includes(routePath)
+  ) {
+    url.searchParams.set("limit", "3");
+  }
+  return url.toString();
+}
+
+async function fetchJson(url, options = {}) {
+  const response = await fetch(url, {
+    ...options,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const contentType = response.headers.get("content-type") || "";
+  assert.match(
+    contentType,
+    /application\/json/,
+    `${url}: expected JSON content-type, got ${contentType || "none"}`,
+  );
+  return {
+    body: await response.json(),
+    headers: response.headers,
+    status: response.status,
+  };
+}
+
+function assertHeader(result, name, expected, route) {
+  assert.equal(
+    result.headers.get(name),
+    expected,
+    `${route}: expected ${name}=${expected}`,
+  );
+}
+
+function normalizeBaseUrl(value) {
+  const url = new URL(value);
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  url.search = "";
+  url.hash = "";
+  return url.toString().replace(/\/$/, "");
+}

--- a/scripts/worker-deploy-dry-run.mjs
+++ b/scripts/worker-deploy-dry-run.mjs
@@ -40,6 +40,11 @@ check(
   "RPC proxy routes must run Worker first",
 );
 check(
+  Array.isArray(config.assets?.run_worker_first) &&
+    config.assets.run_worker_first.includes("/metagraph/*"),
+  "Metagraph artifact routes must run Worker first",
+);
+check(
   assetsIgnore.includes(".DS_Store") && assetsIgnore.includes("Thumbs.db"),
   "public/.assetsignore must block OS metadata uploads",
 );

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,7 +11,7 @@
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",
-    "run_worker_first": ["/api/*", "/rpc/*"],
+    "run_worker_first": ["/api/*", "/rpc/*", "/metagraph/*"],
     "not_found_handling": "404-page",
   },
   "vars": {


### PR DESCRIPTION
## Summary
- Add production smoke coverage for Worker-backed API and raw artifact routes on metagraph.sh.

## What changed
- Makes /metagraph/* run Worker-first so raw artifacts get CORS, ETags, storage-tier headers, and R2 fallback.
- Adds npm run smoke:live for deployed API checks.
- Runs the live smoke after Cloudflare deploys in the publish workflow.
- Extends Cloudflare dry-run checks to enforce Worker-first artifact routing.

## Why
- Current production serves some raw /metagraph/* artifacts as plain static assets without CORS/source/tier headers. Future UI and API-doc consumers need the Worker-mediated contract consistently.

## Validation
- npm run lint
- npm run format:check
- npm run validate:docs
- npm run validate:workflows
- npm run validate:api
- npm run cloudflare:verify:dry-run
- npm run worker:deploy:dry-run
- npm run worker:test
- git diff --check

## Notes
- npm run smoke:live currently fails on production at /metagraph/openapi.json because this PR has not been deployed yet. That is the expected drift this PR fixes.