### PR TITLE
test(intake): add disposable community candidate

### DIFF
--- a/registry/candidates/community/community-sn-0-docs-docs-learnbittensor-org.json
+++ b/registry/candidates/community/community-sn-0-docs-docs-learnbittensor-org.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-0-docs-docs-learnbittensor-org",
+      "kind": "docs",
+      "name": "Bittensor neurons docs",
+      "netuid": 0,
+      "provider": "opentensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://docs.learnbittensor.org/learn/neurons",
+      "source_urls": [
+        "https://docs.learnbittensor.org/learn/neurons"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.learnbittensor.org/learn/neurons"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
## Summary
- disposable UGC submission-gate smoke test
- adds one community candidate file for official Bittensor neuron docs

## Why
This PR is intended to verify the live Metagraphed submission gate path for one-candidate community submissions. It should be reviewed/closed after gate behavior is confirmed.

## Validation
- npm run candidate:new -- --write --netuid 0 --kind docs --url https://docs.learnbittensor.org/learn/neurons --source-url https://docs.learnbittensor.org/learn/neurons --provider opentensor --submitted-by JSONbored --name "Bittensor neurons docs"
- npm run submission:pr -- --changed-files <changed-files.txt> --submitter jsonbored

## Notes
This is a disposable operational test PR, not a production registry update.