### PR TITLE
Fix probe health preservation provenance

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1166,89 +1166,7 @@ async function loadPreviousHealthArtifact() {
   const artifact = await readOptionalJson(
     path.join(repoRoot, ".cache/metagraphed/health/latest.json"),
   );
-  if (artifact?.source === "live-smoke-probe") {
-    return artifact;
-  }
-  return rebuildPreviousHealthFromEndpointIndex();
-}
-
-async function rebuildPreviousHealthFromEndpointIndex() {
-  const endpointsArtifact = await readOptionalJson(
-    path.join(outputRoot, "endpoints.json"),
-  );
-  if (!Array.isArray(endpointsArtifact?.endpoints)) {
-    return null;
-  }
-
-  const surfaces = endpointsArtifact.endpoints
-    .filter(
-      (endpoint) =>
-        endpoint?.surface_id &&
-        endpoint.health_source === "probe-derived" &&
-        endpoint.monitoring_status === "monitored",
-    )
-    .map(endpointHealthRowFromResource);
-  if (surfaces.length === 0) {
-    return null;
-  }
-
-  const freshness = await readOptionalJson(
-    path.join(outputRoot, "freshness.json"),
-  );
-  const observedTimes = surfaces
-    .flatMap((surface) => [surface.last_checked, surface.verified_at])
-    .filter(Boolean);
-  const probeFinishedAt =
-    freshness?.summary?.health_probe_as_of || latestString(observedTimes);
-
-  return {
-    schema_version: 1,
-    contract_version: endpointsArtifact.contract_version || contractVersion,
-    generated_at: endpointsArtifact.generated_at || generatedAt,
-    source: "live-smoke-probe",
-    probe_started_at: earliestString(observedTimes) || probeFinishedAt || null,
-    probe_finished_at: probeFinishedAt || null,
-    summary: endpointsArtifact.summary || {},
-    surfaces,
-  };
-}
-
-function endpointHealthRowFromResource(endpoint) {
-  const verifiedAt = endpoint.observed_at || endpoint.last_checked || null;
-  const row = {
-    archive_support: endpoint.archive_support ?? null,
-    auth_required: endpoint.auth_required,
-    classification: endpoint.classification || "unknown",
-    error: endpoint.error || null,
-    kind: endpoint.kind,
-    last_checked: endpoint.last_checked || verifiedAt,
-    last_ok: endpoint.last_ok || null,
-    latency_ms: Number.isFinite(endpoint.latency_ms)
-      ? endpoint.latency_ms
-      : null,
-    latest_block: Number.isFinite(endpoint.latest_block)
-      ? endpoint.latest_block
-      : null,
-    method_tested: endpoint.method_tested || "not-configured",
-    netuid: endpoint.netuid,
-    provider: endpoint.provider,
-    public_safe: endpoint.public_safe,
-    rpc_method_count: Number.isFinite(endpoint.rpc_method_count)
-      ? endpoint.rpc_method_count
-      : null,
-    status: endpoint.status || "unknown",
-    subnet_name: endpoint.subnet_name,
-    subnet_slug: endpoint.subnet_slug,
-    surface_id: endpoint.surface_id,
-    uptime_sample_ratio: null,
-    url: endpoint.url,
-    verified_at: verifiedAt,
-  };
-
-  if (Array.isArray(endpoint.method_support)) {
-    row.methods_supported = endpoint.method_support;
-  }
-  return row;
+  return artifact?.source === "live-smoke-probe" ? artifact : null;
 }
 
 function buildSurfaceHealthRows({ surfaces, previousHealthArtifact }) {
@@ -2595,10 +2513,6 @@ function badgeColor(status) {
 
 function latestString(values) {
   return values.filter(Boolean).sort().at(-1) || null;
-}
-
-function earliestString(values) {
-  return values.filter(Boolean).sort().at(0) || null;
 }
 
 function average(values) {

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -209,6 +209,85 @@ test("artifact build ignores forged committed health observations by default", (
   }
 }, 30_000);
 
+test("artifact build does not preserve forged endpoint index health", () => {
+  const endpointsPath = artifactFilePath("endpoints.json");
+  const cachePath = ".cache/metagraphed/health/latest.json";
+  const original = readFileSync(endpointsPath, "utf8");
+  const originalCache = existsSync(cachePath)
+    ? readFileSync(cachePath, "utf8")
+    : null;
+  rmSync(cachePath, { force: true });
+  const tampered = JSON.parse(original);
+  const target = tampered.endpoints.find(
+    (endpoint) => endpoint.public_safe === true,
+  );
+  assert(target, "expected a public-safe endpoint row to tamper");
+
+  target.health_source = "probe-derived";
+  target.monitoring_status = "monitored";
+  target.status = "ok";
+  target.classification = "live";
+  target.last_checked = "2999-01-01T00:00:00.000Z";
+  target.last_ok = "2999-01-01T00:00:00.000Z";
+  target.observed_at = "2999-01-01T00:00:00.000Z";
+  target.latency_ms = 7;
+  target.latest_block = 4242424242;
+  target.archive_support = true;
+
+  try {
+    writeFileSync(endpointsPath, `${JSON.stringify(tampered, null, 2)}\n`);
+    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, METAGRAPH_PRESERVE_PROBE_HEALTH: "1" },
+      stdio: "pipe",
+    });
+
+    const rebuilt = JSON.parse(readFileSync(endpointsPath, "utf8"));
+    const rebuiltTarget = rebuilt.endpoints.find(
+      (endpoint) => endpoint.surface_id === target.surface_id,
+    );
+    assert.equal(rebuiltTarget.status, "unknown");
+    assert.equal(rebuiltTarget.classification, "unknown");
+    assert.equal(rebuiltTarget.last_checked, null);
+    assert.equal(rebuiltTarget.latency_ms, null);
+    assert.equal(rebuiltTarget.latest_block, null);
+    assert.equal(rebuiltTarget.archive_support, null);
+    assert.equal(rebuiltTarget.health_source, "missing-probe");
+  } finally {
+    writeFileSync(endpointsPath, original);
+    if (originalCache === null) {
+      rmSync(cachePath, { force: true });
+    } else {
+      writeFileSync(cachePath, originalCache);
+    }
+    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+    execFileSync(process.execPath, ["scripts/generate-types.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+    execFileSync(process.execPath, ["scripts/generate-client.mjs", "--write"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+    execFileSync(process.execPath, ["scripts/r2-manifest.mjs", "--write"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+  }
+}, 30_000);
+
 test("public artifacts are internally consistent", () => {
   const native = JSON.parse(
     readFileSync("registry/native/finney-subnets.json", "utf8"),


### PR DESCRIPTION
### Motivation
- Prevent PR-controlled public artifacts from being used as a trusted source of probe-derived health and thereby avoid allowing malicious PRs to inject forged health, latency, or eligibility metadata into preserved/regenerated artifacts.
- Preserve the original trust boundary: only probe outputs cached under `.cache/metagraphed/health/latest.json` with `source: live-smoke-probe` should be reused when preservation is enabled.

### Description
- Stop reconstructing a synthetic `live-smoke-probe` artifact from checked-out `public/metagraph/endpoints.json` by removing the fallback path that rebuilt previous health from the endpoint index and the associated conversion helpers.
- Change `loadPreviousHealthArtifact()` in `scripts/build-artifacts.mjs` to only return the trusted cached artifact when `METAGRAPH_PRESERVE_PROBE_HEALTH=1` and the cached artifact's `source` is `live-smoke-probe`.
- Add a regression test in `tests/artifacts.test.mjs` that forges a `public/metagraph/endpoints.json` endpoint row, runs the build with preservation enabled and no probe cache, and asserts that forged health fields (status/classification/latency/latest_block/archive_support/health_source) are ignored.

### Testing
- Ran `npm run lint -- --quiet` and the lint check passed.
- Ran `npx prettier --check scripts/build-artifacts.mjs tests/artifacts.test.mjs` and formatting matched Prettier.
- Ran the focused regression test with `npx vitest run tests/artifacts.test.mjs -t "forged endpoint index"` and the added test passed (targeted run: 1 passed, 9 skipped).
- A full test run `npx vitest run tests/artifacts.test.mjs` was attempted but the checkout lacks some generated public artifacts in this environment, causing unrelated reproducibility failures; this does not affect the focused regression proving the vulnerability is fixed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25cbac4280832cb46f3dd731d6ba9a)