### PR TITLE
ci(publish): upload versioned R2 artifacts

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -90,6 +90,7 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           METAGRAPH_ALLOW_R2_UPLOAD: "1"
+          METAGRAPH_R2_UPLOAD_HISTORY: "1"
 
       - name: Publish KV latest pointer
         if: steps.cloudflare-secrets.outputs.kv_publish == 'true'

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -131,6 +131,13 @@ for (const workflow of workflows) {
       "workflow must validate private reviewer and notification boundaries",
     );
   }
+  if (workflow === "publish-cloudflare.yml") {
+    check(
+      content.includes('METAGRAPH_R2_UPLOAD_HISTORY: "1"'),
+      workflow,
+      "publish workflow must upload versioned R2 history objects",
+    );
+  }
 }
 
 if (errors.length > 0) {


### PR DESCRIPTION
## Summary
- enable versioned R2 history uploads in the Cloudflare publish workflow
- add a workflow validator guard so the history flag cannot drift out silently

## Why
Metagraphed should keep latest artifacts and versioned run artifacts in R2. The publish workflow previously uploaded latest objects only unless a local operator set an extra flag.

## Validation
- npm run validate:workflows
- npm run check
- git diff --check HEAD~1 HEAD

## Notes
No generated registry artifacts are included in this PR.