### PR TITLE
fix(freshness): require candidate discovery timestamp

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 29,
-  "artifact_size_bytes": 4999655,
+  "artifact_size_bytes": 4999689,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -65,8 +65,8 @@
     },
     {
       "path": "freshness.json",
-      "sha256": "7c15331678e90ae61a9883a1016223c7b37dba5f457f8abaed1b756e27cc0fc2",
-      "size_bytes": 4366,
+      "sha256": "7a1e9809021e514c17e1e795dae4a95da8d5467464a090c7acddaf5c5a5375af",
+      "size_bytes": 4400,
       "storage_tier": "dual"
     },
     {
@@ -223,7 +223,7 @@
   },
   "endpoint_count": 853,
   "full_artifact_count": 1097,
-  "full_artifact_size_bytes": 38510137,
+  "full_artifact_size_bytes": 38510171,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 14,
@@ -238,7 +238,7 @@
     "r2": 1068
   },
   "storage_tier_size_bytes": {
-    "dual": 4815953,
+    "dual": 4815987,
     "git": 183702,
     "r2": 33510482
   },

--- a/public/metagraph/freshness.json
+++ b/public/metagraph/freshness.json
@@ -43,7 +43,7 @@
       "timestamp_field": null
     },
     {
-      "as_of": "2026-06-07T15:29:09Z",
+      "as_of": null,
       "id": "candidate-discovery",
       "lane": "candidate-discovery",
       "notes": "",
@@ -51,8 +51,8 @@
       "required_for_publish": true,
       "stale_after_hours": 24,
       "stale_behavior": "block",
-      "status": "captured",
-      "timestamp": "2026-06-07T15:29:09Z",
+      "status": "missing",
+      "timestamp": null,
       "timestamp_field": "candidate_discovery_as_of"
     },
     {
@@ -112,16 +112,17 @@
     "adapter_count": 2,
     "adapter_snapshot_as_of": "2026-06-07T15:30:10.650Z",
     "blocking_source_count": 5,
-    "candidate_discovery_as_of": "2026-06-07T15:29:09Z",
+    "candidate_discovery_as_of": null,
     "health_probe_as_of": null,
     "health_surface_count": 852,
-    "missing_blocking_source_count": 1,
+    "missing_blocking_source_count": 2,
     "native_data_as_of": "2026-06-07T15:29:09Z",
     "native_snapshot_captured_at": "2026-06-07T15:29:09Z",
     "openapi_surface_count": 28,
     "publish_ready_without_age_check": false,
     "schema_snapshot_as_of": null,
     "stale_window_warnings": [
+      "candidate-discovery has no observed timestamp; production publish should block.",
       "schema-drift has no observed timestamp; review before relying on this lane.",
       "surface-health has no observed timestamp; production publish should block."
     ],

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 30,
-  "artifact_size_bytes": 5173915,
+  "artifact_size_bytes": 5173949,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -88,8 +88,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "7c15331678e90ae61a9883a1016223c7b37dba5f457f8abaed1b756e27cc0fc2",
-      "size_bytes": 4366,
+      "sha256": "7a1e9809021e514c17e1e795dae4a95da8d5467464a090c7acddaf5c5a5375af",
+      "size_bytes": 4400,
       "storage_tier": "dual"
     },
     {
@@ -277,7 +277,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1098,
-  "full_artifact_size_bytes": 38684397,
+  "full_artifact_size_bytes": 38684431,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -299,7 +299,7 @@
     "r2": 1068
   },
   "storage_tier_size_bytes": {
-    "dual": 4990213,
+    "dual": 4990247,
     "git": 183702,
     "r2": 33510482
   }

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1642,11 +1642,9 @@ function buildFreshnessArtifact({
       status: snapshot.status,
     };
   });
-  const candidateDiscoveryAsOf =
-    nonPlaceholderTimestamp(candidateDiscovery?.generated_at) ||
-    candidateDiscovery?.native_snapshot_captured_at ||
-    native.captured_at ||
-    null;
+  const candidateDiscoveryAsOf = nonPlaceholderTimestamp(
+    candidateDiscovery?.generated_at,
+  );
   const verificationAsOf =
     verificationArtifact.verification_finished_at ||
     nonPlaceholderTimestamp(verificationArtifact.generated_at) ||

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -403,6 +403,25 @@ test("public artifacts are internally consistent", () => {
     native.captured_at,
   );
   assert.equal(freshness.summary.native_data_as_of, native.captured_at);
+  const candidateDiscovery = JSON.parse(
+    readFileSync("registry/candidates/generated/public-sources.json", "utf8"),
+  );
+  const candidateDiscoveryAsOf =
+    candidateDiscovery.generated_at === "1970-01-01T00:00:00.000Z"
+      ? null
+      : candidateDiscovery.generated_at;
+  const candidateDiscoverySource = freshness.sources.find(
+    (source) => source.id === "candidate-discovery",
+  );
+  assert.equal(
+    freshness.summary.candidate_discovery_as_of,
+    candidateDiscoveryAsOf,
+  );
+  assert.equal(candidateDiscoverySource.as_of, candidateDiscoveryAsOf);
+  assert.equal(
+    candidateDiscoverySource.status,
+    candidateDiscoveryAsOf ? "captured" : "missing",
+  );
   assert.equal(
     freshness.summary.blocking_source_count,
     freshness.sources.filter((source) => source.stale_behavior === "block")


### PR DESCRIPTION
### Motivation
- Prevent the candidate-discovery freshness lane from being satisfied by unrelated native timestamps when the discovery artifact is absent or contains the deterministic placeholder timestamp.
- Ensure the production freshness gate reliably blocks publishes when candidate discovery data is missing or stale.

### Description
- Stop synthesizing `candidateDiscoveryAsOf` from `native_snapshot_captured_at` or `native.captured_at` and instead only accept a non-placeholder discovery `generated_at` by changing the compute to `nonPlaceholderTimestamp(candidateDiscovery?.generated_at)` in `scripts/build-artifacts.mjs`.
- Mark the `candidate-discovery` freshness source as `missing` (null `as_of`/`timestamp`) when the discovery artifact has the placeholder `generated_at`, and update generated artifacts accordingly (`public/metagraph/freshness.json`, `public/metagraph/build-summary.json`, `public/metagraph/r2-manifest.json`).
- Add an artifact consistency assertion in `tests/artifacts.test.mjs` that verifies `freshness.summary.candidate_discovery_as_of` and the `candidate-discovery` source `as_of`/`status` reflect the discovery artifact's real `generated_at` or are `null`/`missing` when placeholder.

### Testing
- Ran `npm run build` and the build completed successfully. 
- Ran `node scripts/validate.mjs` (via `npm run validate`) and validation passed for generated artifacts. 
- Ran formatting checks with `npx prettier --check` (after applying formatting) and files matched Prettier style. 
- Ran unit tests with `npx vitest run tests/artifacts.test.mjs` which passed; running the full test suite with `npm test` in this environment shows one unrelated failure in `tests/public-safety.test.mjs` due to DNS resolution differences in the environment rather than this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25b173b8f0832cb8b2fec71d4ef7b3)