### PR TITLE
docs(intake): link duplicate submission example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,8 +122,8 @@ Live PR references:
   https://github.com/JSONbored/metagraphed/pull/87
 - Manual-review direct candidate example:
   https://github.com/JSONbored/metagraphed/pull/84
-- Closed duplicate/invalid examples will be added after the first public
-  rejection example is intentionally run through the current gate.
+- Closed duplicate candidate example:
+  https://github.com/JSONbored/metagraphed/pull/90
 
 Do not include generated `public/metagraph/**` artifacts, native snapshots,
 workflow/script changes, secrets, wallet/PAT material, private URLs, or

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -219,8 +219,8 @@ Reference PRs:
   https://github.com/JSONbored/metagraphed/pull/87
 - Manual-review direct candidate example:
   https://github.com/JSONbored/metagraphed/pull/84
-- Closed duplicate/invalid examples should be linked here after the first public
-  rejection example is intentionally run through the current gate.
+- Closed duplicate candidate example:
+  https://github.com/JSONbored/metagraphed/pull/90
 
 The Worker stores a `last_notification_key` in D1. The key must include the
 target, PR head SHA or issue revision, terminal status, and verdict. Repeated


### PR DESCRIPTION
## Summary
- link the real closed duplicate candidate example from contributor docs
- replace the placeholder closed-example copy in the submission gate docs

## Why
- contributors now have merged, manual-review, and closed duplicate PRs to reference.

## Validation
- `npm run validate:docs`
- `npm run scan:public-safety`
- `git diff --check`