### PR TITLE
fix(build): timestamp production artifact runs

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -3,6 +3,8 @@ import { stableStringify } from "./lib.mjs";
 
 const productionBuild = isProductionPublishBuild();
 const startedAt = new Date().toISOString();
+const effectiveBuildTimestamp =
+  process.env.METAGRAPH_BUILD_TIMESTAMP || (productionBuild ? startedAt : null);
 const steps = productionBuild ? productionSteps() : localSteps();
 const results = [];
 
@@ -13,6 +15,9 @@ for (const step of steps) {
     encoding: "utf8",
     env: {
       ...process.env,
+      ...(effectiveBuildTimestamp
+        ? { METAGRAPH_BUILD_TIMESTAMP: effectiveBuildTimestamp }
+        : {}),
       ...(step.env || {}),
     },
     stdio: "pipe",


### PR DESCRIPTION
## Summary
- make production publish builds inject one real build timestamp into all child generation steps
- keep local/review builds deterministic unless METAGRAPH_BUILD_TIMESTAMP is explicitly set

## Why
Production R2 history should not publish under the deterministic 1970 run prefix used for reviewable local diffs.

## Validation
- npm run lint
- npm run format:check
- git diff --check -- scripts/build.mjs
