### PR TITLE
feat(review): add subnet enrichment queue

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -68,6 +68,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/review/gap-priorities.json`: prioritized backend curation gaps.
 - `/metagraph/review/profile-completeness.json`: profile completeness and contributor targeting report.
 - `/metagraph/review/adapter-candidates.json`: subnets likely worth custom adapters.
+- `/metagraph/review/enrichment-queue.json`: prioritized all-subnet enrichment queue with direct-submission, maintainer-review, adapter, and monitoring lanes.
 - `/metagraph/review/maintainer-decisions.json`: public-safe maintainer decision ledger.
 - `/metagraph/build-summary.json`: generated build summary.
 
@@ -93,6 +94,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/review/gaps`: fetch contributor-targeted subnet gap priorities.
 - `/api/v1/review/profile-completeness`: fetch profile completeness gaps for contributor targeting.
 - `/api/v1/review/adapter-candidates`: fetch subnets worth deeper adapter work.
+- `/api/v1/review/enrichment-queue`: fetch the prioritized all-subnet enrichment queue.
 - `/api/v1/health`: fetch global health summary.
 - `/api/v1/health/history/{date}`: fetch compact daily health history.
 - `/api/v1/subnets/{netuid}/health`: fetch health detail for one subnet.

--- a/docs/curation-playbook.md
+++ b/docs/curation-playbook.md
@@ -20,13 +20,16 @@ npm run curation:brief -- --json
 
 The brief reads existing registry review artifacts:
 
+- `public/metagraph/review/enrichment-queue.json`
 - `public/metagraph/review/profile-completeness.json`
 - `public/metagraph/review/gap-priorities.json`
 - `public/metagraph/review/adapter-candidates.json`
 - `public/metagraph/coverage.json`
 
-It does not add a contribution-target API and does not create new registry
-truth. It is an operator/contributor queue derived from current artifacts.
+The enrichment queue is also available through
+`/api/v1/review/enrichment-queue` for backend consumers. It does not create new
+registry truth; it only prioritizes public-safe work derived from current
+artifacts.
 
 ## What Fully Curated Means
 
@@ -92,10 +95,14 @@ observed health directly.
 
 ## Curation Order
 
-1. Start with the lowest-completeness rows from `npm run curation:brief`.
-2. Submit official docs, website, or source repo evidence first.
-3. Add API/OpenAPI/SSE/data surfaces only when the subnet publicly exposes
+1. Start with the enrichment queue from `npm run curation:brief`.
+2. Prefer `direct-submission` rows for contributor PRs.
+3. Route `maintainer-review`, `adapter-candidate`, and `monitoring-followup`
+   rows through maintainer review.
+4. Submit official docs, website, or source repo evidence before optional app
+   surfaces.
+5. Add API/OpenAPI/SSE/data surfaces only when the subnet publicly exposes
    them.
-4. Use the adapter-candidate queue after baseline identity and operational
+6. Use the adapter-candidate queue after baseline identity and operational
    surfaces are strong.
-5. Promote entries to maintainer-reviewed only after provenance is strong.
+7. Promote entries to maintainer-reviewed only after provenance is strong.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -378,6 +378,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/review/enrichment-queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch the prioritized all-subnet enrichment queue. */
+        get: operations["reviewEnrichmentQueue"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/review/gaps": {
         parameters: {
             query?: never;
@@ -1402,6 +1419,51 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        ReviewEnrichmentQueueArtifact: components["schemas"]["ArtifactBase"] & ({
+            notes: string;
+            queue: components["schemas"]["ReviewEnrichmentQueueEntry"][];
+            summary: {
+                adapter_candidate_count: number;
+                baseline_monitoring_count: number;
+                direct_submission_count: number;
+                lane_counts: components["schemas"]["CountMap"];
+                maintainer_review_count: number;
+                manual_review_required_count: number;
+                monitoring_followup_count: number;
+                queue_count: number;
+                subnet_count: number;
+                top_direct_submission_kinds: components["schemas"]["CountMap"];
+            };
+        } & {
+            [key: string]: unknown;
+        });
+        ReviewEnrichmentQueueEntry: {
+            adapter_score: number;
+            candidate_count: number;
+            completeness_score: number;
+            contribution_hint: string;
+            curation_level: components["schemas"]["CurationLevel"];
+            direct_submission_kinds: components["schemas"]["SurfaceKind"][];
+            endpoint_count: number;
+            /** @enum {unknown} */
+            lane: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+            manual_review_required: boolean;
+            missing_kinds: components["schemas"]["SurfaceKind"][];
+            name: string;
+            netuid: number;
+            operational_interface_count: number;
+            priority_score: number;
+            /** @enum {unknown} */
+            profile_level: "directory-only" | "identity-complete" | "operational" | "adapter-backed";
+            reason_codes: string[];
+            recommended_action: string;
+            review_state: components["schemas"]["ReviewState"];
+            sample_candidate_ids: string[];
+            slug: string;
+            source_urls: string[];
+            surface_count: number;
+            verified_candidate_count: number;
+        };
         ReviewGapPrioritiesArtifact: components["schemas"]["ArtifactBase"] & ({
             priorities: components["schemas"]["ReviewGapPriority"][];
         } & {
@@ -3573,6 +3635,84 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewAdapterCandidatesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    reviewEnrichmentQueue: {
+        parameters: {
+            query?: {
+                lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                netuid?: number;
+                profile_level?: "directory-only" | "identity-complete" | "operational" | "adapter-backed";
+                manual_review_required?: "true" | "false";
+                q?: string;
+                limit?: number;
+                cursor?: number;
+                sort?: "adapter_score" | "candidate_count" | "completeness_score" | "lane" | "name" | "netuid" | "priority_score" | "profile_level" | "verified_candidate_count";
+                order?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["ReviewEnrichmentQueueArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -331,6 +331,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "review-enrichment-queue",
+      "path": "/metagraph/review/enrichment-queue.json",
+      "schema_ref": "#/components/schemas/ReviewEnrichmentQueueArtifact",
+      "storage_tier": "dual"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
       "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
@@ -1928,6 +1935,113 @@
               "netuid",
               "operational_surface_count",
               "priority_score"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "artifact_path": "/metagraph/review/enrichment-queue.json",
+      "cache": "standard",
+      "description": "Fetch the prioritized all-subnet enrichment queue.",
+      "id": "review-enrichment-queue",
+      "method": "GET",
+      "path": "/api/v1/review/enrichment-queue",
+      "public": true,
+      "query_collection": "enrichment-queue",
+      "query_filter_names": [
+        "lane",
+        "netuid",
+        "profile_level",
+        "manual_review_required"
+      ],
+      "query_parameters": [
+        {
+          "name": "lane",
+          "schema": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "profile_level",
+          "schema": {
+            "enum": [
+              "directory-only",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "manual_review_required",
+          "schema": {
+            "enum": [
+              "true",
+              "false"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "q",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "adapter_score",
+              "candidate_count",
+              "completeness_score",
+              "lane",
+              "name",
+              "netuid",
+              "priority_score",
+              "profile_level",
+              "verified_candidate_count"
             ],
             "type": "string"
           }

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -2,29 +2,29 @@
   "adapter_count": 2,
   "artifact_budget_summary": {
     "fail_count": 0,
-    "ok_count": 1097,
+    "ok_count": 1098,
     "warn_count": 0
   },
   "artifact_budgets": [],
-  "artifact_count": 21,
-  "artifact_size_bytes": 3450290,
+  "artifact_count": 22,
+  "artifact_size_bytes": 3695569,
   "artifacts": [
     {
       "path": "api-index.json",
-      "sha256": "c889d7f088d614b9b430e3761acb52aa677198c3efa623a89227940b0718f40d",
-      "size_bytes": 68723,
+      "sha256": "21ce9893dde3ea9167c33e5286e33155a01c30c02d9fc929db42d451748050a8",
+      "size_bytes": 71451,
       "storage_tier": "dual"
     },
     {
       "path": "changelog.json",
-      "sha256": "3d0ce6e417484f823d4d2c0fdc6bb0e578b62980c41f4f95346b94026f123182",
-      "size_bytes": 1497,
+      "sha256": "cf481d4564c2486148c7c695feab215bd56f34d6b519bbca04c52c9251c950f9",
+      "size_bytes": 1361,
       "storage_tier": "dual"
     },
     {
       "path": "contracts.json",
-      "sha256": "518ed03dd9ec8c54315497f6b4a1b368a009dd015bf72124fe39ed451125fdda",
-      "size_bytes": 17403,
+      "sha256": "90b3088030cb6cc1ca0ee04ece29f4dbc69a780c575d8d4dba7dabd86d4a4546",
+      "size_bytes": 17812,
       "storage_tier": "dual"
     },
     {
@@ -59,8 +59,8 @@
     },
     {
       "path": "openapi.json",
-      "sha256": "0f2034ebffec46a3a208864ae0fb1436c50a1588f9989ac629361dde4dd096a5",
-      "size_bytes": 296995,
+      "sha256": "83b127b2bcf5c225ed012c7bd324f85b1f85ff09ee872f080f72688d7f49b9a5",
+      "size_bytes": 308627,
       "storage_tier": "dual"
     },
     {
@@ -85,6 +85,12 @@
       "path": "review/curation.json",
       "sha256": "0719fcf89add77728c955b014ceea0baf7f32b11584bc546889d814dd21715e6",
       "size_bytes": 96733,
+      "storage_tier": "dual"
+    },
+    {
+      "path": "review/enrichment-queue.json",
+      "sha256": "7bab68b334f3a65b3ae961e12f44c224b53db186e18306ba4f9c35f024c62068",
+      "size_bytes": 230646,
       "storage_tier": "dual"
     },
     {
@@ -174,8 +180,8 @@
     "surface_count": 853
   },
   "endpoint_count": 853,
-  "full_artifact_count": 1097,
-  "full_artifact_size_bytes": 27570846,
+  "full_artifact_count": 1098,
+  "full_artifact_size_bytes": 27816125,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 14,
@@ -185,12 +191,12 @@
   },
   "schema_version": 1,
   "storage_tier_counts": {
-    "dual": 20,
+    "dual": 21,
     "git": 1,
     "r2": 1076
   },
   "storage_tier_size_bytes": {
-    "dual": 3380931,
+    "dual": 3626210,
     "git": 69359,
     "r2": 24120556
   },

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,16 +1,12 @@
 {
   "artifacts": {
-    "added": [],
-    "modified": [
+    "added": [
       {
-        "hash": "0f2034ebffec46a3a208864ae0fb1436c50a1588f9989ac629361dde4dd096a5",
-        "path": "openapi.json"
-      },
-      {
-        "hash": "955b231b73ba6593c4852f382056c0c53b8d74a8c8cf61651983bc608270f1f7",
-        "path": "review/profile-completeness.json"
+        "hash": "7bab68b334f3a65b3ae961e12f44c224b53db186e18306ba4f9c35f024c62068",
+        "path": "review/enrichment-queue.json"
       }
     ],
+    "modified": [],
     "removed": []
   },
   "contract_version": "2026-06-06.1",
@@ -27,8 +23,8 @@
     "renamed": []
   },
   "summary": {
-    "artifact_added_count": 0,
-    "artifact_modified_count": 2,
+    "artifact_added_count": 1,
+    "artifact_modified_count": 0,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -426,6 +426,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Prioritized all-subnet enrichment work queue for contributor-safe registry improvements.",
+      "id": "review-enrichment-queue",
+      "path": "/metagraph/review/enrichment-queue.json",
+      "schema_ref": "#/components/schemas/ReviewEnrichmentQueueArtifact",
+      "storage_tier": "dual"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Public-safe maintainer review decision ledger.",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3096,6 +3096,226 @@
           }
         ]
       },
+      "ReviewEnrichmentQueueArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "notes": {
+                "type": "string"
+              },
+              "queue": {
+                "items": {
+                  "$ref": "#/components/schemas/ReviewEnrichmentQueueEntry"
+                },
+                "type": "array"
+              },
+              "summary": {
+                "additionalProperties": false,
+                "properties": {
+                  "adapter_candidate_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "baseline_monitoring_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direct_submission_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lane_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  },
+                  "maintainer_review_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "manual_review_required_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "monitoring_followup_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "queue_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "top_direct_submission_kinds": {
+                    "$ref": "#/components/schemas/CountMap"
+                  }
+                },
+                "required": [
+                  "adapter_candidate_count",
+                  "baseline_monitoring_count",
+                  "direct_submission_count",
+                  "lane_counts",
+                  "maintainer_review_count",
+                  "manual_review_required_count",
+                  "monitoring_followup_count",
+                  "queue_count",
+                  "subnet_count",
+                  "top_direct_submission_kinds"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "notes",
+              "queue",
+              "summary"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ReviewEnrichmentQueueEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "adapter_score": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "completeness_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "contribution_hint": {
+            "type": "string"
+          },
+          "curation_level": {
+            "$ref": "#/components/schemas/CurationLevel"
+          },
+          "direct_submission_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "endpoint_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "lane": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ]
+          },
+          "manual_review_required": {
+            "type": "boolean"
+          },
+          "missing_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "operational_interface_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "priority_score": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile_level": {
+            "enum": [
+              "directory-only",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ]
+          },
+          "reason_codes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "recommended_action": {
+            "type": "string"
+          },
+          "review_state": {
+            "$ref": "#/components/schemas/ReviewState"
+          },
+          "sample_candidate_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "source_urls": {
+            "items": {
+              "format": "uri",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "surface_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "verified_candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "adapter_score",
+          "candidate_count",
+          "completeness_score",
+          "contribution_hint",
+          "curation_level",
+          "direct_submission_kinds",
+          "endpoint_count",
+          "lane",
+          "manual_review_required",
+          "missing_kinds",
+          "name",
+          "netuid",
+          "operational_interface_count",
+          "priority_score",
+          "profile_level",
+          "reason_codes",
+          "recommended_action",
+          "review_state",
+          "sample_candidate_ids",
+          "slug",
+          "source_urls",
+          "surface_count",
+          "verified_candidate_count"
+        ],
+        "type": "object"
+      },
       "ReviewGapPrioritiesArtifact": {
         "allOf": [
           {
@@ -8809,6 +9029,204 @@
         "tags": [
           "adapters",
           "review"
+        ]
+      }
+    },
+    "/api/v1/review/enrichment-queue": {
+      "get": {
+        "operationId": "reviewEnrichmentQueue",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "lane",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-submission",
+                "maintainer-review",
+                "adapter-candidate",
+                "monitoring-followup",
+                "baseline-monitoring"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "profile_level",
+            "required": false,
+            "schema": {
+              "enum": [
+                "directory-only",
+                "identity-complete",
+                "operational",
+                "adapter-backed"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "manual_review_required",
+            "required": false,
+            "schema": {
+              "enum": [
+                "true",
+                "false"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "adapter_score",
+                "candidate_count",
+                "completeness_score",
+                "lane",
+                "name",
+                "netuid",
+                "priority_score",
+                "profile_level",
+                "verified_candidate_count"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/ReviewEnrichmentQueueArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch the prioritized all-subnet enrichment queue.",
+        "tags": [
+          "registry",
+          "review",
+          "profiles"
         ]
       }
     },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
-  "artifact_count": 22,
-  "artifact_size_bytes": 3624825,
+  "artifact_count": 23,
+  "artifact_size_bytes": 3875732,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "c889d7f088d614b9b430e3761acb52aa677198c3efa623a89227940b0718f40d",
-      "size_bytes": 68723,
+      "sha256": "21ce9893dde3ea9167c33e5286e33155a01c30c02d9fc929db42d451748050a8",
+      "size_bytes": 71451,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "3d0ce6e417484f823d4d2c0fdc6bb0e578b62980c41f4f95346b94026f123182",
-      "size_bytes": 1497,
+      "sha256": "cf481d4564c2486148c7c695feab215bd56f34d6b519bbca04c52c9251c950f9",
+      "size_bytes": 1361,
       "storage_tier": "dual"
     },
     {
@@ -25,8 +25,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "518ed03dd9ec8c54315497f6b4a1b368a009dd015bf72124fe39ed451125fdda",
-      "size_bytes": 17403,
+      "sha256": "90b3088030cb6cc1ca0ee04ece29f4dbc69a780c575d8d4dba7dabd86d4a4546",
+      "size_bytes": 17812,
       "storage_tier": "dual"
     },
     {
@@ -79,8 +79,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "0f2034ebffec46a3a208864ae0fb1436c50a1588f9989ac629361dde4dd096a5",
-      "size_bytes": 296995,
+      "sha256": "83b127b2bcf5c225ed012c7bd324f85b1f85ff09ee872f080f72688d7f49b9a5",
+      "size_bytes": 308627,
       "storage_tier": "dual"
     },
     {
@@ -117,6 +117,15 @@
       "path": "/metagraph/review/curation.json",
       "sha256": "0719fcf89add77728c955b014ceea0baf7f32b11584bc546889d814dd21715e6",
       "size_bytes": 96733,
+      "storage_tier": "dual"
+    },
+    {
+      "content_type": "application/json",
+      "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
+      "latest_key": "latest/review/enrichment-queue.json",
+      "path": "/metagraph/review/enrichment-queue.json",
+      "sha256": "7bab68b334f3a65b3ae961e12f44c224b53db186e18306ba4f9c35f024c62068",
+      "size_bytes": 230646,
       "storage_tier": "dual"
     },
     {
@@ -196,16 +205,16 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "17d622b259ea985e32e532aec9ef96ef2dddbd177a970f45962ddff6a35fa37a",
-      "size_bytes": 174535,
+      "sha256": "ab11de49bce1420886c3f56d19293371d61cbfffdfa502f4d576d17ddecb05c2",
+      "size_bytes": 180163,
       "storage_tier": "dual"
     }
   ],
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
-  "full_artifact_count": 1098,
-  "full_artifact_size_bytes": 27745381,
+  "full_artifact_count": 1099,
+  "full_artifact_size_bytes": 27996288,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -222,12 +231,12 @@
   "run_prefix": "runs/1970-01-01T00-00-00-000Z/",
   "schema_version": 1,
   "storage_tier_counts": {
-    "dual": 21,
+    "dual": 22,
     "git": 1,
     "r2": 1076
   },
   "storage_tier_size_bytes": {
-    "dual": 3555466,
+    "dual": 3806373,
     "git": 69359,
     "r2": 24120556
   }

--- a/public/metagraph/review/enrichment-queue.json
+++ b/public/metagraph/review/enrichment-queue.json
@@ -1,0 +1,6421 @@
+{
+  "contract_version": "2026-06-06.1",
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "notes": "Prioritized enrichment queue derived from public-safe profile gaps, candidate counts, review state, adapter potential, and probe-derived endpoint incidents. It is contributor guidance, not a contribution API.",
+  "queue": [
+    {
+      "adapter_score": 255,
+      "candidate_count": 12,
+      "completeness_score": 92,
+      "contribution_hint": "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
+      "curation_level": "adapter-backed",
+      "direct_submission_kinds": [],
+      "endpoint_count": 15,
+      "lane": "adapter-candidate",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "dashboard",
+        "data-artifact"
+      ],
+      "name": "Allways",
+      "netuid": 7,
+      "operational_interface_count": 3,
+      "priority_score": 193,
+      "profile_level": "adapter-backed",
+      "reason_codes": [
+        "adapter-candidate"
+      ],
+      "recommended_action": "evaluate adapter support for openapi, sse, subnet-api",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "community-sn-7-subnet-api-api-all-ways-io",
+        "sn-7-taomarketcap-dashboard",
+        "sn-7-taomarketcap-source-repo",
+        "sn-7-taomarketcap-website",
+        "sn-7-taopedia-article"
+      ],
+      "slug": "allways",
+      "source_urls": [
+        "https://all-ways.io/",
+        "https://docs.all-ways.io/how-it-works.html",
+        "https://github.com/entrius/allways"
+      ],
+      "surface_count": 15,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 69,
+      "candidate_count": 13,
+      "completeness_score": 43,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 9,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "ReadyAI",
+      "netuid": 33,
+      "operational_interface_count": 1,
+      "priority_score": 170,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-data-artifact-1",
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-data-artifact-6",
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-data-artifact-9",
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-docs-2",
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-docs-4"
+      ],
+      "slug": "sn-33",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/33",
+        "https://docs.bittensor.com/subtensor-nodes",
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project",
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/33/subnet.json",
+        "https://taomarketcap.com/subnets/33"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 3,
+      "candidate_count": 11,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Nodexo",
+      "netuid": 27,
+      "operational_interface_count": 0,
+      "priority_score": 161,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-27-taomarketcap-dashboard",
+        "sn-27-taomarketcap-source-repo",
+        "sn-27-taomarketcap-website",
+        "sn-27-taopedia-article",
+        "sn-27-tensorplex-docs"
+      ],
+      "slug": "sn-27",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/27",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json",
+        "https://taomarketcap.com/subnets/27"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 68,
+      "candidate_count": 21,
+      "completeness_score": 58,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Green Compute",
+      "netuid": 110,
+      "operational_interface_count": 1,
+      "priority_score": 156,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-110-taomarketcap-dashboard",
+        "sn-110-taomarketcap-website",
+        "sn-110-taopedia-article",
+        "sn-110-tensorplex-docs",
+        "sn-110-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-110",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/110",
+        "https://github.com/Rich-Kids-of-TAO/rkt-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/110/subnet.json",
+        "https://taomarketcap.com/subnets/110",
+        "https://www.green-compute.com/"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Chunking",
+      "netuid": 40,
+      "operational_interface_count": 0,
+      "priority_score": 150,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-40-taomarketcap-dashboard",
+        "sn-40-taomarketcap-source-repo",
+        "sn-40-taopedia-article",
+        "sn-40-tensorplex-docs"
+      ],
+      "slug": "sn-40",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/40",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_40/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json",
+        "https://taomarketcap.com/subnets/40"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "EfficientFrontier",
+      "netuid": 53,
+      "operational_interface_count": 0,
+      "priority_score": 150,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-53-taomarketcap-dashboard",
+        "sn-53-taomarketcap-source-repo",
+        "sn-53-taopedia-article",
+        "sn-53-tensorplex-docs"
+      ],
+      "slug": "sn-53",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/53",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
+        "https://taomarketcap.com/subnets/53"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 68,
+      "candidate_count": 8,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "website"
+      ],
+      "name": "Pending",
+      "netuid": 58,
+      "operational_interface_count": 1,
+      "priority_score": 150,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-58-github-readme-handshake58-hs58-docs-1",
+        "sn-58-github-readme-handshake58-hs58-subnet-api-2",
+        "sn-58-github-readme-handshake58-hs58-subnet-api-3",
+        "sn-58-github-readme-handshake58-hs58-subnet-api-4",
+        "sn-58-taomarketcap-dashboard"
+      ],
+      "slug": "sn-58",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/58",
+        "https://github.com/Handshake58/HS58",
+        "https://github.com/Handshake58/HS58/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_58/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/58/subnet.json",
+        "https://handshake58.com/skill.md",
+        "https://taomarketcap.com/subnets/58"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Parked",
+      "netuid": 73,
+      "operational_interface_count": 0,
+      "priority_score": 150,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-73-taomarketcap-dashboard",
+        "sn-73-taopedia-article",
+        "sn-73-tensorplex-docs",
+        "sn-73-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-73",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/73",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json",
+        "https://taomarketcap.com/subnets/73"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "hard_sign",
+      "netuid": 116,
+      "operational_interface_count": 0,
+      "priority_score": 150,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-116-taomarketcap-dashboard",
+        "sn-116-taopedia-article",
+        "sn-116-tensorplex-docs",
+        "sn-116-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-116",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/116",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json",
+        "https://taomarketcap.com/subnets/116"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Satori",
+      "netuid": 119,
+      "operational_interface_count": 0,
+      "priority_score": 150,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-119-taomarketcap-dashboard",
+        "sn-119-taomarketcap-source-repo",
+        "sn-119-taopedia-article",
+        "sn-119-tensorplex-docs"
+      ],
+      "slug": "sn-119",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/119",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/119/subnet.json",
+        "https://taomarketcap.com/subnets/119"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 68,
+      "candidate_count": 16,
+      "completeness_score": 58,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Quasar",
+      "netuid": 24,
+      "operational_interface_count": 1,
+      "priority_score": 149,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-24-github-readme-silx-labs-quasar-subnet-data-artifact-1",
+        "sn-24-github-readme-silx-labs-quasar-subnet-data-artifact-2",
+        "sn-24-taomarketcap-dashboard",
+        "sn-24-taomarketcap-source-repo",
+        "sn-24-taomarketcap-website"
+      ],
+      "slug": "sn-24",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/24",
+        "https://github.com/SILX-LABS/QUASAR-SUBNET",
+        "https://github.com/SILX-LABS/QUASAR-SUBNET/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_24/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/24/subnet.json",
+        "https://silxinc.com/",
+        "https://taomarketcap.com/subnets/24"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "gm",
+      "netuid": 28,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-28-taomarketcap-dashboard",
+        "sn-28-taopedia-article",
+        "sn-28-tensorplex-docs"
+      ],
+      "slug": "sn-28",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/28",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/28/subnet.json",
+        "https://taomarketcap.com/subnets/28"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Recall",
+      "netuid": 31,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-31-taomarketcap-dashboard",
+        "sn-31-taopedia-article",
+        "sn-31-tensorplex-docs"
+      ],
+      "slug": "sn-31",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/31",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json",
+        "https://taomarketcap.com/subnets/31"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Subnet 42",
+      "netuid": 42,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-42-taomarketcap-dashboard",
+        "sn-42-taopedia-article",
+        "sn-42-tensorplex-docs"
+      ],
+      "slug": "sn-42",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/42",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_42/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/42/subnet.json",
+        "https://taomarketcap.com/subnets/42"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "ain",
+      "netuid": 69,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-69-taomarketcap-dashboard",
+        "sn-69-taopedia-article",
+        "sn-69-tensorplex-docs"
+      ],
+      "slug": "sn-69",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/69",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/69/subnet.json",
+        "https://taomarketcap.com/subnets/69"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Subnet 86",
+      "netuid": 86,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-86-taomarketcap-dashboard",
+        "sn-86-taopedia-article",
+        "sn-86-tensorplex-docs"
+      ],
+      "slug": "sn-86",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/86",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/86/subnet.json",
+        "https://taomarketcap.com/subnets/86"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "ogham",
+      "netuid": 90,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-90-taomarketcap-dashboard",
+        "sn-90-taopedia-article",
+        "sn-90-tensorplex-docs"
+      ],
+      "slug": "sn-90",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/90",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json",
+        "https://taomarketcap.com/subnets/90"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "eni",
+      "netuid": 101,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-101-taomarketcap-dashboard",
+        "sn-101-taopedia-article",
+        "sn-101-tensorplex-docs"
+      ],
+      "slug": "sn-101",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/101",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/101/subnet.json",
+        "https://taomarketcap.com/subnets/101"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "for sale (burn to uid1)",
+      "netuid": 104,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-104-taomarketcap-dashboard",
+        "sn-104-taopedia-article",
+        "sn-104-tensorplex-docs"
+      ],
+      "slug": "sn-104",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/104",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_104/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/104/subnet.json",
+        "https://taomarketcap.com/subnets/104"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "8 Ball",
+      "netuid": 125,
+      "operational_interface_count": 0,
+      "priority_score": 148,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-125-taomarketcap-dashboard",
+        "sn-125-taopedia-article",
+        "sn-125-tensorplex-docs"
+      ],
+      "slug": "sn-125",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/125",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_125/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/125/subnet.json",
+        "https://taomarketcap.com/subnets/125"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 14,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "InfiniteHash",
+      "netuid": 89,
+      "operational_interface_count": 0,
+      "priority_score": 142,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-89-github-readme-backend-developers-ltd-infinitehash-docs-1",
+        "sn-89-github-readme-backend-developers-ltd-infinitehash-docs-2",
+        "sn-89-github-readme-backend-developers-ltd-infinitehash-docs-3",
+        "sn-89-taomarketcap-dashboard",
+        "sn-89-taomarketcap-source-repo"
+      ],
+      "slug": "sn-89",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/89",
+        "https://docs.docker.com/compose/install/linux",
+        "https://github.com/backend-developers-ltd/InfiniteHash",
+        "https://github.com/backend-developers-ltd/InfiniteHash/blob/master/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_89/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/89/subnet.json",
+        "https://taomarketcap.com/subnets/89"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 4,
+      "candidate_count": 15,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Bitstarter #1",
+      "netuid": 91,
+      "operational_interface_count": 0,
+      "priority_score": 142,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-91-taomarketcap-dashboard",
+        "sn-91-taomarketcap-website",
+        "sn-91-taopedia-article",
+        "sn-91-tensorplex-docs",
+        "sn-91-website-common-api"
+      ],
+      "slug": "sn-91",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/91",
+        "https://bitstarter.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_91/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/91/subnet.json",
+        "https://taomarketcap.com/subnets/91"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 13,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Dojo",
+      "netuid": 52,
+      "operational_interface_count": 0,
+      "priority_score": 141,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-52-github-readme-tensorplex-labs-dojo-docs-1",
+        "sn-52-github-readme-tensorplex-labs-dojo-ui-docs-2",
+        "sn-52-github-readme-tensorplex-labs-dojo-ui-docs-3",
+        "sn-52-github-readme-tensorplex-labs-dojo-ui-docs-4",
+        "sn-52-github-readme-tensorplex-labs-dojo-ui-subnet-api-1"
+      ],
+      "slug": "sn-52",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/52",
+        "https://docs.tensorplex.ai/tensorplex-docs/tensorplex-dojo-bittensor-subnet/subnet-mechanism",
+        "https://github.com/tensorplex-labs/dojo",
+        "https://github.com/tensorplex-labs/dojo-ui/blob/main/README.md",
+        "https://github.com/tensorplex-labs/dojo/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/52/subnet.json",
+        "https://taomarketcap.com/subnets/52"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 72,
+      "candidate_count": 28,
+      "completeness_score": 73,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 12,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "openapi",
+        "sse"
+      ],
+      "name": "Chutes",
+      "netuid": 64,
+      "operational_interface_count": 2,
+      "priority_score": 140,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-64-github-readme-chutesai-chutes-subnet-api-1",
+        "sn-64-github-readme-chutesai-chutes-subnet-api-2",
+        "sn-64-github-readme-chutesai-chutes-subnet-api-3",
+        "sn-64-github-readme-rayonlabs-chutes-miner-docs-1",
+        "sn-64-github-readme-rayonlabs-chutes-miner-subnet-api-2"
+      ],
+      "slug": "sn-64",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/64",
+        "https://chutes.ai/",
+        "https://github.com/chutesai/chutes",
+        "https://github.com/chutesai/chutes/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_64/index.mdx",
+        "https://github.com/rayonlabs/chutes-miner/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/64/subnet.json",
+        "https://kubernetes.io/docs/reference/kubectl"
+      ],
+      "surface_count": 12,
+      "verified_candidate_count": 20
+    },
+    {
+      "adapter_score": 4,
+      "candidate_count": 13,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "GroundLayer",
+      "netuid": 20,
+      "operational_interface_count": 0,
+      "priority_score": 139,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-20-taomarketcap-dashboard",
+        "sn-20-taomarketcap-source-repo",
+        "sn-20-taomarketcap-website",
+        "sn-20-taopedia-article",
+        "sn-20-tensorplex-docs"
+      ],
+      "slug": "sn-20",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/20",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_20/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/20/subnet.json",
+        "https://groundlayer.xyz/",
+        "https://taomarketcap.com/subnets/20"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 13,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Nepher Robotics",
+      "netuid": 49,
+      "operational_interface_count": 0,
+      "priority_score": 139,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-49-github-readme-nepher-ai-nepher-subnet-docs-1",
+        "sn-49-github-readme-nepher-ai-nepher-subnet-subnet-api-2",
+        "sn-49-taomarketcap-dashboard",
+        "sn-49-taomarketcap-source-repo",
+        "sn-49-taomarketcap-website"
+      ],
+      "slug": "sn-49",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/49",
+        "https://docs.nepher.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_49/index.mdx",
+        "https://github.com/nepher-ai/nepher-subnet",
+        "https://github.com/nepher-ai/nepher-subnet/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/49/subnet.json",
+        "https://taomarketcap.com/subnets/49"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 12,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Endure Network",
+      "netuid": 30,
+      "operational_interface_count": 0,
+      "priority_score": 138,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-30-taomarketcap-dashboard",
+        "sn-30-taomarketcap-website",
+        "sn-30-taopedia-article",
+        "sn-30-tensorplex-docs",
+        "sn-30-website-common-api"
+      ],
+      "slug": "sn-30",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/30",
+        "https://endure.network/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_30/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json",
+        "https://taomarketcap.com/subnets/30"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 10,
+      "candidate_count": 28,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 10,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Cacheon",
+      "netuid": 14,
+      "operational_interface_count": 0,
+      "priority_score": 136,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-14-github-readme-latent-to-cacheon-docs-1",
+        "sn-14-github-readme-latent-to-cacheon-docs-10",
+        "sn-14-github-readme-latent-to-cacheon-docs-2",
+        "sn-14-github-readme-latent-to-cacheon-docs-3",
+        "sn-14-github-readme-latent-to-cacheon-docs-4"
+      ],
+      "slug": "sn-14",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/14",
+        "https://cacheon.ai/",
+        "https://cacheon.ai/docs",
+        "https://github.com/latent-to/cacheon",
+        "https://github.com/latent-to/cacheon/blob/main/README.md",
+        "https://github.com/latent-to/taohash/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/14/subnet.json",
+        "https://taohash.com/leaderboard"
+      ],
+      "surface_count": 10,
+      "verified_candidate_count": 22
+    },
+    {
+      "adapter_score": 4,
+      "candidate_count": 11,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Ridges",
+      "netuid": 62,
+      "operational_interface_count": 0,
+      "priority_score": 136,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-62-taomarketcap-dashboard",
+        "sn-62-taomarketcap-source-repo",
+        "sn-62-taomarketcap-website",
+        "sn-62-taopedia-article",
+        "sn-62-tensorplex-docs"
+      ],
+      "slug": "sn-62",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/62",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_62/index.mdx",
+        "https://github.com/ridgesai/ridges",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/62/subnet.json",
+        "https://taomarketcap.com/subnets/62"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 4,
+      "candidate_count": 11,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Byzantium",
+      "netuid": 76,
+      "operational_interface_count": 0,
+      "priority_score": 136,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-76-taomarketcap-dashboard",
+        "sn-76-taomarketcap-website",
+        "sn-76-taopedia-article",
+        "sn-76-tensorplex-docs",
+        "sn-76-website-common-api"
+      ],
+      "slug": "sn-76",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/76",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_76/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/76/subnet.json",
+        "https://taomarketcap.com/subnets/76",
+        "https://www.byzantiumai.net/"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 9,
+      "completeness_score": 43,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Coldint",
+      "netuid": 29,
+      "operational_interface_count": 1,
+      "priority_score": 135,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-29-github-readme-coldint-coldint-validator-dashboard-1",
+        "sn-29-github-readme-coldint-coldint-validator-dashboard-3",
+        "sn-29-github-readme-coldint-coldint-validator-data-artifact-2",
+        "sn-29-github-readme-coldint-coldint-validator-docs-4",
+        "sn-29-taomarketcap-dashboard"
+      ],
+      "slug": "sn-29",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/29",
+        "https://github.com/coldint/coldint_validator",
+        "https://github.com/coldint/coldint_validator/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_29/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/29/subnet.json",
+        "https://taostats.io/subnets/netuid-29"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 27,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Data Universe",
+      "netuid": 13,
+      "operational_interface_count": 0,
+      "priority_score": 133,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-13-github-readme-macrocosm-os-data-universe-docs-1",
+        "sn-13-github-readme-macrocosm-os-data-universe-docs-10",
+        "sn-13-github-readme-macrocosm-os-data-universe-docs-2",
+        "sn-13-github-readme-macrocosm-os-data-universe-docs-3",
+        "sn-13-github-readme-macrocosm-os-data-universe-docs-4"
+      ],
+      "slug": "sn-13",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/13",
+        "https://github.com/macrocosm-os/data-universe",
+        "https://github.com/macrocosm-os/data-universe/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/13/subnet.json",
+        "https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/lawful-basis/a-guide-to-lawful-basis",
+        "https://taomarketcap.com/subnets/13",
+        "https://www.macrocosmos.ai/gravity"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 9,
+      "candidate_count": 25,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 9,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ORO",
+      "netuid": 15,
+      "operational_interface_count": 0,
+      "priority_score": 133,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-15-github-readme-oro-ai-oro-dashboard-1",
+        "sn-15-github-readme-oro-ai-oro-docs-10",
+        "sn-15-github-readme-oro-ai-oro-docs-2",
+        "sn-15-github-readme-oro-ai-oro-docs-3",
+        "sn-15-github-readme-oro-ai-oro-docs-4"
+      ],
+      "slug": "sn-15",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/15",
+        "https://docs.oroagents.com/docs/validators/installation",
+        "https://github.com/ORO-AI/oro",
+        "https://github.com/ORO-AI/oro/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/15/subnet.json",
+        "https://oroagents.com/"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 19
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 8,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "ansuz",
+      "netuid": 84,
+      "operational_interface_count": 0,
+      "priority_score": 133,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-84-github-readme-tatsuproject-chipforge-sn84-docs-1",
+        "sn-84-github-readme-tatsuproject-chipforge-sn84-subnet-api-2",
+        "sn-84-github-readme-tatsuproject-chipforge-sn84-subnet-api-3",
+        "sn-84-taomarketcap-dashboard",
+        "sn-84-taopedia-article"
+      ],
+      "slug": "sn-84",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/84",
+        "https://docs.learnbittensor.org/btcli",
+        "https://github.com/TatsuProject/ChipForge_SN84",
+        "https://github.com/TatsuProject/ChipForge_SN84/blob/master/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_84/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/84/subnet.json",
+        "https://taomarketcap.com/subnets/84"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 25,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Apex",
+      "netuid": 1,
+      "operational_interface_count": 0,
+      "priority_score": 132,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-1-github-readme-macrocosm-os-apex-docs-1",
+        "sn-1-github-readme-macrocosm-os-apex-docs-2",
+        "sn-1-github-readme-macrocosm-os-apex-docs-3",
+        "sn-1-github-readme-macrocosm-os-apex-docs-4",
+        "sn-1-github-readme-macrocosm-os-apex-docs-5"
+      ],
+      "slug": "sn-1",
+      "source_urls": [
+        "https://apex.macrocosmos.ai/",
+        "https://api.taomarketcap.com/public/v1/subnets/1",
+        "https://docs.macrocosmos.ai/subnets/subnet-1-apex",
+        "https://github.com/macrocosm-os/apex",
+        "https://github.com/macrocosm-os/apex/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/1/subnet.json",
+        "https://taomarketcap.com/subnets/1"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 7,
+      "completeness_score": 43,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "EvolAI",
+      "netuid": 47,
+      "operational_interface_count": 1,
+      "priority_score": 132,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-47-github-readme-openevolai-evolai-data-artifact-1",
+        "sn-47-github-readme-reboot-org-reboot-subnet-dashboard-1",
+        "sn-47-taomarketcap-dashboard",
+        "sn-47-taomarketcap-source-repo",
+        "sn-47-taopedia-article"
+      ],
+      "slug": "sn-47",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/47",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_47/index.mdx",
+        "https://github.com/openevolai/evolai.git",
+        "https://github.com/openevolai/evolai/blob/main/README.md",
+        "https://github.com/reboot-org/reboot-subnet/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/47/subnet.json",
+        "https://taostats.io/subnets/47/chart"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 24,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Compelle",
+      "netuid": 82,
+      "operational_interface_count": 0,
+      "priority_score": 132,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-82-github-readme-sn-hermes-hermes-subnet-dashboard-1",
+        "sn-82-github-readme-sn-hermes-hermes-subnet-docs-2",
+        "sn-82-taomarketcap-dashboard",
+        "sn-82-taomarketcap-source-repo",
+        "sn-82-taomarketcap-website"
+      ],
+      "slug": "sn-82",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/82",
+        "https://compelle.com/",
+        "https://docs.bittensor.com/",
+        "https://github.com/SN-Hermes/hermes-subnet/blob/main/README.md",
+        "https://github.com/compelle/compelle-validator",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_82/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/82/subnet.json",
+        "https://taostats.io/"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 4,
+      "candidate_count": 8,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "oneoneone",
+      "netuid": 111,
+      "operational_interface_count": 0,
+      "priority_score": 132,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-111-github-readme-oneoneone-io-subnet-111-subnet-api-1",
+        "sn-111-github-readme-oneoneone-io-subnet-111-subnet-api-2",
+        "sn-111-github-readme-oneoneone-io-subnet-111-subnet-api-3",
+        "sn-111-github-readme-oneoneone-io-subnet-111-subnet-api-4",
+        "sn-111-taomarketcap-dashboard"
+      ],
+      "slug": "sn-111",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/111",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_111/index.mdx",
+        "https://github.com/oneoneone-io/subnet-111",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/111/subnet.json",
+        "https://taomarketcap.com/subnets/111"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 24,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Ditto",
+      "netuid": 118,
+      "operational_interface_count": 0,
+      "priority_score": 132,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-118-github-readme-mobiusfund-etf-dashboard-2",
+        "sn-118-github-readme-mobiusfund-etf-docs-1",
+        "sn-118-github-readme-mobiusfund-etf-docs-3",
+        "sn-118-taomarketcap-dashboard",
+        "sn-118-taomarketcap-source-repo"
+      ],
+      "slug": "sn-118",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/118",
+        "https://docs.learnbittensor.org/miners",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_118/index.mdx",
+        "https://github.com/mobiusfund/etf/blob/main/README.md",
+        "https://github.com/orgs/ditto-assistant/repositories",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/118/subnet.json",
+        "https://heyditto.ai/",
+        "https://taomarketcap.com/subnets/118"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 9,
+      "candidate_count": 23,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 9,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "iota",
+      "netuid": 9,
+      "operational_interface_count": 0,
+      "priority_score": 130,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-9-github-readme-macrocosm-os-iota-dashboard-1",
+        "sn-9-github-readme-macrocosm-os-iota-docs-2",
+        "sn-9-github-readme-macrocosm-os-iota-docs-3",
+        "sn-9-github-readme-macrocosm-os-iota-docs-4",
+        "sn-9-taomarketcap-dashboard"
+      ],
+      "slug": "sn-9",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/9",
+        "https://docs.astral.sh/uv",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_9/index.mdx",
+        "https://github.com/macrocosm-os/iota",
+        "https://github.com/macrocosm-os/iota/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/9/subnet.json",
+        "https://iota.macrocosmos.ai/",
+        "https://iota.macrocosmos.ai/dashboard/mainnet"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 25,
+      "candidate_count": 6,
+      "completeness_score": 43,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "BitMind",
+      "netuid": 34,
+      "operational_interface_count": 1,
+      "priority_score": 130,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-34-github-readme-bitmind-ai-bitmind-subnet-data-artifact-2",
+        "sn-34-github-readme-bitmind-ai-bitmind-subnet-docs-1",
+        "sn-34-taomarketcap-dashboard",
+        "sn-34-taomarketcap-source-repo",
+        "sn-34-taopedia-article"
+      ],
+      "slug": "sn-34",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/34",
+        "https://github.com/BitMind-AI/bitmind-subnet",
+        "https://github.com/BitMind-AI/bitmind-subnet/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_34/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/34/subnet.json",
+        "https://taomarketcap.com/subnets/34"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 23,
+      "completeness_score": 58,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "StreetVision by NATIX",
+      "netuid": 72,
+      "operational_interface_count": 1,
+      "priority_score": 130,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-72-github-readme-natixnetwork-streetvision-subnet-data-artifact-1",
+        "sn-72-github-readme-natixnetwork-streetvision-subnet-docs-2",
+        "sn-72-taomarketcap-dashboard",
+        "sn-72-taomarketcap-source-repo",
+        "sn-72-taomarketcap-website"
+      ],
+      "slug": "sn-72",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/72",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_72/index.mdx",
+        "https://github.com/natixnetwork/streetvision-subnet",
+        "https://github.com/natixnetwork/streetvision-subnet/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/72/subnet.json",
+        "https://taomarketcap.com/subnets/72",
+        "https://www.natix.network/?utm_source=bittensor"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 23,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Hippius",
+      "netuid": 75,
+      "operational_interface_count": 0,
+      "priority_score": 130,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-75-taomarketcap-dashboard",
+        "sn-75-taomarketcap-source-repo",
+        "sn-75-taomarketcap-website",
+        "sn-75-taopedia-article",
+        "sn-75-tensorplex-docs"
+      ],
+      "slug": "sn-75",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/75",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_75/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/75/subnet.json",
+        "https://github.com/thenervelab/thebrain",
+        "https://hippius.com/",
+        "https://taomarketcap.com/subnets/75"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 17
+    },
+    {
+      "adapter_score": 51,
+      "candidate_count": 21,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "Minos",
+      "netuid": 107,
+      "operational_interface_count": 1,
+      "priority_score": 130,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-1",
+        "sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-2",
+        "sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-3",
+        "sn-107-github-readme-tigerinvests-com-sn107-alpha-dashboard-1",
+        "sn-107-github-readme-tigerinvests-com-sn107-alpha-subnet-api-2"
+      ],
+      "slug": "sn-107",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/107",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
+        "https://github.com/minos-protocol/minos_subnet",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/107/subnet.json",
+        "https://github.com/tigerinvests-com/sn107-alpha/blob/main/readme.md",
+        "https://taostats.io/subnets/107/chart",
+        "https://theminos.ai/"
+      ],
+      "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 22,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Targon",
+      "netuid": 4,
+      "operational_interface_count": 0,
+      "priority_score": 129,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-4-taomarketcap-dashboard",
+        "sn-4-taomarketcap-source-repo",
+        "sn-4-taomarketcap-website",
+        "sn-4-taopedia-article",
+        "sn-4-tensorplex-docs"
+      ],
+      "slug": "sn-4",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/4",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_4/index.mdx",
+        "https://github.com/manifold-inc/targon",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/4/subnet.json",
+        "https://taomarketcap.com/subnets/4",
+        "https://targon.com/"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 6,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Compute Horde",
+      "netuid": 12,
+      "operational_interface_count": 0,
+      "priority_score": 129,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-12-github-readme-backend-developers-ltd-computehorde-dashboard-2",
+        "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1",
+        "sn-12-taomarketcap-dashboard",
+        "sn-12-taomarketcap-source-repo",
+        "sn-12-taopedia-article"
+      ],
+      "slug": "sn-12",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/12",
+        "https://github.com/backend-developers-ltd/ComputeHorde",
+        "https://github.com/backend-developers-ltd/ComputeHorde/blob/master/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_12/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/12/subnet.json",
+        "https://taostats.io/subnets/12"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 23,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ItsAI",
+      "netuid": 32,
+      "operational_interface_count": 0,
+      "priority_score": 129,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-32-github-readme-it-s-ai-llm-detection-dashboard-2",
+        "sn-32-github-readme-it-s-ai-llm-detection-docs-1",
+        "sn-32-taomarketcap-dashboard",
+        "sn-32-taomarketcap-source-repo",
+        "sn-32-taomarketcap-website"
+      ],
+      "slug": "sn-32",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/32",
+        "https://arxiv.org/abs/2405.07940",
+        "https://github.com/It-s-AI/llm-detection",
+        "https://github.com/It-s-AI/llm-detection/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_32/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/32/subnet.json",
+        "https://its-ai.org/en",
+        "https://taomarketcap.com/subnets/32"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 23,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "MVTRX",
+      "netuid": 79,
+      "operational_interface_count": 0,
+      "priority_score": 129,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-79-github-readme-taos-im-sn-79-docs-1",
+        "sn-79-github-readme-taos-im-sn-79-docs-2",
+        "sn-79-taomarketcap-dashboard",
+        "sn-79-taomarketcap-website",
+        "sn-79-taopedia-article"
+      ],
+      "slug": "sn-79",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/79",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_79/index.mdx",
+        "https://github.com/taos-im/sn-79",
+        "https://github.com/taos-im/sn-79/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/79/subnet.json",
+        "https://simulate.trading/taos-im-paper",
+        "https://taomarketcap.com/subnets/79",
+        "https://taos.im/"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 22,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Enigma",
+      "netuid": 63,
+      "operational_interface_count": 0,
+      "priority_score": 128,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-63-github-readme-qbittensor-labs-enigma-dashboard-1",
+        "sn-63-taomarketcap-dashboard",
+        "sn-63-taomarketcap-source-repo",
+        "sn-63-taomarketcap-website",
+        "sn-63-taopedia-article"
+      ],
+      "slug": "sn-63",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/63",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_63/index.mdx",
+        "https://github.com/qbittensor-labs/enigma",
+        "https://github.com/qbittensor-labs/enigma/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/63/subnet.json",
+        "https://taostats.io/subnets/63",
+        "https://www.qbittensorlabs.com/"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 26,
+      "candidate_count": 13,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Actual",
+      "netuid": 95,
+      "operational_interface_count": 1,
+      "priority_score": 128,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-source-repo",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-95-taomarketcap-dashboard",
+        "sn-95-taomarketcap-source-repo",
+        "sn-95-taomarketcap-website",
+        "sn-95-taopedia-article",
+        "sn-95-tensorplex-docs"
+      ],
+      "slug": "sn-95",
+      "source_urls": [
+        "https://actual.inc/",
+        "https://api.taomarketcap.com/public/v1/subnets/95",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json",
+        "https://taomarketcap.com/subnets/95"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 21,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Mainframe",
+      "netuid": 25,
+      "operational_interface_count": 0,
+      "priority_score": 127,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-25-github-readme-macrocosm-os-mainframe-dashboard-1",
+        "sn-25-github-readme-macrocosm-os-mainframe-docs-2",
+        "sn-25-github-readme-macrocosm-os-mainframe-subnet-api-3",
+        "sn-25-taomarketcap-dashboard",
+        "sn-25-taomarketcap-source-repo"
+      ],
+      "slug": "sn-25",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/25",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_25/index.mdx",
+        "https://github.com/macrocosm-os/mainframe",
+        "https://github.com/macrocosm-os/mainframe/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/25/subnet.json",
+        "https://macrocosmos.ai/sn25",
+        "https://www.macrocosmos.ai/sn25/dashboard"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 4,
+      "candidate_count": 5,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Graphite",
+      "netuid": 43,
+      "operational_interface_count": 0,
+      "priority_score": 127,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-43-github-readme-graphiteai-graphite-subnet-subnet-api-1",
+        "sn-43-taomarketcap-dashboard",
+        "sn-43-taomarketcap-source-repo",
+        "sn-43-taopedia-article",
+        "sn-43-tensorplex-docs"
+      ],
+      "slug": "sn-43",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/43",
+        "https://github.com/GraphiteAI/Graphite-Subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_43/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/43/subnet.json",
+        "https://taomarketcap.com/subnets/43"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 21,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Djinn",
+      "netuid": 103,
+      "operational_interface_count": 0,
+      "priority_score": 127,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-103-github-readme-djinn-inc-djinn-docs-1",
+        "sn-103-taomarketcap-dashboard",
+        "sn-103-taomarketcap-source-repo",
+        "sn-103-taomarketcap-website",
+        "sn-103-taopedia-article"
+      ],
+      "slug": "sn-103",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/103",
+        "https://djinn.gg/",
+        "https://docs.astral.sh/uv",
+        "https://github.com/Djinn-Inc/djinn",
+        "https://github.com/Djinn-Inc/djinn/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_103/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/103/subnet.json",
+        "https://taomarketcap.com/subnets/103"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 4,
+      "candidate_count": 5,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "gamma_small",
+      "netuid": 122,
+      "operational_interface_count": 0,
+      "priority_score": 127,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-122-github-readme-bitrecs-bitrecs-subnet-data-artifact-1",
+        "sn-122-taomarketcap-dashboard",
+        "sn-122-taopedia-article",
+        "sn-122-tensorplex-docs",
+        "sn-122-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-122",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/122",
+        "https://github.com/bitrecs/bitrecs-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_122/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/122/subnet.json",
+        "https://taomarketcap.com/subnets/122"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 21,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "blockmachine",
+      "netuid": 19,
+      "operational_interface_count": 0,
+      "priority_score": 126,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-19-github-readme-taostat-blockmachine-docs-1",
+        "sn-19-taomarketcap-dashboard",
+        "sn-19-taomarketcap-source-repo",
+        "sn-19-taomarketcap-website",
+        "sn-19-taopedia-article"
+      ],
+      "slug": "sn-19",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/19",
+        "https://blockmachine.io/",
+        "https://blockmachine.io/whitepaper",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_19/index.mdx",
+        "https://github.com/taostat/blockmachine",
+        "https://github.com/taostat/blockmachine/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/19/subnet.json",
+        "https://taomarketcap.com/subnets/19"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 21,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Talisman AI",
+      "netuid": 45,
+      "operational_interface_count": 0,
+      "priority_score": 126,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-45-taomarketcap-dashboard",
+        "sn-45-taomarketcap-source-repo",
+        "sn-45-taomarketcap-website",
+        "sn-45-taopedia-article",
+        "sn-45-tensorplex-docs"
+      ],
+      "slug": "sn-45",
+      "source_urls": [
+        "https://ai.talisman.xyz/",
+        "https://api.taomarketcap.com/public/v1/subnets/45",
+        "https://github.com/Team-Rizzo/talisman-ai",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_45/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/45/subnet.json",
+        "https://taomarketcap.com/subnets/45"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 3,
+      "completeness_score": 20,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 3,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Luminar Network",
+      "netuid": 87,
+      "operational_interface_count": 0,
+      "priority_score": 126,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-87-taomarketcap-dashboard",
+        "sn-87-taopedia-article",
+        "sn-87-tensorplex-docs"
+      ],
+      "slug": "sn-87",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/87",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/87/subnet.json",
+        "https://taomarketcap.com/subnets/87"
+      ],
+      "surface_count": 3,
+      "verified_candidate_count": 3
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 21,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "AdTAO",
+      "netuid": 21,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-21-taomarketcap-dashboard",
+        "sn-21-taomarketcap-source-repo",
+        "sn-21-taomarketcap-website",
+        "sn-21-taopedia-article",
+        "sn-21-tensorplex-docs"
+      ],
+      "slug": "sn-21",
+      "source_urls": [
+        "https://adtao.io/",
+        "https://api.taomarketcap.com/public/v1/subnets/21",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_21/index.mdx",
+        "https://github.com/ippcteam/SN21-adtao",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/21/subnet.json",
+        "https://taomarketcap.com/subnets/21"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 5,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "deprecated",
+      "netuid": 39,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-39-taomarketcap-dashboard",
+        "sn-39-taomarketcap-source-repo",
+        "sn-39-taopedia-article",
+        "sn-39-tensorplex-docs",
+        "sn-39-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-39",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/39",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_39/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/39/subnet.json",
+        "https://github.com/tplr-ai/basilica",
+        "https://taomarketcap.com/subnets/39"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 21,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Quantum Compute",
+      "netuid": 48,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-48-taomarketcap-dashboard",
+        "sn-48-taomarketcap-source-repo",
+        "sn-48-taomarketcap-website",
+        "sn-48-taopedia-article",
+        "sn-48-tensorplex-docs"
+      ],
+      "slug": "sn-48",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/48",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_48/index.mdx",
+        "https://github.com/qbittensor-labs/quantum-compute",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/48/subnet.json",
+        "https://taomarketcap.com/subnets/48",
+        "https://www.qbittensorlabs.com/"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 5,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "deprecated",
+      "netuid": 81,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-81-taomarketcap-dashboard",
+        "sn-81-taomarketcap-source-repo",
+        "sn-81-taopedia-article",
+        "sn-81-tensorplex-docs",
+        "sn-81-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-81",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/81",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_81/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/81/subnet.json",
+        "https://github.com/tplr-ai/grail",
+        "https://taomarketcap.com/subnets/81"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 19,
+      "completeness_score": 58,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "SOMA",
+      "netuid": 114,
+      "operational_interface_count": 1,
+      "priority_score": 125,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-114-taomarketcap-dashboard",
+        "sn-114-taomarketcap-source-repo",
+        "sn-114-taomarketcap-website",
+        "sn-114-taopedia-article",
+        "sn-114-tensorplex-docs"
+      ],
+      "slug": "sn-114",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/114",
+        "https://github.com/DendriteHQ/SOMA",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_114/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/114/subnet.json",
+        "https://taomarketcap.com/subnets/114",
+        "https://thesoma.ai/"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 5,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Subnet 117",
+      "netuid": 117,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-117-taomarketcap-dashboard",
+        "sn-117-taomarketcap-source-repo",
+        "sn-117-taopedia-article",
+        "sn-117-tensorplex-docs",
+        "sn-117-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-117",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/117",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_117/index.mdx",
+        "https://github.com/helionlink/Chi",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/117/subnet.json",
+        "https://taomarketcap.com/subnets/117"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 21,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "sundae_bar",
+      "netuid": 121,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-121-taomarketcap-dashboard",
+        "sn-121-taomarketcap-source-repo",
+        "sn-121-taomarketcap-website",
+        "sn-121-taopedia-article",
+        "sn-121-tensorplex-docs"
+      ],
+      "slug": "sn-121",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/121",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_121/index.mdx",
+        "https://github.com/sundae-bar/bittensor-subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/121/subnet.json",
+        "https://taomarketcap.com/subnets/121",
+        "https://www.sundaebar.ai/"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 32,
+      "candidate_count": 29,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 12,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Zipcode",
+      "netuid": 46,
+      "operational_interface_count": 1,
+      "priority_score": 125,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-46-github-readme-resi-labs-ai-resi-dashboard-1",
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-2",
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-3",
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-4"
+      ],
+      "slug": "sn-46",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/46",
+        "https://dashboard.resilabs.ai/",
+        "https://docs.astral.sh/uv/getting-started/installation",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_46/index.mdx",
+        "https://github.com/resi-labs-ai/RESI-models",
+        "https://github.com/resi-labs-ai/RESI-models/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/46/subnet.json",
+        "https://zipcode.ai/"
+      ],
+      "surface_count": 12,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "deprecated",
+      "netuid": 3,
+      "operational_interface_count": 0,
+      "priority_score": 124,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-3-taomarketcap-dashboard",
+        "sn-3-taopedia-article",
+        "sn-3-tensorplex-docs",
+        "sn-3-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-3",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/3",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_3/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/3/subnet.json",
+        "https://github.com/tplr-ai/templar",
+        "https://taomarketcap.com/subnets/3"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "gaia",
+      "netuid": 57,
+      "operational_interface_count": 0,
+      "priority_score": 124,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-57-taomarketcap-dashboard",
+        "sn-57-taopedia-article",
+        "sn-57-tensorplex-docs",
+        "sn-57-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-57",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/57",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_57/index.mdx",
+        "https://github.com/sparket-ai/sparket-ai",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/57/subnet.json",
+        "https://taomarketcap.com/subnets/57"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "luis",
+      "netuid": 92,
+      "operational_interface_count": 0,
+      "priority_score": 124,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-92-taomarketcap-dashboard",
+        "sn-92-taopedia-article",
+        "sn-92-tensorplex-docs",
+        "sn-92-tensorplex-source-repo-1"
+      ],
+      "slug": "sn-92",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/92",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_92/index.mdx",
+        "https://github.com/tensorclaw/tensorclaw",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/92/subnet.json",
+        "https://taomarketcap.com/subnets/92"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 19,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ForeverMoney",
+      "netuid": 98,
+      "operational_interface_count": 0,
+      "priority_score": 124,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-98-taomarketcap-dashboard",
+        "sn-98-taomarketcap-source-repo",
+        "sn-98-taomarketcap-website",
+        "sn-98-taopedia-article",
+        "sn-98-tensorplex-docs"
+      ],
+      "slug": "sn-98",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/98",
+        "https://forevermoney.ai/",
+        "https://github.com/SN98-ForeverMoney/forever-money",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_98/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/98/subnet.json",
+        "https://taomarketcap.com/subnets/98"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Academia",
+      "netuid": 109,
+      "operational_interface_count": 0,
+      "priority_score": 124,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-109-taomarketcap-dashboard",
+        "sn-109-taomarketcap-source-repo",
+        "sn-109-taopedia-article",
+        "sn-109-tensorplex-docs"
+      ],
+      "slug": "sn-109",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/109",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_109/index.mdx",
+        "https://github.com/fx-integral/academia",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/109/subnet.json",
+        "https://taomarketcap.com/subnets/109"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "HashiChain",
+      "netuid": 115,
+      "operational_interface_count": 0,
+      "priority_score": 124,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-115-taomarketcap-dashboard",
+        "sn-115-taomarketcap-source-repo",
+        "sn-115-taopedia-article",
+        "sn-115-tensorplex-docs"
+      ],
+      "slug": "sn-115",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/115",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_115/index.mdx",
+        "https://github.com/hashi115/hashichain",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/115/subnet.json",
+        "https://taomarketcap.com/subnets/115"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 4,
+      "completeness_score": 35,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 4,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "MANTIS",
+      "netuid": 123,
+      "operational_interface_count": 0,
+      "priority_score": 124,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-123-taomarketcap-dashboard",
+        "sn-123-taomarketcap-source-repo",
+        "sn-123-taopedia-article",
+        "sn-123-tensorplex-docs"
+      ],
+      "slug": "sn-123",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/123",
+        "https://github.com/Barbariandev/MANTIS",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/123/subnet.json",
+        "https://taomarketcap.com/subnets/123"
+      ],
+      "surface_count": 4,
+      "verified_candidate_count": 4
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TensorUSD",
+      "netuid": 113,
+      "operational_interface_count": 0,
+      "priority_score": 122,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-113-github-readme-tensorusd-subnet-docs-1",
+        "sn-113-github-readme-tensorusd-subnet-docs-2",
+        "sn-113-taomarketcap-dashboard",
+        "sn-113-taomarketcap-source-repo",
+        "sn-113-taomarketcap-website"
+      ],
+      "slug": "sn-113",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/113",
+        "https://docs.tensorusd.com/components/subnet",
+        "https://github.com/TensorUSD/subnet",
+        "https://github.com/TensorUSD/subnet/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_113/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/113/subnet.json",
+        "https://taomarketcap.com/subnets/113",
+        "https://tensorusd.com/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 17,
+      "completeness_score": 58,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Hone",
+      "netuid": 5,
+      "operational_interface_count": 1,
+      "priority_score": 121,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-5-github-readme-manifold-inc-hone-data-artifact-1",
+        "sn-5-github-readme-manifold-inc-hone-docs-2",
+        "sn-5-github-readme-manifold-inc-hone-docs-3",
+        "sn-5-taomarketcap-dashboard",
+        "sn-5-taomarketcap-source-repo"
+      ],
+      "slug": "sn-5",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/5",
+        "https://docs.bittensor.com/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx",
+        "https://github.com/manifold-inc/hone",
+        "https://github.com/manifold-inc/hone/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/5/subnet.json",
+        "https://taomarketcap.com/subnets/5",
+        "https://www.hone.training/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 16,
+      "completeness_score": 58,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "NOVA",
+      "netuid": 68,
+      "operational_interface_count": 1,
+      "priority_score": 121,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-68-taomarketcap-dashboard",
+        "sn-68-taomarketcap-source-repo",
+        "sn-68-taomarketcap-website",
+        "sn-68-taopedia-article",
+        "sn-68-tensorplex-docs"
+      ],
+      "slug": "sn-68",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/68",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx",
+        "https://github.com/metanova-labs/nova",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/68/subnet.json",
+        "https://taomarketcap.com/subnets/68",
+        "https://www.metanova-labs.ai/"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Plaτform",
+      "netuid": 100,
+      "operational_interface_count": 0,
+      "priority_score": 121,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-100-taomarketcap-dashboard",
+        "sn-100-taomarketcap-source-repo",
+        "sn-100-taomarketcap-website",
+        "sn-100-taopedia-article",
+        "sn-100-tensorplex-docs"
+      ],
+      "slug": "sn-100",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/100",
+        "https://github.com/PlatformNetwork/platform",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/100/subnet.json",
+        "https://platform.network/",
+        "https://taomarketcap.com/subnets/100"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Numinous",
+      "netuid": 6,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-6-github-readme-numinouslabs-numinous-dashboard-1",
+        "sn-6-github-readme-numinouslabs-numinous-dashboard-2",
+        "sn-6-taomarketcap-dashboard",
+        "sn-6-taomarketcap-source-repo",
+        "sn-6-taomarketcap-website"
+      ],
+      "slug": "sn-6",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/6",
+        "https://app.hex.tech/1644b22a-abe5-4113-9d5f-3ad05e4a8de7/app/Numinous-031erYRYSssIrH3W3KcyHg/latest",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_6/index.mdx",
+        "https://github.com/numinouslabs/numinous",
+        "https://github.com/numinouslabs/numinous/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/6/subnet.json",
+        "https://numinouslabs.io/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 16,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Vanta",
+      "netuid": 8,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-8-github-readme-taoshidev-vanta-network-dashboard-1",
+        "sn-8-github-readme-taoshidev-vanta-network-docs-2",
+        "sn-8-taomarketcap-dashboard",
+        "sn-8-taomarketcap-source-repo",
+        "sn-8-taomarketcap-website"
+      ],
+      "slug": "sn-8",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/8",
+        "https://dashboard.taoshi.io/",
+        "https://docs.taoshi.io/tips/p4",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx",
+        "https://github.com/taoshidev/vanta-network",
+        "https://github.com/taoshidev/vanta-network/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/8/subnet.json",
+        "https://www.vantanetwork.io/"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "404—GEN",
+      "netuid": 17,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-17-github-readme-404-repo-three-gen-subnet-dashboard-1",
+        "sn-17-taomarketcap-dashboard",
+        "sn-17-taomarketcap-source-repo",
+        "sn-17-taomarketcap-website",
+        "sn-17-taopedia-article"
+      ],
+      "slug": "sn-17",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/17",
+        "https://dashboard.404.xyz/d/main/404-gen",
+        "https://github.com/404-Repo/404-gen-subnet",
+        "https://github.com/404-Repo/three-gen-subnet/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_17/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/17/subnet.json",
+        "https://www.404.xyz/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 16,
+      "completeness_score": 58,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "NexisGen",
+      "netuid": 70,
+      "operational_interface_count": 1,
+      "priority_score": 120,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-70-taomarketcap-dashboard",
+        "sn-70-taomarketcap-source-repo",
+        "sn-70-taomarketcap-website",
+        "sn-70-taopedia-article",
+        "sn-70-tensorplex-docs"
+      ],
+      "slug": "sn-70",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/70",
+        "https://github.com/RendixNetwork/nexisgen",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/70/subnet.json",
+        "https://nexisgen.ai/",
+        "https://taomarketcap.com/subnets/70"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ConnitoAI",
+      "netuid": 102,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-102-github-readme-connito-ai-connito-docs-1",
+        "sn-102-github-readme-connito-ai-connito-docs-2",
+        "sn-102-taomarketcap-dashboard",
+        "sn-102-taomarketcap-source-repo",
+        "sn-102-taomarketcap-website"
+      ],
+      "slug": "sn-102",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/102",
+        "https://connito.ai/",
+        "https://github.com/Connito-AI/Connito",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_102/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/102/subnet.json",
+        "https://taomarketcap.com/subnets/102"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 50,
+      "candidate_count": 14,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Verathos",
+      "netuid": 96,
+      "operational_interface_count": 1,
+      "priority_score": 120,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-96-github-readme-verathos-ai-verathos-docs-1",
+        "sn-96-github-readme-verathos-ai-verathos-docs-2",
+        "sn-96-github-readme-verathos-ai-verathos-subnet-api-3",
+        "sn-96-taomarketcap-dashboard",
+        "sn-96-taomarketcap-source-repo"
+      ],
+      "slug": "sn-96",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/96",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_96/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/96/subnet.json",
+        "https://github.com/verathos-ai/verathos",
+        "https://github.com/verathos-ai/verathos/blob/main/README.md",
+        "https://taomarketcap.com/subnets/96",
+        "https://verathos.ai/",
+        "https://verathos.ai/docs"
+      ],
+      "surface_count": 10,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 16,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Zeus",
+      "netuid": 18,
+      "operational_interface_count": 0,
+      "priority_score": 119,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-18-taomarketcap-dashboard",
+        "sn-18-taomarketcap-source-repo",
+        "sn-18-taomarketcap-website",
+        "sn-18-taopedia-article",
+        "sn-18-tensorplex-docs"
+      ],
+      "slug": "sn-18",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/18",
+        "https://github.com/Orpheus-AI/Zeus",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/18/subnet.json",
+        "https://taomarketcap.com/subnets/18",
+        "https://www.zeussubnet.com/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TalkHead",
+      "netuid": 108,
+      "operational_interface_count": 0,
+      "priority_score": 119,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-108-taomarketcap-dashboard",
+        "sn-108-taomarketcap-source-repo",
+        "sn-108-taomarketcap-website",
+        "sn-108-taopedia-article",
+        "sn-108-tensorplex-docs"
+      ],
+      "slug": "sn-108",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/108",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx",
+        "https://github.com/talkheadai/talkhead-subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/108/subnet.json",
+        "https://taomarketcap.com/subnets/108",
+        "https://www.talkhead.ai/"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 49,
+      "candidate_count": 22,
+      "completeness_score": 73,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Gradients",
+      "netuid": 56,
+      "operational_interface_count": 2,
+      "priority_score": 118,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-56-taomarketcap-dashboard",
+        "sn-56-taomarketcap-source-repo",
+        "sn-56-taomarketcap-website",
+        "sn-56-taopedia-article",
+        "sn-56-tensorplex-docs"
+      ],
+      "slug": "sn-56",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/56",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
+        "https://github.com/gradients-ai/G.O.D",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/56/subnet.json",
+        "https://taomarketcap.com/subnets/56",
+        "https://www.gradients.io/"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 20
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 15,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TrajectoryRL",
+      "netuid": 11,
+      "operational_interface_count": 0,
+      "priority_score": 117,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-11-taomarketcap-dashboard",
+        "sn-11-taomarketcap-source-repo",
+        "sn-11-taomarketcap-website",
+        "sn-11-taopedia-article",
+        "sn-11-tensorplex-docs"
+      ],
+      "slug": "sn-11",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/11",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/11/subnet.json",
+        "https://github.com/trajectoryRL/trajectoryRL",
+        "https://taomarketcap.com/subnets/11",
+        "https://trajrl.com/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 15,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Eirel",
+      "netuid": 36,
+      "operational_interface_count": 0,
+      "priority_score": 117,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-36-taomarketcap-dashboard",
+        "sn-36-taomarketcap-source-repo",
+        "sn-36-taomarketcap-website",
+        "sn-36-taopedia-article",
+        "sn-36-tensorplex-docs"
+      ],
+      "slug": "sn-36",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/36",
+        "https://eirel.ai/",
+        "https://github.com/RendixNetwork/eirel-ai",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/36/subnet.json",
+        "https://taomarketcap.com/subnets/36"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 15,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Poker44",
+      "netuid": 126,
+      "operational_interface_count": 0,
+      "priority_score": 117,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-126-taomarketcap-dashboard",
+        "sn-126-taomarketcap-source-repo",
+        "sn-126-taomarketcap-website",
+        "sn-126-taopedia-article",
+        "sn-126-tensorplex-docs"
+      ],
+      "slug": "sn-126",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/126",
+        "https://github.com/Poker44/Poker44-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_126/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/126/subnet.json",
+        "https://poker44.net/",
+        "https://taomarketcap.com/subnets/126"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 22,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 8,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "Aurelius",
+      "netuid": 37,
+      "operational_interface_count": 1,
+      "priority_score": 117,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-37-github-readme-aurelius-protocol-aurelius-protocol-dashboard-2",
+        "sn-37-github-readme-aurelius-protocol-aurelius-protocol-dashboard-3",
+        "sn-37-github-readme-aurelius-protocol-aurelius-protocol-docs-1",
+        "sn-37-github-readme-aurelius-protocol-aurelius-protocol-subnet-api-4",
+        "sn-37-github-readme-aurelius-protocol-aurelius-protocol-subnet-api-5"
+      ],
+      "slug": "sn-37",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/37",
+        "https://aureliusaligned.ai/",
+        "https://docs.bittensor.com/",
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json",
+        "https://taomarketcap.com/subnets/37"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 22,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 8,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "lium.io",
+      "netuid": 51,
+      "operational_interface_count": 1,
+      "priority_score": 117,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-51-github-readme-datura-ai-lium-io-docs-1",
+        "sn-51-taomarketcap-dashboard",
+        "sn-51-taomarketcap-source-repo",
+        "sn-51-taomarketcap-website",
+        "sn-51-taopedia-article"
+      ],
+      "slug": "sn-51",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/51",
+        "https://docs.lium.io/bittensor-subnet/overview",
+        "https://github.com/Datura-ai/lium-io",
+        "https://github.com/Datura-ai/lium-io/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
+        "https://lium.io/",
+        "https://taomarketcap.com/subnets/51"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 17
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 14,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Yanez MIID",
+      "netuid": 54,
+      "operational_interface_count": 0,
+      "priority_score": 116,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-54-github-readme-yanez-compliance-miid-subnet-dashboard-1",
+        "sn-54-taomarketcap-dashboard",
+        "sn-54-taomarketcap-source-repo",
+        "sn-54-taomarketcap-website",
+        "sn-54-taopedia-article"
+      ],
+      "slug": "sn-54",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/54",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_54/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/54/subnet.json",
+        "https://github.com/yanez-compliance/MIID-subnet",
+        "https://github.com/yanez-compliance/MIID-subnet/blob/main/README.md",
+        "https://tao-ui-dashboard.yanez.ai/",
+        "https://www.yanez.ai/"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 15,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "NIOME",
+      "netuid": 55,
+      "operational_interface_count": 0,
+      "priority_score": 116,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-55-taomarketcap-dashboard",
+        "sn-55-taomarketcap-source-repo",
+        "sn-55-taomarketcap-website",
+        "sn-55-taopedia-article",
+        "sn-55-tensorplex-docs"
+      ],
+      "slug": "sn-55",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/55",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_55/index.mdx",
+        "https://github.com/genomesio/subnet-niome",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/55/subnet.json",
+        "https://niome.genomes.io/",
+        "https://taomarketcap.com/subnets/55"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 14,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Harnyx",
+      "netuid": 67,
+      "operational_interface_count": 0,
+      "priority_score": 116,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-67-github-readme-harnyx-harnyx-dashboard-1",
+        "sn-67-taomarketcap-dashboard",
+        "sn-67-taomarketcap-website",
+        "sn-67-taopedia-article",
+        "sn-67-tensorplex-docs"
+      ],
+      "slug": "sn-67",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/67",
+        "https://dashboard.harnyx.ai/benchmark",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_67/index.mdx",
+        "https://github.com/harnyx/harnyx",
+        "https://github.com/harnyx/harnyx/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/67/subnet.json",
+        "https://harnyx.ai/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 14,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Bitsota",
+      "netuid": 94,
+      "operational_interface_count": 0,
+      "priority_score": 116,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-94-taomarketcap-dashboard",
+        "sn-94-taomarketcap-source-repo",
+        "sn-94-taomarketcap-website",
+        "sn-94-taopedia-article",
+        "sn-94-tensorplex-docs"
+      ],
+      "slug": "sn-94",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/94",
+        "https://bitsota.ai/",
+        "https://github.com/AlveusLabs/SN94-BitSota",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json",
+        "https://taomarketcap.com/subnets/94"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 14,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "minotaur",
+      "netuid": 112,
+      "operational_interface_count": 0,
+      "priority_score": 116,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-112-github-readme-subnet112-minotaur-subnet-dashboard-2",
+        "sn-112-github-readme-subnet112-minotaur-subnet-subnet-api-1",
+        "sn-112-taomarketcap-dashboard",
+        "sn-112-taomarketcap-source-repo",
+        "sn-112-taomarketcap-website"
+      ],
+      "slug": "sn-112",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/112",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_112/index.mdx",
+        "https://github.com/subnet112/minotaur_subnet",
+        "https://github.com/subnet112/minotaur_subnet/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/112/subnet.json",
+        "https://minotaursubnet.com/",
+        "https://taostats.io/subnets/112/chart"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 21,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "dogelayer",
+      "netuid": 80,
+      "operational_interface_count": 1,
+      "priority_score": 115,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-80-github-readme-dogelayer-ai-dogelayer-docs-1",
+        "sn-80-github-readme-dogelayer-ai-dogelayer-docs-2",
+        "sn-80-github-readme-dogelayer-ai-dogelayer-docs-3",
+        "sn-80-github-readme-dogelayer-ai-dogelayer-docs-4",
+        "sn-80-github-readme-dogelayer-ai-dogelayer-docs-5"
+      ],
+      "slug": "sn-80",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/80",
+        "https://docs.learnbittensor.org/learn/introduction",
+        "https://dogelayer.ai/",
+        "https://github.com/dogelayer-ai/dogelayer",
+        "https://github.com/dogelayer-ai/dogelayer/blob/main/README.md",
+        "https://taomarketcap.com/subnets/80"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 13,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "OxMarkets",
+      "netuid": 35,
+      "operational_interface_count": 0,
+      "priority_score": 114,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-35-github-readme-general-tao-ventures-cartha-cli-docs-1",
+        "sn-35-taomarketcap-dashboard",
+        "sn-35-taomarketcap-source-repo",
+        "sn-35-taomarketcap-website",
+        "sn-35-taopedia-article"
+      ],
+      "slug": "sn-35",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/35",
+        "https://docs.learnbittensor.org/keys/working-with-keys",
+        "https://github.com/General-Tao-Ventures/cartha-cli/blob/main/README.md",
+        "https://github.com/General-Tao-Ventures/cartha-validator",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_35/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/35/subnet.json",
+        "https://taomarketcap.com/subnets/35",
+        "https://www.0xmarkets.io/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 13,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Score",
+      "netuid": 44,
+      "operational_interface_count": 0,
+      "priority_score": 114,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-44-taomarketcap-dashboard",
+        "sn-44-taomarketcap-source-repo",
+        "sn-44-taomarketcap-website",
+        "sn-44-taopedia-article",
+        "sn-44-tensorplex-docs"
+      ],
+      "slug": "sn-44",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/44",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_44/index.mdx",
+        "https://github.com/score-technologies/turbovision",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/44/subnet.json",
+        "https://taomarketcap.com/subnets/44",
+        "https://www.wearescore.com/"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 13,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "RedTeam",
+      "netuid": 61,
+      "operational_interface_count": 0,
+      "priority_score": 114,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-61-github-readme-redteamsubnet-redteam-dashboard-1",
+        "sn-61-github-readme-redteamsubnet-redteam-docs-2",
+        "sn-61-taomarketcap-dashboard",
+        "sn-61-taomarketcap-source-repo",
+        "sn-61-taomarketcap-website"
+      ],
+      "slug": "sn-61",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/61",
+        "https://dashboard.theredteam.io/",
+        "https://docs.theredteam.io/",
+        "https://github.com/RedTeamSubnet/RedTeam",
+        "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_61/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/61/subnet.json",
+        "https://www.theredteam.io/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 48,
+      "candidate_count": 11,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 8,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Desearch",
+      "netuid": 22,
+      "operational_interface_count": 1,
+      "priority_score": 114,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-22-taomarketcap-dashboard",
+        "sn-22-taomarketcap-source-repo",
+        "sn-22-taomarketcap-website",
+        "sn-22-taopedia-article",
+        "sn-22-tensorplex-docs"
+      ],
+      "slug": "sn-22",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/22",
+        "https://desearch.ai/",
+        "https://github.com/datura-ai/desearch",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_22/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/22/subnet.json",
+        "https://taomarketcap.com/subnets/22"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 12,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Affine",
+      "netuid": 120,
+      "operational_interface_count": 0,
+      "priority_score": 113,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-120-github-readme-affinefoundation-affine-dashboard-1",
+        "sn-120-taomarketcap-dashboard",
+        "sn-120-taomarketcap-source-repo",
+        "sn-120-taomarketcap-website",
+        "sn-120-taopedia-article"
+      ],
+      "slug": "sn-120",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/120",
+        "https://github.com/AffineFoundation/affine",
+        "https://github.com/AffineFoundation/affine/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_120/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/120/subnet.json",
+        "https://www.affine.io/"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 30,
+      "candidate_count": 19,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Vidaio",
+      "netuid": 85,
+      "operational_interface_count": 1,
+      "priority_score": 113,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-85-github-readme-vidaio-subnet-vidaio-subnet-docs-1",
+        "sn-85-taomarketcap-dashboard",
+        "sn-85-taomarketcap-source-repo",
+        "sn-85-taomarketcap-website",
+        "sn-85-taopedia-article"
+      ],
+      "slug": "sn-85",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/85",
+        "https://docs.bittensor.com/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_85/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/85/subnet.json",
+        "https://github.com/vidaio-subnet/vidaio-subnet",
+        "https://github.com/vidaio-subnet/vidaio-subnet/blob/main/README.md",
+        "https://taomarketcap.com/subnets/85",
+        "https://vidaio.io/"
+      ],
+      "surface_count": 10,
+      "verified_candidate_count": 17
+    },
+    {
+      "adapter_score": 50,
+      "candidate_count": 18,
+      "completeness_score": 73,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Leoma",
+      "netuid": 99,
+      "operational_interface_count": 2,
+      "priority_score": 113,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-99-github-readme-rendixnetwork-leoma-data-artifact-3",
+        "sn-99-github-readme-rendixnetwork-leoma-docs-1",
+        "sn-99-github-readme-rendixnetwork-leoma-docs-4",
+        "sn-99-github-readme-rendixnetwork-leoma-docs-5",
+        "sn-99-github-readme-rendixnetwork-leoma-subnet-api-2"
+      ],
+      "slug": "sn-99",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/99",
+        "https://docs.learnbittensor.org/",
+        "https://github.com/RendixNetwork/leoma",
+        "https://github.com/RendixNetwork/leoma/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_99/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/99/subnet.json",
+        "https://leoma.ai/",
+        "https://taomarketcap.com/subnets/99"
+      ],
+      "surface_count": 10,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 31,
+      "candidate_count": 18,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "Trishool",
+      "netuid": 23,
+      "operational_interface_count": 1,
+      "priority_score": 112,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-23-github-readme-trishoolai-trishool-phase2-dashboard-1",
+        "sn-23-github-readme-trishoolai-trishool-phase2-dashboard-2",
+        "sn-23-github-readme-trishoolai-trishool-phase2-subnet-api-3",
+        "sn-23-github-readme-trishoolai-trishool-subnet-docs-1",
+        "sn-23-taomarketcap-dashboard"
+      ],
+      "slug": "sn-23",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/23",
+        "https://github.com/TrishoolAI/trishool-phase2",
+        "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md",
+        "https://github.com/TrishoolAI/trishool-subnet/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_23/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/23/subnet.json",
+        "https://pm2.io/docs/runtime/guide/installation",
+        "https://trishool.ai/"
+      ],
+      "surface_count": 11,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 19,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "Investing",
+      "netuid": 88,
+      "operational_interface_count": 1,
+      "priority_score": 112,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-88-github-readme-mobiusfund-investing-dashboard-1",
+        "sn-88-github-readme-mobiusfund-investing-docs-2",
+        "sn-88-github-readme-mobiusfund-investing-docs-3",
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-4",
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-5"
+      ],
+      "slug": "sn-88",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/88",
+        "https://db.investing88.ai/",
+        "https://docs.learnbittensor.org/miners",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_88/index.mdx",
+        "https://github.com/mobiusfund/investing",
+        "https://github.com/mobiusfund/investing/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/88/subnet.json",
+        "https://investing88.ai/"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 11,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "VoidAI",
+      "netuid": 106,
+      "operational_interface_count": 0,
+      "priority_score": 111,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-106-taomarketcap-dashboard",
+        "sn-106-taomarketcap-source-repo",
+        "sn-106-taomarketcap-website",
+        "sn-106-taopedia-article",
+        "sn-106-tensorplex-docs"
+      ],
+      "slug": "sn-106",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/106",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/106/subnet.json",
+        "https://github.com/v0idai/SN106",
+        "https://taomarketcap.com/subnets/106",
+        "https://voidai.com/"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 18,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TAO Private Network",
+      "netuid": 65,
+      "operational_interface_count": 1,
+      "priority_score": 111,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-65-github-readme-taofu-labs-tpn-subnet-dashboard-1",
+        "sn-65-taomarketcap-dashboard",
+        "sn-65-taomarketcap-source-repo",
+        "sn-65-taomarketcap-website",
+        "sn-65-taopedia-article"
+      ],
+      "slug": "sn-65",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/65",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx",
+        "https://github.com/taofu-labs/tpn-subnet",
+        "https://github.com/taofu-labs/tpn-subnet/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/65/subnet.json",
+        "https://taostats.io/subnets/65/registration",
+        "https://tpn.taofu.xyz/"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 70,
+      "candidate_count": 16,
+      "completeness_score": 80,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse"
+      ],
+      "name": "ninja",
+      "netuid": 66,
+      "operational_interface_count": 2,
+      "priority_score": 111,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-66-github-readme-unarbos-tau-subnet-api-1",
+        "sn-66-github-readme-unarbos-tau-subnet-api-2",
+        "sn-66-taomarketcap-dashboard",
+        "sn-66-taomarketcap-source-repo",
+        "sn-66-taomarketcap-website"
+      ],
+      "slug": "sn-66",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/66",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_66/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/66/subnet.json",
+        "https://github.com/unarbos/tau",
+        "https://github.com/unarbos/tau/blob/main/README.md",
+        "https://ninja.arbos.life/",
+        "https://taomarketcap.com/subnets/66"
+      ],
+      "surface_count": 10,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 18,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Bitcast",
+      "netuid": 93,
+      "operational_interface_count": 1,
+      "priority_score": 111,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-93-github-readme-bitcast-network-bitcast-dashboard-1",
+        "sn-93-github-readme-bitcast-network-bitcast-dashboard-2",
+        "sn-93-taomarketcap-dashboard",
+        "sn-93-taomarketcap-source-repo",
+        "sn-93-taomarketcap-website"
+      ],
+      "slug": "sn-93",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/93",
+        "https://dashboard.bitcast.network/",
+        "https://github.com/bitcast-network/bitcast",
+        "https://github.com/bitcast-network/bitcast/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_93/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/93/subnet.json",
+        "https://stats.bitcast.network/"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 50,
+      "candidate_count": 17,
+      "completeness_score": 73,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Albedo",
+      "netuid": 97,
+      "operational_interface_count": 2,
+      "priority_score": 111,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-97-github-readme-unarbos-albedo-data-artifact-1",
+        "sn-97-github-readme-unitone-labs-flamewire-docs-1",
+        "sn-97-github-readme-unitone-labs-flamewire-docs-2",
+        "sn-97-github-readme-unitone-labs-flamewire-subnet-api-3",
+        "sn-97-taomarketcap-dashboard"
+      ],
+      "slug": "sn-97",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/97",
+        "https://docs.flamewire.io/docs/miners/registration",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_97/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/97/subnet.json",
+        "https://github.com/unarbos/albedo",
+        "https://github.com/unarbos/albedo/blob/main/README.md",
+        "https://github.com/unitone-labs/FlameWire/blob/main/README.md",
+        "https://taomarketcap.com/subnets/97"
+      ],
+      "surface_count": 10,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 5,
+      "candidate_count": 11,
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 5,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Swap",
+      "netuid": 10,
+      "operational_interface_count": 0,
+      "priority_score": 110,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-10-taomarketcap-dashboard",
+        "sn-10-taomarketcap-source-repo",
+        "sn-10-taomarketcap-website",
+        "sn-10-taopedia-article",
+        "sn-10-tensorplex-docs"
+      ],
+      "slug": "sn-10",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/10",
+        "https://github.com/Swap-Subnet/swap-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/10/subnet.json",
+        "https://taomarketcap.com/subnets/10",
+        "https://www.taofi.com/pool"
+      ],
+      "surface_count": 5,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 30,
+      "candidate_count": 17,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Bitsec.ai",
+      "netuid": 60,
+      "operational_interface_count": 1,
+      "priority_score": 110,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-60-github-readme-bitsec-ai-sandbox-dashboard-1",
+        "sn-60-github-readme-bitsec-ai-sandbox-docs-2",
+        "sn-60-github-readme-bitsec-ai-sandbox-docs-3",
+        "sn-60-github-readme-bitsec-ai-subnet-docs-1",
+        "sn-60-github-readme-bitsec-ai-subnet-docs-2"
+      ],
+      "slug": "sn-60",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/60",
+        "https://bitsec.ai/",
+        "https://bittensor.com/whitepaper",
+        "https://github.com/Bitsec-AI/sandbox",
+        "https://github.com/Bitsec-AI/sandbox/blob/main/README.md",
+        "https://github.com/Bitsec-AI/subnet/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/60/subnet.json"
+      ],
+      "surface_count": 10,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 30,
+      "candidate_count": 15,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "DSperse",
+      "netuid": 2,
+      "operational_interface_count": 1,
+      "priority_score": 107,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-2-github-readme-inference-labs-inc-subnet-2-dashboard-2",
+        "sn-2-github-readme-inference-labs-inc-subnet-2-dashboard-3",
+        "sn-2-github-readme-inference-labs-inc-subnet-2-docs-1",
+        "sn-2-github-readme-inference-labs-inc-subnet-2-docs-4",
+        "sn-2-taomarketcap-dashboard"
+      ],
+      "slug": "sn-2",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/2",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_2/index.mdx",
+        "https://github.com/inference-labs-inc/subnet-2",
+        "https://github.com/inference-labs-inc/subnet-2/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/2/subnet.json",
+        "https://sn2-docs.inferencelabs.com/",
+        "https://sn2-stats.inferencelabs.com/",
+        "https://subnet2.inferencelabs.com/"
+      ],
+      "surface_count": 10,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 16,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "Perturb",
+      "netuid": 26,
+      "operational_interface_count": 1,
+      "priority_score": 107,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-26-github-readme-0xsigurd-perturb-subnet-api-1",
+        "sn-26-taomarketcap-dashboard",
+        "sn-26-taomarketcap-source-repo",
+        "sn-26-taomarketcap-website",
+        "sn-26-taopedia-article"
+      ],
+      "slug": "sn-26",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/26",
+        "https://github.com/0xsigurd/Perturb",
+        "https://github.com/0xsigurd/Perturb/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_26/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/26/subnet.json",
+        "https://taomarketcap.com/subnets/26",
+        "https://www.perturbai.io/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 16,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "Babelbit",
+      "netuid": 59,
+      "operational_interface_count": 1,
+      "priority_score": 107,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-59-github-readme-babelbit-babelbit-subnet-subnet-api-1",
+        "sn-59-taomarketcap-dashboard",
+        "sn-59-taomarketcap-source-repo",
+        "sn-59-taomarketcap-website",
+        "sn-59-taopedia-article"
+      ],
+      "slug": "sn-59",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/59",
+        "https://babelbit.ai/",
+        "https://github.com/babelbit/babelbit_subnet",
+        "https://github.com/babelbit/babelbit_subnet/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_59/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json",
+        "https://taomarketcap.com/subnets/59"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 14,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 8,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Almanac",
+      "netuid": 41,
+      "operational_interface_count": 1,
+      "priority_score": 105,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-41-github-readme-sportstensor-sn41-docs-1",
+        "sn-41-github-readme-sportstensor-sn41-docs-2",
+        "sn-41-taomarketcap-dashboard",
+        "sn-41-taomarketcap-source-repo",
+        "sn-41-taomarketcap-website"
+      ],
+      "slug": "sn-41",
+      "source_urls": [
+        "https://almanac.market/",
+        "https://api.taomarketcap.com/public/v1/subnets/41",
+        "https://docs.learnbittensor.org/keys/wallets",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx",
+        "https://github.com/sportstensor/sn41",
+        "https://github.com/sportstensor/sn41/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json",
+        "https://taomarketcap.com/subnets/41"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 26,
+      "candidate_count": 15,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 6,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "Astrid",
+      "netuid": 127,
+      "operational_interface_count": 1,
+      "priority_score": 105,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-127-github-readme-astridintelligence-sn-127-subnet-api-1",
+        "sn-127-taomarketcap-dashboard",
+        "sn-127-taomarketcap-source-repo",
+        "sn-127-taomarketcap-website",
+        "sn-127-taopedia-article"
+      ],
+      "slug": "sn-127",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/127",
+        "https://github.com/astridintelligence/sn-127",
+        "https://github.com/astridintelligence/sn-127/blob/master/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/127/subnet.json",
+        "https://taomarketcap.com/subnets/127",
+        "https://www.astrid.global/"
+      ],
+      "surface_count": 6,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 13,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Vocence",
+      "netuid": 78,
+      "operational_interface_count": 1,
+      "priority_score": 103,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-78-taomarketcap-dashboard",
+        "sn-78-taomarketcap-source-repo",
+        "sn-78-taomarketcap-website",
+        "sn-78-taopedia-article",
+        "sn-78-tensorplex-docs"
+      ],
+      "slug": "sn-78",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/78",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/78/subnet.json",
+        "https://github.com/vocence-78/vocence",
+        "https://taomarketcap.com/subnets/78",
+        "https://www.vocence.ai/"
+      ],
+      "surface_count": 9,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 13,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Liquidity",
+      "netuid": 77,
+      "operational_interface_count": 1,
+      "priority_score": 102,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-77-github-readme-creativebuilds-sn77-subnet-api-1",
+        "sn-77-github-readme-creativebuilds-sn77-subnet-api-2",
+        "sn-77-taomarketcap-dashboard",
+        "sn-77-taomarketcap-source-repo",
+        "sn-77-taomarketcap-website"
+      ],
+      "slug": "sn-77",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/77",
+        "https://github.com/creativebuilds/sn77",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/77/subnet.json",
+        "https://sn77.xyz/",
+        "https://taomarketcap.com/subnets/77"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 12,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 8,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Swarm",
+      "netuid": 124,
+      "operational_interface_count": 1,
+      "priority_score": 102,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-124-github-readme-swarm-subnet-swarm-dashboard-1",
+        "sn-124-taomarketcap-dashboard",
+        "sn-124-taomarketcap-source-repo",
+        "sn-124-taomarketcap-website",
+        "sn-124-taopedia-article"
+      ],
+      "slug": "sn-124",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/124",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_124/index.mdx",
+        "https://github.com/swarm-subnet/swarm",
+        "https://github.com/swarm-subnet/swarm/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/124/subnet.json",
+        "https://swarm124.com/benchmark",
+        "https://www.swarm124.com/"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 12,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 8,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ByteLeap",
+      "netuid": 128,
+      "operational_interface_count": 1,
+      "priority_score": 102,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-128-taomarketcap-dashboard",
+        "sn-128-taomarketcap-source-repo",
+        "sn-128-taomarketcap-website",
+        "sn-128-taopedia-article",
+        "sn-128-tensorplex-docs"
+      ],
+      "slug": "sn-128",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/128",
+        "https://byteleap.ai/",
+        "https://github.com/byteleapai/byteleap-Miner",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json",
+        "https://taomarketcap.com/subnets/128"
+      ],
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 12,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Synth",
+      "netuid": 50,
+      "operational_interface_count": 1,
+      "priority_score": 101,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-50-github-readme-mode-network-synth-subnet-subnet-api-1",
+        "sn-50-taomarketcap-dashboard",
+        "sn-50-taomarketcap-source-repo",
+        "sn-50-taomarketcap-website",
+        "sn-50-taopedia-article"
+      ],
+      "slug": "sn-50",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/50",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx",
+        "https://github.com/mode-network/synth-subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/50/subnet.json",
+        "https://synthdata.co/",
+        "https://taomarketcap.com/subnets/50"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 12,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Leadpoet",
+      "netuid": 71,
+      "operational_interface_count": 1,
+      "priority_score": 101,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-71-github-readme-leadpoet-leadpoet-subnet-api-1",
+        "sn-71-taomarketcap-dashboard",
+        "sn-71-taomarketcap-source-repo",
+        "sn-71-taomarketcap-website",
+        "sn-71-taopedia-article"
+      ],
+      "slug": "sn-71",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/71",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx",
+        "https://github.com/leadpoet/leadpoet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/71/subnet.json",
+        "https://leadpoet.com/",
+        "https://taomarketcap.com/subnets/71"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 11,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "BitAds",
+      "netuid": 16,
+      "operational_interface_count": 1,
+      "priority_score": 99,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-16-taomarketcap-dashboard",
+        "sn-16-taomarketcap-source-repo",
+        "sn-16-taomarketcap-website",
+        "sn-16-taopedia-article",
+        "sn-16-tensorplex-docs"
+      ],
+      "slug": "sn-16",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/16",
+        "https://bitads.ai/",
+        "https://github.com/FirstTensorLabs/BitAds",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
+        "https://taomarketcap.com/subnets/16"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 11,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "colosseum",
+      "netuid": 38,
+      "operational_interface_count": 1,
+      "priority_score": 99,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-38-taomarketcap-dashboard",
+        "sn-38-taomarketcap-source-repo",
+        "sn-38-taomarketcap-website",
+        "sn-38-taopedia-article",
+        "sn-38-tensorplex-docs"
+      ],
+      "slug": "sn-38",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/38",
+        "https://github.com/TAO-Colosseum/tao-colosseum-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/38/subnet.json",
+        "https://taomarketcap.com/subnets/38",
+        "https://www.taocolosseum.com/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 11,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "CliqueAI",
+      "netuid": 83,
+      "operational_interface_count": 1,
+      "priority_score": 99,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-83-taomarketcap-dashboard",
+        "sn-83-taomarketcap-source-repo",
+        "sn-83-taomarketcap-website",
+        "sn-83-taopedia-article",
+        "sn-83-tensorplex-docs"
+      ],
+      "slug": "sn-83",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/83",
+        "https://cliqueai.toptensor.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/83/subnet.json",
+        "https://github.com/toptensor/CliqueAI",
+        "https://taomarketcap.com/subnets/83"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 11,
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 7,
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Beam",
+      "netuid": 105,
+      "operational_interface_count": 1,
+      "priority_score": 99,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-105-taomarketcap-dashboard",
+        "sn-105-taomarketcap-source-repo",
+        "sn-105-taomarketcap-website",
+        "sn-105-taopedia-article",
+        "sn-105-tensorplex-docs"
+      ],
+      "slug": "sn-105",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/105",
+        "https://b1m.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx",
+        "https://github.com/orgs/Beam-Network/repositories",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json",
+        "https://taomarketcap.com/subnets/105"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 27,
+      "candidate_count": 17,
+      "completeness_score": 63,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "adapter-backed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 7,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "dashboard",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Gittensor",
+      "netuid": 74,
+      "operational_interface_count": 1,
+      "priority_score": 94,
+      "profile_level": "adapter-backed",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "community-sn-74-openapi-api-gittensor-io",
+        "sn-74-github-readme-entrius-gittensor-docs-1",
+        "sn-74-github-readme-entrius-gittensor-docs-2",
+        "sn-74-github-readme-entrius-gittensor-docs-3",
+        "sn-74-github-readme-entrius-gittensor-docs-4"
+      ],
+      "slug": "gittensor",
+      "source_urls": [
+        "https://docs.gittensor.io/",
+        "https://docs.gittensor.io/register-repository.html",
+        "https://docs.gittensor.io/repository-hyperparameters",
+        "https://github.com/entrius/gittensor",
+        "https://gittensor.io/"
+      ],
+      "surface_count": 7,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 2,
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 12,
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "root",
+      "netuid": 0,
+      "operational_interface_count": 0,
+      "priority_score": 67,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-0-taomarketcap-dashboard",
+        "sn-0-tensorplex-docs"
+      ],
+      "slug": "root",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/0",
+        "https://bittensor.com",
+        "https://docs.learnbittensor.org/concepts/bittensor-networks",
+        "https://docs.learnbittensor.org/subtensor-nodes/subtensor-node-requirements",
+        "https://docs.nodies.app/rpc-services/public-endpoints",
+        "https://github.com/opentensor/subtensor",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/0/subnet.json",
+        "https://onfinality.io/en/networks/bittensor-finney"
+      ],
+      "surface_count": 12,
+      "verified_candidate_count": 2
+    }
+  ],
+  "schema_version": 1,
+  "summary": {
+    "adapter_candidate_count": 1,
+    "baseline_monitoring_count": 0,
+    "direct_submission_count": 95,
+    "lane_counts": {
+      "adapter-candidate": 1,
+      "direct-submission": 95,
+      "maintainer-review": 33
+    },
+    "maintainer_review_count": 33,
+    "manual_review_required_count": 34,
+    "monitoring_followup_count": 0,
+    "queue_count": 129,
+    "subnet_count": 129,
+    "top_direct_submission_kinds": {
+      "data-artifact": 43,
+      "openapi": 51,
+      "source-repo": 21,
+      "subnet-api": 51,
+      "website": 39
+    }
+  }
+}

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -378,6 +378,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/review/enrichment-queue": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch the prioritized all-subnet enrichment queue. */
+        get: operations["reviewEnrichmentQueue"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/review/gaps": {
         parameters: {
             query?: never;
@@ -1402,6 +1419,51 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        ReviewEnrichmentQueueArtifact: components["schemas"]["ArtifactBase"] & ({
+            notes: string;
+            queue: components["schemas"]["ReviewEnrichmentQueueEntry"][];
+            summary: {
+                adapter_candidate_count: number;
+                baseline_monitoring_count: number;
+                direct_submission_count: number;
+                lane_counts: components["schemas"]["CountMap"];
+                maintainer_review_count: number;
+                manual_review_required_count: number;
+                monitoring_followup_count: number;
+                queue_count: number;
+                subnet_count: number;
+                top_direct_submission_kinds: components["schemas"]["CountMap"];
+            };
+        } & {
+            [key: string]: unknown;
+        });
+        ReviewEnrichmentQueueEntry: {
+            adapter_score: number;
+            candidate_count: number;
+            completeness_score: number;
+            contribution_hint: string;
+            curation_level: components["schemas"]["CurationLevel"];
+            direct_submission_kinds: components["schemas"]["SurfaceKind"][];
+            endpoint_count: number;
+            /** @enum {unknown} */
+            lane: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+            manual_review_required: boolean;
+            missing_kinds: components["schemas"]["SurfaceKind"][];
+            name: string;
+            netuid: number;
+            operational_interface_count: number;
+            priority_score: number;
+            /** @enum {unknown} */
+            profile_level: "directory-only" | "identity-complete" | "operational" | "adapter-backed";
+            reason_codes: string[];
+            recommended_action: string;
+            review_state: components["schemas"]["ReviewState"];
+            sample_candidate_ids: string[];
+            slug: string;
+            source_urls: string[];
+            surface_count: number;
+            verified_candidate_count: number;
+        };
         ReviewGapPrioritiesArtifact: components["schemas"]["ArtifactBase"] & ({
             priorities: components["schemas"]["ReviewGapPriority"][];
         } & {
@@ -3573,6 +3635,84 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewAdapterCandidatesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    reviewEnrichmentQueue: {
+        parameters: {
+            query?: {
+                lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                netuid?: number;
+                profile_level?: "directory-only" | "identity-complete" | "operational" | "adapter-backed";
+                manual_review_required?: "true" | "false";
+                q?: string;
+                limit?: number;
+                cursor?: number;
+                sort?: "adapter_score" | "candidate_count" | "completeness_score" | "lane" | "name" | "netuid" | "priority_score" | "profile_level" | "verified_candidate_count";
+                order?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["ReviewEnrichmentQueueArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3074,6 +3074,226 @@
           }
         ]
       },
+      "ReviewEnrichmentQueueArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "notes": {
+                "type": "string"
+              },
+              "queue": {
+                "items": {
+                  "$ref": "#/components/schemas/ReviewEnrichmentQueueEntry"
+                },
+                "type": "array"
+              },
+              "summary": {
+                "additionalProperties": false,
+                "properties": {
+                  "adapter_candidate_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "baseline_monitoring_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "direct_submission_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "lane_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  },
+                  "maintainer_review_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "manual_review_required_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "monitoring_followup_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "queue_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "top_direct_submission_kinds": {
+                    "$ref": "#/components/schemas/CountMap"
+                  }
+                },
+                "required": [
+                  "adapter_candidate_count",
+                  "baseline_monitoring_count",
+                  "direct_submission_count",
+                  "lane_counts",
+                  "maintainer_review_count",
+                  "manual_review_required_count",
+                  "monitoring_followup_count",
+                  "queue_count",
+                  "subnet_count",
+                  "top_direct_submission_kinds"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "notes",
+              "queue",
+              "summary"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ReviewEnrichmentQueueEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "adapter_score": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "completeness_score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "contribution_hint": {
+            "type": "string"
+          },
+          "curation_level": {
+            "$ref": "#/components/schemas/CurationLevel"
+          },
+          "direct_submission_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "endpoint_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "lane": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ]
+          },
+          "manual_review_required": {
+            "type": "boolean"
+          },
+          "missing_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "operational_interface_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "priority_score": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "profile_level": {
+            "enum": [
+              "directory-only",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ]
+          },
+          "reason_codes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "recommended_action": {
+            "type": "string"
+          },
+          "review_state": {
+            "$ref": "#/components/schemas/ReviewState"
+          },
+          "sample_candidate_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "source_urls": {
+            "items": {
+              "format": "uri",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "surface_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "verified_candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "adapter_score",
+          "candidate_count",
+          "completeness_score",
+          "contribution_hint",
+          "curation_level",
+          "direct_submission_kinds",
+          "endpoint_count",
+          "lane",
+          "manual_review_required",
+          "missing_kinds",
+          "name",
+          "netuid",
+          "operational_interface_count",
+          "priority_score",
+          "profile_level",
+          "reason_codes",
+          "recommended_action",
+          "review_state",
+          "sample_candidate_ids",
+          "slug",
+          "source_urls",
+          "surface_count",
+          "verified_candidate_count"
+        ],
+        "type": "object"
+      },
       "ReviewGapPrioritiesArtifact": {
         "allOf": [
           {

--- a/schemas/components/11-review-intake.schema.json
+++ b/schemas/components/11-review-intake.schema.json
@@ -178,6 +178,143 @@
         },
         "additionalProperties": false
       },
+      "ReviewEnrichmentQueueEntry": {
+        "type": "object",
+        "required": [
+          "adapter_score",
+          "candidate_count",
+          "completeness_score",
+          "contribution_hint",
+          "curation_level",
+          "direct_submission_kinds",
+          "endpoint_count",
+          "lane",
+          "manual_review_required",
+          "missing_kinds",
+          "name",
+          "netuid",
+          "operational_interface_count",
+          "priority_score",
+          "profile_level",
+          "reason_codes",
+          "recommended_action",
+          "review_state",
+          "sample_candidate_ids",
+          "slug",
+          "source_urls",
+          "surface_count",
+          "verified_candidate_count"
+        ],
+        "properties": {
+          "adapter_score": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "candidate_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "completeness_score": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 100
+          },
+          "contribution_hint": {
+            "type": "string"
+          },
+          "curation_level": {
+            "$ref": "#/components/schemas/CurationLevel"
+          },
+          "direct_submission_kinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            }
+          },
+          "endpoint_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "lane": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ]
+          },
+          "manual_review_required": {
+            "type": "boolean"
+          },
+          "missing_kinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "operational_interface_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "priority_score": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "profile_level": {
+            "enum": [
+              "directory-only",
+              "identity-complete",
+              "operational",
+              "adapter-backed"
+            ]
+          },
+          "reason_codes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "recommended_action": {
+            "type": "string"
+          },
+          "review_state": {
+            "$ref": "#/components/schemas/ReviewState"
+          },
+          "sample_candidate_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "slug": {
+            "type": "string"
+          },
+          "source_urls": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          "surface_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "verified_candidate_count": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
       "ReviewDecision": {
         "type": "object",
         "required": [
@@ -379,6 +516,85 @@
                     "$ref": "#/components/schemas/CountMap"
                   },
                   "critical_gap_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
+      },
+      "ReviewEnrichmentQueueArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "type": "object",
+            "required": ["notes", "queue", "summary"],
+            "properties": {
+              "notes": {
+                "type": "string"
+              },
+              "queue": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ReviewEnrichmentQueueEntry"
+                }
+              },
+              "summary": {
+                "type": "object",
+                "required": [
+                  "adapter_candidate_count",
+                  "baseline_monitoring_count",
+                  "direct_submission_count",
+                  "lane_counts",
+                  "maintainer_review_count",
+                  "manual_review_required_count",
+                  "monitoring_followup_count",
+                  "queue_count",
+                  "subnet_count",
+                  "top_direct_submission_kinds"
+                ],
+                "properties": {
+                  "adapter_candidate_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "baseline_monitoring_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "direct_submission_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "lane_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  },
+                  "maintainer_review_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "manual_review_required_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "monitoring_followup_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "queue_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "subnet_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "top_direct_submission_kinds": {
                     "$ref": "#/components/schemas/CountMap"
                   }
                 },

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -261,6 +261,12 @@ const profileArtifacts = buildSubnetProfileArtifacts({
   subnets: mergedSubnets,
   surfaces,
 });
+const enrichmentQueue = buildEnrichmentQueueArtifact({
+  candidates: candidateIndex,
+  curationReview,
+  profiles: profileArtifacts.profiles,
+  reviewProfiles: profileArtifacts.reviewProfiles,
+});
 
 const reviewQueue = candidateIndex.filter((candidate) =>
   ["schema-valid", "maintainer-review", "stale"].includes(candidate.state),
@@ -630,6 +636,7 @@ await writeJson(artifactFile("review/adapter-candidates.json"), {
   generated_at: generatedAt,
   candidates: curationReview.adapter_candidates,
 });
+await writeJson(artifactFile("review/enrichment-queue.json"), enrichmentQueue);
 await writeJson(artifactFile("review/maintainer-decisions.json"), {
   schema_version: 1,
   contract_version: contractVersion,
@@ -938,6 +945,285 @@ function buildSubnetProfileArtifacts({
       by_confidence: countBy(profiles, "confidence"),
     },
   };
+}
+
+function buildEnrichmentQueueArtifact({
+  candidates,
+  curationReview,
+  profiles,
+  reviewProfiles,
+}) {
+  const reviewProfileByNetuid = new Map(
+    reviewProfiles.map((profile) => [profile.netuid, profile]),
+  );
+  const gapPriorityByNetuid = new Map(
+    (curationReview.gap_priorities || []).map((priority) => [
+      priority.netuid,
+      priority,
+    ]),
+  );
+  const adapterCandidateByNetuid = new Map(
+    (curationReview.adapter_candidates || []).map((candidate) => [
+      candidate.netuid,
+      candidate,
+    ]),
+  );
+  const candidatesByNetuid = groupByNetuid(candidates);
+
+  const queue = profiles
+    .map((profile) =>
+      enrichmentQueueEntry({
+        adapterCandidate: adapterCandidateByNetuid.get(profile.netuid),
+        gapPriority: gapPriorityByNetuid.get(profile.netuid),
+        profile,
+        reviewProfile: reviewProfileByNetuid.get(profile.netuid),
+        subnetCandidates: candidatesByNetuid.get(profile.netuid) || [],
+      }),
+    )
+    .sort(
+      (a, b) =>
+        b.priority_score - a.priority_score ||
+        a.lane.localeCompare(b.lane) ||
+        a.netuid - b.netuid,
+    );
+
+  return {
+    schema_version: 1,
+    contract_version: contractVersion,
+    generated_at: generatedAt,
+    notes:
+      "Prioritized enrichment queue derived from public-safe profile gaps, candidate counts, review state, adapter potential, and probe-derived endpoint incidents. It is contributor guidance, not a contribution API.",
+    summary: {
+      subnet_count: profiles.length,
+      queue_count: queue.length,
+      direct_submission_count: queue.filter(
+        (entry) => entry.lane === "direct-submission",
+      ).length,
+      maintainer_review_count: queue.filter(
+        (entry) => entry.lane === "maintainer-review",
+      ).length,
+      adapter_candidate_count: queue.filter(
+        (entry) => entry.lane === "adapter-candidate",
+      ).length,
+      monitoring_followup_count: queue.filter(
+        (entry) => entry.lane === "monitoring-followup",
+      ).length,
+      baseline_monitoring_count: queue.filter(
+        (entry) => entry.lane === "baseline-monitoring",
+      ).length,
+      manual_review_required_count: queue.filter(
+        (entry) => entry.manual_review_required,
+      ).length,
+      lane_counts: countBy(queue, "lane"),
+      top_direct_submission_kinds: countDirectSubmissionKinds(queue),
+    },
+    queue,
+  };
+}
+
+function enrichmentQueueEntry({
+  adapterCandidate,
+  gapPriority,
+  profile,
+  reviewProfile,
+  subnetCandidates,
+}) {
+  const missingRequired = profile.completeness.missing_required || [];
+  const missingOperational = profile.completeness.missing_operational || [];
+  const missingKinds = [
+    ...new Set([
+      ...(gapPriority?.missing_kinds || []),
+      ...missingRequired,
+      ...missingOperational,
+    ]),
+  ].sort();
+  const directSubmissionKinds = directSubmissionKindsForProfile(profile);
+  const lane = enrichmentLane({
+    adapterCandidate,
+    directSubmissionKinds,
+    profile,
+  });
+  const manualReviewRequired = [
+    "maintainer-review",
+    "adapter-candidate",
+  ].includes(lane);
+  const adapterScore = adapterCandidate?.priority_score || 0;
+  const priorityScore =
+    (reviewProfile?.priority_score || 100 - profile.completeness_score) +
+    Math.floor((gapPriority?.priority_score || 0) / 2) +
+    Math.floor(adapterScore / 2);
+
+  return {
+    adapter_score: adapterScore,
+    candidate_count: profile.candidate_count,
+    completeness_score: profile.completeness_score,
+    contribution_hint: enrichmentContributionHint(lane, directSubmissionKinds),
+    curation_level: profile.curation_level,
+    direct_submission_kinds: directSubmissionKinds,
+    endpoint_count: profile.endpoint_count,
+    lane,
+    manual_review_required: manualReviewRequired,
+    missing_kinds: missingKinds,
+    name: profile.name,
+    netuid: profile.netuid,
+    operational_interface_count: profile.operational_interface_count,
+    priority_score: priorityScore,
+    profile_level: profile.profile_level,
+    reason_codes: enrichmentReasonCodes({
+      adapterCandidate,
+      directSubmissionKinds,
+      profile,
+    }),
+    recommended_action: enrichmentRecommendedAction({
+      adapterCandidate,
+      directSubmissionKinds,
+      lane,
+      profile,
+      reviewProfile,
+    }),
+    review_state: profile.review_state,
+    sample_candidate_ids: subnetCandidates
+      .map((candidate) => candidate.id)
+      .filter(Boolean)
+      .sort()
+      .slice(0, 5),
+    slug: profile.slug,
+    source_urls: (profile.provenance.source_urls || []).slice(0, 8),
+    surface_count: profile.surface_count,
+    verified_candidate_count: gapPriority?.verified_candidate_count || 0,
+  };
+}
+
+function directSubmissionKindsForProfile(profile) {
+  const missingRequired = new Set(profile.completeness.missing_required || []);
+  const identityTargets = ["docs", "website", "source-repo"].filter((kind) =>
+    missingRequired.has(kind),
+  );
+  if (identityTargets.length > 0) {
+    return identityTargets;
+  }
+
+  const missingOperational = new Set(
+    profile.completeness.missing_operational || [],
+  );
+  const hasOperationalEvidence = profile.operational_interface_count > 0;
+  const operationalTargets = ["openapi", "subnet-api", "data-artifact"].filter(
+    (kind) => missingOperational.has(kind),
+  );
+  if (!hasOperationalEvidence) {
+    return operationalTargets;
+  }
+
+  const hasApiLikeEvidence = profile.operational_interface_kinds.some((kind) =>
+    ["openapi", "subnet-api"].includes(kind),
+  );
+  if (!hasApiLikeEvidence) {
+    return operationalTargets.filter((kind) =>
+      ["openapi", "subnet-api"].includes(kind),
+    );
+  }
+
+  return [];
+}
+
+function enrichmentLane({ adapterCandidate, directSubmissionKinds, profile }) {
+  if (directSubmissionKinds.length > 0) {
+    return "direct-submission";
+  }
+  if (
+    profile.review_state !== "maintainer-reviewed" &&
+    profile.surface_count > 0
+  ) {
+    return "maintainer-review";
+  }
+  if (adapterCandidate?.operational_surface_count > 0) {
+    return "adapter-candidate";
+  }
+  return "baseline-monitoring";
+}
+
+function enrichmentReasonCodes({
+  adapterCandidate,
+  directSubmissionKinds,
+  profile,
+}) {
+  const reasons = [];
+  if (profile.profile_level === "directory-only") {
+    reasons.push("directory-only-profile");
+  }
+  for (const kind of directSubmissionKinds) {
+    reasons.push(`missing-${kind}`);
+  }
+  if (profile.review_state !== "maintainer-reviewed") {
+    reasons.push("needs-maintainer-review");
+  }
+  if (adapterCandidate?.operational_surface_count > 0) {
+    reasons.push("adapter-candidate");
+  }
+  return [...new Set(reasons)].sort();
+}
+
+function enrichmentContributionHint(lane, directSubmissionKinds) {
+  if (lane === "direct-submission") {
+    const kinds = directSubmissionKinds.join(", ");
+    return `Submit one official public ${kinds || "interface"} candidate with npm run candidate:new.`;
+  }
+  if (lane === "maintainer-review") {
+    return "Maintainer should review current machine-verified surfaces and promote only source-backed entries.";
+  }
+  if (lane === "adapter-candidate") {
+    return "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.";
+  }
+  if (lane === "monitoring-followup") {
+    return "Endpoint status reports can trigger re-probes or review, but observed health remains probe-derived.";
+  }
+  return "No immediate enrichment action; keep monitoring for drift and new public interfaces.";
+}
+
+function enrichmentRecommendedAction({
+  adapterCandidate,
+  directSubmissionKinds,
+  lane,
+  profile,
+  reviewProfile,
+}) {
+  if (lane === "direct-submission") {
+    if (
+      directSubmissionKinds.some((kind) =>
+        ["docs", "website", "source-repo"].includes(kind),
+      )
+    ) {
+      return "submit official docs, website, or source repository evidence";
+    }
+    return "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them";
+  }
+  if (lane === "maintainer-review") {
+    return (
+      reviewProfile?.suggested_next_action ||
+      "review promoted surfaces and mark maintainer-reviewed where provenance is strong"
+    );
+  }
+  if (lane === "adapter-candidate") {
+    const kinds = (adapterCandidate.operational_kinds || []).join(", ");
+    return `evaluate adapter support for ${kinds || "operational surfaces"}`;
+  }
+  if (profile.operational_interface_count > 0) {
+    return "profile is baseline-complete; monitor operational surfaces for drift";
+  }
+  return "profile is baseline-complete; monitor for new public interfaces";
+}
+
+function countDirectSubmissionKinds(queue) {
+  return Object.fromEntries(
+    Object.entries(
+      queue.reduce((accumulator, entry) => {
+        for (const kind of entry.direct_submission_kinds || []) {
+          accumulator[kind] = (accumulator[kind] || 0) + 1;
+        }
+        return accumulator;
+      }, {}),
+    ).sort(([a], [b]) => a.localeCompare(b)),
+  );
 }
 
 function countGapReasons(profiles) {

--- a/scripts/curation-brief.mjs
+++ b/scripts/curation-brief.mjs
@@ -18,17 +18,24 @@ if (isCliEntrypoint()) {
 }
 
 export async function loadCurationSnapshot({ limit = 12 } = {}) {
-  const [coverage, profileCompleteness, gapPriorities, adapterCandidates] =
-    await Promise.all([
-      readArtifact("coverage.json"),
-      readArtifact("review/profile-completeness.json"),
-      readArtifact("review/gap-priorities.json"),
-      readArtifact("review/adapter-candidates.json"),
-    ]);
+  const [
+    coverage,
+    profileCompleteness,
+    gapPriorities,
+    adapterCandidates,
+    enrichmentQueue,
+  ] = await Promise.all([
+    readArtifact("coverage.json"),
+    readArtifact("review/profile-completeness.json"),
+    readArtifact("review/gap-priorities.json"),
+    readArtifact("review/adapter-candidates.json"),
+    readArtifact("review/enrichment-queue.json"),
+  ]);
 
   const profiles = profileCompleteness.profiles || [];
   const priorities = gapPriorities.priorities || [];
   const adapters = adapterCandidates.candidates || [];
+  const queue = enrichmentQueue.queue || [];
 
   return {
     schema_version: 1,
@@ -50,6 +57,8 @@ export async function loadCurationSnapshot({ limit = 12 } = {}) {
       critical_gap_counts:
         profileCompleteness.summary?.critical_gap_counts || {},
     },
+    enrichment_summary: enrichmentQueue.summary || {},
+    enrichment_queue: queue.slice(0, limit).map(enrichmentBriefRow),
     lowest_completeness: profiles.slice(0, limit).map(profileBriefRow),
     highest_gap_priority: priorities.slice(0, limit).map(priorityBriefRow),
     adapter_candidates: adapters.slice(0, limit).map(adapterBriefRow),
@@ -79,6 +88,8 @@ export async function loadCurationSnapshot({ limit = 12 } = {}) {
 }
 
 export function renderCurationBrief(snapshot) {
+  const enrichmentSummary = snapshot.enrichment_summary || {};
+  const enrichmentQueue = snapshot.enrichment_queue || [];
   const lines = [
     "# Metagraphed Curation Brief",
     "",
@@ -100,6 +111,19 @@ export function renderCurationBrief(snapshot) {
     "## Best Direct PR Targets",
     "",
     "Submit one public-safe candidate at a time with `npm run candidate:new`. Official docs, websites, source repos, OpenAPI/schema URLs, public subnet APIs, dashboards, SDKs, examples, and data artifacts are the best auto-review candidates.",
+    "",
+    `- Enrichment queue lanes: ${formatCounts(enrichmentSummary.lane_counts)}`,
+    `- Direct-submission targets: ${enrichmentSummary.direct_submission_count ?? "unknown"}`,
+    `- Maintainer-review targets: ${enrichmentSummary.maintainer_review_count ?? "unknown"}`,
+    `- Manual-review-required targets: ${enrichmentSummary.manual_review_required_count ?? "unknown"}`,
+    "",
+    ...numberedRows(
+      enrichmentQueue,
+      (row) =>
+        `SN${row.netuid} ${row.name} - ${row.lane}; priority ${row.priority_score}; ${row.recommended_action}; target kinds: ${row.direct_submission_kinds.join(", ") || "n/a"}`,
+    ),
+    "",
+    "## Lowest Profile Completeness",
     "",
     ...numberedRows(
       snapshot.lowest_completeness,
@@ -177,6 +201,21 @@ function adapterBriefRow(candidate) {
       candidate.surface_count ?? candidate.operational_surface_count ?? 0,
     surface_kinds: candidate.surface_kinds || candidate.operational_kinds || [],
     suggested_adapter: candidate.suggested_adapter,
+  };
+}
+
+function enrichmentBriefRow(entry) {
+  return {
+    netuid: entry.netuid,
+    name: entry.name,
+    slug: entry.slug,
+    lane: entry.lane,
+    priority_score: entry.priority_score,
+    completeness_score: entry.completeness_score,
+    direct_submission_kinds: entry.direct_submission_kinds || [],
+    manual_review_required: entry.manual_review_required,
+    reason_codes: entry.reason_codes || [],
+    recommended_action: entry.recommended_action,
   };
 }
 

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -160,6 +160,16 @@ const checks = [
     (body) => assert.equal(body.data.candidates.length <= 3, true),
   ],
   [
+    "/api/v1/review/enrichment-queue?lane=direct-submission&limit=3",
+    (body) => {
+      assert.equal(body.data.queue.length <= 3, true);
+      assert.equal(
+        body.data.queue.every((entry) => entry.lane === "direct-submission"),
+        true,
+      );
+    },
+  ],
+  [
     "/api/v1/health",
     (body) => assert.equal(Array.isArray(body.data.subnets), true),
   ],

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -51,6 +51,7 @@ const DUAL_PATTERNS = [
   /^r2-manifest\.json$/,
   /^review\/adapter-candidates\.json$/,
   /^review\/curation\.json$/,
+  /^review\/enrichment-queue\.json$/,
   /^review\/gap-priorities\.json$/,
   /^review\/maintainer-decisions\.json$/,
   /^schema-drift\.json$/,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -267,6 +267,37 @@ export const API_QUERY_COLLECTIONS = {
       "priority_score",
     ],
   }),
+  "enrichment-queue": queryCollection("queue", {
+    filters: {
+      lane: enumSchema([
+        "direct-submission",
+        "maintainer-review",
+        "adapter-candidate",
+        "monitoring-followup",
+        "baseline-monitoring",
+      ]),
+      netuid: integerSchema,
+      profile_level: enumSchema([
+        "directory-only",
+        "identity-complete",
+        "operational",
+        "adapter-backed",
+      ]),
+      manual_review_required: enumSchema(["true", "false"]),
+    },
+    search: ["name", "slug", "recommended_action", "reason_codes"],
+    sort: [
+      "adapter_score",
+      "candidate_count",
+      "completeness_score",
+      "lane",
+      "name",
+      "netuid",
+      "priority_score",
+      "profile_level",
+      "verified_candidate_count",
+    ],
+  }),
   "health-subnets": queryCollection("subnets", {
     filters: {
       netuid: integerSchema,
@@ -637,6 +668,12 @@ export const PUBLIC_ARTIFACTS = [
     "ReviewAdapterCandidatesArtifact",
   ),
   artifact(
+    "review-enrichment-queue",
+    "/metagraph/review/enrichment-queue.json",
+    "Prioritized all-subnet enrichment work queue for contributor-safe registry improvements.",
+    "ReviewEnrichmentQueueArtifact",
+  ),
+  artifact(
     "review-decisions",
     "/metagraph/review/maintainer-decisions.json",
     "Public-safe maintainer review decision ledger.",
@@ -855,6 +892,16 @@ export const API_ROUTES = [
     "standard",
     ["adapters", "review"],
     listQuery("adapter-candidates"),
+  ),
+  route(
+    "review-enrichment-queue",
+    "GET",
+    "/api/v1/review/enrichment-queue",
+    "/metagraph/review/enrichment-queue.json",
+    "Fetch the prioritized all-subnet enrichment queue.",
+    "standard",
+    ["registry", "review", "profiles"],
+    listQuery("enrichment-queue"),
   ),
   route(
     "health",

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -369,6 +369,7 @@ test("public artifacts are internally consistent", () => {
   const gapPriorities = readArtifact("review/gap-priorities.json");
   const profileCompleteness = readArtifact("review/profile-completeness.json");
   const adapterCandidates = readArtifact("review/adapter-candidates.json");
+  const enrichmentQueue = readArtifact("review/enrichment-queue.json");
   const reviewDecisions = readArtifact("review/maintainer-decisions.json");
   const generatedCandidateDiscovery = JSON.parse(
     readFileSync("registry/candidates/generated/public-sources.json", "utf8"),
@@ -604,6 +605,23 @@ test("public artifacts are internally consistent", () => {
   assert.equal(reviewCuration.summary.subnet_count, native.subnets.length);
   assert.equal(gapPriorities.priorities.length, native.subnets.length);
   assert.equal(profileCompleteness.profiles.length, native.subnets.length);
+  assert.equal(enrichmentQueue.summary.subnet_count, native.subnets.length);
+  assert.equal(enrichmentQueue.summary.queue_count, native.subnets.length);
+  assert.equal(enrichmentQueue.queue.length, native.subnets.length);
+  assert.equal(
+    enrichmentQueue.queue.some((entry) => entry.lane === "direct-submission"),
+    true,
+  );
+  assert.equal(
+    enrichmentQueue.queue.some((entry) => entry.manual_review_required),
+    true,
+  );
+  assert.equal(
+    enrichmentQueue.queue.every((entry) =>
+      Array.isArray(entry.direct_submission_kinds),
+    ),
+    true,
+  );
   assert.deepEqual(profileCompleteness.summary.by_profile_level, {
     "adapter-backed": 2,
     "directory-only": 38,


### PR DESCRIPTION
## Summary
- add a compact all-subnet enrichment queue artifact and API route
- classify enrichment work into direct submission, maintainer review, adapter candidate, monitoring follow-up, and baseline monitoring lanes
- update curation docs/briefs so contributors can pick useful subnet data work without a separate contribution API

## What changed
- Added `/metagraph/review/enrichment-queue.json` and `/api/v1/review/enrichment-queue`.
- Added strict JSON Schema/OpenAPI/TypeScript contract coverage for the queue.
- Updated `npm run curation:brief` to show enrichment lane counts and prioritized targets.
- Added artifact tests so the queue covers every active netuid and includes both direct and manual-review lanes.

## Why
Metagraphed already has full active-subnet coverage, but enrichment work was split across separate profile, gap, and adapter reports. This gives contributors and future UI/API consumers one stable backend work queue for improving every subnet one verified public interface at a time.

## Validation
- `npm run check`
- `npm run test:coverage` - 97.38% statements, 85 tests
- `npm run validate:api` - 39 routes
- `npm run validate:schemas`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:openapi-examples`
- `npm run validate:generated-client`
- `npm run validate:artifact-budgets` - 0 warnings
- `npm run scan:public-safety`
- `git diff --check`

## Notes
- This does not refresh candidate data or promote new subnet surfaces.
- Health and endpoint status remain probe-derived only.
- The queue is contributor guidance and backend metadata, not a new UGC API.
