### PR TITLE
feat(intake): submit gittensor OpenAPI candidate

### DIFF
--- a/registry/candidates/community/community-sn-74-openapi-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-openapi-api-gittensor-io.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-openapi-api-gittensor-io",
+      "kind": "openapi",
+      "name": "Gittensor API OpenAPI schema",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gittensor.io/swagger",
+      "source_urls": [
+        "https://api.gittensor.io/swagger"
+      ],
+      "state": "schema-valid",
+      "url": "https://api.gittensor.io/swagger-json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
## Summary
- submits a one-file community candidate for the Gittensor public OpenAPI schema
- keeps generated artifacts untouched so the private submission gate can review the PR cleanly

## What changed
- adds `registry/candidates/community/community-sn-74-openapi-api-gittensor-io.json`
- points the candidate at `https://api.gittensor.io/swagger-json`
- uses `https://api.gittensor.io/swagger` as the public source/provenance URL

## Why
- this is a real operational interface candidate for SN74 that is not currently published as a curated surface
- it exercises the contributor path with a realistic one-file UGC PR

## Validation
- `npm run submission:pr -- --changed-files .cache/metagraphed/changed-files-ugc-test.txt --submitter jsonbored`
- `npm run validate:intake`
- `npm run scan:public-safety`
- `git diff --check`

## Notes
- no generated registry artifacts were committed
