### PR TITLE
fix(freshness): block missing candidate discovery timestamps

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1644,10 +1644,7 @@ function buildFreshnessArtifact({
     };
   });
   const candidateDiscoveryAsOf =
-    nonPlaceholderTimestamp(candidateDiscovery?.generated_at) ||
-    candidateDiscovery?.native_snapshot_captured_at ||
-    native.captured_at ||
-    null;
+    nonPlaceholderTimestamp(candidateDiscovery?.generated_at) || null;
   const verificationAsOf =
     verificationArtifact.verification_finished_at ||
     nonPlaceholderTimestamp(verificationArtifact.generated_at) ||

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -331,6 +331,9 @@ test("public artifacts are internally consistent", () => {
   const profileCompleteness = readArtifact("review/profile-completeness.json");
   const adapterCandidates = readArtifact("review/adapter-candidates.json");
   const reviewDecisions = readArtifact("review/maintainer-decisions.json");
+  const generatedCandidateDiscovery = JSON.parse(
+    readFileSync("registry/candidates/generated/public-sources.json", "utf8"),
+  );
 
   assert.equal(subnets.subnets.length, native.subnets.length);
   assert.equal(surfaces.surfaces.length, coverage.surface_count);
@@ -352,6 +355,23 @@ test("public artifacts are internally consistent", () => {
   );
   assert.equal(endpoints.endpoints.length, surfaces.surfaces.length);
   assert.equal(profiles.profiles.length, native.subnets.length);
+  const candidateDiscoverySource = freshness.sources.find(
+    (source) => source.id === "candidate-discovery",
+  );
+  const expectedCandidateDiscoveryAsOf =
+    generatedCandidateDiscovery.generated_at &&
+    generatedCandidateDiscovery.generated_at !== "1970-01-01T00:00:00.000Z"
+      ? generatedCandidateDiscovery.generated_at
+      : null;
+  assert.equal(
+    freshness.summary.candidate_discovery_as_of,
+    expectedCandidateDiscoveryAsOf,
+  );
+  assert.equal(candidateDiscoverySource.as_of, expectedCandidateDiscoveryAsOf);
+  assert.equal(
+    candidateDiscoverySource.status,
+    expectedCandidateDiscoveryAsOf ? "captured" : "missing",
+  );
   assert.equal(
     profiles.profiles.every(
       (profile) =>


### PR DESCRIPTION
## Summary
- replaces the stale/conflicting freshness PR with a focused signed fix
- treats placeholder candidate-discovery timestamps as missing instead of falling back to native snapshot timestamps
- updates compact freshness/build metadata and adds a regression assertion

## What changed
- candidate-discovery freshness now only uses a real discovery `generated_at` value
- placeholder discovery output marks the publish lane as missing/blocking
- artifact consistency tests cover the placeholder case

## Why
The candidate-discovery lane should prove candidate discovery actually ran. Falling back to unrelated native timestamps can make stale or missing discovery data look publish-ready.

## Validation
- `npm run validate`
- `npm run validate:artifact-budgets`
- `npm run validate:types`
- `npx vitest run tests/artifacts.test.mjs`

## Notes
Supersedes PR #82 with a clean branch and without reintroducing broad generated artifact churn.