### PR TITLE
fix(test): keep artifact checks from dirtying outputs

### DIFF
--- a/.github/workflows/submission-gate.yml
+++ b/.github/workflows/submission-gate.yml
@@ -48,12 +48,29 @@ jobs:
             git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
           fi
 
+      - name: Classify submission route
+        id: route
+        run: node scripts/ci-validate-route.mjs --changed-files changed-files.txt --out submission-route.json
+
       - name: Run public submission preflight
+        if: steps.route.outputs.mode == 'ugc'
         env:
           GITHUB_ACTOR: ${{ github.actor }}
         run: npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json
 
       - name: Show public preflight report
+        if: steps.route.outputs.mode == 'ugc'
         run: |
           npm run submission:comment -- --report submission-report.json --out submission-comment.md
           cat submission-comment.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Skip normal PR
+        if: steps.route.outputs.mode != 'ugc'
+        run: |
+          {
+            echo "## Metagraphed Submission Gate"
+            echo
+            echo "No exact one-file UGC submission detected."
+            echo
+            echo "Normal backend, docs, data-refresh, and mixed maintenance PRs are ignored by the public submission gate."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build:artifacts": "node scripts/build-artifacts.mjs",
     "pipeline:check": "node scripts/pipeline.mjs --check",
     "pipeline:refresh": "node scripts/pipeline.mjs --refresh",
+    "artifacts:prepare-local": "node scripts/prepare-local-r2-staging.mjs",
     "sync:subnets": "node scripts/sync-subnets.mjs --write",
     "sync:subnets:dry-run": "node scripts/sync-subnets.mjs --dry-run",
     "discover:candidates": "node scripts/discover-candidates.mjs --write",

--- a/registry/candidates/community/community-sn-7-subnet-api-api-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-subnet-api-api-all-ways-io.json
@@ -15,9 +15,7 @@
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
       "source_url": "https://api.all-ways.io/swagger",
-      "source_urls": [
-        "https://api.all-ways.io/swagger"
-      ],
+      "source_urls": ["https://api.all-ways.io/swagger"],
       "state": "schema-valid",
       "url": "https://api.all-ways.io/swaps"
     }

--- a/scripts/ci-validate-route.mjs
+++ b/scripts/ci-validate-route.mjs
@@ -8,7 +8,7 @@ const options = parseArgs(process.argv.slice(2));
 const changedFiles = await readChangedFiles(options.changedFiles);
 const classification = classifyPrScope(changedFiles);
 const mode =
-  classification.scope === "direct-candidate" &&
+  ["direct-candidate", "direct-provider"].includes(classification.scope) &&
   classification.errors.length === 0
     ? "ugc"
     : "full";
@@ -19,6 +19,7 @@ const report = {
   scope: classification.scope,
   changed_files: normalizeChangedFiles(changedFiles),
   candidate_files: classification.candidateFiles,
+  provider_files: classification.providerFiles,
   errors: classification.errors,
 };
 

--- a/scripts/ci-verify-submitted-artifacts.mjs
+++ b/scripts/ci-verify-submitted-artifacts.mjs
@@ -46,10 +46,14 @@ if (deterministicArtifacts.length === 0) {
 }
 
 try {
-  execFileSync("git", ["diff", "--exit-code", "--", ...deterministicArtifacts], {
-    encoding: "utf8",
-    stdio: "pipe",
-  });
+  execFileSync(
+    "git",
+    ["diff", "--exit-code", "--", ...deterministicArtifacts],
+    {
+      encoding: "utf8",
+      stdio: "pipe",
+    },
+  );
   console.log("Deterministic submitted public artifacts are reproducible.");
 } catch (error) {
   process.stdout.write(error.stdout || "");

--- a/scripts/pipeline.mjs
+++ b/scripts/pipeline.mjs
@@ -53,6 +53,7 @@ console.log(
 
 function checkCommands() {
   return [
+    step("artifacts:prepare-local"),
     step("sync:subnets:dry-run"),
     step("discover:candidates:dry-run"),
     step("verify:candidates:dry-run"),

--- a/scripts/prepare-local-r2-staging.mjs
+++ b/scripts/prepare-local-r2-staging.mjs
@@ -1,0 +1,64 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { repoRoot } from "./lib.mjs";
+
+const trackedPublicArtifacts = execFileSync(
+  "git",
+  ["ls-files", "public/metagraph"],
+  {
+    cwd: repoRoot,
+    encoding: "utf8",
+  },
+)
+  .split(/\r?\n/)
+  .filter(Boolean);
+
+const originals = new Map();
+for (const relativePath of trackedPublicArtifacts) {
+  const filePath = path.join(repoRoot, relativePath);
+  originals.set(relativePath, {
+    existed: existsSync(filePath),
+    content: existsSync(filePath) ? await readFile(filePath) : null,
+  });
+}
+
+const result = spawnSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+  cwd: repoRoot,
+  encoding: "utf8",
+  env: {
+    ...process.env,
+    METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
+  },
+  stdio: "pipe",
+});
+
+for (const [relativePath, original] of originals) {
+  const filePath = path.join(repoRoot, relativePath);
+  if (!original.existed) {
+    await rm(filePath, { force: true });
+    continue;
+  }
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, original.content);
+}
+
+process.stdout.write(result.stdout || "");
+process.stderr.write(result.stderr || "");
+
+if (result.status !== 0) {
+  process.exit(result.status || 1);
+}
+
+console.log(
+  JSON.stringify(
+    {
+      mode: "local-r2-staging",
+      result: "prepared",
+      restored_public_artifact_count: originals.size,
+    },
+    null,
+    2,
+  ),
+);

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -17,6 +17,12 @@ import {
 } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
+const SUPPORT_ARTIFACT_PATHS = [
+  "public/metagraph/build-summary.json",
+  "public/metagraph/changelog.json",
+  "public/metagraph/r2-manifest.json",
+];
+
 function runNode(script) {
   execFileSync(process.execPath, [script], {
     cwd: process.cwd(),
@@ -137,6 +143,7 @@ test("artifact build ignores forged committed health observations by default", (
   const originalCache = existsSync(cachePath)
     ? readFileSync(cachePath, "utf8")
     : null;
+  const supportArtifacts = snapshotSupportArtifacts();
   rmSync(cachePath, { force: true });
   const tampered = JSON.parse(original);
   const target = tampered.surfaces.find(
@@ -160,7 +167,10 @@ test("artifact build ignores forged committed health observations by default", (
     execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
       cwd: process.cwd(),
       encoding: "utf8",
-      env: process.env,
+      env: {
+        ...process.env,
+        METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
+      },
       stdio: "pipe",
     });
 
@@ -185,7 +195,10 @@ test("artifact build ignores forged committed health observations by default", (
     execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
       cwd: process.cwd(),
       encoding: "utf8",
-      env: process.env,
+      env: {
+        ...process.env,
+        METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
+      },
       stdio: "pipe",
     });
     execFileSync(process.execPath, ["scripts/generate-types.mjs"], {
@@ -206,6 +219,7 @@ test("artifact build ignores forged committed health observations by default", (
       env: process.env,
       stdio: "pipe",
     });
+    restoreSupportArtifacts(supportArtifacts);
   }
 }, 30_000);
 
@@ -216,6 +230,7 @@ test("artifact build does not preserve forged endpoint index health", () => {
   const originalCache = existsSync(cachePath)
     ? readFileSync(cachePath, "utf8")
     : null;
+  const supportArtifacts = snapshotSupportArtifacts();
   rmSync(cachePath, { force: true });
   const tampered = JSON.parse(original);
   const target = tampered.endpoints.find(
@@ -264,7 +279,10 @@ test("artifact build does not preserve forged endpoint index health", () => {
     execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
       cwd: process.cwd(),
       encoding: "utf8",
-      env: process.env,
+      env: {
+        ...process.env,
+        METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
+      },
       stdio: "pipe",
     });
     execFileSync(process.execPath, ["scripts/generate-types.mjs"], {
@@ -285,6 +303,7 @@ test("artifact build does not preserve forged endpoint index health", () => {
       env: process.env,
       stdio: "pipe",
     });
+    restoreSupportArtifacts(supportArtifacts);
   }
 }, 30_000);
 
@@ -674,4 +693,19 @@ function latestArtifactDate(relativePath) {
     .map((file) => file.replace(/\.json$/, ""))
     .sort()
     .at(-1);
+}
+
+function snapshotSupportArtifacts() {
+  return new Map(
+    SUPPORT_ARTIFACT_PATHS.map((filePath) => [
+      filePath,
+      readFileSync(filePath, "utf8"),
+    ]),
+  );
+}
+
+function restoreSupportArtifacts(snapshot) {
+  for (const [filePath, content] of snapshot) {
+    writeFileSync(filePath, content);
+  }
 }


### PR DESCRIPTION
## Summary
- keep local check/test runs from leaving probe-derived public artifacts downgraded
- prepare ignored R2 staging before pipeline validation while restoring tracked public artifacts
- format the AI-merged Allways candidate and CI helper
- skip the public submission-gate preflight for normal or mixed maintenance PRs

## Why
- `npm run check` should be reliable for contributors without requiring manual cleanup of generated operational artifacts.
- Probe-derived endpoint and health summaries should stay production/R2-owned, not become accidental local churn.
- The submission gate should only adjudicate exact one-file UGC submissions; backend/code PRs stay under normal review.

## Validation
- `npm run check`
- `npm run validate:workflows`
- route fixture checks for mixed PR, one candidate PR, and one provider PR
- `git diff --check`

## Notes
- Live dry-run sync currently reports SN76 native identity recovery; that should be handled as a separate data refresh PR.