### PR TITLE
test(intake): exercise submission gate smoke flow

### DIFF
--- a/registry/candidates/community/community-sn-7-docs-docs-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-docs-docs-all-ways-io.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-docs-docs-all-ways-io",
+      "kind": "docs",
+      "name": "Allways docs gate smoke candidate",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://docs.all-ways.io/how-it-works.html",
+      "source_urls": [
+        "https://docs.all-ways.io/how-it-works.html"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.all-ways.io/how-it-works.html?metagraphed-gate-smoke=2026-06-07"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}

--- a/registry/candidates/community/community-sn-7-docs-docs-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-docs-docs-all-ways-io.json
@@ -10,7 +10,7 @@
       "provider": "allways",
       "public_safe": true,
       "rate_limit_notes": "",
-      "review_notes": "Community-submitted public interface candidate.",
+      "review_notes": "Community-submitted public interface candidate. Smoke rerun after gate decoration fix.",
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",


### PR DESCRIPTION
## Summary
- Adds one disposable community candidate to exercise the Metagraphed submission gate.
- This PR is expected to be closed after webhook, review, label/comment, and Discord notification behavior are verified.

## Validation
- npm run validate:intake
- git diff --check