### PR TITLE
feat(curation): add contributor curation brief tooling

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,14 @@ Start with subnets that are still profile-light: directory-only entries,
 subnets missing websites or source repos, and subnets with public APIs that do
 not yet have OpenAPI/schema metadata in Metagraphed.
 
+Generate the current queue with:
+
+```bash
+npm run curation:brief
+```
+
+The curation playbook is in `docs/curation-playbook.md`.
+
 Good direct candidate PRs are small: exactly one public URL, one public source
 URL proving the claim, one active netuid, and no generated artifacts.
 

--- a/README.md
+++ b/README.md
@@ -236,6 +236,10 @@ npm run probes:smoke
 
 Metagraphed supports PR-first and issue-first UGC for public subnet interface corrections. Direct UGC PRs must change exactly one `registry/candidates/community/*.json` file and no generated artifacts. Public preflight returns broad states (`submit_pr`, `fix_required`, `route_away`, `manual_review`); private gate scoring and merge heuristics are intentionally not committed.
 
+Use `npm run curation:brief` to generate a current Markdown curation queue from
+the existing profile completeness, gap priority, adapter candidate, and coverage
+artifacts. The curation playbook lives in `docs/curation-playbook.md`.
+
 See `docs/submission-gate.md` and `CONTRIBUTING.md` for the submission contract.
 
 ## Repository Layout

--- a/docs/curation-playbook.md
+++ b/docs/curation-playbook.md
@@ -1,0 +1,101 @@
+# Metagraphed Curation Playbook
+
+Metagraphed already lists every active Finney netuid. Curation work is about
+turning machine-verified baseline entries into stronger public operational
+profiles, one verified fact at a time.
+
+## Generate The Current Queue
+
+```bash
+npm run curation:brief
+```
+
+Use `-- --limit 20` for a longer Markdown queue, or `-- --json` for a
+machine-readable snapshot:
+
+```bash
+npm run curation:brief -- --limit 20
+npm run curation:brief -- --json
+```
+
+The brief reads existing registry review artifacts:
+
+- `public/metagraph/review/profile-completeness.json`
+- `public/metagraph/review/gap-priorities.json`
+- `public/metagraph/review/adapter-candidates.json`
+- `public/metagraph/coverage.json`
+
+It does not add a contribution-target API and does not create new registry
+truth. It is an operator/contributor queue derived from current artifacts.
+
+## What Fully Curated Means
+
+For each subnet, aim to confirm the maximum public surface set the subnet
+actually supports:
+
+- official docs;
+- official website;
+- source repository;
+- dashboard or explorer;
+- OpenAPI/Swagger JSON URL;
+- public subnet API;
+- SSE endpoint;
+- public data artifact;
+- SDK or example repository;
+- auth and rate-limit notes where public.
+
+Some subnets may only have docs and a website. That is acceptable if the gaps
+are explicit and source-backed. Do not invent API surfaces to make entries look
+complete.
+
+## Best Auto-Review Contributions
+
+Direct PRs should add exactly one candidate file under
+`registry/candidates/community/*.json` and no generated artifacts.
+
+Use:
+
+```bash
+npm run candidate:new -- --netuid <netuid> --kind <kind> --url <public-url> --source-url <source-url> --provider <provider> --submitted-by <github-login> --write
+```
+
+Best candidate kinds:
+
+- `docs`
+- `website`
+- `source-repo`
+- `dashboard`
+- `openapi`
+- `subnet-api`
+- `sse`
+- `data-artifact`
+- `sdk`
+- `example`
+
+## Manual Review Contributions
+
+These are useful, but they should not auto-merge:
+
+- provider/operator profiles;
+- Bittensor base-layer RPC/WSS/archive endpoints;
+- authenticated or paid APIs;
+- unknown providers;
+- adapter requests;
+- identity disputes;
+- endpoint status reports.
+
+## Health Boundary
+
+Health, uptime, latency, incidents, and pool eligibility are probe-derived only.
+Contributor reports can trigger review or re-probes, but they cannot set
+observed health directly.
+
+## Curation Order
+
+1. Start with the lowest-completeness rows from `npm run curation:brief`.
+2. Submit official docs, website, or source repo evidence first.
+3. Add API/OpenAPI/SSE/data surfaces only when the subnet publicly exposes
+   them.
+4. Use the adapter-candidate queue after baseline identity and operational
+   surfaces are strong.
+5. Promote entries to maintainer-reviewed only after provenance is strong.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "check": "npm run lint && npm run format:check && npm run pipeline:check && npm run validate:docs",
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
-    "submission-gate:health": "node scripts/submission-gate-health.mjs"
+    "submission-gate:health": "node scripts/submission-gate-health.mjs",
+    "curation:brief": "node scripts/curation-brief.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/scripts/curation-brief.mjs
+++ b/scripts/curation-brief.mjs
@@ -1,0 +1,211 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { repoRoot, stableStringify } from "./lib.mjs";
+
+const args = new Set(process.argv.slice(2));
+const jsonMode = args.has("--json");
+const limit = positiveInt(valueAfter("--limit"), 12);
+
+if (isCliEntrypoint()) {
+  const snapshot = await loadCurationSnapshot({ limit });
+
+  if (jsonMode) {
+    console.log(stableStringify(snapshot));
+  } else {
+    console.log(renderCurationBrief(snapshot));
+  }
+}
+
+export async function loadCurationSnapshot({ limit = 12 } = {}) {
+  const [coverage, profileCompleteness, gapPriorities, adapterCandidates] =
+    await Promise.all([
+      readArtifact("coverage.json"),
+      readArtifact("review/profile-completeness.json"),
+      readArtifact("review/gap-priorities.json"),
+      readArtifact("review/adapter-candidates.json"),
+    ]);
+
+  const profiles = profileCompleteness.profiles || [];
+  const priorities = gapPriorities.priorities || [];
+  const adapters = adapterCandidates.candidates || [];
+
+  return {
+    schema_version: 1,
+    generated_at: profileCompleteness.generated_at,
+    contract_version: profileCompleteness.contract_version,
+    coverage: {
+      active_netuids: coverage.chain_subnet_count,
+      application_subnets: coverage.application_subnet_count,
+      curated_overlays: coverage.curated_overlay_count,
+      native_only: coverage.native_only_count,
+      surfaces: coverage.surface_count,
+      probed_surfaces: coverage.probed_surface_count,
+      candidates: coverage.candidate_count,
+    },
+    profile_summary: {
+      average_completeness_score:
+        profileCompleteness.summary?.average_completeness_score ?? null,
+      by_level: profileCompleteness.summary?.by_profile_level || {},
+      critical_gap_counts:
+        profileCompleteness.summary?.critical_gap_counts || {},
+    },
+    lowest_completeness: profiles.slice(0, limit).map(profileBriefRow),
+    highest_gap_priority: priorities.slice(0, limit).map(priorityBriefRow),
+    adapter_candidates: adapters.slice(0, limit).map(adapterBriefRow),
+    suggested_submission_kinds: [
+      "docs",
+      "website",
+      "source-repo",
+      "dashboard",
+      "openapi",
+      "subnet-api",
+      "sse",
+      "data-artifact",
+      "sdk",
+      "example",
+    ],
+    manual_review_kinds: [
+      "provider profile",
+      "subtensor-rpc",
+      "subtensor-wss",
+      "archive endpoint",
+      "authenticated API",
+      "adapter request",
+      "identity dispute",
+      "endpoint status report",
+    ],
+  };
+}
+
+export function renderCurationBrief(snapshot) {
+  const lines = [
+    "# Metagraphed Curation Brief",
+    "",
+    "Use this brief to choose high-value GitHub issue or PR submissions. It is generated from existing registry review artifacts; it is not a separate contribution API.",
+    "",
+    "## Coverage",
+    "",
+    `- Active Finney netuids: ${snapshot.coverage.active_netuids}`,
+    `- Application subnets: ${snapshot.coverage.application_subnets}`,
+    `- Curated overlays: ${snapshot.coverage.curated_overlays}`,
+    `- Native-only entries: ${snapshot.coverage.native_only}`,
+    `- Published surfaces/endpoints: ${snapshot.coverage.surfaces}`,
+    `- Probed surfaces: ${snapshot.coverage.probed_surfaces}`,
+    `- Candidate surfaces: ${snapshot.coverage.candidates}`,
+    `- Average profile completeness: ${snapshot.profile_summary.average_completeness_score ?? "unknown"}`,
+    "",
+    "## Best Direct PR Targets",
+    "",
+    "Submit one public-safe candidate at a time with `npm run candidate:new`. Official docs, websites, source repos, OpenAPI/schema URLs, public subnet APIs, dashboards, SDKs, examples, and data artifacts are the best auto-review candidates.",
+    "",
+    ...numberedRows(
+      snapshot.lowest_completeness,
+      (row) =>
+        `SN${row.netuid} ${row.name} - score ${row.completeness_score}; ${row.suggested_next_action}; gaps: ${row.gaps.join(", ")}`,
+    ),
+    "",
+    "## Highest Maintainer Review Priorities",
+    "",
+    "These entries already have candidate or surface evidence but need stronger maintainer review, official-source confirmation, or adapter consideration.",
+    "",
+    ...numberedRows(
+      snapshot.highest_gap_priority,
+      (row) =>
+        `SN${row.netuid} ${row.name} - priority ${row.priority_score}; ${row.suggested_next_action}; missing: ${row.missing_kinds.join(", ")}`,
+    ),
+    "",
+    "## Adapter Candidate Queue",
+    "",
+    "Adapters are for subnets with enough API/schema/data surface to justify subnet-specific normalized metrics.",
+    "",
+    ...numberedRows(
+      snapshot.adapter_candidates,
+      (row) =>
+        `SN${row.netuid} ${row.name} - score ${row.adapter_score}; kinds: ${row.surface_kinds.join(", ")}`,
+    ),
+    "",
+    "## Manual Review Targets",
+    "",
+    ...snapshot.manual_review_kinds.map((kind) => `- ${kind}`),
+    "",
+    "Health, uptime, latency, incidents, and pool eligibility stay probe-derived only. Contributor reports can trigger review or re-probes, but they cannot set observed health.",
+  ];
+
+  return `${lines.join("\n")}\n`;
+}
+
+function profileBriefRow(profile) {
+  return {
+    netuid: profile.netuid,
+    name: profile.name,
+    slug: profile.slug,
+    profile_level: profile.profile_level,
+    completeness_score: profile.completeness_score,
+    priority_score: profile.priority_score,
+    candidate_count: profile.candidate_count,
+    gaps: profile.gap_reasons || [],
+    suggested_next_action: profile.suggested_next_action,
+  };
+}
+
+function priorityBriefRow(priority) {
+  return {
+    netuid: priority.netuid,
+    name: priority.name,
+    slug: priority.slug,
+    curation_level: priority.curation_level,
+    review_state: priority.review_state,
+    priority_score: priority.priority_score,
+    surface_count: priority.surface_count,
+    candidate_count: priority.candidate_count,
+    verified_candidate_count: priority.verified_candidate_count,
+    missing_kinds: priority.missing_kinds || [],
+    suggested_next_action: priority.suggested_next_action,
+  };
+}
+
+function adapterBriefRow(candidate) {
+  return {
+    netuid: candidate.netuid,
+    name: candidate.name,
+    slug: candidate.slug,
+    adapter_score: candidate.adapter_score ?? candidate.priority_score,
+    surface_count:
+      candidate.surface_count ?? candidate.operational_surface_count ?? 0,
+    surface_kinds: candidate.surface_kinds || candidate.operational_kinds || [],
+    suggested_adapter: candidate.suggested_adapter,
+  };
+}
+
+function numberedRows(rows, formatter) {
+  if (rows.length === 0) {
+    return ["No rows available."];
+  }
+  return rows.map((row, index) => `${index + 1}. ${formatter(row)}`);
+}
+
+async function readArtifact(relativePath) {
+  return JSON.parse(
+    await readFile(path.join(repoRoot, "public/metagraph", relativePath), {
+      encoding: "utf8",
+    }),
+  );
+}
+
+function valueAfter(flag) {
+  const values = process.argv.slice(2);
+  const index = values.indexOf(flag);
+  return index === -1 ? null : values[index + 1];
+}
+
+function positiveInt(value, fallback) {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isCliEntrypoint() {
+  return process.argv[1]
+    ? import.meta.url === pathToFileURL(process.argv[1]).href
+    : false;
+}

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -54,6 +54,7 @@ import {
   isR2OnlyArtifactPath,
 } from "../src/artifact-storage.mjs";
 import { buildCanonicalOpenApiArtifact } from "../scripts/openapi-components.mjs";
+import { renderCurationBrief } from "../scripts/curation-brief.mjs";
 import {
   buildIssueIntakeReport,
   buildEndpointStatusReportIntakeReport,
@@ -156,6 +157,59 @@ describe("script utility contracts", () => {
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
+  });
+
+  test("renders a contributor curation brief from review artifacts", () => {
+    const brief = renderCurationBrief({
+      coverage: {
+        active_netuids: 129,
+        application_subnets: 128,
+        curated_overlays: 129,
+        native_only: 0,
+        surfaces: 853,
+        probed_surfaces: 852,
+        candidates: 1772,
+      },
+      profile_summary: {
+        average_completeness_score: 49,
+      },
+      lowest_completeness: [
+        {
+          netuid: 27,
+          name: "Nodexo",
+          completeness_score: 20,
+          suggested_next_action:
+            "submit official docs, website, or source repository evidence",
+          gaps: ["missing-source-repo", "missing-website"],
+        },
+      ],
+      highest_gap_priority: [
+        {
+          netuid: 33,
+          name: "ReadyAI",
+          priority_score: 93,
+          suggested_next_action:
+            "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+          missing_kinds: ["website", "openapi"],
+        },
+      ],
+      adapter_candidates: [
+        {
+          netuid: 64,
+          name: "Chutes",
+          adapter_score: 72,
+          surface_kinds: ["data-artifact", "subnet-api"],
+        },
+      ],
+      manual_review_kinds: ["provider profile", "archive endpoint"],
+    });
+
+    assert.match(brief, /Metagraphed Curation Brief/);
+    assert.match(brief, /Active Finney netuids: 129/);
+    assert.match(brief, /SN27 Nodexo - score 20/);
+    assert.match(brief, /SN33 ReadyAI - priority 93/);
+    assert.match(brief, /SN64 Chutes - score 72/);
+    assert.match(brief, /Health, uptime, latency, incidents/);
   });
 
   test("refresh pipeline persists candidate discovery timestamps", async () => {


### PR DESCRIPTION
## Summary
- add a curation brief generator for contributor and maintainer targeting
- document how to use the generated queue without adding a contribution-target API
- cover the brief renderer in script utility tests

## What changed
- `npm run curation:brief` prints a Markdown queue from existing review artifacts.
- `npm run curation:brief -- --json` emits the same snapshot as JSON for local operator use.
- `docs/curation-playbook.md` defines what fully curated means and what contributors should submit first.
- README and CONTRIBUTING link the playbook and command.

## Why
- All active subnets are listed, but many profiles still need official docs, websites, repos, API/OpenAPI surfaces, and stronger provenance. This makes the next curation work repeatable without creating a new API route or asking contributors to infer priorities.

## Validation
- `npm run curation:brief -- --limit 3`
- `npm run curation:brief -- --json --limit 2`
- `npm test -- --run tests/script-utils.test.mjs`
- `npm run check`
- `npm run test:coverage`
- `npm run smoke:live`
- `git diff --check`

## Notes
- Health, uptime, latency, incidents, and pool eligibility remain probe-derived only.
