### PR TITLE
fix(build): preserve probe health during local artifact builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,7 +119,7 @@ URLs, provider profiles, profile/source corrections, and status reports.
 Live PR references:
 
 - AI-merged safe candidate example:
-  https://github.com/JSONbored/metagraphed/pull/87
+  https://github.com/JSONbored/metagraphed/pull/96
 - Manual-review direct candidate example:
   https://github.com/JSONbored/metagraphed/pull/84
 - Closed duplicate candidate example:

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -216,7 +216,7 @@ normal backend/code PRs.
 Reference PRs:
 
 - AI-merged safe candidate example:
-  https://github.com/JSONbored/metagraphed/pull/87
+  https://github.com/JSONbored/metagraphed/pull/96
 - Manual-review direct candidate example:
   https://github.com/JSONbored/metagraphed/pull/84
 - Closed duplicate candidate example:

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 21,
-  "artifact_size_bytes": 3449517,
+  "artifact_size_bytes": 3449093,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -17,8 +17,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "2745d198340f2f301ef958e6d702e12142ca5f04a306b671fd26d88ab13fda59",
-      "size_bytes": 1633,
+      "sha256": "560420248798a5952d089a6f0d2c850bf6f6bd9a258b319ed3b52c204113880e",
+      "size_bytes": 1209,
       "storage_tier": "dual"
     },
     {
@@ -175,7 +175,7 @@
   },
   "endpoint_count": 853,
   "full_artifact_count": 1097,
-  "full_artifact_size_bytes": 27570073,
+  "full_artifact_size_bytes": 27569649,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 14,
@@ -190,7 +190,7 @@
     "r2": 1076
   },
   "storage_tier_size_bytes": {
-    "dual": 3380590,
+    "dual": 3380166,
     "git": 68927,
     "r2": 24120556
   },

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,20 +1,7 @@
 {
   "artifacts": {
     "added": [],
-    "modified": [
-      {
-        "hash": "5057a500457537513b25eebb11914b86e3a64ec103958db08e09cb428d195919",
-        "path": "freshness.json"
-      },
-      {
-        "hash": "0719fcf89add77728c955b014ceea0baf7f32b11584bc546889d814dd21715e6",
-        "path": "review/curation.json"
-      },
-      {
-        "hash": "2fd6b049e95bf2d2ad4b9df5d8d39e67a9f8be680051012ff35a860973a69509",
-        "path": "review/gap-priorities.json"
-      }
-    ],
+    "modified": [],
     "removed": []
   },
   "contract_version": "2026-06-06.1",
@@ -32,7 +19,7 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 3,
+    "artifact_modified_count": 0,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 22,
-  "artifact_size_bytes": 3623845,
+  "artifact_size_bytes": 3623421,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "2745d198340f2f301ef958e6d702e12142ca5f04a306b671fd26d88ab13fda59",
-      "size_bytes": 1633,
+      "sha256": "560420248798a5952d089a6f0d2c850bf6f6bd9a258b319ed3b52c204113880e",
+      "size_bytes": 1209,
       "storage_tier": "dual"
     },
     {
@@ -205,7 +205,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1098,
-  "full_artifact_size_bytes": 27744401,
+  "full_artifact_size_bytes": 27743977,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -227,7 +227,7 @@
     "r2": 1076
   },
   "storage_tier_size_bytes": {
-    "dual": 3554918,
+    "dual": 3554494,
     "git": 68927,
     "r2": 24120556
   }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -57,7 +57,9 @@ console.log(
 function localSteps() {
   return [
     nodeStep("bundle-schemas", "scripts/bundle-schemas.mjs", "--write"),
-    nodeStep("build-artifacts", "scripts/build-artifacts.mjs"),
+    nodeStep("build-artifacts", "scripts/build-artifacts.mjs", {
+      METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
+    }),
     nodeStep("generate-types", "scripts/generate-types.mjs"),
     nodeStep("generate-client", "scripts/generate-client.mjs", "--write"),
     nodeStep("r2-manifest", "scripts/r2-manifest.mjs", "--write"),


### PR DESCRIPTION
## Summary
- preserve cached probe-derived health during local artifact builds
- normalize compact changelog/R2 manifest summaries after the latest registry publish
- update contributor docs to point at the current AI-merged UGC example

## What changed
- `scripts/build.mjs` passes `METAGRAPH_PRESERVE_PROBE_HEALTH=1` for local artifact builds.
- Compact generated control artifacts now report the local build as a no-op instead of stale modified rows.
- `CONTRIBUTING.md` and `docs/submission-gate.md` point at the current merged UGC PR example.

## Why
- Local builds should not erase probe-derived freshness metadata or create confusing compact artifact churn.
- Contributors need a current example of the safe direct-candidate flow that the private gate can merge.

## Validation
- `npm run build`
- `npm run check`
- `npm run test:coverage`
- `npm run smoke:live`
- `npm run submission-gate:health`
- `node --test private/metagraphed-submission-gate/test/notifications.test.mjs`
- `git diff --check`

## Notes
- Private reviewer implementation details remain outside the public repository.
