### PR TITLE
docs(intake): update contributor gate examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ Live PR references:
 - Manual-review direct candidate example:
   https://github.com/JSONbored/metagraphed/pull/84
 - Closed duplicate candidate example:
-  https://github.com/JSONbored/metagraphed/pull/90
+  https://github.com/JSONbored/metagraphed/pull/105
 
 Do not include generated `public/metagraph/**` artifacts, native snapshots,
 workflow/script changes, secrets, wallet/PAT material, private URLs, or
@@ -158,6 +158,10 @@ private reviewer may merge/import clean submissions, close hard failures, or
 route rare edge cases to manual review. Public comments expose broad reason
 categories only; private scoring prompts, thresholds, and corpus weights are not
 part of the public repo.
+
+Maintainer automation branches such as `codex/*` are intentionally ignored by
+the private UGC gate. Contributor examples should use normal feature branches
+with one candidate or provider file.
 
 Status reports never set uptime, latency, health status, incident state, or pool
 eligibility. They can only trigger review or a future re-probe; operational state

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ npm run validate:workflows
 npm run submission:pr -- --changed-files changed-files.txt
 npm run curation:brief
 npm run endpoint:brief
+npm run endpoint:ops:brief
 npm run r2:manifest:dry-run
 npm run r2:download:dry-run
 npm run kv:publish:dry-run

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -119,6 +119,10 @@ Direct provider profile PRs always route to manual/private review. They are
 useful, but they identify operators and can affect future endpoint trust, so
 they are not direct-merge content.
 
+Maintainer automation branches such as `codex/*` are ignored before D1 state,
+labels, comments, AI review, or Discord notifications. Direct UGC examples
+should use normal feature branches and exactly one candidate or provider file.
+
 ## Supported UGC Types
 
 The public gate accepts or routes:
@@ -220,7 +224,7 @@ Reference PRs:
 - Manual-review direct candidate example:
   https://github.com/JSONbored/metagraphed/pull/84
 - Closed duplicate candidate example:
-  https://github.com/JSONbored/metagraphed/pull/90
+  https://github.com/JSONbored/metagraphed/pull/105
 
 The Worker stores a `last_notification_key` in D1. The key must include the
 target, PR head SHA or issue revision, terminal status, and verdict. Repeated

--- a/package.json
+++ b/package.json
@@ -83,7 +83,8 @@
     "test:coverage": "vitest run --coverage",
     "submission-gate:health": "node scripts/submission-gate-health.mjs",
     "curation:brief": "node scripts/curation-brief.mjs",
-    "endpoint:brief": "node scripts/endpoint-ops-brief.mjs"
+    "endpoint:brief": "node scripts/endpoint-ops-brief.mjs",
+    "endpoint:ops:brief": "node scripts/endpoint-ops-brief.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary
- Add an `endpoint:ops:brief` alias for the endpoint operations brief.
- Update contributor docs to reference the live closed duplicate proof PR.
- Document that internal `codex/*` branches are ignored by the private UGC gate.

## Why
- Keeps operator commands aligned with roadmap language.
- Gives contributors a current closed-by-gate example to copy against.
- Makes branch routing explicit without exposing private reviewer internals.

## Validation
- npm run endpoint:ops:brief -- --json
- npm run validate:docs
- npm run validate:intake
- npm run validate:private-boundary
- npm run format:check
- git diff --check
