### PR TITLE
fix(intake): bound submission comment lookup

### DIFF
--- a/.github/workflows/intake-validation.yml
+++ b/.github/workflows/intake-validation.yml
@@ -50,14 +50,12 @@ jobs:
             const { execFileSync } = require('child_process');
             execFileSync('npm', ['run', 'submission:comment', '--', '--report', 'intake-report.json', '--out', 'intake-comment.md'], { stdio: 'inherit' });
             const body = fs.readFileSync('intake-comment.md', 'utf8');
-            const marker = '<!-- metagraphed-submission-gate -->';
-            const comments = await github.paginate(github.rest.issues.listComments, {
+            const { findSubmissionComment } = await import(`${process.env.GITHUB_WORKSPACE}/scripts/submission-comment.mjs`);
+            const existing = await findSubmissionComment(github, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.payload.issue.number,
-              per_page: 100
+              issueNumber: context.payload.issue.number
             });
-            const existing = comments.find((comment) => comment.user?.type === 'Bot' && comment.body?.includes(marker));
             if (existing) {
               await github.rest.issues.updateComment({
                 owner: context.repo.owner,

--- a/scripts/submission-comment.mjs
+++ b/scripts/submission-comment.mjs
@@ -72,6 +72,51 @@ export function buildSubmissionMarkdown(report) {
   return lines.join("\n");
 }
 
+export async function findSubmissionComment(
+  github,
+  {
+    owner,
+    repo,
+    issueNumber,
+    marker = SUBMISSION_REVIEW_MARKER,
+    botLogin = "github-actions[bot]",
+    maxPages = 2,
+    perPage = 100,
+  },
+) {
+  const pagesToScan = Math.max(1, maxPages);
+  const commentsPerPage = Math.min(100, Math.max(1, perPage));
+  let pagesScanned = 0;
+
+  for await (const page of github.paginate.iterator(
+    github.rest.issues.listComments,
+    {
+      owner,
+      repo,
+      issue_number: issueNumber,
+      per_page: commentsPerPage,
+    },
+  )) {
+    pagesScanned += 1;
+    const existing = page.data.find(
+      (comment) =>
+        comment.user?.type === "Bot" &&
+        comment.user?.login === botLogin &&
+        comment.body?.includes(marker),
+    );
+
+    if (existing) {
+      return existing;
+    }
+
+    if (pagesScanned >= pagesToScan) {
+      break;
+    }
+  }
+
+  return null;
+}
+
 async function main(args) {
   const reportPath = valueAfter(args, "--report");
   const outPath = valueAfter(args, "--out");

--- a/tests/submission-comment.test.mjs
+++ b/tests/submission-comment.test.mjs
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
-import { buildSubmissionMarkdown } from "../scripts/submission-comment.mjs";
+import {
+  buildSubmissionMarkdown,
+  findSubmissionComment,
+} from "../scripts/submission-comment.mjs";
 
 describe("submission comment Markdown rendering", () => {
   test("escapes candidate and list values before rendering GitHub summaries", () => {
@@ -69,3 +72,107 @@ describe("submission comment Markdown rendering", () => {
     assert.doesNotMatch(markdown, /^!\\[Injected trusted CI badge]/m);
   });
 });
+
+describe("submission comment lookup", () => {
+  test("stops paginating as soon as the actions bot marker comment is found", async () => {
+    const calls = [];
+    const github = mockGithubWithCommentPages(
+      [
+        [
+          {
+            id: 123,
+            user: { type: "Bot", login: "github-actions[bot]" },
+            body: "<!-- metagraphed-submission-gate -->\nready",
+          },
+        ],
+        [
+          {
+            id: 456,
+            user: { type: "User", login: "attacker" },
+            body: "noise",
+          },
+        ],
+      ],
+      calls,
+    );
+
+    const comment = await findSubmissionComment(github, {
+      owner: "JSONbored",
+      repo: "metagraphed",
+      issueNumber: 7,
+    });
+
+    assert.equal(comment.id, 123);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], {
+      owner: "JSONbored",
+      repo: "metagraphed",
+      issue_number: 7,
+      per_page: 100,
+    });
+  });
+
+  test("bounds marker searches and ignores spoofed non-actions-bot comments", async () => {
+    const calls = [];
+    const github = mockGithubWithCommentPages(
+      [
+        [
+          {
+            id: 123,
+            user: { type: "Bot", login: "not-actions[bot]" },
+            body: "<!-- metagraphed-submission-gate -->",
+          },
+        ],
+        [
+          {
+            id: 456,
+            user: { type: "User", login: "github-actions[bot]" },
+            body: "<!-- metagraphed-submission-gate -->",
+          },
+        ],
+        [
+          {
+            id: 789,
+            user: { type: "Bot", login: "github-actions[bot]" },
+            body: "<!-- metagraphed-submission-gate -->",
+          },
+        ],
+      ],
+      calls,
+    );
+
+    const comment = await findSubmissionComment(github, {
+      owner: "JSONbored",
+      repo: "metagraphed",
+      issueNumber: 7,
+      maxPages: 2,
+      perPage: 250,
+    });
+
+    assert.equal(comment, null);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].per_page, 100);
+  });
+});
+
+function mockGithubWithCommentPages(pages, calls) {
+  const listComments = () => {};
+  return {
+    rest: {
+      issues: {
+        listComments,
+      },
+    },
+    paginate: {
+      iterator(endpoint, options) {
+        assert.equal(endpoint, listComments);
+        return (async function* commentPages() {
+          for (const page of pages) {
+            calls.push(options);
+            yield { data: page };
+          }
+        })();
+      },
+    },
+  };
+}


### PR DESCRIPTION
### Motivation
- Prevent unbounded pagination of public issue comments in the intake workflow that can be amplified by attacker comment spam and exhaust Actions/GitHub API resources.

### Description
- Replace materializing `github.paginate(...)` with a new `findSubmissionComment` helper that uses `github.paginate.iterator(...)`, scans a bounded number of pages, and exits early when the marker is found.
- Restrict marker matches to the expected `github-actions[bot]` identity to avoid spoofed matches from other users or bots.
- Update `.github/workflows/intake-validation.yml` to import and call `findSubmissionComment` and preserve the existing update/create comment behavior.
- Add focused tests in `tests/submission-comment.test.mjs` covering early exit, page bounding, `per_page` clamping, and spoofed non-actions-bot comments.

### Testing
- Ran the targeted unit tests with `npm test -- --run tests/submission-comment.test.mjs`, which passed (4 tests passing).
- Ran `npm run lint -- scripts/submission-comment.mjs tests/submission-comment.test.mjs` and `npx prettier --check .github/workflows/intake-validation.yml scripts/submission-comment.mjs tests/submission-comment.test.mjs`, both succeeded after formatting changes.
- Ran `npm run validate:workflows`, which validated the workflow files successfully.
- Ran the full test suite with `npm test`; unrelated environment/fixture issues caused unrelated test failures (missing generated `public/metagraph` and `dist/metagraph-r2` artifacts and container DNS behavior), not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25858d2718832ca49415c320145316)