### PR TITLE
fix(discovery): accept GH token for source refreshes

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -24,6 +24,11 @@ This updates native subnet data, candidates, verification, baseline curation, ad
 
 The refresh keeps Git reviewable: compact artifacts remain in `public/metagraph`, while per-subnet candidates, verification details, health detail/history, adapter snapshots, schema snapshots, and provider detail outputs are staged for R2 and should not be committed.
 
+Candidate discovery reads public GitHub sources such as Tensorplex
+`subnet-docs` and Taopedia articles. Set `GITHUB_TOKEN` or `GH_TOKEN` for
+authenticated read-only GitHub API requests during local refreshes; scheduled
+sync and publish workflows already pass `GITHUB_TOKEN` from GitHub Actions.
+
 Live health probes are only written when explicitly enabled:
 
 ```bash

--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -1098,11 +1098,12 @@ async function fetchWithSafeRedirects(url, init, redirectCount = 0) {
 }
 
 function githubHeaders() {
-  if (!process.env.GITHUB_TOKEN) {
+  const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (!token) {
     return {};
   }
   return {
-    authorization: `Bearer ${process.env.GITHUB_TOKEN}`,
+    authorization: `Bearer ${token}`,
     "x-github-api-version": "2022-11-28",
   };
 }


### PR DESCRIPTION
## Summary
- allow candidate discovery to authenticate GitHub API reads with `GH_TOKEN` as well as `GITHUB_TOKEN`
- document the source discovery auth behavior for local operators

## What changed
- `scripts/discover-candidates.mjs` now uses `GITHUB_TOKEN || GH_TOKEN` for read-only GitHub API requests.
- `docs/operations.md` explains when to set a token and notes that scheduled workflows already pass `GITHUB_TOKEN`.

## Why
- Local and CI environments commonly expose either token name. Supporting both reduces Tensorplex/Taopedia source-discovery rate-limit noise without changing source authority or publishing behavior.

## Validation
- `npm run check`
- `git diff --check`

## Notes
- This does not make third-party sources canonical; they remain enrichment only.
