### PR TITLE
Require verification evidence for registry-observed surfaces

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -143,7 +143,13 @@ function validateProvider(provider) {
   );
 }
 
-function validateSubnet(subnet, providerIds, surfaceIds, surfaceLocators) {
+function validateSubnet(
+  subnet,
+  providerIds,
+  surfaceIds,
+  surfaceLocators,
+  registryVerificationEvidence,
+) {
   assert(
     subnet.schema_version === 1,
     `${subnet.slug || "subnet"}: schema_version must be 1`,
@@ -249,9 +255,35 @@ function validateSubnet(subnet, providerIds, surfaceIds, surfaceLocators) {
         Array.isArray(surface.source_urls) && surface.source_urls.length > 0,
         `${surfaceKey}: source_urls required`,
       );
-      if (surface.verification !== undefined) {
+      const verificationEvidence =
+        surface.verification ||
+        registryVerificationEvidence.get(
+          registrySurfaceKey({
+            ...surface,
+            netuid: subnet.netuid,
+          }),
+        );
+      assert(
+        verificationEvidence !== undefined,
+        `${surfaceKey}: registry-observed surface requires verification evidence`,
+      );
+      if (verificationEvidence !== undefined) {
+        validateVerification(
+          `${surfaceKey}:verification evidence`,
+          verificationEvidence,
+        );
         assert(
-          ["live", "redirected"].includes(surface.verification?.classification),
+          verificationEvidence.candidate_id === undefined ||
+            verificationEvidence.candidate_id === surface.id,
+          `${surfaceKey}: verification evidence must match surface id`,
+        );
+        assert(
+          verificationEvidence.provider === undefined ||
+            verificationEvidence.provider === surface.provider,
+          `${surfaceKey}: verification evidence must match provider`,
+        );
+        assert(
+          ["live", "redirected"].includes(verificationEvidence.classification),
           `${surfaceKey}: promoted registry-observed surface must be live or redirected`,
         );
       }
@@ -1193,6 +1225,12 @@ const slugs = new Set();
 const surfaceIds = new Set();
 const surfaceLocators = new Set();
 const nativeNetuids = validateNativeSnapshot(nativeSnapshot);
+const registryVerificationEvidence = new Map(
+  (verificationDocument.results || []).map((result) => [
+    registrySurfaceKey(result),
+    result,
+  ]),
+);
 const candidateIds = new Set();
 const candidateLocators = new Set();
 
@@ -1218,7 +1256,13 @@ for (const subnet of subnets) {
   );
   netuids.add(subnet.netuid);
   slugs.add(subnet.slug);
-  validateSubnet(subnet, providerIds, surfaceIds, surfaceLocators);
+  validateSubnet(
+    subnet,
+    providerIds,
+    surfaceIds,
+    surfaceLocators,
+    registryVerificationEvidence,
+  );
 }
 
 for (const nativeNetuid of nativeNetuids) {

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -29,6 +29,43 @@ test("registry validates", () => {
   runNode("scripts/validate.mjs");
 });
 
+test("registry validation rejects registry-observed surfaces without verification evidence", () => {
+  const overlayPath = "registry/subnets/generated/sn-1.json";
+  const original = readFileSync(overlayPath, "utf8");
+  const tampered = JSON.parse(original);
+
+  tampered.surfaces.push({
+    id: "sn-1-unverified-registry-observed",
+    name: "Unverified registry-observed surface",
+    kind: "website",
+    url: "https://example.invalid/unverified-registry-observed",
+    provider: "taomarketcap",
+    auth_required: false,
+    authority: "registry-observed",
+    public_safe: true,
+    source_urls: ["https://example.invalid/source"],
+  });
+
+  let failure;
+  try {
+    writeFileSync(overlayPath, `${JSON.stringify(tampered, null, 2)}\n`);
+    runNode("scripts/validate.mjs");
+  } catch (error) {
+    failure = error;
+  } finally {
+    writeFileSync(overlayPath, original);
+  }
+
+  assert(
+    failure,
+    "expected validation to reject a registry-observed surface without verification evidence",
+  );
+  assert.match(
+    `${failure.stdout || ""}\n${failure.stderr || ""}`,
+    /registry-observed surface requires verification evidence/,
+  );
+});
+
 test("registry validation rejects tampered per-subnet artifacts", () => {
   const artifactPath = artifactFilePath("subnets/0.json");
   const original = readFileSync(artifactPath, "utf8");


### PR DESCRIPTION
### Motivation
- A recent change allowed generated overlays to mark surfaces as `registry-observed`/`public_safe` while omitting a `verification` object, which weakened validation and let unverified registry surfaces be published as verified artifacts.
- This patch restores the intended integrity invariant by requiring live/redirected verification evidence for promoted `registry-observed` surfaces, preventing forged or malicious surfaces from being treated as verified metadata.

### Description
- Update `scripts/validate.mjs` to read `registry/verification/latest.json` into a `registryVerificationEvidence` map and pass it into `validateSubnet` so registry ledger entries can be used as evidence. 
- Change `validateSubnet` to require verification evidence for `authority === "registry-observed"` by using either `surface.verification` or a matching ledger entry and to validate that evidence with `validateVerification`.
- Add integrity checks that external verification evidence must match the surface `id` and `provider` before it can satisfy the promoted invariant and require classification to be `live` or `redirected`.
- Add a regression test `tests/artifacts.test.mjs` that injects a forged `registry-observed` surface into `registry/subnets/generated/sn-1.json` and asserts `scripts/validate.mjs` rejects it.

### Testing
- Ran `npm run build` and the build steps (`build-artifacts`, `generate-types`, `generate-client`, `r2-manifest`) completed successfully. 
- Ran `npm run validate` after build and it printed a successful validation summary, so validation now enforces the evidence requirement. 
- Ran formatting and linting with `npx prettier --write`, `npm run format:check`, and `npm run lint`, which all succeeded. 
- Ran the unit/regression tests with `npm test -- tests/artifacts.test.mjs` (Vitest) and the test suite passed (`Test Files 1 passed`, `Tests 8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2597f36dec832c9299754531819e66)