### PR TITLE
refactor(registry): keep generated overlays stable

### DIFF
--- a/scripts/curate-baseline.mjs
+++ b/scripts/curate-baseline.mjs
@@ -108,12 +108,6 @@ function buildGeneratedOverlay(nativeSubnet) {
   const sourceUrls = new Set(
     promotedSurfaces.flatMap((surface) => surface.source_urls || []),
   );
-  const verifiedAt =
-    promotedSurfaces
-      .map((surface) => surface.verification?.verified_at)
-      .filter(Boolean)
-      .sort()
-      .at(-1) || null;
 
   const slug = nativeSubnet.netuid === 0 ? "root" : `sn-${nativeSubnet.netuid}`;
   const existingOverlay = existingGeneratedByNetuid.get(nativeSubnet.netuid);
@@ -146,7 +140,7 @@ function buildGeneratedOverlay(nativeSubnet) {
           : "candidate-discovered",
       review_state: "machine-generated",
       reviewed_at: null,
-      verified_at: verifiedAt,
+      verified_at: null,
       source_count: sourceUrls.size,
       gap_notes: gaps.gap_notes,
     },
@@ -286,22 +280,6 @@ function promoteCandidate(candidate, verification) {
     authority: "registry-observed",
     public_safe: true,
     source_urls: candidate.source_urls || [candidate.source_url],
-    verification: {
-      archived: verification.archived,
-      classification: verification.classification,
-      confidence_score: verification.confidence_score,
-      content_type: verification.content_type || null,
-      default_branch: verification.default_branch,
-      github_api_url: verification.github_api_url,
-      homepage: verification.homepage,
-      last_push_at: verification.last_push_at,
-      latency_ms: verification.latency_ms,
-      method_tested: verification.method_tested,
-      redirect_target: verification.redirect_target || null,
-      status_code: verification.status_code,
-      topics: verification.topics,
-      verified_at: verification.verified_at,
-    },
     quality_signals: verification.quality_signals,
     rate_limit_notes: candidate.rate_limit_notes,
     probe: probeForKind(candidate.kind),

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -249,14 +249,12 @@ function validateSubnet(subnet, providerIds, surfaceIds, surfaceLocators) {
         Array.isArray(surface.source_urls) && surface.source_urls.length > 0,
         `${surfaceKey}: source_urls required`,
       );
-      assert(
-        surface.verification !== undefined,
-        `${surfaceKey}: verification is required for registry-observed surfaces`,
-      );
-      assert(
-        ["live", "redirected"].includes(surface.verification?.classification),
-        `${surfaceKey}: promoted registry-observed surface must be live or redirected`,
-      );
+      if (surface.verification !== undefined) {
+        assert(
+          ["live", "redirected"].includes(surface.verification?.classification),
+          `${surfaceKey}: promoted registry-observed surface must be live or redirected`,
+        );
+      }
     }
 
     if (surface.probe !== undefined) {


### PR DESCRIPTION
## Summary
- remove volatile per-surface verification snapshots from generated subnet overlays
- keep generated overlay review metadata stable between probe runs
- continue validating embedded verification metadata when hand-curated overlays include it

## Why
Generated overlays should describe reviewed public interface metadata. Probe-derived freshness, latency, redirect state, and health belong in verification/health artifacts and R2 history, otherwise routine probe runs create noisy registry PRs.

## Validation
- npm run validate
- npm run test:coverage
- npm run lint
- npm run format:check
- git diff --check

## Notes
This is source-only. The actual registry data refresh should be rerun after this lands so the data PR is smaller and easier to review.