### PR TITLE
test(artifacts): avoid pinning live profile buckets

### DIFF
--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -622,12 +622,32 @@ test("public artifacts are internally consistent", () => {
     ),
     true,
   );
-  assert.deepEqual(profileCompleteness.summary.by_profile_level, {
-    "adapter-backed": 2,
-    "directory-only": 38,
-    "identity-complete": 43,
-    operational: 46,
-  });
+  assert.deepEqual(
+    profileCompleteness.summary.by_profile_level,
+    profileCompleteness.profiles.reduce((counts, profile) => {
+      counts[profile.profile_level] = (counts[profile.profile_level] || 0) + 1;
+      return counts;
+    }, {}),
+  );
+  assert.equal(
+    Object.values(profileCompleteness.summary.by_profile_level).reduce(
+      (sum, count) => sum + count,
+      0,
+    ),
+    native.subnets.length,
+  );
+  assert.equal(
+    profileCompleteness.summary.by_profile_level["adapter-backed"] >= 2,
+    true,
+  );
+  assert.equal(
+    profileCompleteness.summary.by_profile_level["directory-only"] > 0,
+    true,
+  );
+  assert.equal(
+    profileCompleteness.summary.by_profile_level.operational > 0,
+    true,
+  );
   assert.equal(
     profileCompleteness.summary.critical_gap_counts["missing-openapi"] > 0,
     true,


### PR DESCRIPTION
## Summary
- Make the artifact consistency test compare profile bucket summaries against generated profile rows.
- Keep live profile distribution checks as invariants instead of fixed counts.

## Why
- The publish refresh can legitimately move subnets between profile buckets as live candidate verification changes.
- The old test blocked publish on a valid live-data distribution change.

## Validation
- `npm run check`
- `npm run test:coverage`
- `npm test`
- `git diff --check`

## Notes
- No generated registry artifacts are included in this PR.