### PR TITLE
fix(intake): enforce formatted community submissions

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 21,
-  "artifact_size_bytes": 3449264,
+  "artifact_size_bytes": 3449517,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -17,8 +17,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "829e04ab4d74ffcaacd0799ca02ef4b9183294762d42eae2950dbe001bf209bd",
-      "size_bytes": 1347,
+      "sha256": "2745d198340f2f301ef958e6d702e12142ca5f04a306b671fd26d88ab13fda59",
+      "size_bytes": 1633,
       "storage_tier": "dual"
     },
     {
@@ -29,13 +29,13 @@
     },
     {
       "path": "coverage.json",
-      "sha256": "5e659f9ff90e5a2f71ea161799cc0a3222a43e50f380d33a1b97701b1d1836b7",
+      "sha256": "682260af04ab17ef7bec8fe34135b94dda0d1e11307cb6e7fec0b27f648d0f23",
       "size_bytes": 982,
       "storage_tier": "dual"
     },
     {
       "path": "curation.json",
-      "sha256": "8adedc2c348366df221a40fd02524f3cf0962fcf3aa2927e781165483179a56a",
+      "sha256": "17753108f7ac047c62bc511ad02b076cf37721d6660c63502431bea8db757a54",
       "size_bytes": 144924,
       "storage_tier": "dual"
     },
@@ -47,8 +47,8 @@
     },
     {
       "path": "freshness.json",
-      "sha256": "86c6ee41912929334eaac9e9ebbbefd98808c2a8c617ec8a0a1383bb2216ed3e",
-      "size_bytes": 4404,
+      "sha256": "5057a500457537513b25eebb11914b86e3a64ec103958db08e09cb428d195919",
+      "size_bytes": 4371,
       "storage_tier": "dual"
     },
     {
@@ -65,7 +65,7 @@
     },
     {
       "path": "profiles.json",
-      "sha256": "b4a970cb0c02781d81a5f19f2a4e4b29ebaf644cae24be525d733157d1b9597c",
+      "sha256": "0dfcbd3963c819c59925537367ac6cedabe20e41c073619d1e6152e6367e8199",
       "size_bytes": 345980,
       "storage_tier": "dual"
     },
@@ -77,19 +77,19 @@
     },
     {
       "path": "review/adapter-candidates.json",
-      "sha256": "b0a3d38dbd305f58c681cb96b35b7ce2b1575577361be8af60eb8c6ea47cf4c7",
+      "sha256": "3c5a31a95e7da23defa4ff5f045a4ea78c847685d8eb627749907159e62b0dd6",
       "size_bytes": 27960,
       "storage_tier": "dual"
     },
     {
       "path": "review/curation.json",
-      "sha256": "624975b50509c0bfe892044ea5ab2ce7645e2dcd00e4da70a2da5f100803632f",
+      "sha256": "0719fcf89add77728c955b014ceea0baf7f32b11584bc546889d814dd21715e6",
       "size_bytes": 96733,
       "storage_tier": "dual"
     },
     {
       "path": "review/gap-priorities.json",
-      "sha256": "42b7dd940be2c466d7ebc92de78ca234fd93409f469a92a1479365cb1d5576b9",
+      "sha256": "2fd6b049e95bf2d2ad4b9df5d8d39e67a9f8be680051012ff35a860973a69509",
       "size_bytes": 66900,
       "storage_tier": "dual"
     },
@@ -101,7 +101,7 @@
     },
     {
       "path": "review/profile-completeness.json",
-      "sha256": "acd9f160414959280241f4e24f7252613e21eb56c190298069795f19d12b19bc",
+      "sha256": "830faf07379a045831befc710716bdd26176d3190d5b03b5bd3c3e5074f8d912",
       "size_bytes": 68927,
       "storage_tier": "git"
     },
@@ -125,7 +125,7 @@
     },
     {
       "path": "subnets.json",
-      "sha256": "b1c268c5552c8a94ced0dac8d6e5e54304d00169d63d365de1f004e66743a42b",
+      "sha256": "30efb88eee37f6862b991bcc4cf51d3f98b6a467874e3fb19a1d46df84816870",
       "size_bytes": 114671,
       "storage_tier": "dual"
     },
@@ -136,11 +136,11 @@
       "storage_tier": "dual"
     }
   ],
-  "candidate_count": 1771,
+  "candidate_count": 1772,
   "contract_version": "2026-06-06.1",
   "coverage": {
     "application_subnet_count": 128,
-    "candidate_count": 1771,
+    "candidate_count": 1772,
     "candidate_subnet_count": 129,
     "chain_subnet_count": 129,
     "curated_overlay_count": 129,
@@ -175,7 +175,7 @@
   },
   "endpoint_count": 853,
   "full_artifact_count": 1097,
-  "full_artifact_size_bytes": 38513589,
+  "full_artifact_size_bytes": 27570073,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 14,
@@ -190,9 +190,9 @@
     "r2": 1076
   },
   "storage_tier_size_bytes": {
-    "dual": 3380337,
+    "dual": 3380590,
     "git": 68927,
-    "r2": 35064325
+    "r2": 24120556
   },
   "subnet_count": 129,
   "surface_count": 853

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -3,8 +3,16 @@
     "added": [],
     "modified": [
       {
-        "hash": "86c6ee41912929334eaac9e9ebbbefd98808c2a8c617ec8a0a1383bb2216ed3e",
+        "hash": "5057a500457537513b25eebb11914b86e3a64ec103958db08e09cb428d195919",
         "path": "freshness.json"
+      },
+      {
+        "hash": "0719fcf89add77728c955b014ceea0baf7f32b11584bc546889d814dd21715e6",
+        "path": "review/curation.json"
+      },
+      {
+        "hash": "2fd6b049e95bf2d2ad4b9df5d8d39e67a9f8be680051012ff35a860973a69509",
+        "path": "review/gap-priorities.json"
       }
     ],
     "removed": []
@@ -24,12 +32,12 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 1,
+    "artifact_modified_count": 3,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {
-        "after": 1771,
-        "before": 1771,
+        "after": 1772,
+        "before": 1772,
         "delta": 0
       },
       "curated_overlay_count": {

--- a/public/metagraph/coverage.json
+++ b/public/metagraph/coverage.json
@@ -1,6 +1,6 @@
 {
   "application_subnet_count": 128,
-  "candidate_count": 1771,
+  "candidate_count": 1772,
   "candidate_subnet_count": 129,
   "chain_subnet_count": 129,
   "curated_overlay_count": 129,

--- a/public/metagraph/curation.json
+++ b/public/metagraph/curation.json
@@ -3103,7 +3103,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [

--- a/public/metagraph/freshness.json
+++ b/public/metagraph/freshness.json
@@ -56,7 +56,7 @@
       "timestamp_field": "candidate_discovery_as_of"
     },
     {
-      "as_of": "2026-06-07T22:30:40.414Z",
+      "as_of": null,
       "id": "candidate-verification",
       "lane": "candidate-verification",
       "notes": "",
@@ -64,8 +64,8 @@
       "required_for_publish": true,
       "stale_after_hours": 24,
       "stale_behavior": "block",
-      "status": "captured",
-      "timestamp": "2026-06-07T22:30:40.414Z",
+      "status": "missing",
+      "timestamp": null,
       "timestamp_field": "verification_as_of"
     },
     {
@@ -95,7 +95,7 @@
       "timestamp_field": "schema_snapshot_as_of"
     },
     {
-      "as_of": "2026-06-07T21:53:25.348Z",
+      "as_of": "2026-06-08T00:34:16.831Z",
       "id": "surface-health",
       "lane": "health-probe",
       "notes": "Observed health is probe-derived.",
@@ -104,7 +104,7 @@
       "stale_after_hours": 6,
       "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-07T21:53:25.348Z",
+      "timestamp": "2026-06-08T00:34:16.831Z",
       "timestamp_field": "health_probe_as_of"
     }
   ],
@@ -113,9 +113,9 @@
     "adapter_snapshot_as_of": "2026-06-07T21:52:49.513Z",
     "blocking_source_count": 5,
     "candidate_discovery_as_of": null,
-    "health_probe_as_of": "2026-06-07T21:53:25.348Z",
+    "health_probe_as_of": "2026-06-08T00:34:16.831Z",
     "health_surface_count": 852,
-    "missing_blocking_source_count": 1,
+    "missing_blocking_source_count": 2,
     "native_data_as_of": "2026-06-07T21:51:54Z",
     "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
     "openapi_surface_count": 28,
@@ -123,9 +123,10 @@
     "schema_snapshot_as_of": null,
     "stale_window_warnings": [
       "candidate-discovery has no observed timestamp; production publish should block.",
+      "candidate-verification has no observed timestamp; production publish should block.",
       "schema-drift has no observed timestamp; review before relying on this lane."
     ],
-    "verification_as_of": "2026-06-07T22:30:40.414Z",
+    "verification_as_of": null,
     "verification_generated_at": "1970-01-01T00:00:00.000Z",
     "warning_source_count": 3
   }

--- a/public/metagraph/profiles.json
+++ b/public/metagraph/profiles.json
@@ -6117,7 +6117,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "developer-tools",
         "repositories",

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 22,
-  "artifact_size_bytes": 3623592,
+  "artifact_size_bytes": 3623845,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "829e04ab4d74ffcaacd0799ca02ef4b9183294762d42eae2950dbe001bf209bd",
-      "size_bytes": 1347,
+      "sha256": "2745d198340f2f301ef958e6d702e12142ca5f04a306b671fd26d88ab13fda59",
+      "size_bytes": 1633,
       "storage_tier": "dual"
     },
     {
@@ -34,7 +34,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/coverage.json",
       "latest_key": "latest/coverage.json",
       "path": "/metagraph/coverage.json",
-      "sha256": "5e659f9ff90e5a2f71ea161799cc0a3222a43e50f380d33a1b97701b1d1836b7",
+      "sha256": "682260af04ab17ef7bec8fe34135b94dda0d1e11307cb6e7fec0b27f648d0f23",
       "size_bytes": 982,
       "storage_tier": "dual"
     },
@@ -43,7 +43,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/curation.json",
       "latest_key": "latest/curation.json",
       "path": "/metagraph/curation.json",
-      "sha256": "8adedc2c348366df221a40fd02524f3cf0962fcf3aa2927e781165483179a56a",
+      "sha256": "17753108f7ac047c62bc511ad02b076cf37721d6660c63502431bea8db757a54",
       "size_bytes": 144924,
       "storage_tier": "dual"
     },
@@ -61,8 +61,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "86c6ee41912929334eaac9e9ebbbefd98808c2a8c617ec8a0a1383bb2216ed3e",
-      "size_bytes": 4404,
+      "sha256": "5057a500457537513b25eebb11914b86e3a64ec103958db08e09cb428d195919",
+      "size_bytes": 4371,
       "storage_tier": "dual"
     },
     {
@@ -88,7 +88,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/profiles.json",
       "latest_key": "latest/profiles.json",
       "path": "/metagraph/profiles.json",
-      "sha256": "b4a970cb0c02781d81a5f19f2a4e4b29ebaf644cae24be525d733157d1b9597c",
+      "sha256": "0dfcbd3963c819c59925537367ac6cedabe20e41c073619d1e6152e6367e8199",
       "size_bytes": 345980,
       "storage_tier": "dual"
     },
@@ -106,7 +106,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/adapter-candidates.json",
       "latest_key": "latest/review/adapter-candidates.json",
       "path": "/metagraph/review/adapter-candidates.json",
-      "sha256": "b0a3d38dbd305f58c681cb96b35b7ce2b1575577361be8af60eb8c6ea47cf4c7",
+      "sha256": "3c5a31a95e7da23defa4ff5f045a4ea78c847685d8eb627749907159e62b0dd6",
       "size_bytes": 27960,
       "storage_tier": "dual"
     },
@@ -115,7 +115,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/curation.json",
       "latest_key": "latest/review/curation.json",
       "path": "/metagraph/review/curation.json",
-      "sha256": "624975b50509c0bfe892044ea5ab2ce7645e2dcd00e4da70a2da5f100803632f",
+      "sha256": "0719fcf89add77728c955b014ceea0baf7f32b11584bc546889d814dd21715e6",
       "size_bytes": 96733,
       "storage_tier": "dual"
     },
@@ -124,7 +124,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/gap-priorities.json",
       "latest_key": "latest/review/gap-priorities.json",
       "path": "/metagraph/review/gap-priorities.json",
-      "sha256": "42b7dd940be2c466d7ebc92de78ca234fd93409f469a92a1479365cb1d5576b9",
+      "sha256": "2fd6b049e95bf2d2ad4b9df5d8d39e67a9f8be680051012ff35a860973a69509",
       "size_bytes": 66900,
       "storage_tier": "dual"
     },
@@ -142,7 +142,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/profile-completeness.json",
       "latest_key": "latest/review/profile-completeness.json",
       "path": "/metagraph/review/profile-completeness.json",
-      "sha256": "acd9f160414959280241f4e24f7252613e21eb56c190298069795f19d12b19bc",
+      "sha256": "830faf07379a045831befc710716bdd26176d3190d5b03b5bd3c3e5074f8d912",
       "size_bytes": 68927,
       "storage_tier": "git"
     },
@@ -178,7 +178,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/subnets.json",
       "latest_key": "latest/subnets.json",
       "path": "/metagraph/subnets.json",
-      "sha256": "b1c268c5552c8a94ced0dac8d6e5e54304d00169d63d365de1f004e66743a42b",
+      "sha256": "30efb88eee37f6862b991bcc4cf51d3f98b6a467874e3fb19a1d46df84816870",
       "size_bytes": 114671,
       "storage_tier": "dual"
     },
@@ -205,7 +205,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1098,
-  "full_artifact_size_bytes": 38687917,
+  "full_artifact_size_bytes": 27744401,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -227,8 +227,8 @@
     "r2": 1076
   },
   "storage_tier_size_bytes": {
-    "dual": 3554665,
+    "dual": 3554918,
     "git": 68927,
-    "r2": 35064325
+    "r2": 24120556
   }
 }

--- a/public/metagraph/review/adapter-candidates.json
+++ b/public/metagraph/review/adapter-candidates.json
@@ -500,7 +500,7 @@
       "slug": "sn-72"
     },
     {
-      "candidate_api_count": 5,
+      "candidate_api_count": 6,
       "curation_level": "adapter-backed",
       "name": "Gittensor",
       "netuid": 74,

--- a/public/metagraph/review/curation.json
+++ b/public/metagraph/review/curation.json
@@ -500,7 +500,7 @@
       "slug": "sn-72"
     },
     {
-      "candidate_api_count": 5,
+      "candidate_api_count": 6,
       "curation_level": "adapter-backed",
       "name": "Gittensor",
       "netuid": 74,
@@ -3440,7 +3440,7 @@
       "verified_candidate_count": 3
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "dashboard",
@@ -3450,7 +3450,7 @@
       ],
       "name": "Gittensor",
       "netuid": 74,
-      "priority_score": 23,
+      "priority_score": 24,
       "review_state": "maintainer-reviewed",
       "slug": "gittensor",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",

--- a/public/metagraph/review/gap-priorities.json
+++ b/public/metagraph/review/gap-priorities.json
@@ -2296,7 +2296,7 @@
       "verified_candidate_count": 3
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "dashboard",
@@ -2306,7 +2306,7 @@
       ],
       "name": "Gittensor",
       "netuid": 74,
-      "priority_score": 23,
+      "priority_score": 24,
       "review_state": "maintainer-reviewed",
       "slug": "gittensor",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",

--- a/public/metagraph/review/profile-completeness.json
+++ b/public/metagraph/review/profile-completeness.json
@@ -1809,6 +1809,23 @@
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them"
     },
     {
+      "candidate_count": 17,
+      "completeness_score": 63,
+      "confidence": "high",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse"
+      ],
+      "missing_critical_count": 3,
+      "name": "Gittensor",
+      "netuid": 74,
+      "priority_score": 69,
+      "profile_level": "adapter-backed",
+      "slug": "gittensor",
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them"
+    },
+    {
       "candidate_count": 19,
       "completeness_score": 65,
       "confidence": "medium",
@@ -1840,23 +1857,6 @@
       "priority_score": 69,
       "profile_level": "operational",
       "slug": "sn-88",
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them"
-    },
-    {
-      "candidate_count": 16,
-      "completeness_score": 63,
-      "confidence": "high",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse"
-      ],
-      "missing_critical_count": 3,
-      "name": "Gittensor",
-      "netuid": 74,
-      "priority_score": 68,
-      "profile_level": "adapter-backed",
-      "slug": "gittensor",
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them"
     },
     {

--- a/public/metagraph/subnets.json
+++ b/public/metagraph/subnets.json
@@ -2089,7 +2089,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "developer-tools",
         "repositories",

--- a/registry/candidates/community/community-sn-74-openapi-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-openapi-api-gittensor-io.json
@@ -15,9 +15,7 @@
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
       "source_url": "https://api.gittensor.io/swagger",
-      "source_urls": [
-        "https://api.gittensor.io/swagger"
-      ],
+      "source_urls": ["https://api.gittensor.io/swagger"],
       "state": "schema-valid",
       "url": "https://api.gittensor.io/swagger-json"
     }

--- a/scripts/candidate-new.mjs
+++ b/scripts/candidate-new.mjs
@@ -8,7 +8,7 @@ import {
   repoRoot,
   slugify,
   stableStringify,
-  writeJson,
+  writeRepositoryJson,
 } from "./lib.mjs";
 import {
   buildPrSubmissionReport,
@@ -102,7 +102,7 @@ if (report.blocking) {
 }
 
 if (write) {
-  await writeJson(outputPath, document);
+  await writeRepositoryJson(outputPath, document);
 }
 
 console.log(

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -63,6 +63,16 @@ export async function writeJson(filePath, value) {
   await fs.writeFile(filePath, `${stableStringify(value)}\n`, "utf8");
 }
 
+export async function formatRepositoryJson(value) {
+  const prettier = await import("prettier");
+  return prettier.format(`${stableStringify(value)}\n`, { parser: "json" });
+}
+
+export async function writeRepositoryJson(filePath, value) {
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, await formatRepositoryJson(value), "utf8");
+}
+
 export function artifactFilePath(relativePath, options = {}) {
   const normalized = artifactRelativePath(relativePath);
   const tier = artifactStorageTierForRelativePath(normalized);

--- a/scripts/provider-new.mjs
+++ b/scripts/provider-new.mjs
@@ -8,7 +8,7 @@ import {
   repoRoot,
   slugify,
   stableStringify,
-  writeJson,
+  writeRepositoryJson,
 } from "./lib.mjs";
 import {
   buildPrSubmissionReport,
@@ -99,7 +99,7 @@ if (report.blocking) {
 }
 
 if (write) {
-  await writeJson(outputPath, document);
+  await writeRepositoryJson(outputPath, document);
 }
 
 console.log(

--- a/scripts/submission-formatting.mjs
+++ b/scripts/submission-formatting.mjs
@@ -1,0 +1,17 @@
+import { formatRepositoryJson } from "./lib.mjs";
+
+export async function submissionFormattingErrors(entries = []) {
+  const errors = [];
+  for (const entry of entries) {
+    if (!entry?.file || !entry.document || typeof entry.raw !== "string") {
+      continue;
+    }
+    const formatted = await formatRepositoryJson(entry.document);
+    if (entry.raw !== formatted) {
+      errors.push(
+        `${entry.file} is not formatted with the repository JSON style; run Prettier or regenerate it with npm run candidate:new/provider:new`,
+      );
+    }
+  }
+  return errors;
+}

--- a/scripts/submission-pr.mjs
+++ b/scripts/submission-pr.mjs
@@ -15,6 +15,7 @@ import {
   buildPrSubmissionReport,
   normalizeChangedFiles,
 } from "./submission-policy.mjs";
+import { submissionFormattingErrors } from "./submission-formatting.mjs";
 
 const args = process.argv.slice(2);
 const changedFilesPath = valueAfter("--changed-files");
@@ -43,6 +44,18 @@ const candidateDocument = directCandidateFile
 const providerDocument = directProviderFile
   ? await readJson(path.resolve(directProviderFile))
   : null;
+const directSubmissionRaw = new Map(
+  (
+    await Promise.all(
+      [directCandidateFile, directProviderFile]
+        .filter(Boolean)
+        .map(async (file) => [
+          file,
+          await fs.readFile(path.resolve(file), "utf8"),
+        ]),
+    )
+  ).map(([file, raw]) => [file, raw]),
+);
 const existingCandidates = directCandidateFile
   ? (await loadCandidates()).filter(
       (candidate) =>
@@ -68,13 +81,42 @@ const report = buildPrSubmissionReport({
   existingSubnets: await loadSubnets(),
 });
 
+const formattingErrors = await submissionFormattingErrors([
+  {
+    file: directCandidateFile,
+    raw: directSubmissionRaw.get(directCandidateFile),
+    document: candidateDocument,
+  },
+  {
+    file: directProviderFile,
+    raw: directSubmissionRaw.get(directProviderFile),
+    document: providerDocument,
+  },
+]);
+const outputReport =
+  formattingErrors.length === 0
+    ? report
+    : {
+        ...report,
+        state: "schema-invalid",
+        public_state: "fix_required",
+        errors: [...report.errors, ...formattingErrors],
+        error_categories: [
+          ...report.error_categories,
+          ...formattingErrors.map(() => "unsupported-shape"),
+        ],
+        blocking: true,
+        private_review_required: false,
+        next_action: "resubmission-needed",
+      };
+
 if (outPath) {
-  await writeJson(path.resolve(outPath), report);
+  await writeJson(path.resolve(outPath), outputReport);
 }
 
-console.log(stableStringify(report));
+console.log(stableStringify(outputReport));
 
-if (failOnBlocking && report.blocking) {
+if (failOnBlocking && outputReport.blocking) {
   process.exit(1);
 }
 

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -19,6 +19,7 @@ import {
   artifactOutputPath,
   createLocalArtifactEnv,
   flattenSurfaces,
+  formatRepositoryJson,
   hashJson,
   isCredentialedUrl,
   isHtmlContentType,
@@ -43,6 +44,7 @@ import {
   slugify,
   stableStringify,
   writeJson,
+  writeRepositoryJson,
 } from "../scripts/lib.mjs";
 import {
   ARTIFACT_STORAGE_TIERS,
@@ -68,6 +70,7 @@ import {
   validateCandidateForSubmission,
   validateSubmissionProvenance,
 } from "../scripts/submission-policy.mjs";
+import { submissionFormattingErrors } from "../scripts/submission-formatting.mjs";
 
 const native = {
   subnets: [
@@ -105,6 +108,51 @@ describe("script utility contracts", () => {
         await listJsonFilesRecursive(path.join(dir, "missing")),
         [],
       );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("formats contributor JSON with repository style", async () => {
+    const document = {
+      schema_version: 1,
+      source_urls: ["https://docs.all-ways.io/how-it-works.html"],
+    };
+    const formatted = await formatRepositoryJson(document);
+
+    assert.match(
+      formatted,
+      /"source_urls": \["https:\/\/docs\.all-ways\.io\/how-it-works\.html"\]/,
+    );
+    assert.equal(formatted.endsWith("\n"), true);
+    assert.deepEqual(
+      await submissionFormattingErrors([
+        {
+          file: "registry/candidates/community/example.json",
+          raw: `${JSON.stringify(document, null, 2)}\n`,
+          document,
+        },
+      ]),
+      [
+        "registry/candidates/community/example.json is not formatted with the repository JSON style; run Prettier or regenerate it with npm run candidate:new/provider:new",
+      ],
+    );
+    assert.deepEqual(
+      await submissionFormattingErrors([
+        {
+          file: "registry/candidates/community/example.json",
+          raw: formatted,
+          document,
+        },
+      ]),
+      [],
+    );
+
+    const dir = await mkdtemp(path.join(os.tmpdir(), "metagraphed-json-"));
+    try {
+      const filePath = path.join(dir, "candidate.json");
+      await writeRepositoryJson(filePath, document);
+      assert.equal(await readFile(filePath, "utf8"), formatted);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- hardens direct community UGC submissions so malformed JSON formatting cannot pass preflight and break repository checks
- formats the AI-merged Gittensor OpenAPI candidate and refreshes compact registry summaries for the new candidate count
- keeps high-churn generated detail artifacts out of the PR

## What changed
- adds a repository JSON formatter helper for contributor-facing candidate/provider generators
- blocks direct candidate/provider PR preflight when the submitted JSON does not match repository formatting
- refreshes compact public summaries to account for 1,772 candidates
- adds non-mutating test coverage for contributor JSON formatting

## Why
- PR #96 proved the private AI gate can review and merge a valid UGC submission, but the generated candidate JSON format was not compatible with `npm run check`
- the gate should not be able to merge UGC that leaves `main` failing formatting checks

## Validation
- `npm run check`
- `npm run test:coverage`
- `npm run smoke:live`
- `npm run scan:public-safety`
- `git diff --check`

## Notes
- `npm run check` reported transient GitHub API 403 source-discovery warnings for Tensorplex subnet-docs and Taopedia during dry-run discovery; they did not block validation
- private submission-gate Worker changes for Discord metadata hydration and duplicate review suppression were deployed separately outside public git
