### PR TITLE
docs(intake): add allways swaps API candidate

### DIFF
--- a/registry/candidates/community/community-sn-7-subnet-api-api-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-subnet-api-api-all-ways-io.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-subnet-api-api-all-ways-io",
+      "kind": "subnet-api",
+      "name": "Allways swaps API",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.all-ways.io/swagger",
+      "source_urls": [
+        "https://api.all-ways.io/swagger"
+      ],
+      "state": "schema-valid",
+      "url": "https://api.all-ways.io/swaps"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
## Direct Candidate Submission

This PR adds one public subnet interface candidate.

## Candidate

- Netuid: 7
- Kind: subnet-api
- Public URL: https://api.all-ways.io/swaps
- Source URL: https://api.all-ways.io/swagger
- Provider/operator: allways

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated artifacts.

## Validation

- `npm run candidate:new -- --netuid 7 --kind subnet-api --url https://api.all-ways.io/swaps --source-url https://api.all-ways.io/swagger --provider allways --submitted-by JSONbored --name "Allways swaps API"`