### PR TITLE
feat(intake): add freshness gates and profile submissions

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-update-subnet-profile-source.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-subnet-profile-source.yml
@@ -1,0 +1,94 @@
+name: Add or update subnet profile source
+description: Submit an official docs, website, source repo, dashboard, or profile source correction.
+title: "profile: "
+labels:
+  - interface-submission
+  - profile-correction
+  - metagraphed-under-review
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this for profile/source corrections such as official websites, docs, source repos, dashboards, or public data artifacts. These submissions become review candidates; they do not directly change observed health, uptime, latency, or pool eligibility.
+  - type: input
+    id: netuid
+    attributes:
+      label: Netuid
+      description: Bittensor subnet netuid for this profile/source correction.
+      placeholder: "7"
+    validations:
+      required: true
+  - type: input
+    id: subnet_name
+    attributes:
+      label: Subnet name
+      placeholder: Allways
+    validations:
+      required: true
+  - type: dropdown
+    id: kind
+    attributes:
+      label: Interface kind
+      description: Choose the public surface this correction updates.
+      options:
+        - website
+        - docs
+        - source-repo
+        - dashboard
+        - data-artifact
+        - openapi
+        - subnet-api
+        - sse
+        - sdk
+        - example
+    validations:
+      required: true
+  - type: input
+    id: url
+    attributes:
+      label: Public URL
+      description: The exact public URL that should be reviewed for this subnet profile.
+      placeholder: https://example.com/docs
+    validations:
+      required: true
+  - type: input
+    id: source_url
+    attributes:
+      label: Source URL
+      description: Public docs, repository, official site, or announcement supporting the correction.
+      placeholder: https://docs.example.com
+    validations:
+      required: true
+  - type: input
+    id: provider
+    attributes:
+      label: Provider or team
+      placeholder: example-team
+    validations:
+      required: true
+  - type: dropdown
+    id: auth_required
+    attributes:
+      label: Does this interface require authentication?
+      options:
+        - "no"
+        - "yes"
+        - "unknown"
+    validations:
+      required: true
+  - type: textarea
+    id: rate_limits
+    attributes:
+      label: Public notes
+      description: Include public-safe context about the correction, rate limits, auth requirements, or source provenance. Do not include credentials.
+  - type: checkboxes
+    id: public_safety
+    attributes:
+      label: Public-safety confirmation
+      options:
+        - label: This correction includes only public-safe source/profile metadata.
+          required: true
+        - label: The submitted URL can be checked with read-only probes if it is probeable.
+          required: true
+        - label: I understand profile/source corrections still require review before publication.
+          required: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,8 +47,9 @@ two supported paths:
 - PR-first: add exactly one `registry/candidates/community/*.json` candidate
   document or exactly one `registry/providers/community/*.json` provider
   profile document and no other files.
-- Issue-first: submit an `interface-submission` issue and let the import
-  workflow create the candidate PR after approval.
+- Issue-first: submit an `interface-submission`, `profile-correction`,
+  `endpoint-submission`, `provider-submission`, or `status-report` issue and
+  let the import/review workflow create the candidate PR after approval.
 - Endpoint/provider/status issues: submit endpoint resources, provider profiles,
   or status reports through the matching issue template. These create review or
   re-probe work; they do not directly change observed health.
@@ -66,6 +67,8 @@ npm run provider:new -- --id example-operator --name "Example Operator" --kind i
 ```
 
 Example payloads live under `docs/examples/submissions`.
+Useful examples include direct candidates, endpoint resources, OpenAPI/schema
+URLs, provider profiles, profile/source corrections, and status reports.
 
 Do not include generated `public/metagraph/**` artifacts, native snapshots,
 workflow/script changes, secrets, wallet/PAT material, private URLs, or
@@ -97,6 +100,11 @@ Status reports never set uptime, latency, health status, incident state, or pool
 eligibility. They can only trigger review or a future re-probe; operational state
 comes from Metagraphed probes and adapters.
 
+Profile/source corrections are welcome for official websites, docs, source
+repos, dashboards, OpenAPI/schema URLs, SDKs, examples, or public data artifacts.
+Approved corrections improve profile completeness and gap reports; they do not
+override native chain state or observed endpoint health.
+
 The issue import flow is:
 
 1. Submit an `interface-submission` issue.
@@ -119,6 +127,16 @@ npm run pipeline:refresh
 ```
 
 for full local refreshes. Set `METAGRAPH_WRITE_PROBE_RESULTS=1` only when you intentionally want live probe artifacts updated.
+
+Production publishes can require freshness gates:
+
+```bash
+METAGRAPH_REQUIRE_PROBE_HEALTH=1 METAGRAPH_REQUIRE_FRESHNESS=1 npm run validate
+```
+
+Freshness is exposed in `/metagraph/freshness.json` and `/api/v1/freshness`.
+Required publish lanes include native subnet data, candidate discovery,
+candidate verification, probe-derived health, and adapter snapshots.
 
 ## Pull Requests
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ Worker API routes expose stable envelopes over the same canonical artifacts:
 - `/api/v1`
 - `/api/v1/subnets`
 - `/api/v1/subnets/{netuid}`
+- `/api/v1/profiles`
+- `/api/v1/subnets/{netuid}/profile`
 - `/api/v1/surfaces`
 - `/api/v1/subnets/{netuid}/surfaces`
 - `/api/v1/endpoints`
@@ -151,6 +153,9 @@ Worker API routes expose stable envelopes over the same canonical artifacts:
 - `/api/v1/coverage`
 - `/api/v1/curation`
 - `/api/v1/gaps`
+- `/api/v1/review/gaps`
+- `/api/v1/review/profile-completeness`
+- `/api/v1/review/adapter-candidates`
 - `/api/v1/health`
 - `/api/v1/health/history/{date}`
 - `/api/v1/subnets/{netuid}/health`
@@ -162,6 +167,7 @@ Worker API routes expose stable envelopes over the same canonical artifacts:
 - `/api/v1/rpc/endpoints`
 - `/api/v1/rpc/pools`
 - `/api/v1/endpoint-pools`
+- `/api/v1/endpoint-incidents`
 - `/api/v1/schemas`
 - `/api/v1/adapters/{slug}`
 - `/api/v1/search`

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -46,7 +46,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/gaps.json`: missing public interface facets by subnet.
 - `/metagraph/verification/latest.json`: latest candidate verification results. R2-backed.
 - `/metagraph/verification/subnets/{netuid}.json`: latest candidate verification results for one subnet. R2-backed.
-- `/metagraph/freshness.json`: freshness and staleness metadata for generated backend data.
+- `/metagraph/freshness.json`: freshness and staleness metadata for generated backend data. It exposes `native_data_as_of`, `candidate_discovery_as_of`, `verification_as_of`, `health_probe_as_of`, `adapter_snapshot_as_of`, and stale-window requirements.
 - `/metagraph/source-health.json`: source/provider health summary.
 - `/metagraph/source-snapshots.json`: compact hashes and counts for canonical source inputs. R2-backed.
 - `/metagraph/evidence-ledger.json`: public evidence ledger for material registry claims.
@@ -142,6 +142,16 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `npm run validate:workflows`: validate workflow hardening rules.
 - `npm run worker:deploy:dry-run`: validate Worker/Wrangler deployment shape without contacting Cloudflare.
 - `npm run sync:summary`: generate a registry-refresh PR summary from actual artifact diffs.
+
+Production publish validation can enforce operational freshness with:
+
+```bash
+METAGRAPH_REQUIRE_PROBE_HEALTH=1 METAGRAPH_REQUIRE_FRESHNESS=1 npm run validate
+```
+
+Those gates require fresh native subnet data, candidate discovery, candidate
+verification, probe-derived health, and adapter snapshots. Schema drift remains
+warning-only until more subnets expose machine-readable schemas.
 
 ## Cloudflare Runtime
 

--- a/docs/examples/submissions/direct-endpoint-resource.json
+++ b/docs/examples/submissions/direct-endpoint-resource.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "example-contributor",
+    "submitted_by_url": "https://github.com/example-contributor"
+  },
+  "candidates": [
+    {
+      "schema_version": 1,
+      "id": "community-sn-0-subtensor-rpc-rpc-example-onfinality-io",
+      "netuid": 0,
+      "state": "schema-valid",
+      "name": "Example Bittensor RPC endpoint",
+      "kind": "subtensor-rpc",
+      "url": "https://rpc-example.onfinality.io",
+      "source_url": "https://onfinality.io/en/networks/bittensor-finney",
+      "source_urls": ["https://onfinality.io/en/networks/bittensor-finney"],
+      "source_type": "community-pr-intake",
+      "source_tier": "community-docs",
+      "confidence": "medium",
+      "provider": "onfinality",
+      "auth_required": false,
+      "public_safe": true,
+      "rate_limit_notes": "Public read-only RPC endpoint candidate. Base-layer RPC claims require maintainer/private-gate review before monitoring or pool eligibility.",
+      "review_notes": "Community-submitted endpoint resource candidate."
+    }
+  ]
+}

--- a/docs/examples/submissions/direct-openapi-schema.json
+++ b/docs/examples/submissions/direct-openapi-schema.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "example-contributor",
+    "submitted_by_url": "https://github.com/example-contributor"
+  },
+  "candidates": [
+    {
+      "schema_version": 1,
+      "id": "community-sn-7-openapi-api-all-ways-io",
+      "netuid": 7,
+      "state": "schema-valid",
+      "name": "Allways OpenAPI schema",
+      "kind": "openapi",
+      "url": "https://api.all-ways.io/swagger/json",
+      "source_url": "https://api.all-ways.io/swagger",
+      "source_urls": ["https://api.all-ways.io/swagger"],
+      "source_type": "community-pr-intake",
+      "source_tier": "official-docs",
+      "confidence": "medium",
+      "provider": "allways",
+      "auth_required": false,
+      "public_safe": true,
+      "rate_limit_notes": "Machine-readable schema URL candidate. HTML Swagger pages should be submitted as docs or dashboard unless a JSON schema URL is available.",
+      "review_notes": "Community-submitted OpenAPI/schema candidate."
+    }
+  ]
+}

--- a/docs/examples/submissions/direct-profile-correction.json
+++ b/docs/examples/submissions/direct-profile-correction.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "example-contributor",
+    "submitted_by_url": "https://github.com/example-contributor"
+  },
+  "candidates": [
+    {
+      "schema_version": 1,
+      "id": "community-sn-7-source-repo-github-com-allways",
+      "netuid": 7,
+      "state": "schema-valid",
+      "name": "Allways source repository correction",
+      "kind": "source-repo",
+      "url": "https://github.com/example/allways-public-repo",
+      "source_url": "https://docs.all-ways.io/how-it-works.html",
+      "source_urls": ["https://docs.all-ways.io/how-it-works.html"],
+      "source_type": "community-pr-intake",
+      "source_tier": "official-docs",
+      "confidence": "medium",
+      "provider": "allways",
+      "auth_required": false,
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted profile/source correction candidate. Approved corrections can improve subnet profile completeness, but observed health remains probe-derived only."
+    }
+  ]
+}

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -24,6 +24,8 @@ the gate is harder to game.
 - `metagraphed-closed-by-gate`: the gate closed a hard failure.
 - `metagraphed-merged-by-gate`: the gate merged or imported a passing item.
 - `metagraphed-import-approved`: an issue submission can open an import PR.
+- `profile-correction`: the issue is about subnet profile/source metadata such
+  as official docs, websites, source repos, dashboards, or schema URLs.
 
 The stable marker comment is:
 
@@ -108,6 +110,8 @@ make any endpoint pool-eligible.
 The public gate accepts or routes:
 
 - subnet interface additions and corrections;
+- subnet profile/source corrections for official websites, docs, source repos,
+  dashboards, OpenAPI/schema URLs, SDKs, examples, and data artifacts;
 - endpoint resource submissions for `subtensor-rpc`, `subtensor-wss`,
   `archive`, `subnet-api`, `openapi`, `sse`, `data-artifact`, `dashboard`,
   `docs`, `website`, `source-repo`, `sdk`, and `example`;
@@ -123,6 +127,11 @@ Endpoint and status submissions can create candidates, reports, or re-probe
 work. They cannot directly set observed uptime, latency, status, health class,
 or pool eligibility; those values are generated only from Metagraphed probes and
 adapter checks.
+
+Profile/source corrections can improve `/api/v1/profiles`,
+`/api/v1/review/profile-completeness`, and related gap reports after review.
+They do not replace native chain identity, and they do not directly alter
+observed endpoint health.
 
 ## Private Gate Runtime
 

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1059,21 +1059,40 @@ export interface components {
             sources: components["schemas"]["FreshnessSource"][];
             summary: {
                 adapter_count: number;
+                adapter_snapshot_as_of: string | null;
+                blocking_source_count: number;
+                candidate_discovery_as_of: string | null;
+                health_probe_as_of: string | null;
                 health_surface_count: number;
+                missing_blocking_source_count: number;
+                native_data_as_of: string;
                 native_snapshot_captured_at: string;
                 openapi_surface_count: number;
-                verification_generated_at: string;
+                publish_ready_without_age_check: boolean;
+                schema_snapshot_as_of: string | null;
+                stale_window_warnings: string[];
+                verification_as_of: string | null;
+                verification_generated_at: string | null;
+                warning_source_count: number;
             };
         } & {
             [key: string]: unknown;
         });
         FreshnessSource: {
+            as_of: string | null;
             id: string;
+            /** @enum {unknown} */
+            lane: "adapter-snapshot" | "candidate-discovery" | "candidate-verification" | "health-probe" | "native-data" | "schema-snapshot";
+            notes?: string;
             path: string;
+            required_for_publish: boolean;
             stale_after_hours: number;
+            /** @enum {unknown} */
+            stale_behavior: "block" | "warn";
             /** @enum {unknown} */
             status: "captured" | "current" | "degraded" | "missing" | "stale";
             timestamp: string | null;
+            timestamp_field: string | null;
         };
         Gaps: {
             gap_notes: string[];

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 29,
-  "artifact_size_bytes": 4993674,
+  "artifact_size_bytes": 4999655,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -65,8 +65,8 @@
     },
     {
       "path": "freshness.json",
-      "sha256": "b2ac2fb3342cfc1d010c780753ccf6a705a3121809bc62489029c727e65feb61",
-      "size_bytes": 1573,
+      "sha256": "7c15331678e90ae61a9883a1016223c7b37dba5f457f8abaed1b756e27cc0fc2",
+      "size_bytes": 4366,
       "storage_tier": "dual"
     },
     {
@@ -89,8 +89,8 @@
     },
     {
       "path": "openapi.json",
-      "sha256": "fca574a30a3c4fd1bcfe433348f32db6c8b9093122bcb079b3e49eeb01bf7500",
-      "size_bytes": 293202,
+      "sha256": "82362342a41b778b7b3340d062df9c6be0cf0c7bfee8ce25b9ac81e56520ef76",
+      "size_bytes": 296390,
       "storage_tier": "dual"
     },
     {
@@ -223,7 +223,7 @@
   },
   "endpoint_count": 853,
   "full_artifact_count": 1097,
-  "full_artifact_size_bytes": 38504156,
+  "full_artifact_size_bytes": 38510137,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 14,
@@ -238,7 +238,7 @@
     "r2": 1068
   },
   "storage_tier_size_bytes": {
-    "dual": 4809972,
+    "dual": 4815953,
     "git": 183702,
     "r2": 33510482
   },

--- a/public/metagraph/freshness.json
+++ b/public/metagraph/freshness.json
@@ -4,53 +4,129 @@
   "schema_version": 1,
   "sources": [
     {
+      "as_of": "2026-06-07T15:30:10.650Z",
+      "id": "adapter-snapshots",
+      "lane": "adapter-snapshot",
+      "notes": "",
+      "path": "registry/adapters/latest",
+      "required_for_publish": true,
+      "stale_after_hours": 12,
+      "stale_behavior": "block",
+      "status": "captured",
+      "timestamp": "2026-06-07T15:30:10.650Z",
+      "timestamp_field": "adapter_snapshot_as_of"
+    },
+    {
+      "as_of": "2026-06-07T15:30:10.650Z",
       "id": "adapter:allways",
+      "lane": "adapter-snapshot",
+      "notes": "",
       "path": "registry/adapters/latest/allways.json",
+      "required_for_publish": false,
       "stale_after_hours": 12,
+      "stale_behavior": "warn",
       "status": "captured",
-      "timestamp": "1970-01-01T00:00:00.000Z"
+      "timestamp": "2026-06-07T15:30:10.650Z",
+      "timestamp_field": null
     },
     {
+      "as_of": "2026-06-07T15:30:09.603Z",
       "id": "adapter:gittensor",
+      "lane": "adapter-snapshot",
+      "notes": "",
       "path": "registry/adapters/latest/gittensor.json",
+      "required_for_publish": false,
       "stale_after_hours": 12,
+      "stale_behavior": "warn",
       "status": "captured",
-      "timestamp": "1970-01-01T00:00:00.000Z"
+      "timestamp": "2026-06-07T15:30:09.603Z",
+      "timestamp_field": null
     },
     {
-      "id": "candidate-verification",
-      "path": "registry/verification/latest.json",
-      "stale_after_hours": 12,
-      "status": "captured",
-      "timestamp": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "id": "native-subnets",
-      "path": "registry/native/finney-subnets.json",
+      "as_of": "2026-06-07T15:29:09Z",
+      "id": "candidate-discovery",
+      "lane": "candidate-discovery",
+      "notes": "",
+      "path": "registry/candidates/generated/public-sources.json",
+      "required_for_publish": true,
       "stale_after_hours": 24,
+      "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-07T15:29:09Z"
+      "timestamp": "2026-06-07T15:29:09Z",
+      "timestamp_field": "candidate_discovery_as_of"
     },
     {
+      "as_of": "2026-06-07T15:30:07.541Z",
+      "id": "candidate-verification",
+      "lane": "candidate-verification",
+      "notes": "",
+      "path": "registry/verification/latest.json",
+      "required_for_publish": true,
+      "stale_after_hours": 24,
+      "stale_behavior": "block",
+      "status": "captured",
+      "timestamp": "2026-06-07T15:30:07.541Z",
+      "timestamp_field": "verification_as_of"
+    },
+    {
+      "as_of": "2026-06-07T15:29:09Z",
+      "id": "native-subnets",
+      "lane": "native-data",
+      "notes": "",
+      "path": "registry/native/finney-subnets.json",
+      "required_for_publish": true,
+      "stale_after_hours": 24,
+      "stale_behavior": "block",
+      "status": "captured",
+      "timestamp": "2026-06-07T15:29:09Z",
+      "timestamp_field": "native_data_as_of"
+    },
+    {
+      "as_of": null,
       "id": "schema-drift",
+      "lane": "schema-snapshot",
+      "notes": "Schema drift snapshots are warning-only until more subnets publish machine-readable schemas.",
       "path": "public/metagraph/schema-drift.json",
-      "stale_after_hours": 12,
-      "status": "captured",
-      "timestamp": "1970-01-01T00:00:00.000Z"
+      "required_for_publish": false,
+      "stale_after_hours": 168,
+      "stale_behavior": "warn",
+      "status": "missing",
+      "timestamp": null,
+      "timestamp_field": "schema_snapshot_as_of"
     },
     {
+      "as_of": null,
       "id": "surface-health",
+      "lane": "health-probe",
+      "notes": "Run probes with METAGRAPH_WRITE_PROBE_RESULTS=1 before production publish.",
       "path": "public/metagraph/health/latest.json",
-      "stale_after_hours": 12,
-      "status": "captured",
-      "timestamp": "1970-01-01T00:00:00.000Z"
+      "required_for_publish": true,
+      "stale_after_hours": 6,
+      "stale_behavior": "block",
+      "status": "missing",
+      "timestamp": null,
+      "timestamp_field": "health_probe_as_of"
     }
   ],
   "summary": {
     "adapter_count": 2,
+    "adapter_snapshot_as_of": "2026-06-07T15:30:10.650Z",
+    "blocking_source_count": 5,
+    "candidate_discovery_as_of": "2026-06-07T15:29:09Z",
+    "health_probe_as_of": null,
     "health_surface_count": 852,
+    "missing_blocking_source_count": 1,
+    "native_data_as_of": "2026-06-07T15:29:09Z",
     "native_snapshot_captured_at": "2026-06-07T15:29:09Z",
     "openapi_surface_count": 28,
-    "verification_generated_at": "1970-01-01T00:00:00.000Z"
+    "publish_ready_without_age_check": false,
+    "schema_snapshot_as_of": null,
+    "stale_window_warnings": [
+      "schema-drift has no observed timestamp; review before relying on this lane.",
+      "surface-health has no observed timestamp; production publish should block."
+    ],
+    "verification_as_of": "2026-06-07T15:30:07.541Z",
+    "verification_generated_at": "1970-01-01T00:00:00.000Z",
+    "warning_source_count": 3
   }
 }

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1693,9 +1693,38 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "adapter_snapshot_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "blocking_source_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "candidate_discovery_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "health_probe_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "health_surface_count": {
                     "minimum": 0,
                     "type": "integer"
+                  },
+                  "missing_blocking_source_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "native_data_as_of": {
+                    "type": "string"
                   },
                   "native_snapshot_captured_at": {
                     "type": "string"
@@ -1704,16 +1733,55 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "publish_ready_without_age_check": {
+                    "type": "boolean"
+                  },
+                  "schema_snapshot_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "stale_window_warnings": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "verification_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "verification_generated_at": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "warning_source_count": {
+                    "minimum": 0,
+                    "type": "integer"
                   }
                 },
                 "required": [
                   "adapter_count",
+                  "adapter_snapshot_as_of",
+                  "blocking_source_count",
+                  "candidate_discovery_as_of",
                   "health_surface_count",
+                  "health_probe_as_of",
+                  "missing_blocking_source_count",
                   "native_snapshot_captured_at",
+                  "native_data_as_of",
                   "openapi_surface_count",
-                  "verification_generated_at"
+                  "publish_ready_without_age_check",
+                  "schema_snapshot_as_of",
+                  "stale_window_warnings",
+                  "verification_as_of",
+                  "verification_generated_at",
+                  "warning_source_count"
                 ],
                 "type": "object"
               }
@@ -1729,15 +1797,43 @@
       "FreshnessSource": {
         "additionalProperties": false,
         "properties": {
+          "as_of": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
+            "type": "string"
+          },
+          "lane": {
+            "enum": [
+              "adapter-snapshot",
+              "candidate-discovery",
+              "candidate-verification",
+              "health-probe",
+              "native-data",
+              "schema-snapshot"
+            ]
+          },
+          "notes": {
             "type": "string"
           },
           "path": {
             "type": "string"
           },
+          "required_for_publish": {
+            "type": "boolean"
+          },
           "stale_after_hours": {
             "minimum": 0,
             "type": "integer"
+          },
+          "stale_behavior": {
+            "enum": [
+              "block",
+              "warn"
+            ]
           },
           "status": {
             "enum": [
@@ -1753,14 +1849,25 @@
               "string",
               "null"
             ]
+          },
+          "timestamp_field": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
+          "as_of",
           "id",
+          "lane",
           "path",
+          "required_for_publish",
           "stale_after_hours",
+          "stale_behavior",
           "status",
-          "timestamp"
+          "timestamp",
+          "timestamp_field"
         ],
         "type": "object"
       },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 30,
-  "artifact_size_bytes": 5166953,
+  "artifact_size_bytes": 5173915,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -88,8 +88,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "b2ac2fb3342cfc1d010c780753ccf6a705a3121809bc62489029c727e65feb61",
-      "size_bytes": 1573,
+      "sha256": "7c15331678e90ae61a9883a1016223c7b37dba5f457f8abaed1b756e27cc0fc2",
+      "size_bytes": 4366,
       "storage_tier": "dual"
     },
     {
@@ -124,8 +124,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "fca574a30a3c4fd1bcfe433348f32db6c8b9093122bcb079b3e49eeb01bf7500",
-      "size_bytes": 293202,
+      "sha256": "82362342a41b778b7b3340d062df9c6be0cf0c7bfee8ce25b9ac81e56520ef76",
+      "size_bytes": 296390,
       "storage_tier": "dual"
     },
     {
@@ -268,8 +268,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "4fb89ed9ff36563b1286977639e2de1aaa5f47febe1f29f8e843e083b0281fdd",
-      "size_bytes": 173279,
+      "sha256": "8a788e7b072e3c9a431f204946c6b7ab58197f90c398fefa0edeec985001a744",
+      "size_bytes": 174260,
       "storage_tier": "dual"
     }
   ],
@@ -277,7 +277,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1098,
-  "full_artifact_size_bytes": 38677435,
+  "full_artifact_size_bytes": 38684397,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -299,7 +299,7 @@
     "r2": 1068
   },
   "storage_tier_size_bytes": {
-    "dual": 4983251,
+    "dual": 4990213,
     "git": 183702,
     "r2": 33510482
   }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1059,21 +1059,40 @@ export interface components {
             sources: components["schemas"]["FreshnessSource"][];
             summary: {
                 adapter_count: number;
+                adapter_snapshot_as_of: string | null;
+                blocking_source_count: number;
+                candidate_discovery_as_of: string | null;
+                health_probe_as_of: string | null;
                 health_surface_count: number;
+                missing_blocking_source_count: number;
+                native_data_as_of: string;
                 native_snapshot_captured_at: string;
                 openapi_surface_count: number;
-                verification_generated_at: string;
+                publish_ready_without_age_check: boolean;
+                schema_snapshot_as_of: string | null;
+                stale_window_warnings: string[];
+                verification_as_of: string | null;
+                verification_generated_at: string | null;
+                warning_source_count: number;
             };
         } & {
             [key: string]: unknown;
         });
         FreshnessSource: {
+            as_of: string | null;
             id: string;
+            /** @enum {unknown} */
+            lane: "adapter-snapshot" | "candidate-discovery" | "candidate-verification" | "health-probe" | "native-data" | "schema-snapshot";
+            notes?: string;
             path: string;
+            required_for_publish: boolean;
             stale_after_hours: number;
+            /** @enum {unknown} */
+            stale_behavior: "block" | "warn";
             /** @enum {unknown} */
             status: "captured" | "current" | "degraded" | "missing" | "stale";
             timestamp: string | null;
+            timestamp_field: string | null;
         };
         Gaps: {
             gap_notes: string[];

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1679,9 +1679,38 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "adapter_snapshot_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "blocking_source_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "candidate_discovery_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "health_probe_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "health_surface_count": {
                     "minimum": 0,
                     "type": "integer"
+                  },
+                  "missing_blocking_source_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "native_data_as_of": {
+                    "type": "string"
                   },
                   "native_snapshot_captured_at": {
                     "type": "string"
@@ -1690,16 +1719,55 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "publish_ready_without_age_check": {
+                    "type": "boolean"
+                  },
+                  "schema_snapshot_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "stale_window_warnings": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "verification_as_of": {
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
                   "verification_generated_at": {
-                    "type": "string"
+                    "type": [
+                      "string",
+                      "null"
+                    ]
+                  },
+                  "warning_source_count": {
+                    "minimum": 0,
+                    "type": "integer"
                   }
                 },
                 "required": [
                   "adapter_count",
+                  "adapter_snapshot_as_of",
+                  "blocking_source_count",
+                  "candidate_discovery_as_of",
                   "health_surface_count",
+                  "health_probe_as_of",
+                  "missing_blocking_source_count",
                   "native_snapshot_captured_at",
+                  "native_data_as_of",
                   "openapi_surface_count",
-                  "verification_generated_at"
+                  "publish_ready_without_age_check",
+                  "schema_snapshot_as_of",
+                  "stale_window_warnings",
+                  "verification_as_of",
+                  "verification_generated_at",
+                  "warning_source_count"
                 ],
                 "type": "object"
               }
@@ -1715,15 +1783,43 @@
       "FreshnessSource": {
         "additionalProperties": false,
         "properties": {
+          "as_of": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
+            "type": "string"
+          },
+          "lane": {
+            "enum": [
+              "adapter-snapshot",
+              "candidate-discovery",
+              "candidate-verification",
+              "health-probe",
+              "native-data",
+              "schema-snapshot"
+            ]
+          },
+          "notes": {
             "type": "string"
           },
           "path": {
             "type": "string"
           },
+          "required_for_publish": {
+            "type": "boolean"
+          },
           "stale_after_hours": {
             "minimum": 0,
             "type": "integer"
+          },
+          "stale_behavior": {
+            "enum": [
+              "block",
+              "warn"
+            ]
           },
           "status": {
             "enum": [
@@ -1739,14 +1835,25 @@
               "string",
               "null"
             ]
+          },
+          "timestamp_field": {
+            "type": [
+              "string",
+              "null"
+            ]
           }
         },
         "required": [
+          "as_of",
           "id",
+          "lane",
           "path",
+          "required_for_publish",
           "stale_after_hours",
+          "stale_behavior",
           "status",
-          "timestamp"
+          "timestamp",
+          "timestamp_field"
         ],
         "type": "object"
       },

--- a/schemas/components/08-evidence-search-sources.schema.json
+++ b/schemas/components/08-evidence-search-sources.schema.json
@@ -88,22 +88,58 @@
       },
       "FreshnessSource": {
         "type": "object",
-        "required": ["id", "path", "stale_after_hours", "status", "timestamp"],
+        "required": [
+          "as_of",
+          "id",
+          "lane",
+          "path",
+          "required_for_publish",
+          "stale_after_hours",
+          "stale_behavior",
+          "status",
+          "timestamp",
+          "timestamp_field"
+        ],
         "properties": {
+          "as_of": {
+            "type": ["string", "null"]
+          },
           "id": {
+            "type": "string"
+          },
+          "lane": {
+            "enum": [
+              "adapter-snapshot",
+              "candidate-discovery",
+              "candidate-verification",
+              "health-probe",
+              "native-data",
+              "schema-snapshot"
+            ]
+          },
+          "notes": {
             "type": "string"
           },
           "path": {
             "type": "string"
           },
+          "required_for_publish": {
+            "type": "boolean"
+          },
           "stale_after_hours": {
             "type": "integer",
             "minimum": 0
+          },
+          "stale_behavior": {
+            "enum": ["block", "warn"]
           },
           "status": {
             "enum": ["captured", "current", "degraded", "missing", "stale"]
           },
           "timestamp": {
+            "type": ["string", "null"]
+          },
+          "timestamp_field": {
             "type": ["string", "null"]
           }
         },
@@ -245,29 +281,79 @@
                 "type": "object",
                 "required": [
                   "adapter_count",
+                  "adapter_snapshot_as_of",
+                  "blocking_source_count",
+                  "candidate_discovery_as_of",
                   "health_surface_count",
+                  "health_probe_as_of",
+                  "missing_blocking_source_count",
                   "native_snapshot_captured_at",
+                  "native_data_as_of",
                   "openapi_surface_count",
-                  "verification_generated_at"
+                  "publish_ready_without_age_check",
+                  "schema_snapshot_as_of",
+                  "stale_window_warnings",
+                  "verification_as_of",
+                  "verification_generated_at",
+                  "warning_source_count"
                 ],
                 "properties": {
                   "adapter_count": {
                     "type": "integer",
                     "minimum": 0
                   },
+                  "adapter_snapshot_as_of": {
+                    "type": ["string", "null"]
+                  },
+                  "blocking_source_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "candidate_discovery_as_of": {
+                    "type": ["string", "null"]
+                  },
                   "health_surface_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "health_probe_as_of": {
+                    "type": ["string", "null"]
+                  },
+                  "missing_blocking_source_count": {
                     "type": "integer",
                     "minimum": 0
                   },
                   "native_snapshot_captured_at": {
                     "type": "string"
                   },
+                  "native_data_as_of": {
+                    "type": "string"
+                  },
                   "openapi_surface_count": {
                     "type": "integer",
                     "minimum": 0
                   },
+                  "publish_ready_without_age_check": {
+                    "type": "boolean"
+                  },
+                  "schema_snapshot_as_of": {
+                    "type": ["string", "null"]
+                  },
+                  "stale_window_warnings": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "verification_as_of": {
+                    "type": ["string", "null"]
+                  },
                   "verification_generated_at": {
-                    "type": "string"
+                    "type": ["string", "null"]
+                  },
+                  "warning_source_count": {
+                    "type": "integer",
+                    "minimum": 0
                   }
                 },
                 "additionalProperties": false

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -41,6 +41,9 @@ import {
 const providers = await loadProviders();
 const overlays = await loadSubnets();
 const candidates = await loadCandidates();
+const candidateDiscovery = await readOptionalJson(
+  path.join(repoRoot, "registry/candidates/generated/public-sources.json"),
+);
 const verification = redactCredentialedUrls(await loadVerification());
 const adapterSnapshots = await loadAdapterSnapshots();
 const reviewDecisions = await loadReviewDecisions();
@@ -535,6 +538,7 @@ await writeJson(
   artifactFile("freshness.json"),
   buildFreshnessArtifact({
     adapterSnapshots,
+    candidateDiscovery,
     generatedAt,
     healthArtifacts,
     nativeSnapshot,
@@ -1617,72 +1621,213 @@ function compactTokens(values) {
 
 function buildFreshnessArtifact({
   adapterSnapshots: snapshots,
+  candidateDiscovery,
   generatedAt: timestamp,
   healthArtifacts: health,
   nativeSnapshot: native,
   schemaDrift,
   verification: verificationArtifact,
 }) {
-  const adapterRows = [...snapshots.values()].map((snapshot) => ({
-    generated_at: snapshot.generated_at,
-    slug: snapshot.slug,
-    status: snapshot.status,
-  }));
+  const adapterRows = [...snapshots.values()].map((snapshot) => {
+    const capturedAt = latestTimestamp([
+      snapshot.generated_at,
+      ...Object.values(snapshot.dimensions || {}).map(
+        (dimension) => dimension?.captured_at,
+      ),
+    ]);
+    return {
+      as_of: capturedAt || snapshot.generated_at || null,
+      generated_at: snapshot.generated_at,
+      slug: snapshot.slug,
+      status: snapshot.status,
+    };
+  });
+  const candidateDiscoveryAsOf =
+    nonPlaceholderTimestamp(candidateDiscovery?.generated_at) ||
+    candidateDiscovery?.native_snapshot_captured_at ||
+    native.captured_at ||
+    null;
+  const verificationAsOf =
+    verificationArtifact.verification_finished_at ||
+    nonPlaceholderTimestamp(verificationArtifact.generated_at) ||
+    null;
+  const healthProbeAsOf =
+    health.latest.source === "live-smoke-probe"
+      ? health.latest.probe_finished_at ||
+        nonPlaceholderTimestamp(health.latest.generated_at) ||
+        null
+      : null;
+  const adapterSnapshotAsOf = latestTimestamp(
+    adapterRows.map((row) => row.as_of),
+  );
+  const schemaSnapshotAsOf =
+    nonPlaceholderTimestamp(schemaDrift.generated_at) || null;
+  const sources = [
+    freshnessSource({
+      asOf: native.captured_at,
+      id: "native-subnets",
+      lane: "native-data",
+      pathValue: "registry/native/finney-subnets.json",
+      requiredForPublish: true,
+      staleAfterHours: 24,
+      timestampField: "native_data_as_of",
+    }),
+    freshnessSource({
+      asOf: candidateDiscoveryAsOf,
+      id: "candidate-discovery",
+      lane: "candidate-discovery",
+      pathValue: "registry/candidates/generated/public-sources.json",
+      requiredForPublish: true,
+      staleAfterHours: 24,
+      timestampField: "candidate_discovery_as_of",
+    }),
+    freshnessSource({
+      asOf: verificationAsOf,
+      id: "candidate-verification",
+      lane: "candidate-verification",
+      pathValue: "registry/verification/latest.json",
+      requiredForPublish: true,
+      staleAfterHours: 24,
+      timestampField: "verification_as_of",
+    }),
+    freshnessSource({
+      asOf: healthProbeAsOf,
+      id: "surface-health",
+      lane: "health-probe",
+      notes:
+        health.latest.source === "live-smoke-probe"
+          ? "Observed health is probe-derived."
+          : "Run probes with METAGRAPH_WRITE_PROBE_RESULTS=1 before production publish.",
+      pathValue: "public/metagraph/health/latest.json",
+      requiredForPublish: true,
+      staleAfterHours: 6,
+      status: health.latest.source === "live-smoke-probe" ? "captured" : null,
+      staleBehavior: "block",
+      timestampField: "health_probe_as_of",
+    }),
+    freshnessSource({
+      asOf: adapterSnapshotAsOf,
+      id: "adapter-snapshots",
+      lane: "adapter-snapshot",
+      pathValue: "registry/adapters/latest",
+      requiredForPublish: true,
+      staleAfterHours: 12,
+      timestampField: "adapter_snapshot_as_of",
+    }),
+    freshnessSource({
+      asOf: schemaSnapshotAsOf,
+      id: "schema-drift",
+      lane: "schema-snapshot",
+      notes:
+        "Schema drift snapshots are warning-only until more subnets publish machine-readable schemas.",
+      pathValue: "public/metagraph/schema-drift.json",
+      requiredForPublish: false,
+      staleAfterHours: 168,
+      staleBehavior: "warn",
+      timestampField: "schema_snapshot_as_of",
+    }),
+    ...adapterRows.map((row) =>
+      freshnessSource({
+        asOf: row.as_of,
+        id: `adapter:${row.slug}`,
+        lane: "adapter-snapshot",
+        pathValue: `registry/adapters/latest/${row.slug}.json`,
+        requiredForPublish: false,
+        staleAfterHours: 12,
+        status: row.status,
+        staleBehavior: "warn",
+      }),
+    ),
+  ].sort((a, b) => a.id.localeCompare(b.id));
+  const blockingSources = sources.filter(
+    (source) => source.stale_behavior === "block",
+  );
+  const missingBlockingSources = blockingSources.filter(
+    (source) => source.status === "missing",
+  );
+  const warningSources = sources.filter(
+    (source) => source.stale_behavior === "warn",
+  );
   return {
     schema_version: 1,
     contract_version: contractVersion,
     generated_at: timestamp,
     summary: {
       adapter_count: adapterRows.length,
+      adapter_snapshot_as_of: adapterSnapshotAsOf,
+      blocking_source_count: blockingSources.length,
+      candidate_discovery_as_of: candidateDiscoveryAsOf,
       health_surface_count: health.latest.surfaces.length,
+      health_probe_as_of: healthProbeAsOf,
+      missing_blocking_source_count: missingBlockingSources.length,
       native_snapshot_captured_at: native.captured_at,
+      native_data_as_of: native.captured_at,
       openapi_surface_count:
         schemaDrift.openapi_surface_count ||
         schemaDrift.summary?.surface_count ||
         0,
-      verification_generated_at: verificationArtifact.generated_at || null,
-    },
-    sources: [
-      freshnessSource(
-        "native-subnets",
-        native.captured_at,
-        "registry/native/finney-subnets.json",
-      ),
-      freshnessSource(
-        "candidate-verification",
-        verificationArtifact.generated_at || null,
-        "registry/verification/latest.json",
-      ),
-      freshnessSource(
-        "surface-health",
-        health.latest.generated_at,
-        "public/metagraph/health/latest.json",
-      ),
-      freshnessSource(
-        "schema-drift",
-        schemaDrift.generated_at,
-        "public/metagraph/schema-drift.json",
-      ),
-      ...adapterRows.map((row) =>
-        freshnessSource(
-          `adapter:${row.slug}`,
-          row.generated_at,
-          `registry/adapters/latest/${row.slug}.json`,
-          row.status,
+      publish_ready_without_age_check: missingBlockingSources.length === 0,
+      schema_snapshot_as_of: schemaSnapshotAsOf,
+      stale_window_warnings: sources
+        .filter((source) => source.status === "missing")
+        .map(
+          (source) =>
+            `${source.id} has no observed timestamp; ${source.stale_behavior === "block" ? "production publish should block" : "review before relying on this lane"}.`,
         ),
-      ),
-    ].sort((a, b) => a.id.localeCompare(b.id)),
+      verification_as_of: verificationAsOf,
+      verification_generated_at: verificationArtifact.generated_at || null,
+      warning_source_count: warningSources.length,
+    },
+    sources,
   };
 }
 
-function freshnessSource(id, timestamp, pathValue, status = "captured") {
+function freshnessSource({
+  asOf,
+  id,
+  lane,
+  notes = "",
+  pathValue,
+  requiredForPublish,
+  staleAfterHours,
+  staleBehavior = requiredForPublish ? "block" : "warn",
+  status = null,
+  timestampField = null,
+}) {
+  const timestamp = asOf || null;
   return {
+    as_of: timestamp,
     id,
+    lane,
+    notes,
     path: pathValue,
-    status,
+    required_for_publish: requiredForPublish,
+    stale_after_hours: staleAfterHours,
+    stale_behavior: staleBehavior,
+    status: status || (timestamp ? "captured" : "missing"),
     timestamp,
-    stale_after_hours: id === "native-subnets" ? 24 : 12,
+    timestamp_field: timestampField,
   };
+}
+
+function nonPlaceholderTimestamp(value) {
+  if (!value || value === "1970-01-01T00:00:00.000Z") {
+    return null;
+  }
+  return value;
+}
+
+function latestTimestamp(values) {
+  const parsed = values
+    .map(nonPlaceholderTimestamp)
+    .filter(Boolean)
+    .map((value) => {
+      const time = Date.parse(value);
+      return Number.isFinite(time) ? { time, value } : null;
+    })
+    .filter(Boolean)
+    .sort((a, b) => b.time - a.time);
+  return parsed[0]?.value || null;
 }
 
 function buildSourceHealthArtifact({

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -15,6 +15,7 @@ export const SUBMISSION_LABELS = {
   importApproved: "metagraphed-import-approved",
   interfaceSubmission: "interface-submission",
   endpointSubmission: "endpoint-submission",
+  profileCorrection: "profile-correction",
   providerSubmission: "provider-submission",
   statusReport: "status-report",
 };

--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -19,6 +19,10 @@ const providerTemplate = await fs.readFile(
   path.join(templateRoot, "add-update-provider-profile.yml"),
   "utf8",
 );
+const profileSourceTemplate = await fs.readFile(
+  path.join(templateRoot, "add-update-subnet-profile-source.yml"),
+  "utf8",
+);
 const pullRequestTemplate = await fs.readFile(
   path.join(repoRoot, ".github/pull_request_template.md"),
   "utf8",
@@ -38,6 +42,21 @@ const directProviderExample = await readJson(
 );
 const statusReportExample = await readJson(
   path.join(repoRoot, "docs/examples/submissions/status-report.json"),
+);
+const endpointResourceExample = await readJson(
+  path.join(
+    repoRoot,
+    "docs/examples/submissions/direct-endpoint-resource.json",
+  ),
+);
+const openapiSchemaExample = await readJson(
+  path.join(repoRoot, "docs/examples/submissions/direct-openapi-schema.json"),
+);
+const profileCorrectionExample = await readJson(
+  path.join(
+    repoRoot,
+    "docs/examples/submissions/direct-profile-correction.json",
+  ),
 );
 const errors = [];
 
@@ -116,6 +135,25 @@ checkIncludes(providerTemplate, "provider profile template", [
   "provider approval is required before endpoints can become pool-eligible",
 ]);
 
+checkIncludes(profileSourceTemplate, "profile source template", [
+  "interface-submission",
+  "profile-correction",
+  "metagraphed-under-review",
+  "id: netuid",
+  "id: kind",
+  "id: url",
+  "id: source_url",
+  "id: provider",
+  "id: auth_required",
+  "website",
+  "docs",
+  "source-repo",
+  "data-artifact",
+  "openapi",
+  "do not directly change observed health",
+  "read-only probes",
+]);
+
 checkIncludes(pullRequestTemplate, "pull request template", [
   "registry/candidates/community/*.json",
   "registry/providers/community/*.json",
@@ -154,6 +192,9 @@ checkExampleCandidate(candidateExample);
 checkExampleProvider(providerExample);
 checkExampleProviderSubmission(directProviderExample);
 checkExampleStatusReport(statusReportExample);
+checkExampleCandidate(endpointResourceExample);
+checkExampleCandidate(openapiSchemaExample);
+checkExampleCandidate(profileCorrectionExample);
 
 if (errors.length > 0) {
   console.error(`Intake validation failed with ${errors.length} issue(s):`);

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1034,6 +1034,48 @@ async function validateGeneratedArtifacts(
     "freshness: native snapshot timestamp mismatch",
   );
   assert(
+    freshnessArtifact.summary?.native_data_as_of === nativeSnapshot.captured_at,
+    "freshness: native_data_as_of mismatch",
+  );
+  assert(
+    freshnessArtifact.summary?.verification_as_of ===
+      verificationArtifact.verification_finished_at,
+    "freshness: verification_as_of mismatch",
+  );
+  assert(
+    freshnessArtifact.summary?.blocking_source_count ===
+      freshnessArtifact.sources.filter(
+        (source) => source.stale_behavior === "block",
+      ).length,
+    "freshness: blocking source count mismatch",
+  );
+  assert(
+    freshnessArtifact.summary?.missing_blocking_source_count ===
+      freshnessArtifact.sources.filter(
+        (source) =>
+          source.stale_behavior === "block" && source.status === "missing",
+      ).length,
+    "freshness: missing blocking source count mismatch",
+  );
+  for (const source of freshnessArtifact.sources) {
+    assert(
+      source.as_of === source.timestamp,
+      `freshness:${source.id}: as_of and timestamp must match`,
+    );
+    assert(
+      ["block", "warn"].includes(source.stale_behavior),
+      `freshness:${source.id}: stale_behavior is invalid`,
+    );
+    assert(
+      source.stale_behavior === "block" ||
+        source.required_for_publish === false,
+      `freshness:${source.id}: warning sources cannot be required for publish`,
+    );
+  }
+  if (requiresFreshness()) {
+    validateFreshnessForPublish(freshnessArtifact);
+  }
+  assert(
     sourceHealthArtifact.summary?.provider_count ===
       providersArtifact.providers.length,
     "source health: provider count mismatch",
@@ -1205,6 +1247,50 @@ function requiresProbeHealth() {
     process.env.GITHUB_ACTIONS === "true" &&
     process.env.GITHUB_WORKFLOW === "Publish Cloudflare Backend" &&
     process.env.GITHUB_REF === "refs/heads/main"
+  );
+}
+
+function requiresFreshness() {
+  if (process.env.METAGRAPH_REQUIRE_FRESHNESS === "1") {
+    return true;
+  }
+  return (
+    process.env.GITHUB_ACTIONS === "true" &&
+    process.env.GITHUB_WORKFLOW === "Publish Cloudflare Backend" &&
+    process.env.GITHUB_REF === "refs/heads/main"
+  );
+}
+
+function validateFreshnessForPublish(freshnessArtifact) {
+  const now = Date.now();
+  const failures = [];
+  for (const source of freshnessArtifact.sources.filter(
+    (entry) => entry.stale_behavior === "block",
+  )) {
+    if (source.status === "missing" || !source.as_of) {
+      failures.push(`${source.id} is missing`);
+      continue;
+    }
+    if (!["captured", "current"].includes(source.status)) {
+      failures.push(`${source.id} status is ${source.status}`);
+      continue;
+    }
+    const observedAt = Date.parse(source.as_of);
+    if (!Number.isFinite(observedAt)) {
+      failures.push(`${source.id} has invalid as_of timestamp`);
+      continue;
+    }
+    const ageHours = (now - observedAt) / 3_600_000;
+    if (ageHours > source.stale_after_hours) {
+      failures.push(
+        `${source.id} is stale (${ageHours.toFixed(1)}h > ${source.stale_after_hours}h)`,
+      );
+    }
+  }
+
+  assert(
+    failures.length === 0,
+    `freshness: publish requires fresh blocking sources: ${failures.join("; ")}`,
   );
 }
 

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -361,6 +361,33 @@ test("public artifacts are internally consistent", () => {
     freshness.summary.native_snapshot_captured_at,
     native.captured_at,
   );
+  assert.equal(freshness.summary.native_data_as_of, native.captured_at);
+  assert.equal(
+    freshness.summary.blocking_source_count,
+    freshness.sources.filter((source) => source.stale_behavior === "block")
+      .length,
+  );
+  assert.equal(
+    freshness.summary.missing_blocking_source_count,
+    freshness.sources.filter(
+      (source) =>
+        source.stale_behavior === "block" && source.status === "missing",
+    ).length,
+  );
+  for (const source of freshness.sources) {
+    assert.equal(source.as_of, source.timestamp);
+    assert.equal(typeof source.required_for_publish, "boolean");
+    assert.equal(["block", "warn"].includes(source.stale_behavior), true);
+  }
+  assert.equal(
+    freshness.sources.some(
+      (source) =>
+        source.id === "surface-health" &&
+        source.lane === "health-probe" &&
+        source.stale_behavior === "block",
+    ),
+    true,
+  );
   assert.equal(sourceHealth.summary.provider_count > 0, true);
   assert.equal(
     sourceSnapshots.summary.source_count,


### PR DESCRIPTION
## Summary
- add explicit freshness lanes for native data, candidate discovery, verification, health probes, adapter snapshots, and schema snapshots
- add production freshness validation gates while keeping normal local builds deterministic
- add a profile/source correction issue template plus endpoint, OpenAPI, and profile correction examples for contributor UGC

## What changed
- `/metagraph/freshness.json` now exposes `native_data_as_of`, `candidate_discovery_as_of`, `verification_as_of`, `health_probe_as_of`, `adapter_snapshot_as_of`, required publish lanes, stale behavior, and stale-window warnings
- `npm run validate` can enforce production freshness with `METAGRAPH_REQUIRE_FRESHNESS=1`
- contributor intake docs now cover profile/source corrections, endpoint resources, OpenAPI/schema URLs, provider profiles, and status reports
- generated OpenAPI and TypeScript contracts were refreshed from the canonical JSON Schema

## Why
- production publish needs an explicit way to block stale or missing operational data instead of relying on informal review
- contributors need a clearer path for profile/source corrections without confusing those with observed health or uptime

## Validation
- `npm run build`
- `npm run validate`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:contract-drift`
- `npm run validate:schema-enums`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:artifact-budgets`
- `npm run validate:docs`
- `npm run validate:intake`
- `npm run worker:test`
- `npm run test:coverage`
- `npm run check`
- `npm run scan:public-safety`
- `git diff --check`

## Notes
- Expected-negative check: `METAGRAPH_REQUIRE_FRESHNESS=1 npm run validate` correctly blocks because current committed health is not probe-derived yet.
- Candidate discovery dry-run still reports upstream GitHub 403 warnings for unauthenticated Tensorplex/Taopedia source calls; those remain non-blocking source-health warnings.