### PR TITLE
docs(contributing): clarify UGC submission workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-update-endpoint-resource.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-endpoint-resource.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Submit one public endpoint/resource candidate at a time. Accepted submissions create candidates for review and probing; contributors cannot directly set uptime, latency, status, or pool eligibility.
+        Submit one public endpoint/resource candidate at a time. Accepted submissions create candidates for review and probing; contributors cannot directly set uptime, latency, status, or pool eligibility. Base-layer RPC/WSS/archive endpoints and unknown providers always require manual/private review.
   - type: input
     id: netuid
     attributes:

--- a/.github/ISSUE_TEMPLATE/add-update-provider-profile.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-provider-profile.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Provider profiles identify who operates endpoints or maintains public resources. Profiles must be approved before submitted endpoints can become pool-eligible.
+        Provider profiles identify who operates endpoints or maintains public resources. Profiles are review inputs only and must be approved before submitted endpoints can become pool-eligible.
   - type: input
     id: provider_slug
     attributes:

--- a/.github/ISSUE_TEMPLATE/add-update-subnet-interface.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-subnet-interface.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for helping improve Metagraphed. Schema-valid submissions are not auto-published; public validation is followed by the private Metagraphed submission gate. Clean submissions can be imported automatically after approval; edge cases get routed to manual review. Approved imports require the `metagraphed-import-approved` label and open a pull request.
+        Thanks for helping improve Metagraphed. Use this issue path when you want a low-friction review/import request. Schema-valid issues are not auto-published; approved issue imports require the `metagraphed-import-approved` label and open a pull request. If you want the fastest path for a simple public-safe interface, open a direct PR with exactly one `registry/candidates/community/*.json` file instead.
   - type: input
     id: netuid
     attributes:
@@ -92,5 +92,5 @@ body:
           required: true
         - label: The submitted URL can be checked with read-only probes.
           required: true
-        - label: I understand schema-valid submissions still require maintainer review.
+        - label: I understand issue submissions create review/import work and do not directly publish registry data.
           required: true

--- a/.github/ISSUE_TEMPLATE/add-update-subnet-profile-source.yml
+++ b/.github/ISSUE_TEMPLATE/add-update-subnet-profile-source.yml
@@ -9,7 +9,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Use this for profile/source corrections such as official websites, docs, source repos, dashboards, or public data artifacts. These submissions become review candidates; they do not directly change observed health, uptime, latency, or pool eligibility.
+        Use this for profile/source corrections such as official websites, docs, source repos, dashboards, or public data artifacts. Issue submissions become review/import candidates; they do not directly change observed health, uptime, latency, or pool eligibility.
   - type: input
     id: netuid
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE/backend-code.md
+++ b/.github/PULL_REQUEST_TEMPLATE/backend-code.md
@@ -1,0 +1,32 @@
+## Summary
+
+-
+
+## What Changed
+
+-
+
+## Registry Safety
+
+- [ ] No secrets, PATs, wallet data, private dashboards, private URLs, or
+      validator-local state.
+- [ ] Generated artifacts were produced by repo scripts, not hand-edited.
+- [ ] R2-only/high-churn detail artifacts are not committed.
+- [ ] Public API/OpenAPI/schema changes are intentional and documented.
+
+## Validation
+
+- [ ] `npm run check`
+- [ ] `npm run validate`
+- [ ] `npm run validate:schemas`
+- [ ] `npm run validate:api`
+- [ ] `npm run validate:openapi`
+- [ ] `npm run validate:types`
+- [ ] `npm run validate:artifact-budgets`
+- [ ] `npm run validate:docs`
+- [ ] `npm run validate:intake`
+- [ ] `npm run validate:workflows`
+- [ ] `npm run worker:test`
+- [ ] `npm run test:coverage`
+- [ ] `npm run scan:public-safety`
+- [ ] `git diff --check`

--- a/.github/PULL_REQUEST_TEMPLATE/direct-candidate.md
+++ b/.github/PULL_REQUEST_TEMPLATE/direct-candidate.md
@@ -1,0 +1,37 @@
+## Direct Candidate Submission
+
+This PR adds or updates exactly one public subnet/interface candidate.
+
+## Candidate
+
+- Netuid:
+- Kind:
+- Public URL:
+- Source URL:
+- Provider/operator:
+
+## Checklist
+
+- [ ] This PR changes exactly one `registry/candidates/community/*.json` file.
+- [ ] I generated the file with `npm run candidate:new` or matched
+      `docs/examples/submissions/direct-candidate.json`.
+- [ ] The submitted URL is public and safe for read-only probes.
+- [ ] The source URL publicly supports the interface claim.
+- [ ] This does not require authentication.
+- [ ] This does not duplicate an existing Metagraphed surface or candidate.
+- [ ] This does not include secrets, wallet/PAT data, private URLs, private
+      dashboards, validator internals, or generated artifacts.
+
+## Gate Expectations
+
+Safe app-layer submissions can be AI-reviewed by the private Metagraphed gate
+and may be merged automatically by the GitHub App after public checks pass.
+
+Base-layer RPC/WSS/archive endpoints, authenticated surfaces, unknown
+providers, identity disputes, and adapter requests route to manual review.
+
+## Validation
+
+- [ ] `npm run submission:pr -- --changed-files <changed-files.txt>`
+- [ ] `npm run validate:intake`
+- [ ] `npm run scan:public-safety`

--- a/.github/PULL_REQUEST_TEMPLATE/docs-only.md
+++ b/.github/PULL_REQUEST_TEMPLATE/docs-only.md
@@ -1,0 +1,21 @@
+## Docs Change
+
+## Summary
+
+-
+
+## Checklist
+
+- [ ] This PR changes docs/templates only.
+- [ ] No generated `public/metagraph/**` artifacts are included.
+- [ ] No private research notes, local paths, secrets, wallet/PAT data, private
+      URLs, or validator internals are included.
+- [ ] Any referenced API route or artifact path exists in the current backend
+      contracts.
+
+## Validation
+
+- [ ] `npm run validate:docs`
+- [ ] `npm run validate:intake`
+- [ ] `npm run scan:public-safety`
+- [ ] `git diff --check`

--- a/.github/PULL_REQUEST_TEMPLATE/provider-profile.md
+++ b/.github/PULL_REQUEST_TEMPLATE/provider-profile.md
@@ -1,0 +1,37 @@
+## Provider Profile Submission
+
+This PR adds or updates exactly one provider/operator profile review file.
+
+## Provider
+
+- Provider slug:
+- Provider name:
+- Provider kind:
+- Website URL:
+- GitHub URL:
+- Contact URL:
+
+## Checklist
+
+- [ ] This PR changes exactly one `registry/providers/community/*.json` file.
+- [ ] I generated the file with `npm run provider:new` or matched
+      `docs/examples/submissions/direct-provider-profile.json`.
+- [ ] The profile contains only public-safe metadata.
+- [ ] The provider/operator identity is supported by a public website, GitHub
+      org/repo, docs page, status page, or contact page.
+- [ ] This does not claim endpoint health, uptime, latency, archive support, or
+      pool eligibility.
+- [ ] This does not include secrets, wallet/PAT data, private URLs, private
+      dashboards, validator internals, or generated artifacts.
+
+## Gate Expectations
+
+Provider profile submissions always route to manual/private review. Approved
+profiles can support future endpoint submissions, but they do not directly make
+any endpoint pool-eligible.
+
+## Validation
+
+- [ ] `npm run submission:pr -- --changed-files <changed-files.txt>`
+- [ ] `npm run validate:intake`
+- [ ] `npm run scan:public-safety`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,32 +1,24 @@
+## Pick The Right Template
+
+Use the matching PR template so the submission gate can classify your PR
+correctly:
+
+- [Direct subnet/interface candidate](?template=direct-candidate.md): one
+  `registry/candidates/community/*.json` file only.
+- [Provider/operator profile](?template=provider-profile.md): one
+  `registry/providers/community/*.json` file only.
+- [Backend/code change](?template=backend-code.md): scripts, schemas,
+  contracts, workflows, or registry generator logic.
+- [Docs-only change](?template=docs-only.md): README or docs edits only.
+
+For direct UGC submissions, do not edit generated `public/metagraph/**`
+artifacts, native snapshots, scripts, workflows, package files, or multiple
+candidate/provider files.
+
 ## Summary
 
 -
 
-## What changed
+## Template Used
 
 -
-
-## Registry safety
-
-- [ ] No secrets, PATs, wallet data, private dashboards, private URLs, or validator-local state.
-- [ ] Generated artifacts came from repo scripts, not hand-edited public JSON.
-- [ ] Direct community submissions change exactly one `registry/candidates/community/*.json` or `registry/providers/community/*.json` file and no generated artifacts.
-- [ ] Community-submitted interfaces pass public preflight before private gate review.
-- [ ] Direct community submission files were generated with `npm run candidate:new` / `npm run provider:new` or match `docs/examples/submissions/direct-candidate.json` / `docs/examples/submissions/direct-provider-profile.json`.
-
-## Validation
-
-- [ ] `npm run validate`
-- [ ] `npm run validate:schemas`
-- [ ] `npm run validate:api`
-- [ ] `npm run validate:openapi`
-- [ ] `npm run validate:types`
-- [ ] `npm run validate:artifact-budgets`
-- [ ] `npm run validate:docs`
-- [ ] `npm run validate:intake`
-- [ ] `npm run validate:workflows`
-- [ ] `npm run submission:pr -- --changed-files <changed-files.txt>` for direct UGC submissions
-- [ ] `npm run worker:test`
-- [ ] `npm run test:coverage`
-- [ ] `npm run scan:public-safety`
-- [ ] `git diff --check`

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -50,33 +50,43 @@ jobs:
               if file.strip()
           )
           candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
+          provider_pattern = re.compile(r"^registry/providers/community/[a-z0-9][a-z0-9-]*\.json$")
           candidate_files = [file for file in changed_files if candidate_pattern.fullmatch(file)]
+          provider_files = [file for file in changed_files if provider_pattern.fullmatch(file)]
           touched_community = [
-              file for file in changed_files if file.startswith("registry/candidates/community/")
+              file for file in changed_files
+              if file.startswith("registry/candidates/community/")
+              or file.startswith("registry/providers/community/")
           ]
           errors = []
-          if not candidate_files and not touched_community:
+          submission_files = candidate_files + provider_files
+          if not submission_files and not touched_community:
               scope = "normal-pr"
           else:
-              scope = "direct-candidate"
-              if len(candidate_files) != 1:
+              scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
+              if len(submission_files) != 1:
                   errors.append({
                       "category": "unsupported-shape",
-                      "message": "direct submissions must change exactly one registry/candidates/community/*.json file",
+                      "message": "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file",
                   })
-              unrelated = [file for file in changed_files if not candidate_pattern.fullmatch(file)]
+              unrelated = [
+                  file for file in changed_files
+                  if not candidate_pattern.fullmatch(file)
+                  and not provider_pattern.fullmatch(file)
+              ]
               if unrelated:
                   errors.append({
                       "category": "generated-artifact-tampering",
                       "message": "direct submissions cannot change other files: " + ", ".join(unrelated),
                   })
-          mode = "ugc" if scope == "direct-candidate" and not errors else "full"
+          mode = "ugc" if scope in {"direct-candidate", "direct-provider"} and not errors else "full"
           report = {
               "schema_version": 1,
               "mode": mode,
               "scope": scope,
               "changed_files": changed_files,
               "candidate_files": candidate_files,
+              "provider_files": provider_files,
               "errors": errors,
           }
           pathlib.Path("validate-route.json").write_text(

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,52 @@ two supported paths:
   or status reports through the matching issue template. These create review or
   re-probe work; they do not directly change observed health.
 
+## What To Submit First
+
+The most useful contributions are public operational facts that close real
+registry gaps:
+
+- official docs;
+- official website;
+- source repository;
+- dashboard or explorer;
+- OpenAPI/Swagger schema URL;
+- public subnet API URL;
+- SSE endpoint;
+- public data artifact;
+- SDK or example repository.
+
+Start with subnets that are still profile-light: directory-only entries,
+subnets missing websites or source repos, and subnets with public APIs that do
+not yet have OpenAPI/schema metadata in Metagraphed.
+
+Good direct candidate PRs are small: exactly one public URL, one public source
+URL proving the claim, one active netuid, and no generated artifacts.
+
+## Auto-Reviewed vs Manual
+
+Safe direct candidate PRs can be AI-reviewed by the private Metagraphed gate and
+may be merged automatically by the GitHub App after public checks pass. These
+are usually app-layer or docs/data surfaces such as `docs`, `website`,
+`source-repo`, `dashboard`, `openapi`, `subnet-api`, `sse`, `data-artifact`,
+`sdk`, `example`, and `repo-registry`.
+
+The gate still routes higher-risk or ambiguous submissions to manual review:
+
+- provider/operator profiles;
+- Bittensor base-layer `subtensor-rpc`, `subtensor-wss`, or `archive`
+  endpoints;
+- authenticated or paid APIs;
+- unknown providers/operators;
+- adapter requests;
+- endpoint status reports;
+- identity disputes or conflicting official sources.
+
+Do not submit health, uptime, latency, incident, or pool-eligibility values.
+Those are generated only from Metagraphed probes and adapters. Status reports
+can trigger review or a future re-probe, but they cannot change observed
+operational state directly.
+
 You can generate a direct candidate PR file locally:
 
 ```bash
@@ -69,6 +115,13 @@ npm run provider:new -- --id example-operator --name "Example Operator" --kind i
 Example payloads live under `docs/examples/submissions`.
 Useful examples include direct candidates, endpoint resources, OpenAPI/schema
 URLs, provider profiles, profile/source corrections, and status reports.
+
+Live PR references:
+
+- Manual-review direct candidate example:
+  https://github.com/JSONbored/metagraphed/pull/84
+- Merged safe candidate and closed duplicate examples will be added after the
+  first public example submissions land through the current AI gate.
 
 Do not include generated `public/metagraph/**` artifacts, native snapshots,
 workflow/script changes, secrets, wallet/PAT material, private URLs, or

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -8,6 +8,10 @@ templates, broad labels, and safe reason categories. Private scoring prompts,
 thresholds, corpus weights, and merge heuristics stay outside the public repo so
 the gate is harder to game.
 
+Normal backend, docs, schema, workflow, and generated-artifact PRs are not UGC
+submissions. The private gate should ignore them completely: no D1 row, no
+marker comment, no Discord notification, and no AI content verdict.
+
 ## Public States
 
 - `submit_pr`: the submission shape is valid and ready for private review.
@@ -105,6 +109,16 @@ Provider profile submissions are review inputs only; they cannot claim official
 authority, directly modify canonical provider manifests, set endpoint health, or
 make any endpoint pool-eligible.
 
+Clean direct candidate PRs for public-safe app-layer surfaces can be
+AI-reviewed by the private Metagraphed gate and merged directly by the GitHub
+App after required public checks pass. Public preflight only decides whether a
+submission is shaped correctly enough for private review; it does not expose AI
+scoring, thresholds, prompts, examples, corpus weights, or model internals.
+
+Direct provider profile PRs always route to manual/private review. They are
+useful, but they identify operators and can affect future endpoint trust, so
+they are not direct-merge content.
+
 ## Supported UGC Types
 
 The public gate accepts or routes:
@@ -147,6 +161,12 @@ The private `metagraphed-submission-gate` should run on Cloudflare:
 
 The public workflow job `metagraphed-submission-gate` only runs deterministic
 preflight. It must not publish, merge, or expose private review details.
+
+The private runtime makes the final UGC decision. For low-risk direct candidate
+PRs, the AI reviewer returns a strict public-safe verdict object. Deterministic
+hard guards still win over AI: unsafe URLs, secrets, private endpoints,
+duplicates, generated artifact edits, unsupported file shapes, base-layer
+RPC/archive claims, and authenticated surfaces cannot be merged automatically.
 
 Production GitHub writes must use a GitHub App installation token. A fallback
 `GITHUB_TOKEN` can exist for emergency/local testing only when the private
@@ -192,6 +212,14 @@ V1 sends one notification for terminal UGC decisions only:
 
 The gate should not notify for `route_away`, `submit_pr`, `fix_required`, or
 normal backend/code PRs.
+
+Reference PRs:
+
+- Manual-review direct candidate example:
+  https://github.com/JSONbored/metagraphed/pull/84
+- Merged safe candidate and closed duplicate examples should be linked here
+  after the first public example submissions are intentionally run through the
+  current gate.
 
 The Worker stores a `last_notification_key` in D1. The key must include the
 target, PR head SHA or issue revision, terminal status, and verdict. Repeated

--- a/scripts/validate-intake.mjs
+++ b/scripts/validate-intake.mjs
@@ -27,6 +27,23 @@ const pullRequestTemplate = await fs.readFile(
   path.join(repoRoot, ".github/pull_request_template.md"),
   "utf8",
 );
+const prTemplateRoot = path.join(repoRoot, ".github/PULL_REQUEST_TEMPLATE");
+const directCandidateTemplate = await fs.readFile(
+  path.join(prTemplateRoot, "direct-candidate.md"),
+  "utf8",
+);
+const providerProfileTemplate = await fs.readFile(
+  path.join(prTemplateRoot, "provider-profile.md"),
+  "utf8",
+);
+const backendCodeTemplate = await fs.readFile(
+  path.join(prTemplateRoot, "backend-code.md"),
+  "utf8",
+);
+const docsOnlyTemplate = await fs.readFile(
+  path.join(prTemplateRoot, "docs-only.md"),
+  "utf8",
+);
 const submissionGateDocs = await fs.readFile(
   path.join(repoRoot, "docs/submission-gate.md"),
   "utf8",
@@ -68,7 +85,8 @@ checkIncludes(interfaceTemplate.toLowerCase(), "interface template", [
   "id: url",
   "id: source_url",
   "id: auth_required",
-  "schema-valid submissions are not auto-published",
+  "schema-valid issues are not auto-published",
+  "direct pr with exactly one `registry/candidates/community/*.json` file",
   "metagraphed-import-approved",
   "read-only probes",
 ]);
@@ -154,11 +172,60 @@ checkIncludes(profileSourceTemplate, "profile source template", [
   "read-only probes",
 ]);
 
-checkIncludes(pullRequestTemplate, "pull request template", [
+checkIncludes(pullRequestTemplate, "pull request template router", [
+  "?template=direct-candidate.md",
+  "?template=provider-profile.md",
+  "?template=backend-code.md",
+  "?template=docs-only.md",
   "registry/candidates/community/*.json",
   "registry/providers/community/*.json",
-  "npm run submission:pr",
+  "generated `public/metagraph/**`",
 ]);
+
+checkIncludes(directCandidateTemplate, "direct candidate PR template", [
+  "registry/candidates/community/*.json",
+  "npm run candidate:new",
+  "docs/examples/submissions/direct-candidate.json",
+  "AI-reviewed",
+  "merged automatically",
+  "Base-layer RPC/WSS/archive",
+  "npm run submission:pr",
+  "npm run validate:intake",
+  "npm run scan:public-safety",
+]);
+
+checkIncludes(providerProfileTemplate, "provider profile PR template", [
+  "registry/providers/community/*.json",
+  "npm run provider:new",
+  "docs/examples/submissions/direct-provider-profile.json",
+  "manual/private review",
+  "pool-eligible",
+  "npm run submission:pr",
+  "npm run validate:intake",
+  "npm run scan:public-safety",
+]);
+
+checkIncludes(backendCodeTemplate, "backend code PR template", [
+  "npm run check",
+  "npm run validate:api",
+  "npm run validate:openapi",
+  "npm run test:coverage",
+  "R2-only/high-churn detail artifacts are not committed",
+]);
+
+checkIncludes(docsOnlyTemplate, "docs-only PR template", [
+  "docs/templates only",
+  "No generated `public/metagraph/**` artifacts",
+  "npm run validate:docs",
+  "npm run validate:intake",
+  "git diff --check",
+]);
+
+checkIncludes(
+  pullRequestTemplate + directCandidateTemplate,
+  "direct UGC docs",
+  ["npm run submission:pr"],
+);
 
 checkIncludes(submissionGateDocs, "submission gate docs", [
   "submit_pr",


### PR DESCRIPTION
## Summary
- adds dedicated PR templates for direct candidates, provider profiles, backend/code changes, and docs-only changes
- clarifies which UGC submissions can be AI-reviewed/direct-merged and which route to manual review
- updates issue template copy and validation so direct provider submissions are treated as UGC instead of full backend PRs

## What changed
- default PR template now routes contributors to the right template
- public submission docs explain normal PRs are ignored by the private gate
- validate workflow supports one-file provider profile PRs in the UGC lane
- intake validation now covers the new PR templates

## Why
Contributors need a GitHub-native path for improving subnet operational data without touching generated artifacts or accidentally triggering full backend workflows.

## Validation
- `npm run check`
- `npm run validate:intake`
- `npm run validate:workflows`
- `npm run validate:docs`
- `npm run scan:public-safety`
- `git diff --check`

## Notes
No API routes are added. Contribution workflow remains GitHub issues, PR templates, examples, and private gate review.