### PR TITLE
fix(ci): detect tampered public artifacts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -121,6 +121,18 @@ jobs:
         if: steps.route.outputs.mode == 'full'
         run: npm run build
 
+      - name: Verify submitted public artifacts are reproducible
+        if: steps.route.outputs.mode == 'full' && github.event_name == 'pull_request'
+        run: |
+          mapfile -t submitted_artifacts < <(
+            awk '/^public\/metagraph\// { print }' changed-files.txt
+          )
+          if [ "${#submitted_artifacts[@]}" -eq 0 ]; then
+            echo "No submitted public artifacts to verify."
+            exit 0
+          fi
+          git diff --exit-code -- "${submitted_artifacts[@]}"
+
       - name: Validate registry
         if: steps.route.outputs.mode == 'full'
         run: npm run validate


### PR DESCRIPTION
### Motivation
- The workflow previously ran `npm run build` before registry validation, which allowed CI to overwrite any maliciously modified checked-in files in `public/metagraph` and then validate the regenerated artifacts instead of the submitted contents. 
- Add a reproducibility check so PRs that modify public generated artifacts cannot hide tampering by relying on CI rebuilds.

### Description
- Inserted a workflow step in `.github/workflows/validate.yml` that runs after the `Build artifacts` step and only on `pull_request` full-mode runs to verify submitted public artifacts are reproducible. 
- The step extracts `public/metagraph/**` paths from `changed-files.txt` and exits successfully if none are present. 
- If submitted public artifacts exist, the step runs `git diff --exit-code -- "${submitted_artifacts[@]}"` to fail CI when regenerated artifacts differ from the PR content.

### Testing
- Ran `npm run validate:workflows` and the workflow files validation succeeded. 
- Performed a tamper PoC by staging a modified `public/metagraph/coverage.json`, running `npm run build`, and confirmed the new `git diff --exit-code` check detected regenerated differences (test passed by failing as expected). 
- Ran `npm run build && npm run validate` to ensure the normal build+validate flow still completes successfully (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25574e904c832c916c810106cebf18)