### PR TITLE
test(intake): add duplicate allways candidate smoke

### DIFF
--- a/registry/candidates/community/community-sn-7-subnet-api-duplicate-smoke.json
+++ b/registry/candidates/community/community-sn-7-subnet-api-duplicate-smoke.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-subnet-api-duplicate-smoke",
+      "kind": "subnet-api",
+      "name": "Allways swaps API duplicate smoke",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Duplicate smoke-test candidate for submission gate validation.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.all-ways.io/swagger",
+      "source_urls": ["https://api.all-ways.io/swagger"],
+      "state": "schema-valid",
+      "url": "https://api.all-ways.io/swaps"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a deliberately duplicate Allways subnet API candidate.

## Why
- Smoke-tests the Metagraphed submission gate duplicate-close path after the Discord notification metadata refresh deployment.

## Expected Gate Result
- The submission gate should classify this as duplicate UGC and close it automatically.
- No generated artifacts should be accepted from this PR.
