### PR TITLE
fix(ci): verify all submitted public artifacts

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -125,12 +125,7 @@ jobs:
         if: steps.route.outputs.mode == 'full' && github.event_name == 'pull_request'
         run: |
           mapfile -t submitted_artifacts < <(
-            awk '
-              /^public\/metagraph\// &&
-              $0 != "public/metagraph/build-summary.json" &&
-              $0 != "public/metagraph/changelog.json" &&
-              $0 != "public/metagraph/r2-manifest.json" { print }
-            ' changed-files.txt
+            awk '/^public\/metagraph\// { print }' changed-files.txt
           )
           if [ "${#submitted_artifacts[@]}" -eq 0 ]; then
             echo "No submitted public artifacts to verify."


### PR DESCRIPTION
### Motivation
- Prevent a CI bypass where rebuilt generated artifacts (notably `public/metagraph/r2-manifest.json`, `build-summary.json`, and `changelog.json`) could be regenerated before the reproducibility check and therefore let tampered committed public artifacts pass validation.

### Description
- Remove the exclusion list from the reproducibility gate in `.github/workflows/validate.yml` so the `awk` filter now includes every `public/metagraph/*` path (changed block replaced with `awk '/^public\/metagraph\// { print }' changed-files.txt`) and `git diff --exit-code` runs against all submitted public artifacts.

### Testing
- Ran `git diff --check` and `npm run validate:workflows`, exercised the `awk '/^public\/metagraph\// { print }'` selection manually, and attempted `npm test` (CI/workflow validation commands succeeded; `npm test` failed in this environment due to missing generated artifacts and differing DNS behavior, not due to the workflow change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a258b1ad0fc832ca04650646cabfacf)