### PR TITLE
fix(registry): require ledger evidence for observed surfaces

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -255,14 +255,12 @@ function validateSubnet(
         Array.isArray(surface.source_urls) && surface.source_urls.length > 0,
         `${surfaceKey}: source_urls required`,
       );
-      const verificationEvidence =
-        surface.verification ||
-        registryVerificationEvidence.get(
-          registrySurfaceKey({
-            ...surface,
-            netuid: subnet.netuid,
-          }),
-        );
+      const verificationEvidence = registryVerificationEvidence.get(
+        registrySurfaceKey({
+          ...surface,
+          netuid: subnet.netuid,
+        }),
+      );
       assert(
         verificationEvidence !== undefined,
         `${surfaceKey}: registry-observed surface requires verification evidence`,

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -66,6 +66,47 @@ test("registry validation rejects registry-observed surfaces without verificatio
   );
 });
 
+test("registry validation rejects registry-observed surfaces with only inline verification", () => {
+  const overlayPath = "registry/subnets/generated/sn-1.json";
+  const original = readFileSync(overlayPath, "utf8");
+  const tampered = JSON.parse(original);
+
+  tampered.surfaces.push({
+    id: "sn-1-forged-inline-verification",
+    name: "Forged inline verification surface",
+    kind: "website",
+    url: "https://example.invalid/forged-inline-verification",
+    provider: "taomarketcap",
+    auth_required: false,
+    authority: "registry-observed",
+    public_safe: true,
+    source_urls: ["https://example.invalid/source"],
+    verification: {
+      classification: "live",
+      verified_at: "2999-01-01T00:00:00.000Z",
+    },
+  });
+
+  let failure;
+  try {
+    writeFileSync(overlayPath, `${JSON.stringify(tampered, null, 2)}\n`);
+    runNode("scripts/validate.mjs");
+  } catch (error) {
+    failure = error;
+  } finally {
+    writeFileSync(overlayPath, original);
+  }
+
+  assert(
+    failure,
+    "expected validation to reject forged inline verification without ledger evidence",
+  );
+  assert.match(
+    `${failure.stdout || ""}\n${failure.stderr || ""}`,
+    /registry-observed surface requires verification evidence/,
+  );
+});
+
 test("registry validation rejects tampered per-subnet artifacts", () => {
   const artifactPath = artifactFilePath("subnets/0.json");
   const original = readFileSync(artifactPath, "utf8");


### PR DESCRIPTION
### Motivation

- The previous change trusted `surface.verification` as equivalent to ledger evidence, allowing a malicious registry overlay to self-attest a `registry-observed` surface as `live` and bypass ledger enforcement.
- The goal is to ensure `registry-observed` surfaces are only accepted when backed by entries in `registry/verification/latest.json`, while still schema-validating any inline `verification` objects.

### Description

- Stop treating `surface.verification` as ledger evidence by selecting verification evidence exclusively from the `registryVerificationEvidence` map instead of `surface.verification` (in `scripts/validate.mjs`).
- Preserve schema validation for `surface.verification` but do not let it satisfy the ledger-evidence requirement for `registry-observed` surfaces.
- Add a regression test that forges an inline `verification` object and asserts validation still rejects the surface when no ledger evidence exists (in `tests/artifacts.test.mjs`).
- Files changed: `scripts/validate.mjs`, `tests/artifacts.test.mjs`.

### Testing

- Ran `node scripts/build.mjs` to regenerate artifacts, which completed successfully.
- Ran `node scripts/validate.mjs` and observed successful validation of the registry snapshot after the fix.
- Ran formatting check `npx prettier --check scripts/validate.mjs tests/artifacts.test.mjs` and `npm test -- --run tests/artifacts.test.mjs`, and the test suite (targeted tests) passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a259fcea2f4832c9de1f31c4044c345)