### PR TITLE
fix(publish): persist discovery freshness during refresh

### DIFF
--- a/scripts/pipeline.mjs
+++ b/scripts/pipeline.mjs
@@ -90,6 +90,7 @@ function refreshCommands(refreshTimestamp) {
   const refreshEnv = {
     METAGRAPH_BUILD_TIMESTAMP: refreshTimestamp,
     METAGRAPH_DISCOVERY_OBSERVED_AT: refreshTimestamp,
+    METAGRAPH_PERSIST_DISCOVERY_OBSERVED_AT: "1",
   };
   const commands = [
     step("sync:subnets"),

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -110,6 +110,16 @@ describe("script utility contracts", () => {
     }
   });
 
+  test("refresh pipeline persists candidate discovery timestamps", async () => {
+    const source = await readFile(
+      path.join(repoRoot, "scripts/pipeline.mjs"),
+      "utf8",
+    );
+
+    assert.match(source, /METAGRAPH_DISCOVERY_OBSERVED_AT:\s*refreshTimestamp/);
+    assert.match(source, /METAGRAPH_PERSIST_DISCOVERY_OBSERVED_AT:\s*"1"/);
+  });
+
   test("classifies artifact storage tiers for files and route templates", async () => {
     assert.equal(
       artifactRelativePath("/metagraph/subnets/7.json"),


### PR DESCRIPTION
## Summary
- persist candidate discovery observed timestamps during refresh pipeline runs
- add a regression guard so the publish path keeps recording discovery freshness

## Why
The publish workflow should not require a hidden local env variable to avoid missing candidate-discovery freshness. This keeps production refreshes equivalent between local, CI, and scheduled publishing.

## Validation
- npm test -- tests/script-utils.test.mjs
- npm run validate:workflows
- npm run validate:private-boundary
- npm run check
- git diff --check HEAD~1 HEAD