### PR TITLE
fix(worker): allowlist static raw artifact fallback

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -105,14 +105,16 @@ describe("Worker runtime", () => {
     assert.equal((await response.json()).network, "finney");
   });
 
-  test("rejects raw artifact paths outside public contracts before R2 lookup", async () => {
+  test("rejects raw artifact paths outside public contracts before storage lookup", async () => {
+    const assetRequests = [];
     const r2KeysRequested = [];
     const response = await handleRequest(
       new Request("https://metagraph.sh/metagraph/internal/control.json"),
       {
         ASSETS: {
-          async fetch() {
-            return new Response("not found", { status: 404 });
+          async fetch(request) {
+            assetRequests.push(new URL(request.url).pathname);
+            return Response.json({ secret_token: "should-not-be-public" });
           },
         },
         METAGRAPH_ARCHIVE: {
@@ -131,6 +133,7 @@ describe("Worker runtime", () => {
 
     assert.equal(response.status, 404);
     assert.equal(response.headers.get("x-metagraph-error-code"), "not_found");
+    assert.deepEqual(assetRequests, []);
     assert.deepEqual(r2KeysRequested, []);
     assert.equal(
       (await response.json()).meta.artifact_path,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -44,6 +44,7 @@ const DENIED_RPC_PREFIXES = [
 ];
 const MAX_RPC_BODY_BYTES = 65536;
 const METAGRAPH_LATEST_KEY = "metagraph:latest";
+const STATIC_RAW_ARTIFACT_PATHS = new Set(["/metagraph/metagraph/latest.json"]);
 const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
   "https://bittensor-finney.api.onfinality.io",
   "https://bittensor-public.nodies.app",
@@ -143,6 +144,10 @@ async function handleRawArtifactRequest(request, env, url) {
 }
 
 async function readStaticRawArtifact(request, env, url) {
+  if (!STATIC_RAW_ARTIFACT_PATHS.has(url.pathname)) {
+    return null;
+  }
+
   if (!env.ASSETS?.fetch) {
     return null;
   }


### PR DESCRIPTION
### Motivation
- Prevent overbroad exposure of arbitrary static JSON under `/metagraph/` by restoring deny-by-default behavior and only permitting the explicit generated static artifact fallback.

### Description
- Add a narrow allowlist `STATIC_RAW_ARTIFACT_PATHS` and check it in `readStaticRawArtifact` so `env.ASSETS.fetch` is only attempted for explicitly allowed paths (currently `/metagraph/metagraph/latest.json`).
- Update the worker runtime test in `tests/worker-runtime.test.mjs` to assert unmatched raw artifact paths are rejected before any static `ASSETS` or R2 lookup occurs and to ensure `ASSETS` is not called for denied paths.
- Changes are limited to `workers/api.mjs` and `tests/worker-runtime.test.mjs` to minimize surface area.

### Testing
- Ran targeted tests with `npx vitest run tests/worker-runtime.test.mjs -t "falls back|rejects raw"`, and the targeted security/regression tests passed.
- Ran linters and formatter checks with `npm run lint` and `npm run format:check`, both of which succeeded.
- Running the full worker runtime test file with `npm test -- tests/worker-runtime.test.mjs` still shows unrelated fixture/R2-backed storage failures in other tests due to missing local artifact/R2 fixture data; the introduced allowlist change does not cause these failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259979b470832cb44d349effb7eaee)