### PR TITLE
fix(r2): publish control artifacts after artifact uploads

### DIFF
--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -71,7 +71,8 @@ const remoteManifestByPath = new Map(
 );
 let changedArtifactCount = 0;
 let skippedArtifactCount = 0;
-const uploadJobs = [];
+const artifactUploadJobs = [];
+const controlUploadJobs = [];
 
 for (const artifact of plannedArtifacts) {
   const localPath = artifactLocalPath(artifact.path);
@@ -85,7 +86,7 @@ for (const artifact of plannedArtifacts) {
     continue;
   }
   changedArtifactCount += 1;
-  uploadJobs.push(
+  artifactUploadJobs.push(
     uploadJob(
       localPath,
       artifact.latest_key,
@@ -95,7 +96,7 @@ for (const artifact of plannedArtifacts) {
     ),
   );
   if (uploadHistory) {
-    uploadJobs.push(
+    artifactUploadJobs.push(
       uploadJob(
         localPath,
         artifact.key,
@@ -108,7 +109,7 @@ for (const artifact of plannedArtifacts) {
 }
 
 for (const controlArtifact of plannedControlArtifacts) {
-  uploadJobs.push(
+  controlUploadJobs.push(
     uploadJob(
       controlArtifact.local_path,
       controlArtifact.latest_key,
@@ -118,7 +119,7 @@ for (const controlArtifact of plannedControlArtifacts) {
     ),
   );
   if (uploadHistory) {
-    uploadJobs.push(
+    controlUploadJobs.push(
       uploadJob(
         controlArtifact.local_path,
         controlArtifact.key,
@@ -130,11 +131,16 @@ for (const controlArtifact of plannedControlArtifacts) {
   }
 }
 
-await putObjects(uploadJobs, {
+await putObjects(artifactUploadJobs, {
+  concurrency: uploadConcurrency,
+  progressInterval,
+});
+await putObjects(controlUploadJobs, {
   concurrency: uploadConcurrency,
   progressInterval,
 });
 
+const uploadJobs = [...artifactUploadJobs, ...controlUploadJobs];
 const uploadedLatestCount = uploadJobs.filter(
   (job) => job.kind === "latest",
 ).length;


### PR DESCRIPTION
### Motivation
- Prevent a race where `latest/r2-manifest.json` or other control artifacts can be uploaded before all referenced data artifacts have successfully finished, which can cause retries to skip missing or stale objects.
- Preserve existing delta/skip semantics and `latest`/`history` upload behavior while restoring the previous invariant that control artifacts are published only after data objects succeed.

### Description
- Split the single `uploadJobs` queue into `artifactUploadJobs` and `controlUploadJobs` so data artifacts are uploaded in a separate phase from control artifacts in `scripts/r2-upload.mjs`.
- Await `putObjects(artifactUploadJobs, ...)` to completion before calling `putObjects(controlUploadJobs, ...)` to enforce a barrier between artifact and control uploads.
- Combine the two phased job lists into `uploadJobs = [...artifactUploadJobs, ...controlUploadJobs]` afterward to retain the existing upload summary counting for `latest`, `history`, and `control` kinds.
- Kept existing behaviors such as `verifyLocalArtifact`, `uploadHistory` handling, content-type propagation, and manifest delta checks intact.

### Testing
- Ran `npm run lint`, which completed successfully.
- Ran `npx prettier --check scripts/r2-upload.mjs`, which passed after formatting the file with `prettier --write`.
- Ran `node scripts/r2-upload.mjs --dry-run`, which produced the expected dry-run JSON output.
- Ran the full test suite with `npm test` (Vitest), which failed due to missing generated public artifacts and environment DNS behavior unrelated to the R2 upload ordering change; the failures are environmental and not caused by this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2556e69848832c877e2fdc2d958763)