### PR TITLE
fix(worker): keep dual artifacts static-first

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -311,7 +311,7 @@ describe("Worker runtime", () => {
     assert.equal((await r2Miss.json()).error.code, "artifact_not_found");
   });
 
-  test("prefers R2 for operational dual artifacts with static fallback", async () => {
+  test("prefers static assets for operational dual artifacts with R2 fallback", async () => {
     const r2KeysRequested = [];
     const response = await handleRequest(
       new Request("https://metagraph.sh/api/v1/endpoints"),
@@ -358,32 +358,38 @@ describe("Worker runtime", () => {
 
     assert.equal(response.status, 200);
     const body = await response.json();
-    assert.equal(body.meta.source, "r2");
-    assert.deepEqual(r2KeysRequested, ["latest/endpoints.json"]);
-    assert.equal(body.data.endpoints[0].id, "endpoint-r2");
-    assert.equal(body.data.endpoints[0].status, "ok");
+    assert.equal(body.meta.source, "static-assets");
+    assert.deepEqual(r2KeysRequested, []);
+    assert.equal(body.data.endpoints[0].id, "endpoint-static");
+    assert.equal(body.data.endpoints[0].status, "unknown");
 
     const fallback = await handleRequest(
       new Request("https://metagraph.sh/api/v1/endpoints"),
       {
         ASSETS: {
           async fetch() {
-            return Response.json({
-              schema_version: 1,
-              generated_at: "1970-01-01T00:00:00.000Z",
-              endpoints: [
-                {
-                  id: "endpoint-static",
-                  status: "unknown",
-                  provider: "static",
-                },
-              ],
-            });
+            return new Response("not found", { status: 404 });
           },
         },
         METAGRAPH_ARCHIVE: {
-          async get() {
-            return null;
+          async get(key) {
+            r2KeysRequested.push(key);
+            assert.equal(key, "latest/endpoints.json");
+            return {
+              async json() {
+                return {
+                  schema_version: 1,
+                  generated_at: "1970-01-01T00:00:00.000Z",
+                  endpoints: [
+                    {
+                      id: "endpoint-r2",
+                      status: "ok",
+                      provider: "r2",
+                    },
+                  ],
+                };
+              },
+            };
           },
         },
       },
@@ -392,8 +398,9 @@ describe("Worker runtime", () => {
 
     assert.equal(fallback.status, 200);
     const fallbackBody = await fallback.json();
-    assert.equal(fallbackBody.meta.source, "static-assets");
-    assert.equal(fallbackBody.data.endpoints[0].id, "endpoint-static");
+    assert.equal(fallbackBody.meta.source, "r2");
+    assert.deepEqual(r2KeysRequested, ["latest/endpoints.json"]);
+    assert.equal(fallbackBody.data.endpoints[0].id, "endpoint-r2");
   });
 
   test("keeps RPC proxy disabled and blocks unsafe methods", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -45,16 +45,6 @@ const DENIED_RPC_PREFIXES = [
 const MAX_RPC_BODY_BYTES = 65536;
 const METAGRAPH_LATEST_KEY = "metagraph:latest";
 const STATIC_RAW_ARTIFACT_PATHS = new Set(["/metagraph/metagraph/latest.json"]);
-const R2_PREFERRED_DUAL_ARTIFACT_PATHS = new Set([
-  "/metagraph/endpoint-incidents.json",
-  "/metagraph/endpoint-pools.json",
-  "/metagraph/endpoints.json",
-  "/metagraph/freshness.json",
-  "/metagraph/health/summary.json",
-  "/metagraph/rpc/pools.json",
-  "/metagraph/rpc-endpoints.json",
-  "/metagraph/source-health.json",
-]);
 const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
   "https://bittensor-finney.api.onfinality.io",
   "https://bittensor-public.nodies.app",
@@ -390,23 +380,6 @@ async function readArtifact(env, artifactPath) {
       return r2;
     }
     return readAsset(env, artifactPath, storageTier);
-  }
-
-  if (
-    storageTier === ARTIFACT_STORAGE_TIERS.dual &&
-    R2_PREFERRED_DUAL_ARTIFACT_PATHS.has(artifactPath)
-  ) {
-    const r2 = await readR2(env, artifactPath, storageTier);
-    if (r2.ok) {
-      return r2;
-    }
-
-    const asset = await readAsset(env, artifactPath, storageTier);
-    if (asset.ok) {
-      return asset;
-    }
-
-    return r2.status !== 404 ? r2 : asset;
   }
 
   const asset = await readAsset(env, artifactPath, storageTier);


### PR DESCRIPTION
### Motivation
- Prevent mutable R2/KV state from overriding reviewed static public artifacts for operational metadata (endpoints/pools/health), restoring the static-assets-first trust boundary to avoid serving unreviewed or attacker-controlled data.

### Description
- Remove the R2-preference override (`R2_PREFERRED_DUAL_ARTIFACT_PATHS`) and its special-case read order in `readArtifact`, so non-R2 artifacts are served from static assets first and R2 is only used as a fallback when the static asset is missing.
- Preserve existing behavior for R2-only tier artifacts and the `METAGRAPH_ALLOW_R2_STATIC_FALLBACK` handling for r2-tier artifacts, so true R2-tier artifacts remain unchanged.
- Update `tests/worker-runtime.test.mjs` to assert static-assets-first behavior for dual operational artifacts and add a fallback case that exercises R2 when the static asset is absent.

### Testing
- Ran lint with `npm run lint` which succeeded.
- Fixed formatting and ran `npm run format:check` which succeeded after applying Prettier.
- Ran unit tests for the modified scenario with `npm test -- --run tests/worker-runtime.test.mjs -t "prefers static assets"` which passed.
- Ran the full worker runtime test file `npm test -- --run tests/worker-runtime.test.mjs` where unrelated failures remain due to missing generated R2 staging artifacts in the local checkout (causing some 404/null fixture failures) rather than the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25ac1ac7a4832c9d6552967b5011d0)