### PR TITLE
fix(worker): fall back to static metagraph artifacts when not in raw allowlist

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -82,6 +82,29 @@ describe("Worker runtime", () => {
     assert.equal(assetMissing.status, 404);
   });
 
+  test("falls back to static assets for generated raw artifacts outside public contracts", async () => {
+    const r2KeysRequested = [];
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/metagraph/latest.json"),
+      {
+        ASSETS: env.ASSETS,
+        METAGRAPH_ARCHIVE: {
+          async get(key) {
+            r2KeysRequested.push(key);
+            return null;
+          },
+        },
+      },
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-metagraph-artifact-source"), "assets");
+    assert.equal(response.headers.get("x-metagraph-storage-tier"), "git");
+    assert.deepEqual(r2KeysRequested, []);
+    assert.equal((await response.json()).network, "finney");
+  });
+
   test("rejects raw artifact paths outside public contracts before R2 lookup", async () => {
     const r2KeysRequested = [];
     const response = await handleRequest(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -106,6 +106,11 @@ export async function handleRequest(request, env = {}, _ctx = {}) {
 
 async function handleRawArtifactRequest(request, env, url) {
   if (!matchRawArtifact(url.pathname)) {
+    const staticAsset = await readStaticRawArtifact(request, env, url);
+    if (staticAsset) {
+      return staticAsset;
+    }
+
     return errorResponse(
       "not_found",
       "No public artifact contract matched this path.",
@@ -133,6 +138,32 @@ async function handleRawArtifactRequest(request, env, url) {
   }
   return new Response(request.method === "HEAD" ? null : body, {
     status: 200,
+    headers,
+  });
+}
+
+async function readStaticRawArtifact(request, env, url) {
+  if (!env.ASSETS?.fetch) {
+    return null;
+  }
+
+  const assetResponse = await env.ASSETS.fetch(request);
+  if (assetResponse.status === 404) {
+    return null;
+  }
+
+  const headers = new Headers(assetResponse.headers);
+  for (const [name, value] of apiHeaders("standard")) {
+    headers.set(name, value);
+  }
+  headers.set("x-metagraph-artifact-source", "assets");
+  headers.set(
+    "x-metagraph-storage-tier",
+    artifactStorageTierForPath(url.pathname),
+  );
+  return new Response(request.method === "HEAD" ? null : assetResponse.body, {
+    status: assetResponse.status,
+    statusText: assetResponse.statusText,
     headers,
   });
 }


### PR DESCRIPTION
### Motivation
- The Worker intercepts `/metagraph/*.json` (Cloudflare `run_worker_first`) and returns a JSON 404 when a path is not in the Worker raw artifact allowlist, which hides checked-in generated artifacts such as `/metagraph/metagraph/latest.json` that are served from the Static Assets binding.
- Preserve availability and API compatibility by allowing unmatched `/metagraph/*.json` requests to fall through to the static asset binding before returning the existing JSON 404.

### Description
- Try the Static Assets binding for unmatched raw artifact paths by adding a `readStaticRawArtifact(request, env, url)` helper and calling it from `handleRawArtifactRequest` when `matchRawArtifact` is false; this returns the asset response with standard API headers and artifact metadata if present.
- Ensure the original JSON 404 (`not_found`) remains the fallback when neither a public artifact contract nor a static asset exists.
- Update `workers/api.mjs` to add the fallback logic and the `readStaticRawArtifact` helper.
- Add a regression test in `tests/worker-runtime.test.mjs` that verifies `/metagraph/metagraph/latest.json` is served from `ASSETS` when it is outside the Worker raw allowlist.

### Testing
- Ran targeted regression test: `npm test -- tests/worker-runtime.test.mjs -t "falls back to static assets"`, and it passed.
- Verified formatting with `npx prettier --check workers/api.mjs tests/worker-runtime.test.mjs`, which passed, and lint with `npm run lint -- workers/api.mjs tests/worker-runtime.test.mjs`, which passed.
- Ran the dedicated worker runtime smoke test `npm run worker:test`, which reported "Worker runtime tests passed." and thus exercised the new behavior.
- Ran the full worker runtime test file `npm test -- tests/worker-runtime.test.mjs`; the run showed unrelated failures due to this checkout missing generated R2 fixture files under `dist/metagraph-r2/metagraph` (pre-existing environment/fixture gap), not caused by the new fallback logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a258be4d5d4832caf2b220d31e32ccb)