### PR TITLE
feat(review): add enrichment evidence details

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -69,6 +69,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/review/profile-completeness.json`: profile completeness and contributor targeting report.
 - `/metagraph/review/adapter-candidates.json`: subnets likely worth custom adapters.
 - `/metagraph/review/enrichment-queue.json`: prioritized all-subnet enrichment queue with direct-submission, maintainer-review, adapter, and monitoring lanes.
+- `/metagraph/review/enrichment-evidence.json`: detailed candidate evidence by missing or contributor-target surface kind. R2-backed.
 - `/metagraph/review/maintainer-decisions.json`: public-safe maintainer decision ledger.
 - `/metagraph/build-summary.json`: generated build summary.
 
@@ -95,6 +96,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/review/profile-completeness`: fetch profile completeness gaps for contributor targeting.
 - `/api/v1/review/adapter-candidates`: fetch subnets worth deeper adapter work.
 - `/api/v1/review/enrichment-queue`: fetch the prioritized all-subnet enrichment queue.
+- `/api/v1/review/enrichment-evidence`: fetch detailed candidate evidence behind the enrichment queue.
 - `/api/v1/health`: fetch global health summary.
 - `/api/v1/health/history/{date}`: fetch compact daily health history.
 - `/api/v1/subnets/{netuid}/health`: fetch health detail for one subnet.

--- a/docs/curation-playbook.md
+++ b/docs/curation-playbook.md
@@ -31,6 +31,29 @@ The enrichment queue is also available through
 registry truth; it only prioritizes public-safe work derived from current
 artifacts.
 
+Detailed candidate evidence behind the queue is available through
+`/api/v1/review/enrichment-evidence`. That route is R2-backed so full
+per-kind candidate classifications do not create noisy Git diffs.
+
+Queue entries include `evidence_action` so contributors and maintainers can
+avoid duplicate work:
+
+- `submit-new-evidence`: no useful candidate exists for the target gap yet;
+- `verify-existing-evidence`: candidate records exist, but recurring
+  verification has not produced a live classification yet;
+- `replace-stale-evidence`: candidates exist, but current verification did not
+  produce live registry truth;
+- `review-existing-evidence`: live or redirected candidates exist and need
+  source review before promotion;
+- `maintainer-review-existing-evidence`: the entry belongs in maintainer or
+  adapter review instead of a direct contributor PR;
+- `monitor`: no immediate enrichment action is available.
+
+Queue rows include a compact `candidate_evidence_summary`; the detailed
+`candidate_evidence_by_kind` map lives in the evidence artifact. This is
+guidance only; health, uptime, latency, and pool eligibility remain
+probe-derived.
+
 ## What Fully Curated Means
 
 For each subnet, aim to confirm the maximum public surface set the subnet

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -378,6 +378,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/review/enrichment-evidence": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch detailed candidate evidence behind the enrichment queue. */
+        get: operations["reviewEnrichmentEvidence"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/review/enrichment-queue": {
         parameters: {
             query?: never;
@@ -1389,6 +1406,26 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        ReviewCandidateEvidence: {
+            candidate_count: number;
+            classifications: components["schemas"]["CountMap"];
+            live_or_redirected_count: number;
+            reviewable_count: number;
+            sample_candidate_ids: string[];
+            stale_or_failed_count: number;
+            unverified_count: number;
+        };
+        ReviewCandidateEvidenceSummary: {
+            candidate_count: number;
+            kinds_with_candidates: components["schemas"]["SurfaceKind"][];
+            live_kinds: components["schemas"]["SurfaceKind"][];
+            live_or_redirected_count: number;
+            reviewable_count: number;
+            stale_kinds: components["schemas"]["SurfaceKind"][];
+            stale_or_failed_count: number;
+            unverified_count: number;
+            unverified_kinds: components["schemas"]["SurfaceKind"][];
+        };
         ReviewCurationArtifact: components["schemas"]["ArtifactBase"] & ({
             adapter_candidates: components["schemas"]["ReviewAdapterCandidate"][];
             gap_priorities: components["schemas"]["ReviewGapPriority"][];
@@ -1419,6 +1456,35 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        ReviewEnrichmentEvidenceArtifact: components["schemas"]["ArtifactBase"] & ({
+            entries: components["schemas"]["ReviewEnrichmentEvidenceEntry"][];
+            notes: string;
+            summary: {
+                entry_count: number;
+                evidence_action_counts: components["schemas"]["CountMap"];
+                stale_candidate_count: number;
+                subnet_count: number;
+                unverified_candidate_count: number;
+            };
+        } & {
+            [key: string]: unknown;
+        });
+        ReviewEnrichmentEvidenceEntry: {
+            candidate_evidence_by_kind: {
+                [key: string]: components["schemas"]["ReviewCandidateEvidence"];
+            };
+            candidate_evidence_summary: components["schemas"]["ReviewCandidateEvidenceSummary"];
+            direct_submission_kinds: components["schemas"]["SurfaceKind"][];
+            evidence_action: components["schemas"]["ReviewEvidenceAction"];
+            lane: components["schemas"]["ReviewEnrichmentLane"];
+            missing_kinds: components["schemas"]["SurfaceKind"][];
+            name: string;
+            netuid: number;
+            priority_score: number;
+            slug: string;
+        };
+        /** @enum {unknown} */
+        ReviewEnrichmentLane: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
         ReviewEnrichmentQueueArtifact: components["schemas"]["ArtifactBase"] & ({
             notes: string;
             queue: components["schemas"]["ReviewEnrichmentQueueEntry"][];
@@ -1426,6 +1492,7 @@ export interface components {
                 adapter_candidate_count: number;
                 baseline_monitoring_count: number;
                 direct_submission_count: number;
+                evidence_action_counts: components["schemas"]["CountMap"];
                 lane_counts: components["schemas"]["CountMap"];
                 maintainer_review_count: number;
                 manual_review_required_count: number;
@@ -1440,13 +1507,14 @@ export interface components {
         ReviewEnrichmentQueueEntry: {
             adapter_score: number;
             candidate_count: number;
+            candidate_evidence_summary: components["schemas"]["ReviewCandidateEvidenceSummary"];
             completeness_score: number;
             contribution_hint: string;
             curation_level: components["schemas"]["CurationLevel"];
             direct_submission_kinds: components["schemas"]["SurfaceKind"][];
             endpoint_count: number;
-            /** @enum {unknown} */
-            lane: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+            evidence_action: components["schemas"]["ReviewEvidenceAction"];
+            lane: components["schemas"]["ReviewEnrichmentLane"];
             manual_review_required: boolean;
             missing_kinds: components["schemas"]["SurfaceKind"][];
             name: string;
@@ -1461,9 +1529,12 @@ export interface components {
             sample_candidate_ids: string[];
             slug: string;
             source_urls: string[];
+            stale_candidate_count: number;
             surface_count: number;
             verified_candidate_count: number;
         };
+        /** @enum {unknown} */
+        ReviewEvidenceAction: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
         ReviewGapPrioritiesArtifact: components["schemas"]["ArtifactBase"] & ({
             priorities: components["schemas"]["ReviewGapPriority"][];
         } & {
@@ -3635,6 +3706,83 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewAdapterCandidatesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    reviewEnrichmentEvidence: {
+        parameters: {
+            query?: {
+                evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                netuid?: number;
+                q?: string;
+                limit?: number;
+                cursor?: number;
+                sort?: "evidence_action" | "lane" | "name" | "netuid" | "priority_score";
+                order?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["ReviewEnrichmentEvidenceArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -338,6 +338,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "review-enrichment-evidence",
+      "path": "/metagraph/review/enrichment-evidence.json",
+      "schema_ref": "#/components/schemas/ReviewEnrichmentEvidenceArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",
       "schema_ref": "#/components/schemas/ReviewDecisionsArtifact",
@@ -2042,6 +2049,100 @@
               "priority_score",
               "profile_level",
               "verified_candidate_count"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "order",
+          "schema": {
+            "enum": [
+              "asc",
+              "desc"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "artifact_path": "/metagraph/review/enrichment-evidence.json",
+      "cache": "standard",
+      "description": "Fetch detailed candidate evidence behind the enrichment queue.",
+      "id": "review-enrichment-evidence",
+      "method": "GET",
+      "path": "/api/v1/review/enrichment-evidence",
+      "public": true,
+      "query_collection": "enrichment-evidence",
+      "query_filter_names": [
+        "evidence_action",
+        "lane",
+        "netuid"
+      ],
+      "query_parameters": [
+        {
+          "name": "evidence_action",
+          "schema": {
+            "enum": [
+              "submit-new-evidence",
+              "verify-existing-evidence",
+              "replace-stale-evidence",
+              "review-existing-evidence",
+              "maintainer-review-existing-evidence",
+              "monitor"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "lane",
+          "schema": {
+            "enum": [
+              "direct-submission",
+              "maintainer-review",
+              "adapter-candidate",
+              "monitoring-followup",
+              "baseline-monitoring"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "netuid",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "q",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "limit",
+          "schema": {
+            "maximum": 1000,
+            "minimum": 1,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "cursor",
+          "schema": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        {
+          "name": "sort",
+          "schema": {
+            "enum": [
+              "evidence_action",
+              "lane",
+              "name",
+              "netuid",
+              "priority_score"
             ],
             "type": "string"
           }

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -2,29 +2,29 @@
   "adapter_count": 2,
   "artifact_budget_summary": {
     "fail_count": 0,
-    "ok_count": 1098,
+    "ok_count": 1099,
     "warn_count": 0
   },
   "artifact_budgets": [],
   "artifact_count": 22,
-  "artifact_size_bytes": 3695569,
+  "artifact_size_bytes": 3775161,
   "artifacts": [
     {
       "path": "api-index.json",
-      "sha256": "21ce9893dde3ea9167c33e5286e33155a01c30c02d9fc929db42d451748050a8",
-      "size_bytes": 71451,
+      "sha256": "05d06b56a2084e498c7f2ae450278e87fed697093adbd4675e53f60c276be188",
+      "size_bytes": 73942,
       "storage_tier": "dual"
     },
     {
       "path": "changelog.json",
-      "sha256": "cf481d4564c2486148c7c695feab215bd56f34d6b519bbca04c52c9251c950f9",
-      "size_bytes": 1361,
+      "sha256": "560420248798a5952d089a6f0d2c850bf6f6bd9a258b319ed3b52c204113880e",
+      "size_bytes": 1209,
       "storage_tier": "dual"
     },
     {
       "path": "contracts.json",
-      "sha256": "90b3088030cb6cc1ca0ee04ece29f4dbc69a780c575d8d4dba7dabd86d4a4546",
-      "size_bytes": 17812,
+      "sha256": "4b443c83aa9d91ffc38a5f3f76b8e103cd12b55cf04a708b16b7048eb132b24f",
+      "size_bytes": 18234,
       "storage_tier": "dual"
     },
     {
@@ -59,8 +59,8 @@
     },
     {
       "path": "openapi.json",
-      "sha256": "83b127b2bcf5c225ed012c7bd324f85b1f85ff09ee872f080f72688d7f49b9a5",
-      "size_bytes": 308627,
+      "sha256": "0464e6b910a5aedf9a0c3319b8695a24e96fae61c51762414105a9ee04853dd6",
+      "size_bytes": 320919,
       "storage_tier": "dual"
     },
     {
@@ -89,8 +89,8 @@
     },
     {
       "path": "review/enrichment-queue.json",
-      "sha256": "7bab68b334f3a65b3ae961e12f44c224b53db186e18306ba4f9c35f024c62068",
-      "size_bytes": 230646,
+      "sha256": "8de97fe6a20a3cb84b4b17bf4c591a3ec6dae8643eaf2892d708802cce145e68",
+      "size_bytes": 295185,
       "storage_tier": "dual"
     },
     {
@@ -180,8 +180,8 @@
     "surface_count": 853
   },
   "endpoint_count": 853,
-  "full_artifact_count": 1098,
-  "full_artifact_size_bytes": 27816125,
+  "full_artifact_count": 1099,
+  "full_artifact_size_bytes": 28179463,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 14,
@@ -193,12 +193,12 @@
   "storage_tier_counts": {
     "dual": 21,
     "git": 1,
-    "r2": 1076
+    "r2": 1077
   },
   "storage_tier_size_bytes": {
-    "dual": 3626210,
+    "dual": 3705802,
     "git": 69359,
-    "r2": 24120556
+    "r2": 24404302
   },
   "subnet_count": 129,
   "surface_count": 853

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,11 +1,6 @@
 {
   "artifacts": {
-    "added": [
-      {
-        "hash": "7bab68b334f3a65b3ae961e12f44c224b53db186e18306ba4f9c35f024c62068",
-        "path": "review/enrichment-queue.json"
-      }
-    ],
+    "added": [],
     "modified": [],
     "removed": []
   },
@@ -23,7 +18,7 @@
     "renamed": []
   },
   "summary": {
-    "artifact_added_count": 1,
+    "artifact_added_count": 0,
     "artifact_modified_count": 0,
     "artifact_removed_count": 0,
     "coverage_delta": {

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -435,6 +435,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Detailed candidate evidence by missing or contributor-target surface kind for enrichment work.",
+      "id": "review-enrichment-evidence",
+      "path": "/metagraph/review/enrichment-evidence.json",
+      "schema_ref": "#/components/schemas/ReviewEnrichmentEvidenceArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Public-safe maintainer review decision ledger.",
       "id": "review-decisions",
       "path": "/metagraph/review/maintainer-decisions.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2955,6 +2955,111 @@
           }
         ]
       },
+      "ReviewCandidateEvidence": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "classifications": {
+            "$ref": "#/components/schemas/CountMap"
+          },
+          "live_or_redirected_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "reviewable_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sample_candidate_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "stale_or_failed_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unverified_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "candidate_count",
+          "classifications",
+          "live_or_redirected_count",
+          "reviewable_count",
+          "sample_candidate_ids",
+          "stale_or_failed_count",
+          "unverified_count"
+        ],
+        "type": "object"
+      },
+      "ReviewCandidateEvidenceSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "kinds_with_candidates": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "live_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "live_or_redirected_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "reviewable_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "stale_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "stale_or_failed_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unverified_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unverified_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "candidate_count",
+          "kinds_with_candidates",
+          "live_kinds",
+          "live_or_redirected_count",
+          "reviewable_count",
+          "stale_kinds",
+          "stale_or_failed_count",
+          "unverified_count",
+          "unverified_kinds"
+        ],
+        "type": "object"
+      },
       "ReviewCurationArtifact": {
         "allOf": [
           {
@@ -3096,6 +3201,133 @@
           }
         ]
       },
+      "ReviewEnrichmentEvidenceArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "entries": {
+                "items": {
+                  "$ref": "#/components/schemas/ReviewEnrichmentEvidenceEntry"
+                },
+                "type": "array"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "summary": {
+                "additionalProperties": false,
+                "properties": {
+                  "entry_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "evidence_action_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  },
+                  "stale_candidate_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "unverified_candidate_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "entry_count",
+                  "evidence_action_counts",
+                  "stale_candidate_count",
+                  "subnet_count",
+                  "unverified_candidate_count"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "entries",
+              "notes",
+              "summary"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ReviewEnrichmentEvidenceEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_evidence_by_kind": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ReviewCandidateEvidence"
+            },
+            "type": "object"
+          },
+          "candidate_evidence_summary": {
+            "$ref": "#/components/schemas/ReviewCandidateEvidenceSummary"
+          },
+          "direct_submission_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "evidence_action": {
+            "$ref": "#/components/schemas/ReviewEvidenceAction"
+          },
+          "lane": {
+            "$ref": "#/components/schemas/ReviewEnrichmentLane"
+          },
+          "missing_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "priority_score": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "candidate_evidence_by_kind",
+          "candidate_evidence_summary",
+          "direct_submission_kinds",
+          "evidence_action",
+          "lane",
+          "missing_kinds",
+          "name",
+          "netuid",
+          "priority_score",
+          "slug"
+        ],
+        "type": "object"
+      },
+      "ReviewEnrichmentLane": {
+        "enum": [
+          "direct-submission",
+          "maintainer-review",
+          "adapter-candidate",
+          "monitoring-followup",
+          "baseline-monitoring"
+        ]
+      },
       "ReviewEnrichmentQueueArtifact": {
         "allOf": [
           {
@@ -3128,6 +3360,9 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "evidence_action_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  },
                   "lane_counts": {
                     "$ref": "#/components/schemas/CountMap"
                   },
@@ -3159,6 +3394,7 @@
                   "adapter_candidate_count",
                   "baseline_monitoring_count",
                   "direct_submission_count",
+                  "evidence_action_counts",
                   "lane_counts",
                   "maintainer_review_count",
                   "manual_review_required_count",
@@ -3190,6 +3426,9 @@
             "minimum": 0,
             "type": "integer"
           },
+          "candidate_evidence_summary": {
+            "$ref": "#/components/schemas/ReviewCandidateEvidenceSummary"
+          },
           "completeness_score": {
             "maximum": 100,
             "minimum": 0,
@@ -3211,14 +3450,11 @@
             "minimum": 0,
             "type": "integer"
           },
+          "evidence_action": {
+            "$ref": "#/components/schemas/ReviewEvidenceAction"
+          },
           "lane": {
-            "enum": [
-              "direct-submission",
-              "maintainer-review",
-              "adapter-candidate",
-              "monitoring-followup",
-              "baseline-monitoring"
-            ]
+            "$ref": "#/components/schemas/ReviewEnrichmentLane"
           },
           "manual_review_required": {
             "type": "boolean"
@@ -3280,6 +3516,10 @@
             },
             "type": "array"
           },
+          "stale_candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
           "surface_count": {
             "minimum": 0,
             "type": "integer"
@@ -3291,12 +3531,14 @@
         },
         "required": [
           "adapter_score",
+          "candidate_evidence_summary",
           "candidate_count",
           "completeness_score",
           "contribution_hint",
           "curation_level",
           "direct_submission_kinds",
           "endpoint_count",
+          "evidence_action",
           "lane",
           "manual_review_required",
           "missing_kinds",
@@ -3311,10 +3553,21 @@
           "sample_candidate_ids",
           "slug",
           "source_urls",
+          "stale_candidate_count",
           "surface_count",
           "verified_candidate_count"
         ],
         "type": "object"
+      },
+      "ReviewEvidenceAction": {
+        "enum": [
+          "submit-new-evidence",
+          "verify-existing-evidence",
+          "replace-stale-evidence",
+          "review-existing-evidence",
+          "maintainer-review-existing-evidence",
+          "monitor"
+        ]
       },
       "ReviewGapPrioritiesArtifact": {
         "allOf": [
@@ -9029,6 +9282,190 @@
         "tags": [
           "adapters",
           "review"
+        ]
+      }
+    },
+    "/api/v1/review/enrichment-evidence": {
+      "get": {
+        "operationId": "reviewEnrichmentEvidence",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "evidence_action",
+            "required": false,
+            "schema": {
+              "enum": [
+                "submit-new-evidence",
+                "verify-existing-evidence",
+                "replace-stale-evidence",
+                "review-existing-evidence",
+                "maintainer-review-existing-evidence",
+                "monitor"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "lane",
+            "required": false,
+            "schema": {
+              "enum": [
+                "direct-submission",
+                "maintainer-review",
+                "adapter-candidate",
+                "monitoring-followup",
+                "baseline-monitoring"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "netuid",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "maximum": 1000,
+              "minimum": 1,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "sort",
+            "required": false,
+            "schema": {
+              "enum": [
+                "evidence_action",
+                "lane",
+                "name",
+                "netuid",
+                "priority_score"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "required": false,
+            "schema": {
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/ReviewEnrichmentEvidenceArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch detailed candidate evidence behind the enrichment queue.",
+        "tags": [
+          "registry",
+          "review",
+          "profiles"
         ]
       }
     },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 3875732,
+  "artifact_size_bytes": 3961548,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "21ce9893dde3ea9167c33e5286e33155a01c30c02d9fc929db42d451748050a8",
-      "size_bytes": 71451,
+      "sha256": "05d06b56a2084e498c7f2ae450278e87fed697093adbd4675e53f60c276be188",
+      "size_bytes": 73942,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "cf481d4564c2486148c7c695feab215bd56f34d6b519bbca04c52c9251c950f9",
-      "size_bytes": 1361,
+      "sha256": "560420248798a5952d089a6f0d2c850bf6f6bd9a258b319ed3b52c204113880e",
+      "size_bytes": 1209,
       "storage_tier": "dual"
     },
     {
@@ -25,8 +25,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "90b3088030cb6cc1ca0ee04ece29f4dbc69a780c575d8d4dba7dabd86d4a4546",
-      "size_bytes": 17812,
+      "sha256": "4b443c83aa9d91ffc38a5f3f76b8e103cd12b55cf04a708b16b7048eb132b24f",
+      "size_bytes": 18234,
       "storage_tier": "dual"
     },
     {
@@ -79,8 +79,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "83b127b2bcf5c225ed012c7bd324f85b1f85ff09ee872f080f72688d7f49b9a5",
-      "size_bytes": 308627,
+      "sha256": "0464e6b910a5aedf9a0c3319b8695a24e96fae61c51762414105a9ee04853dd6",
+      "size_bytes": 320919,
       "storage_tier": "dual"
     },
     {
@@ -124,8 +124,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
       "latest_key": "latest/review/enrichment-queue.json",
       "path": "/metagraph/review/enrichment-queue.json",
-      "sha256": "7bab68b334f3a65b3ae961e12f44c224b53db186e18306ba4f9c35f024c62068",
-      "size_bytes": 230646,
+      "sha256": "8de97fe6a20a3cb84b4b17bf4c591a3ec6dae8643eaf2892d708802cce145e68",
+      "size_bytes": 295185,
       "storage_tier": "dual"
     },
     {
@@ -205,16 +205,16 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "ab11de49bce1420886c3f56d19293371d61cbfffdfa502f4d576d17ddecb05c2",
-      "size_bytes": 180163,
+      "sha256": "0b8db8296c7e326edde6d9fad724011b0ac79ea35e46658f3ac94394cb79bc18",
+      "size_bytes": 186387,
       "storage_tier": "dual"
     }
   ],
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
-  "full_artifact_count": 1099,
-  "full_artifact_size_bytes": 27996288,
+  "full_artifact_count": 1100,
+  "full_artifact_size_bytes": 28365850,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -224,6 +224,7 @@
     "/metagraph/candidates.json",
     "/metagraph/health/latest.json",
     "/metagraph/review-queue.json",
+    "/metagraph/review/enrichment-evidence.json",
     "/metagraph/source-snapshots.json",
     "/metagraph/types.d.ts",
     "/metagraph/verification/latest.json"
@@ -233,11 +234,11 @@
   "storage_tier_counts": {
     "dual": 22,
     "git": 1,
-    "r2": 1076
+    "r2": 1077
   },
   "storage_tier_size_bytes": {
-    "dual": 3806373,
+    "dual": 3892189,
     "git": 69359,
-    "r2": 24120556
+    "r2": 24404302
   }
 }

--- a/public/metagraph/review/enrichment-queue.json
+++ b/public/metagraph/review/enrichment-queue.json
@@ -6,11 +6,27 @@
     {
       "adapter_score": 255,
       "candidate_count": 12,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "dashboard"
+        ],
+        "live_kinds": [
+          "dashboard"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 1,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 92,
       "contribution_hint": "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
       "curation_level": "adapter-backed",
       "direct_submission_kinds": [],
       "endpoint_count": 15,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "adapter-candidate",
       "manual_review_required": true,
       "missing_kinds": [
@@ -40,12 +56,28 @@
         "https://docs.all-ways.io/how-it-works.html",
         "https://github.com/entrius/allways"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 15,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 69,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 2,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 43,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -53,6 +85,7 @@
         "website"
       ],
       "endpoint_count": 9,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -89,12 +122,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/33/subnet.json",
         "https://taomarketcap.com/subnets/33"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 9,
       "verified_candidate_count": 11
     },
     {
       "adapter_score": 3,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 7,
+        "kinds_with_candidates": [
+          "openapi",
+          "source-repo",
+          "subnet-api",
+          "website"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 7,
+        "stale_kinds": [
+          "openapi",
+          "source-repo",
+          "subnet-api",
+          "website"
+        ],
+        "stale_or_failed_count": 7,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -103,6 +158,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -140,12 +196,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json",
         "https://taomarketcap.com/subnets/27"
       ],
+      "stale_candidate_count": 7,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 68,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 58,
       "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -154,6 +228,7 @@
         "subnet-api"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -190,12 +265,28 @@
         "https://taomarketcap.com/subnets/110",
         "https://www.green-compute.com/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "source-repo"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -204,6 +295,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -240,12 +332,28 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json",
         "https://taomarketcap.com/subnets/40"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "source-repo"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -254,6 +362,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -290,12 +399,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
         "https://taomarketcap.com/subnets/53"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 68,
       "candidate_count": 8,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -303,6 +424,7 @@
         "website"
       ],
       "endpoint_count": 8,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -340,12 +462,28 @@
         "https://handshake58.com/skill.md",
         "https://taomarketcap.com/subnets/58"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 8,
       "verified_candidate_count": 8
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "source-repo"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -354,6 +492,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -390,12 +529,28 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json",
         "https://taomarketcap.com/subnets/73"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "source-repo"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -404,6 +559,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -440,12 +596,28 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json",
         "https://taomarketcap.com/subnets/116"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "source-repo"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -454,6 +626,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -490,12 +663,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/119/subnet.json",
         "https://taomarketcap.com/subnets/119"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 68,
       "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 58,
       "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -504,6 +695,7 @@
         "subnet-api"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -541,12 +733,24 @@
         "https://silxinc.com/",
         "https://taomarketcap.com/subnets/24"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -555,6 +759,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -590,12 +795,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/28/subnet.json",
         "https://taomarketcap.com/subnets/28"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -604,6 +821,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -639,12 +857,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json",
         "https://taomarketcap.com/subnets/31"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -653,6 +883,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -688,12 +919,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/42/subnet.json",
         "https://taomarketcap.com/subnets/42"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -702,6 +945,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -737,12 +981,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/69/subnet.json",
         "https://taomarketcap.com/subnets/69"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -751,6 +1007,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -786,12 +1043,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/86/subnet.json",
         "https://taomarketcap.com/subnets/86"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -800,6 +1069,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -835,12 +1105,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json",
         "https://taomarketcap.com/subnets/90"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -849,6 +1131,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -884,12 +1167,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/101/subnet.json",
         "https://taomarketcap.com/subnets/101"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -898,6 +1193,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -933,12 +1229,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/104/subnet.json",
         "https://taomarketcap.com/subnets/104"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -947,6 +1255,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -982,12 +1291,32 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/125/subnet.json",
         "https://taomarketcap.com/subnets/125"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 6,
       "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api",
+          "website"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api",
+          "website"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -995,6 +1324,7 @@
         "website"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1033,12 +1363,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/89/subnet.json",
         "https://taomarketcap.com/subnets/89"
       ],
+      "stale_candidate_count": 6,
       "surface_count": 6,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 4,
       "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1046,6 +1394,7 @@
         "source-repo"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1082,12 +1431,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/91/subnet.json",
         "https://taomarketcap.com/subnets/91"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 4,
       "verified_candidate_count": 8
     },
     {
       "adapter_score": 8,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1095,6 +1462,7 @@
         "website"
       ],
       "endpoint_count": 8,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1133,17 +1501,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/52/subnet.json",
         "https://taomarketcap.com/subnets/52"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 8,
       "verified_candidate_count": 12
     },
     {
       "adapter_score": 72,
       "candidate_count": 28,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 73,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 12,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -1179,12 +1564,32 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/64/subnet.json",
         "https://kubernetes.io/docs/reference/kubectl"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 12,
       "verified_candidate_count": 20
     },
     {
       "adapter_score": 4,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "source-repo",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "source-repo",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1192,6 +1597,7 @@
         "source-repo"
       ],
       "endpoint_count": 4,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1228,12 +1634,32 @@
         "https://groundlayer.xyz/",
         "https://taomarketcap.com/subnets/20"
       ],
+      "stale_candidate_count": 6,
       "surface_count": 4,
       "verified_candidate_count": 6
     },
     {
       "adapter_score": 5,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 7,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api",
+          "website"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 7,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api",
+          "website"
+        ],
+        "stale_or_failed_count": 7,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1241,6 +1667,7 @@
         "website"
       ],
       "endpoint_count": 5,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1279,12 +1706,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/49/subnet.json",
         "https://taomarketcap.com/subnets/49"
       ],
+      "stale_candidate_count": 7,
       "surface_count": 5,
       "verified_candidate_count": 5
     },
     {
       "adapter_score": 5,
       "candidate_count": 12,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1292,6 +1737,7 @@
         "source-repo"
       ],
       "endpoint_count": 5,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1328,12 +1774,32 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json",
         "https://taomarketcap.com/subnets/30"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 5,
       "verified_candidate_count": 5
     },
     {
       "adapter_score": 10,
       "candidate_count": 28,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1343,6 +1809,7 @@
         "data-artifact"
       ],
       "endpoint_count": 10,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1382,12 +1849,28 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/14/subnet.json",
         "https://taohash.com/leaderboard"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 10,
       "verified_candidate_count": 22
     },
     {
       "adapter_score": 4,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api",
+          "website"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1395,6 +1878,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "verify-existing-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1431,12 +1915,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/62/subnet.json",
         "https://taomarketcap.com/subnets/62"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 4,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1444,6 +1946,7 @@
         "source-repo"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1480,12 +1983,24 @@
         "https://taomarketcap.com/subnets/76",
         "https://www.byzantiumai.net/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 4,
       "verified_candidate_count": 5
     },
     {
       "adapter_score": 27,
       "candidate_count": 9,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 43,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1493,6 +2008,7 @@
         "website"
       ],
       "endpoint_count": 7,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1529,12 +2045,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/29/subnet.json",
         "https://taostats.io/subnets/netuid-29"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 7,
       "candidate_count": 27,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1544,6 +2078,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1582,12 +2117,30 @@
         "https://taomarketcap.com/subnets/13",
         "https://www.macrocosmos.ai/gravity"
       ],
+      "stale_candidate_count": 6,
       "surface_count": 7,
       "verified_candidate_count": 18
     },
     {
       "adapter_score": 9,
       "candidate_count": 25,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1597,6 +2150,7 @@
         "data-artifact"
       ],
       "endpoint_count": 9,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1634,12 +2188,28 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/15/subnet.json",
         "https://oroagents.com/"
       ],
+      "stale_candidate_count": 6,
       "surface_count": 9,
       "verified_candidate_count": 19
     },
     {
       "adapter_score": 6,
       "candidate_count": 8,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 2,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 2,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1647,6 +2217,7 @@
         "website"
       ],
       "endpoint_count": 6,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1685,12 +2256,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/84/subnet.json",
         "https://taomarketcap.com/subnets/84"
       ],
+      "stale_candidate_count": 2,
       "surface_count": 6,
       "verified_candidate_count": 6
     },
     {
       "adapter_score": 7,
       "candidate_count": 25,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1700,6 +2289,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1738,12 +2328,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/1/subnet.json",
         "https://taomarketcap.com/subnets/1"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 18
     },
     {
       "adapter_score": 27,
       "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 43,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1751,6 +2353,7 @@
         "website"
       ],
       "endpoint_count": 7,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1788,12 +2391,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/47/subnet.json",
         "https://taostats.io/subnets/47/chart"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 8,
       "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1803,6 +2424,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1842,12 +2464,28 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/82/subnet.json",
         "https://taostats.io/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 18
     },
     {
       "adapter_score": 4,
       "candidate_count": 8,
+      "candidate_evidence_summary": {
+        "candidate_count": 4,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 4,
+        "reviewable_count": 4,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1855,6 +2493,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1891,12 +2530,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/111/subnet.json",
         "https://taomarketcap.com/subnets/111"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 8
     },
     {
       "adapter_score": 8,
       "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1906,6 +2563,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1945,12 +2603,30 @@
         "https://heyditto.ai/",
         "https://taomarketcap.com/subnets/118"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 18
     },
     {
       "adapter_score": 9,
       "candidate_count": 23,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -1960,6 +2636,7 @@
         "data-artifact"
       ],
       "endpoint_count": 9,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -1999,12 +2676,24 @@
         "https://iota.macrocosmos.ai/",
         "https://iota.macrocosmos.ai/dashboard/mainnet"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 9,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 25,
       "candidate_count": 6,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 43,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2012,6 +2701,7 @@
         "website"
       ],
       "endpoint_count": 5,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2048,12 +2738,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/34/subnet.json",
         "https://taomarketcap.com/subnets/34"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 5,
       "verified_candidate_count": 5
     },
     {
       "adapter_score": 27,
       "candidate_count": 23,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 58,
       "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2062,6 +2770,7 @@
         "subnet-api"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2099,12 +2808,32 @@
         "https://taomarketcap.com/subnets/72",
         "https://www.natix.network/?utm_source=bittensor"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 14
     },
     {
       "adapter_score": 8,
       "candidate_count": 23,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2114,6 +2843,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2151,17 +2881,34 @@
         "https://hippius.com/",
         "https://taomarketcap.com/subnets/75"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 17
     },
     {
       "adapter_score": 51,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -2198,12 +2945,30 @@
         "https://taostats.io/subnets/107/chart",
         "https://theminos.ai/"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 11,
       "verified_candidate_count": 14
     },
     {
       "adapter_score": 8,
       "candidate_count": 22,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2213,6 +2978,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2250,12 +3016,28 @@
         "https://taomarketcap.com/subnets/4",
         "https://targon.com/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 16
     },
     {
       "adapter_score": 5,
       "candidate_count": 6,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 1,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2263,6 +3045,7 @@
         "website"
       ],
       "endpoint_count": 5,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2300,12 +3083,32 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/12/subnet.json",
         "https://taostats.io/subnets/12"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 5,
       "verified_candidate_count": 6
     },
     {
       "adapter_score": 6,
       "candidate_count": 23,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2315,6 +3118,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2354,12 +3158,30 @@
         "https://its-ai.org/en",
         "https://taomarketcap.com/subnets/32"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 6,
       "verified_candidate_count": 16
     },
     {
       "adapter_score": 6,
       "candidate_count": 23,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2369,6 +3191,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2408,12 +3231,30 @@
         "https://taomarketcap.com/subnets/79",
         "https://taos.im/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 6,
       "verified_candidate_count": 16
     },
     {
       "adapter_score": 6,
       "candidate_count": 22,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2423,6 +3264,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2461,12 +3303,31 @@
         "https://taostats.io/subnets/63",
         "https://www.qbittensorlabs.com/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 6,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 26,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "source-repo",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2474,6 +3335,7 @@
         "source-repo"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2509,12 +3371,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json",
         "https://taomarketcap.com/subnets/95"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 6,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 8,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2524,6 +3404,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2562,12 +3443,28 @@
         "https://macrocosmos.ai/sn25",
         "https://www.macrocosmos.ai/sn25/dashboard"
       ],
+      "stale_candidate_count": 6,
       "surface_count": 8,
       "verified_candidate_count": 13
     },
     {
       "adapter_score": 4,
       "candidate_count": 5,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 1,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2575,6 +3472,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2611,12 +3509,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/43/subnet.json",
         "https://taomarketcap.com/subnets/43"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 5
     },
     {
       "adapter_score": 8,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2626,6 +3542,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2665,12 +3582,28 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/103/subnet.json",
         "https://taomarketcap.com/subnets/103"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 16
     },
     {
       "adapter_score": 4,
       "candidate_count": 5,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "data-artifact"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "data-artifact"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2678,6 +3611,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2714,12 +3648,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/122/subnet.json",
         "https://taomarketcap.com/subnets/122"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 7,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2729,6 +3681,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2768,12 +3721,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/19/subnet.json",
         "https://taomarketcap.com/subnets/19"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 16
     },
     {
       "adapter_score": 7,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2783,6 +3754,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2820,12 +3792,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/45/subnet.json",
         "https://taomarketcap.com/subnets/45"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 0,
       "candidate_count": 3,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 20,
       "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2834,6 +3818,7 @@
         "source-repo"
       ],
       "endpoint_count": 3,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2868,12 +3853,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/87/subnet.json",
         "https://taomarketcap.com/subnets/87"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 3,
       "verified_candidate_count": 3
     },
     {
       "adapter_score": 5,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2883,6 +3886,7 @@
         "data-artifact"
       ],
       "endpoint_count": 5,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2920,12 +3924,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/21/subnet.json",
         "https://taomarketcap.com/subnets/21"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 5,
       "verified_candidate_count": 13
     },
     {
       "adapter_score": 0,
       "candidate_count": 5,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2933,6 +3949,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -2969,12 +3986,30 @@
         "https://github.com/tplr-ai/basilica",
         "https://taomarketcap.com/subnets/39"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 5,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -2984,6 +4019,7 @@
         "data-artifact"
       ],
       "endpoint_count": 5,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3021,12 +4057,24 @@
         "https://taomarketcap.com/subnets/48",
         "https://www.qbittensorlabs.com/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 5,
       "verified_candidate_count": 14
     },
     {
       "adapter_score": 0,
       "candidate_count": 5,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3034,6 +4082,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3070,12 +4119,32 @@
         "https://github.com/tplr-ai/grail",
         "https://taomarketcap.com/subnets/81"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 28,
       "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 4,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 58,
       "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3084,6 +4153,7 @@
         "subnet-api"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3120,12 +4190,24 @@
         "https://taomarketcap.com/subnets/114",
         "https://thesoma.ai/"
       ],
+      "stale_candidate_count": 4,
       "surface_count": 8,
       "verified_candidate_count": 14
     },
     {
       "adapter_score": 0,
       "candidate_count": 5,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3133,6 +4215,7 @@
         "website"
       ],
       "endpoint_count": 5,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3169,12 +4252,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/117/subnet.json",
         "https://taomarketcap.com/subnets/117"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 5,
       "verified_candidate_count": 5
     },
     {
       "adapter_score": 5,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3184,6 +4285,7 @@
         "data-artifact"
       ],
       "endpoint_count": 5,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3221,17 +4323,36 @@
         "https://taomarketcap.com/subnets/121",
         "https://www.sundaebar.ai/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 5,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 32,
       "candidate_count": 29,
+      "candidate_evidence_summary": {
+        "candidate_count": 11,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 11,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 8,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 12,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -3268,12 +4389,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/46/subnet.json",
         "https://zipcode.ai/"
       ],
+      "stale_candidate_count": 8,
       "surface_count": 12,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3281,6 +4414,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3316,12 +4450,24 @@
         "https://github.com/tplr-ai/templar",
         "https://taomarketcap.com/subnets/3"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3329,6 +4475,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3364,12 +4511,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/57/subnet.json",
         "https://taomarketcap.com/subnets/57"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3377,6 +4536,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3412,12 +4572,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/92/subnet.json",
         "https://taomarketcap.com/subnets/92"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 8,
       "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3427,6 +4605,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3464,12 +4643,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/98/subnet.json",
         "https://taomarketcap.com/subnets/98"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 13
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3477,6 +4668,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3512,12 +4704,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/109/subnet.json",
         "https://taomarketcap.com/subnets/109"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3525,6 +4729,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3560,12 +4765,24 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/115/subnet.json",
         "https://taomarketcap.com/subnets/115"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 0,
       "candidate_count": 4,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 35,
       "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3573,6 +4790,7 @@
         "website"
       ],
       "endpoint_count": 4,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3608,12 +4826,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/123/subnet.json",
         "https://taomarketcap.com/subnets/123"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 4,
       "verified_candidate_count": 4
     },
     {
       "adapter_score": 7,
       "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3623,6 +4859,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3662,12 +4899,30 @@
         "https://taomarketcap.com/subnets/113",
         "https://tensorusd.com/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 11
     },
     {
       "adapter_score": 27,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 58,
       "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3676,6 +4931,7 @@
         "subnet-api"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3714,12 +4970,30 @@
         "https://taomarketcap.com/subnets/5",
         "https://www.hone.training/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 28,
       "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 58,
       "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3728,6 +5002,7 @@
         "subnet-api"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3764,12 +5039,30 @@
         "https://taomarketcap.com/subnets/68",
         "https://www.metanova-labs.ai/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 8,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3779,6 +5072,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3816,12 +5110,29 @@
         "https://platform.network/",
         "https://taomarketcap.com/subnets/100"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 12
     },
     {
       "adapter_score": 7,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 6,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3831,6 +5142,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "verify-existing-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3869,12 +5181,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/6/subnet.json",
         "https://numinouslabs.io/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 8,
       "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3884,6 +5214,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3923,12 +5254,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/8/subnet.json",
         "https://www.vantanetwork.io/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 7,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3938,6 +5287,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -3976,12 +5326,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/17/subnet.json",
         "https://www.404.xyz/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 11
     },
     {
       "adapter_score": 27,
       "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 58,
       "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -3990,6 +5358,7 @@
         "subnet-api"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4026,12 +5395,30 @@
         "https://nexisgen.ai/",
         "https://taomarketcap.com/subnets/70"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 11
     },
     {
       "adapter_score": 7,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4041,6 +5428,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4078,17 +5466,36 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/102/subnet.json",
         "https://taomarketcap.com/subnets/102"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 50,
       "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -4125,12 +5532,32 @@
         "https://verathos.ai/",
         "https://verathos.ai/docs"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 10,
       "verified_candidate_count": 12
     },
     {
       "adapter_score": 7,
       "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 4,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4140,6 +5567,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4177,12 +5605,30 @@
         "https://taomarketcap.com/subnets/18",
         "https://www.zeussubnet.com/"
       ],
+      "stale_candidate_count": 4,
       "surface_count": 7,
       "verified_candidate_count": 11
     },
     {
       "adapter_score": 5,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4192,6 +5638,7 @@
         "data-artifact"
       ],
       "endpoint_count": 5,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4229,17 +5676,34 @@
         "https://taomarketcap.com/subnets/108",
         "https://www.talkhead.ai/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 5,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 49,
       "candidate_count": 22,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 73,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -4273,12 +5737,30 @@
         "https://taomarketcap.com/subnets/56",
         "https://www.gradients.io/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 9,
       "verified_candidate_count": 20
     },
     {
       "adapter_score": 7,
       "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4288,6 +5770,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4325,12 +5808,30 @@
         "https://taomarketcap.com/subnets/11",
         "https://trajrl.com/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 7,
       "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4340,6 +5841,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4377,12 +5879,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/36/subnet.json",
         "https://taomarketcap.com/subnets/36"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 6,
       "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4392,6 +5912,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4429,17 +5950,34 @@
         "https://poker44.net/",
         "https://taomarketcap.com/subnets/126"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 6,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 28,
       "candidate_count": 22,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 8,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -4476,17 +6014,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json",
         "https://taomarketcap.com/subnets/37"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 8,
       "verified_candidate_count": 12
     },
     {
       "adapter_score": 28,
       "candidate_count": 22,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 8,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -4523,12 +6078,30 @@
         "https://lium.io/",
         "https://taomarketcap.com/subnets/51"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 8,
       "verified_candidate_count": 17
     },
     {
       "adapter_score": 6,
       "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4538,6 +6111,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4576,12 +6150,30 @@
         "https://tao-ui-dashboard.yanez.ai/",
         "https://www.yanez.ai/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 6,
       "verified_candidate_count": 8
     },
     {
       "adapter_score": 5,
       "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4591,6 +6183,7 @@
         "data-artifact"
       ],
       "endpoint_count": 5,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4628,12 +6221,30 @@
         "https://niome.genomes.io/",
         "https://taomarketcap.com/subnets/55"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 5,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 7,
       "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4643,6 +6254,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4681,12 +6293,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/67/subnet.json",
         "https://harnyx.ai/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 8
     },
     {
       "adapter_score": 7,
       "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4696,6 +6326,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4733,12 +6364,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json",
         "https://taomarketcap.com/subnets/94"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 6,
       "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4748,6 +6397,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4786,17 +6436,36 @@
         "https://minotaursubnet.com/",
         "https://taostats.io/subnets/112/chart"
       ],
+      "stale_candidate_count": 6,
       "surface_count": 6,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 29,
       "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 2,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -4831,12 +6500,30 @@
         "https://github.com/dogelayer-ai/dogelayer/blob/main/README.md",
         "https://taomarketcap.com/subnets/80"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 9,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 7,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4846,6 +6533,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4885,12 +6573,30 @@
         "https://taomarketcap.com/subnets/35",
         "https://www.0xmarkets.io/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 6,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4900,6 +6606,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4937,12 +6644,30 @@
         "https://taomarketcap.com/subnets/44",
         "https://www.wearescore.com/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 6,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 7,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -4952,6 +6677,7 @@
         "data-artifact"
       ],
       "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -4991,17 +6717,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/61/subnet.json",
         "https://www.theredteam.io/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 7,
       "verified_candidate_count": 7
     },
     {
       "adapter_score": 48,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 8,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5036,12 +6779,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/22/subnet.json",
         "https://taomarketcap.com/subnets/22"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 8,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 6,
       "candidate_count": 12,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -5051,6 +6812,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -5088,17 +6850,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/120/subnet.json",
         "https://www.affine.io/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 6,
       "verified_candidate_count": 6
     },
     {
       "adapter_score": 30,
       "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5135,17 +6914,36 @@
         "https://taomarketcap.com/subnets/85",
         "https://vidaio.io/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 10,
       "verified_candidate_count": 17
     },
     {
       "adapter_score": 50,
       "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 4,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 3,
+        "reviewable_count": 4,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 73,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5181,17 +6979,34 @@
         "https://leoma.ai/",
         "https://taomarketcap.com/subnets/99"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 10,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 31,
       "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5228,17 +7043,34 @@
         "https://pm2.io/docs/runtime/guide/installation",
         "https://trishool.ai/"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 11,
       "verified_candidate_count": 12
     },
     {
       "adapter_score": 29,
       "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5275,12 +7107,30 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/88/subnet.json",
         "https://investing88.ai/"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 9,
       "verified_candidate_count": 13
     },
     {
       "adapter_score": 6,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -5290,6 +7140,7 @@
         "data-artifact"
       ],
       "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -5327,17 +7178,34 @@
         "https://taomarketcap.com/subnets/106",
         "https://voidai.com/"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 6,
       "verified_candidate_count": 6
     },
     {
       "adapter_score": 29,
       "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5373,17 +7241,30 @@
         "https://taostats.io/subnets/65/registration",
         "https://tpn.taofu.xyz/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 9,
       "verified_candidate_count": 16
     },
     {
       "adapter_score": 70,
       "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 80,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5418,17 +7299,34 @@
         "https://ninja.arbos.life/",
         "https://taomarketcap.com/subnets/66"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 10,
       "verified_candidate_count": 14
     },
     {
       "adapter_score": 29,
       "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5464,17 +7362,36 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/93/subnet.json",
         "https://stats.bitcast.network/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 9,
       "verified_candidate_count": 15
     },
     {
       "adapter_score": 50,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 73,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5510,12 +7427,30 @@
         "https://github.com/unitone-labs/FlameWire/blob/main/README.md",
         "https://taomarketcap.com/subnets/97"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 10,
       "verified_candidate_count": 14
     },
     {
       "adapter_score": 5,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 50,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "machine-verified",
@@ -5525,6 +7460,7 @@
         "data-artifact"
       ],
       "endpoint_count": 5,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -5562,17 +7498,36 @@
         "https://taomarketcap.com/subnets/10",
         "https://www.taofi.com/pool"
       ],
+      "stale_candidate_count": 5,
       "surface_count": 5,
       "verified_candidate_count": 5
     },
     {
       "adapter_score": 30,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 2,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5609,17 +7564,34 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/60/subnet.json"
       ],
+      "stale_candidate_count": 1,
       "surface_count": 10,
       "verified_candidate_count": 13
     },
     {
       "adapter_score": 30,
       "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5656,17 +7628,34 @@
         "https://sn2-stats.inferencelabs.com/",
         "https://subnet2.inferencelabs.com/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 10,
       "verified_candidate_count": 13
     },
     {
       "adapter_score": 27,
       "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5702,17 +7691,34 @@
         "https://taomarketcap.com/subnets/26",
         "https://www.perturbai.io/"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 7,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 27,
       "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5748,17 +7754,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json",
         "https://taomarketcap.com/subnets/59"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 7,
       "verified_candidate_count": 8
     },
     {
       "adapter_score": 28,
       "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 8,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5795,17 +7818,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json",
         "https://taomarketcap.com/subnets/41"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 8,
       "verified_candidate_count": 12
     },
     {
       "adapter_score": 26,
       "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 6,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5841,17 +7881,34 @@
         "https://taomarketcap.com/subnets/127",
         "https://www.astrid.global/"
       ],
+      "stale_candidate_count": 3,
       "surface_count": 6,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 29,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5886,17 +7943,34 @@
         "https://taomarketcap.com/subnets/78",
         "https://www.vocence.ai/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 9,
       "verified_candidate_count": 11
     },
     {
       "adapter_score": 27,
       "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 4,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 4,
+        "reviewable_count": 4,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5931,17 +8005,34 @@
         "https://sn77.xyz/",
         "https://taomarketcap.com/subnets/77"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 11
     },
     {
       "adapter_score": 28,
       "candidate_count": 12,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 8,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -5977,17 +8068,34 @@
         "https://swarm124.com/benchmark",
         "https://www.swarm124.com/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 8,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 28,
       "candidate_count": 12,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 8,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -6022,17 +8130,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json",
         "https://taomarketcap.com/subnets/128"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 8,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 27,
       "candidate_count": 12,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 3,
+        "reviewable_count": 3,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -6067,17 +8192,34 @@
         "https://synthdata.co/",
         "https://taomarketcap.com/subnets/50"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 27,
       "candidate_count": 12,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 3,
+        "reviewable_count": 3,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -6112,17 +8254,34 @@
         "https://leadpoet.com/",
         "https://taomarketcap.com/subnets/71"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 10
     },
     {
       "adapter_score": 27,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -6157,17 +8316,34 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
         "https://taomarketcap.com/subnets/16"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 27,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -6202,17 +8378,34 @@
         "https://taomarketcap.com/subnets/38",
         "https://www.taocolosseum.com/"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 27,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -6247,17 +8440,34 @@
         "https://github.com/toptensor/CliqueAI",
         "https://taomarketcap.com/subnets/83"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 27,
       "candidate_count": 11,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 65,
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
       "endpoint_count": 7,
+      "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
       "missing_kinds": [
@@ -6292,12 +8502,36 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json",
         "https://taomarketcap.com/subnets/105"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 9
     },
     {
       "adapter_score": 27,
       "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 7,
+        "kinds_with_candidates": [
+          "dashboard",
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "dashboard",
+          "openapi",
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 4,
+        "reviewable_count": 7,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 2,
+        "unverified_count": 1,
+        "unverified_kinds": [
+          "openapi"
+        ]
+      },
       "completeness_score": 63,
       "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
       "curation_level": "adapter-backed",
@@ -6306,6 +8540,7 @@
         "subnet-api"
       ],
       "endpoint_count": 7,
+      "evidence_action": "review-existing-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -6341,12 +8576,24 @@
         "https://github.com/entrius/gittensor",
         "https://gittensor.io/"
       ],
+      "stale_candidate_count": 2,
       "surface_count": 7,
       "verified_candidate_count": 13
     },
     {
       "adapter_score": 0,
       "candidate_count": 2,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
       "completeness_score": 55,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "maintainer-reviewed",
@@ -6356,6 +8603,7 @@
         "data-artifact"
       ],
       "endpoint_count": 12,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -6391,6 +8639,7 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/0/subnet.json",
         "https://onfinality.io/en/networks/bittensor-finney"
       ],
+      "stale_candidate_count": 0,
       "surface_count": 12,
       "verified_candidate_count": 2
     }
@@ -6400,6 +8649,13 @@
     "adapter_candidate_count": 1,
     "baseline_monitoring_count": 0,
     "direct_submission_count": 95,
+    "evidence_action_counts": {
+      "maintainer-review-existing-evidence": 34,
+      "replace-stale-evidence": 58,
+      "review-existing-evidence": 1,
+      "submit-new-evidence": 34,
+      "verify-existing-evidence": 2
+    },
     "lane_counts": {
       "adapter-candidate": 1,
       "direct-submission": 95,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -378,6 +378,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/review/enrichment-evidence": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch detailed candidate evidence behind the enrichment queue. */
+        get: operations["reviewEnrichmentEvidence"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/review/enrichment-queue": {
         parameters: {
             query?: never;
@@ -1389,6 +1406,26 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        ReviewCandidateEvidence: {
+            candidate_count: number;
+            classifications: components["schemas"]["CountMap"];
+            live_or_redirected_count: number;
+            reviewable_count: number;
+            sample_candidate_ids: string[];
+            stale_or_failed_count: number;
+            unverified_count: number;
+        };
+        ReviewCandidateEvidenceSummary: {
+            candidate_count: number;
+            kinds_with_candidates: components["schemas"]["SurfaceKind"][];
+            live_kinds: components["schemas"]["SurfaceKind"][];
+            live_or_redirected_count: number;
+            reviewable_count: number;
+            stale_kinds: components["schemas"]["SurfaceKind"][];
+            stale_or_failed_count: number;
+            unverified_count: number;
+            unverified_kinds: components["schemas"]["SurfaceKind"][];
+        };
         ReviewCurationArtifact: components["schemas"]["ArtifactBase"] & ({
             adapter_candidates: components["schemas"]["ReviewAdapterCandidate"][];
             gap_priorities: components["schemas"]["ReviewGapPriority"][];
@@ -1419,6 +1456,35 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        ReviewEnrichmentEvidenceArtifact: components["schemas"]["ArtifactBase"] & ({
+            entries: components["schemas"]["ReviewEnrichmentEvidenceEntry"][];
+            notes: string;
+            summary: {
+                entry_count: number;
+                evidence_action_counts: components["schemas"]["CountMap"];
+                stale_candidate_count: number;
+                subnet_count: number;
+                unverified_candidate_count: number;
+            };
+        } & {
+            [key: string]: unknown;
+        });
+        ReviewEnrichmentEvidenceEntry: {
+            candidate_evidence_by_kind: {
+                [key: string]: components["schemas"]["ReviewCandidateEvidence"];
+            };
+            candidate_evidence_summary: components["schemas"]["ReviewCandidateEvidenceSummary"];
+            direct_submission_kinds: components["schemas"]["SurfaceKind"][];
+            evidence_action: components["schemas"]["ReviewEvidenceAction"];
+            lane: components["schemas"]["ReviewEnrichmentLane"];
+            missing_kinds: components["schemas"]["SurfaceKind"][];
+            name: string;
+            netuid: number;
+            priority_score: number;
+            slug: string;
+        };
+        /** @enum {unknown} */
+        ReviewEnrichmentLane: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
         ReviewEnrichmentQueueArtifact: components["schemas"]["ArtifactBase"] & ({
             notes: string;
             queue: components["schemas"]["ReviewEnrichmentQueueEntry"][];
@@ -1426,6 +1492,7 @@ export interface components {
                 adapter_candidate_count: number;
                 baseline_monitoring_count: number;
                 direct_submission_count: number;
+                evidence_action_counts: components["schemas"]["CountMap"];
                 lane_counts: components["schemas"]["CountMap"];
                 maintainer_review_count: number;
                 manual_review_required_count: number;
@@ -1440,13 +1507,14 @@ export interface components {
         ReviewEnrichmentQueueEntry: {
             adapter_score: number;
             candidate_count: number;
+            candidate_evidence_summary: components["schemas"]["ReviewCandidateEvidenceSummary"];
             completeness_score: number;
             contribution_hint: string;
             curation_level: components["schemas"]["CurationLevel"];
             direct_submission_kinds: components["schemas"]["SurfaceKind"][];
             endpoint_count: number;
-            /** @enum {unknown} */
-            lane: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+            evidence_action: components["schemas"]["ReviewEvidenceAction"];
+            lane: components["schemas"]["ReviewEnrichmentLane"];
             manual_review_required: boolean;
             missing_kinds: components["schemas"]["SurfaceKind"][];
             name: string;
@@ -1461,9 +1529,12 @@ export interface components {
             sample_candidate_ids: string[];
             slug: string;
             source_urls: string[];
+            stale_candidate_count: number;
             surface_count: number;
             verified_candidate_count: number;
         };
+        /** @enum {unknown} */
+        ReviewEvidenceAction: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
         ReviewGapPrioritiesArtifact: components["schemas"]["ArtifactBase"] & ({
             priorities: components["schemas"]["ReviewGapPriority"][];
         } & {
@@ -3635,6 +3706,83 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewAdapterCandidatesArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    reviewEnrichmentEvidence: {
+        parameters: {
+            query?: {
+                evidence_action?: "submit-new-evidence" | "verify-existing-evidence" | "replace-stale-evidence" | "review-existing-evidence" | "maintainer-review-existing-evidence" | "monitor";
+                lane?: "direct-submission" | "maintainer-review" | "adapter-candidate" | "monitoring-followup" | "baseline-monitoring";
+                netuid?: number;
+                q?: string;
+                limit?: number;
+                cursor?: number;
+                sort?: "evidence_action" | "lane" | "name" | "netuid" | "priority_score";
+                order?: "asc" | "desc";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["ReviewEnrichmentEvidenceArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -2933,6 +2933,111 @@
           }
         ]
       },
+      "ReviewCandidateEvidence": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "classifications": {
+            "$ref": "#/components/schemas/CountMap"
+          },
+          "live_or_redirected_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "reviewable_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "sample_candidate_ids": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "stale_or_failed_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unverified_count": {
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "candidate_count",
+          "classifications",
+          "live_or_redirected_count",
+          "reviewable_count",
+          "sample_candidate_ids",
+          "stale_or_failed_count",
+          "unverified_count"
+        ],
+        "type": "object"
+      },
+      "ReviewCandidateEvidenceSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "kinds_with_candidates": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "live_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "live_or_redirected_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "reviewable_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "stale_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "stale_or_failed_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unverified_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "unverified_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "candidate_count",
+          "kinds_with_candidates",
+          "live_kinds",
+          "live_or_redirected_count",
+          "reviewable_count",
+          "stale_kinds",
+          "stale_or_failed_count",
+          "unverified_count",
+          "unverified_kinds"
+        ],
+        "type": "object"
+      },
       "ReviewCurationArtifact": {
         "allOf": [
           {
@@ -3074,6 +3179,133 @@
           }
         ]
       },
+      "ReviewEnrichmentEvidenceArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "entries": {
+                "items": {
+                  "$ref": "#/components/schemas/ReviewEnrichmentEvidenceEntry"
+                },
+                "type": "array"
+              },
+              "notes": {
+                "type": "string"
+              },
+              "summary": {
+                "additionalProperties": false,
+                "properties": {
+                  "entry_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "evidence_action_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  },
+                  "stale_candidate_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "unverified_candidate_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
+                "required": [
+                  "entry_count",
+                  "evidence_action_counts",
+                  "stale_candidate_count",
+                  "subnet_count",
+                  "unverified_candidate_count"
+                ],
+                "type": "object"
+              }
+            },
+            "required": [
+              "entries",
+              "notes",
+              "summary"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "ReviewEnrichmentEvidenceEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "candidate_evidence_by_kind": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ReviewCandidateEvidence"
+            },
+            "type": "object"
+          },
+          "candidate_evidence_summary": {
+            "$ref": "#/components/schemas/ReviewCandidateEvidenceSummary"
+          },
+          "direct_submission_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "evidence_action": {
+            "$ref": "#/components/schemas/ReviewEvidenceAction"
+          },
+          "lane": {
+            "$ref": "#/components/schemas/ReviewEnrichmentLane"
+          },
+          "missing_kinds": {
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "priority_score": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "candidate_evidence_by_kind",
+          "candidate_evidence_summary",
+          "direct_submission_kinds",
+          "evidence_action",
+          "lane",
+          "missing_kinds",
+          "name",
+          "netuid",
+          "priority_score",
+          "slug"
+        ],
+        "type": "object"
+      },
+      "ReviewEnrichmentLane": {
+        "enum": [
+          "direct-submission",
+          "maintainer-review",
+          "adapter-candidate",
+          "monitoring-followup",
+          "baseline-monitoring"
+        ]
+      },
       "ReviewEnrichmentQueueArtifact": {
         "allOf": [
           {
@@ -3106,6 +3338,9 @@
                     "minimum": 0,
                     "type": "integer"
                   },
+                  "evidence_action_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  },
                   "lane_counts": {
                     "$ref": "#/components/schemas/CountMap"
                   },
@@ -3137,6 +3372,7 @@
                   "adapter_candidate_count",
                   "baseline_monitoring_count",
                   "direct_submission_count",
+                  "evidence_action_counts",
                   "lane_counts",
                   "maintainer_review_count",
                   "manual_review_required_count",
@@ -3168,6 +3404,9 @@
             "minimum": 0,
             "type": "integer"
           },
+          "candidate_evidence_summary": {
+            "$ref": "#/components/schemas/ReviewCandidateEvidenceSummary"
+          },
           "completeness_score": {
             "maximum": 100,
             "minimum": 0,
@@ -3189,14 +3428,11 @@
             "minimum": 0,
             "type": "integer"
           },
+          "evidence_action": {
+            "$ref": "#/components/schemas/ReviewEvidenceAction"
+          },
           "lane": {
-            "enum": [
-              "direct-submission",
-              "maintainer-review",
-              "adapter-candidate",
-              "monitoring-followup",
-              "baseline-monitoring"
-            ]
+            "$ref": "#/components/schemas/ReviewEnrichmentLane"
           },
           "manual_review_required": {
             "type": "boolean"
@@ -3258,6 +3494,10 @@
             },
             "type": "array"
           },
+          "stale_candidate_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
           "surface_count": {
             "minimum": 0,
             "type": "integer"
@@ -3269,12 +3509,14 @@
         },
         "required": [
           "adapter_score",
+          "candidate_evidence_summary",
           "candidate_count",
           "completeness_score",
           "contribution_hint",
           "curation_level",
           "direct_submission_kinds",
           "endpoint_count",
+          "evidence_action",
           "lane",
           "manual_review_required",
           "missing_kinds",
@@ -3289,10 +3531,21 @@
           "sample_candidate_ids",
           "slug",
           "source_urls",
+          "stale_candidate_count",
           "surface_count",
           "verified_candidate_count"
         ],
         "type": "object"
+      },
+      "ReviewEvidenceAction": {
+        "enum": [
+          "submit-new-evidence",
+          "verify-existing-evidence",
+          "replace-stale-evidence",
+          "review-existing-evidence",
+          "maintainer-review-existing-evidence",
+          "monitor"
+        ]
       },
       "ReviewGapPrioritiesArtifact": {
         "allOf": [

--- a/schemas/components/11-review-intake.schema.json
+++ b/schemas/components/11-review-intake.schema.json
@@ -178,16 +178,37 @@
         },
         "additionalProperties": false
       },
+      "ReviewEnrichmentLane": {
+        "enum": [
+          "direct-submission",
+          "maintainer-review",
+          "adapter-candidate",
+          "monitoring-followup",
+          "baseline-monitoring"
+        ]
+      },
+      "ReviewEvidenceAction": {
+        "enum": [
+          "submit-new-evidence",
+          "verify-existing-evidence",
+          "replace-stale-evidence",
+          "review-existing-evidence",
+          "maintainer-review-existing-evidence",
+          "monitor"
+        ]
+      },
       "ReviewEnrichmentQueueEntry": {
         "type": "object",
         "required": [
           "adapter_score",
+          "candidate_evidence_summary",
           "candidate_count",
           "completeness_score",
           "contribution_hint",
           "curation_level",
           "direct_submission_kinds",
           "endpoint_count",
+          "evidence_action",
           "lane",
           "manual_review_required",
           "missing_kinds",
@@ -202,6 +223,7 @@
           "sample_candidate_ids",
           "slug",
           "source_urls",
+          "stale_candidate_count",
           "surface_count",
           "verified_candidate_count"
         ],
@@ -213,6 +235,9 @@
           "candidate_count": {
             "type": "integer",
             "minimum": 0
+          },
+          "candidate_evidence_summary": {
+            "$ref": "#/components/schemas/ReviewCandidateEvidenceSummary"
           },
           "completeness_score": {
             "type": "integer",
@@ -235,14 +260,11 @@
             "type": "integer",
             "minimum": 0
           },
+          "evidence_action": {
+            "$ref": "#/components/schemas/ReviewEvidenceAction"
+          },
           "lane": {
-            "enum": [
-              "direct-submission",
-              "maintainer-review",
-              "adapter-candidate",
-              "monitoring-followup",
-              "baseline-monitoring"
-            ]
+            "$ref": "#/components/schemas/ReviewEnrichmentLane"
           },
           "manual_review_required": {
             "type": "boolean"
@@ -304,6 +326,10 @@
               "format": "uri"
             }
           },
+          "stale_candidate_count": {
+            "type": "integer",
+            "minimum": 0
+          },
           "surface_count": {
             "type": "integer",
             "minimum": 0
@@ -311,6 +337,170 @@
           "verified_candidate_count": {
             "type": "integer",
             "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReviewCandidateEvidence": {
+        "type": "object",
+        "required": [
+          "candidate_count",
+          "classifications",
+          "live_or_redirected_count",
+          "reviewable_count",
+          "sample_candidate_ids",
+          "stale_or_failed_count",
+          "unverified_count"
+        ],
+        "properties": {
+          "candidate_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "classifications": {
+            "$ref": "#/components/schemas/CountMap"
+          },
+          "live_or_redirected_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "reviewable_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "sample_candidate_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "stale_or_failed_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "unverified_count": {
+            "type": "integer",
+            "minimum": 0
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReviewCandidateEvidenceSummary": {
+        "type": "object",
+        "required": [
+          "candidate_count",
+          "kinds_with_candidates",
+          "live_kinds",
+          "live_or_redirected_count",
+          "reviewable_count",
+          "stale_kinds",
+          "stale_or_failed_count",
+          "unverified_count",
+          "unverified_kinds"
+        ],
+        "properties": {
+          "candidate_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "kinds_with_candidates": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            }
+          },
+          "live_kinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            }
+          },
+          "live_or_redirected_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "reviewable_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "stale_kinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            }
+          },
+          "stale_or_failed_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "unverified_count": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "unverified_kinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "ReviewEnrichmentEvidenceEntry": {
+        "type": "object",
+        "required": [
+          "candidate_evidence_by_kind",
+          "candidate_evidence_summary",
+          "direct_submission_kinds",
+          "evidence_action",
+          "lane",
+          "missing_kinds",
+          "name",
+          "netuid",
+          "priority_score",
+          "slug"
+        ],
+        "properties": {
+          "candidate_evidence_by_kind": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/ReviewCandidateEvidence"
+            }
+          },
+          "candidate_evidence_summary": {
+            "$ref": "#/components/schemas/ReviewCandidateEvidenceSummary"
+          },
+          "direct_submission_kinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            }
+          },
+          "evidence_action": {
+            "$ref": "#/components/schemas/ReviewEvidenceAction"
+          },
+          "lane": {
+            "$ref": "#/components/schemas/ReviewEnrichmentLane"
+          },
+          "missing_kinds": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SurfaceKind"
+            }
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "priority_score": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "slug": {
+            "type": "string"
           }
         },
         "additionalProperties": false
@@ -550,6 +740,7 @@
                   "adapter_candidate_count",
                   "baseline_monitoring_count",
                   "direct_submission_count",
+                  "evidence_action_counts",
                   "lane_counts",
                   "maintainer_review_count",
                   "manual_review_required_count",
@@ -570,6 +761,9 @@
                   "direct_submission_count": {
                     "type": "integer",
                     "minimum": 0
+                  },
+                  "evidence_action_counts": {
+                    "$ref": "#/components/schemas/CountMap"
                   },
                   "lane_counts": {
                     "$ref": "#/components/schemas/CountMap"
@@ -596,6 +790,61 @@
                   },
                   "top_direct_submission_kinds": {
                     "$ref": "#/components/schemas/CountMap"
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
+      },
+      "ReviewEnrichmentEvidenceArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "type": "object",
+            "required": ["entries", "notes", "summary"],
+            "properties": {
+              "entries": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ReviewEnrichmentEvidenceEntry"
+                }
+              },
+              "notes": {
+                "type": "string"
+              },
+              "summary": {
+                "type": "object",
+                "required": [
+                  "entry_count",
+                  "evidence_action_counts",
+                  "stale_candidate_count",
+                  "subnet_count",
+                  "unverified_candidate_count"
+                ],
+                "properties": {
+                  "entry_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "evidence_action_counts": {
+                    "$ref": "#/components/schemas/CountMap"
+                  },
+                  "stale_candidate_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "subnet_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "unverified_candidate_count": {
+                    "type": "integer",
+                    "minimum": 0
                   }
                 },
                 "additionalProperties": false

--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -11,6 +11,8 @@ export const ARTIFACT_SIZE_BUDGETS = [
   budget("search.json", 750_000, 2_000_000),
   budget("openapi.json", 500_000, 1_000_000),
   budget("profiles.json", 500_000, 1_000_000),
+  budget("review/enrichment-evidence.json", 500_000, 1_000_000),
+  budget("review/enrichment-queue.json", 500_000, 1_000_000),
 ];
 
 const DEFAULT_BUDGET = budget("*", 250_000, 1_000_000);

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -261,12 +261,14 @@ const profileArtifacts = buildSubnetProfileArtifacts({
   subnets: mergedSubnets,
   surfaces,
 });
-const enrichmentQueue = buildEnrichmentQueueArtifact({
+const enrichmentArtifacts = buildEnrichmentQueueArtifacts({
   candidates: candidateIndex,
   curationReview,
   profiles: profileArtifacts.profiles,
   reviewProfiles: profileArtifacts.reviewProfiles,
+  verification,
 });
+const enrichmentQueue = enrichmentArtifacts.queueArtifact;
 
 const reviewQueue = candidateIndex.filter((candidate) =>
   ["schema-valid", "maintainer-review", "stale"].includes(candidate.state),
@@ -637,6 +639,10 @@ await writeJson(artifactFile("review/adapter-candidates.json"), {
   candidates: curationReview.adapter_candidates,
 });
 await writeJson(artifactFile("review/enrichment-queue.json"), enrichmentQueue);
+await writeJson(
+  artifactFile("review/enrichment-evidence.json"),
+  enrichmentArtifacts.evidenceArtifact,
+);
 await writeJson(artifactFile("review/maintainer-decisions.json"), {
   schema_version: 1,
   contract_version: contractVersion,
@@ -947,12 +953,16 @@ function buildSubnetProfileArtifacts({
   };
 }
 
-function buildEnrichmentQueueArtifact({
+function buildEnrichmentQueueArtifacts({
   candidates,
   curationReview,
   profiles,
   reviewProfiles,
+  verification,
 }) {
+  const verificationByCandidate = new Map(
+    (verification.results || []).map((result) => [result.candidate_id, result]),
+  );
   const reviewProfileByNetuid = new Map(
     reviewProfiles.map((profile) => [profile.netuid, profile]),
   );
@@ -970,7 +980,7 @@ function buildEnrichmentQueueArtifact({
   );
   const candidatesByNetuid = groupByNetuid(candidates);
 
-  const queue = profiles
+  const fullQueue = profiles
     .map((profile) =>
       enrichmentQueueEntry({
         adapterCandidate: adapterCandidateByNetuid.get(profile.netuid),
@@ -978,6 +988,7 @@ function buildEnrichmentQueueArtifact({
         profile,
         reviewProfile: reviewProfileByNetuid.get(profile.netuid),
         subnetCandidates: candidatesByNetuid.get(profile.netuid) || [],
+        verificationByCandidate,
       }),
     )
     .sort(
@@ -986,8 +997,10 @@ function buildEnrichmentQueueArtifact({
         a.lane.localeCompare(b.lane) ||
         a.netuid - b.netuid,
     );
+  const queue = fullQueue.map(compactEnrichmentQueueEntry);
+  const evidenceEntries = fullQueue.map(enrichmentEvidenceEntry);
 
-  return {
+  const queueArtifact = {
     schema_version: 1,
     contract_version: contractVersion,
     generated_at: generatedAt,
@@ -1015,10 +1028,100 @@ function buildEnrichmentQueueArtifact({
         (entry) => entry.manual_review_required,
       ).length,
       lane_counts: countBy(queue, "lane"),
+      evidence_action_counts: countBy(queue, "evidence_action"),
       top_direct_submission_kinds: countDirectSubmissionKinds(queue),
     },
     queue,
   };
+  const evidenceArtifact = {
+    schema_version: 1,
+    contract_version: contractVersion,
+    generated_at: generatedAt,
+    notes:
+      "Detailed candidate evidence by missing or contributor-target surface kind. This is contributor guidance and maintainer review context; it does not create registry truth or observed health.",
+    entries: evidenceEntries,
+    summary: {
+      subnet_count: evidenceEntries.length,
+      entry_count: evidenceEntries.length,
+      evidence_action_counts: countBy(evidenceEntries, "evidence_action"),
+      stale_candidate_count: evidenceEntries.reduce(
+        (sum, entry) =>
+          sum + entry.candidate_evidence_summary.stale_or_failed_count,
+        0,
+      ),
+      unverified_candidate_count: evidenceEntries.reduce(
+        (sum, entry) => sum + entry.candidate_evidence_summary.unverified_count,
+        0,
+      ),
+    },
+  };
+  return { evidenceArtifact, queueArtifact };
+}
+
+function compactEnrichmentQueueEntry(entry) {
+  const { candidate_evidence_by_kind: evidenceByKind, ...compact } = entry;
+  return {
+    ...compact,
+    candidate_evidence_summary: summarizeCandidateEvidence(evidenceByKind),
+  };
+}
+
+function enrichmentEvidenceEntry(entry) {
+  return {
+    candidate_evidence_by_kind: entry.candidate_evidence_by_kind,
+    candidate_evidence_summary: summarizeCandidateEvidence(
+      entry.candidate_evidence_by_kind,
+    ),
+    direct_submission_kinds: entry.direct_submission_kinds,
+    evidence_action: entry.evidence_action,
+    lane: entry.lane,
+    missing_kinds: entry.missing_kinds,
+    name: entry.name,
+    netuid: entry.netuid,
+    priority_score: entry.priority_score,
+    slug: entry.slug,
+  };
+}
+
+function summarizeCandidateEvidence(evidenceByKind) {
+  const entries = Object.entries(evidenceByKind || {});
+  const summary = {
+    candidate_count: 0,
+    kinds_with_candidates: [],
+    live_kinds: [],
+    live_or_redirected_count: 0,
+    reviewable_count: 0,
+    stale_kinds: [],
+    stale_or_failed_count: 0,
+    unverified_count: 0,
+    unverified_kinds: [],
+  };
+
+  for (const [kind, evidence] of entries) {
+    summary.candidate_count += evidence.candidate_count || 0;
+    summary.live_or_redirected_count += evidence.live_or_redirected_count || 0;
+    summary.reviewable_count += evidence.reviewable_count || 0;
+    summary.stale_or_failed_count += evidence.stale_or_failed_count || 0;
+    summary.unverified_count += evidence.unverified_count || 0;
+    if ((evidence.candidate_count || 0) > 0) {
+      summary.kinds_with_candidates.push(kind);
+    }
+    if ((evidence.live_or_redirected_count || 0) > 0) {
+      summary.live_kinds.push(kind);
+    }
+    if ((evidence.stale_or_failed_count || 0) > 0) {
+      summary.stale_kinds.push(kind);
+    }
+    if ((evidence.unverified_count || 0) > 0) {
+      summary.unverified_kinds.push(kind);
+    }
+  }
+
+  summary.kinds_with_candidates.sort();
+  summary.live_kinds.sort();
+  summary.stale_kinds.sort();
+  summary.unverified_kinds.sort();
+  return summary;
 }
 
 function enrichmentQueueEntry({
@@ -1027,6 +1130,7 @@ function enrichmentQueueEntry({
   profile,
   reviewProfile,
   subnetCandidates,
+  verificationByCandidate,
 }) {
   const missingRequired = profile.completeness.missing_required || [];
   const missingOperational = profile.completeness.missing_operational || [];
@@ -1038,10 +1142,21 @@ function enrichmentQueueEntry({
     ]),
   ].sort();
   const directSubmissionKinds = directSubmissionKindsForProfile(profile);
+  const candidateEvidenceByKind = candidateEvidenceByKindForQueue({
+    directSubmissionKinds,
+    missingKinds,
+    subnetCandidates,
+    verificationByCandidate,
+  });
   const lane = enrichmentLane({
     adapterCandidate,
     directSubmissionKinds,
     profile,
+  });
+  const evidenceAction = enrichmentEvidenceAction({
+    candidateEvidenceByKind,
+    directSubmissionKinds,
+    lane,
   });
   const manualReviewRequired = [
     "maintainer-review",
@@ -1055,12 +1170,14 @@ function enrichmentQueueEntry({
 
   return {
     adapter_score: adapterScore,
+    candidate_evidence_by_kind: candidateEvidenceByKind,
     candidate_count: profile.candidate_count,
     completeness_score: profile.completeness_score,
     contribution_hint: enrichmentContributionHint(lane, directSubmissionKinds),
     curation_level: profile.curation_level,
     direct_submission_kinds: directSubmissionKinds,
     endpoint_count: profile.endpoint_count,
+    evidence_action: evidenceAction,
     lane,
     manual_review_required: manualReviewRequired,
     missing_kinds: missingKinds,
@@ -1089,9 +1206,125 @@ function enrichmentQueueEntry({
       .slice(0, 5),
     slug: profile.slug,
     source_urls: (profile.provenance.source_urls || []).slice(0, 8),
+    stale_candidate_count: staleCandidateCount(candidateEvidenceByKind),
     surface_count: profile.surface_count,
     verified_candidate_count: gapPriority?.verified_candidate_count || 0,
   };
+}
+
+function candidateEvidenceByKindForQueue({
+  directSubmissionKinds,
+  missingKinds,
+  subnetCandidates,
+  verificationByCandidate,
+}) {
+  const relevantKinds = [
+    ...new Set([...missingKinds, ...directSubmissionKinds]),
+  ].sort();
+  const candidatesByKind = groupBy(
+    subnetCandidates.filter((candidate) =>
+      relevantKinds.includes(candidate.kind),
+    ),
+    "kind",
+  );
+
+  return Object.fromEntries(
+    relevantKinds.map((kind) => {
+      const kindCandidates = candidatesByKind.get(kind) || [];
+      const classifications = countBy(
+        kindCandidates.map((candidate) => ({
+          classification:
+            verificationByCandidate.get(candidate.id)?.classification ||
+            candidate.verification?.classification ||
+            candidate.state ||
+            "unknown",
+        })),
+        "classification",
+      );
+      const liveCount =
+        (classifications.live || 0) + (classifications.redirected || 0);
+      const unverifiedCount =
+        (classifications["schema-valid"] || 0) +
+        (classifications["maintainer-review"] || 0) +
+        (classifications.verified || 0) +
+        (classifications.unknown || 0);
+      const deadCount =
+        (classifications.dead || 0) +
+        (classifications.unsafe || 0) +
+        (classifications.unsupported || 0) +
+        (classifications["content-mismatch"] || 0);
+      const reviewableCount = kindCandidates.filter((candidate) =>
+        ["schema-valid", "maintainer-review", "verified"].includes(
+          candidate.state,
+        ),
+      ).length;
+      return [
+        kind,
+        {
+          candidate_count: kindCandidates.length,
+          classifications,
+          live_or_redirected_count: liveCount,
+          reviewable_count: reviewableCount,
+          stale_or_failed_count: deadCount,
+          unverified_count: unverifiedCount,
+          sample_candidate_ids: kindCandidates
+            .map((candidate) => candidate.id)
+            .filter(Boolean)
+            .sort()
+            .slice(0, 3),
+        },
+      ];
+    }),
+  );
+}
+
+function enrichmentEvidenceAction({
+  candidateEvidenceByKind,
+  directSubmissionKinds,
+  lane,
+}) {
+  if (["adapter-candidate", "maintainer-review"].includes(lane)) {
+    return "maintainer-review-existing-evidence";
+  }
+  if (lane !== "direct-submission") {
+    return "monitor";
+  }
+
+  const targetEvidence = directSubmissionKinds.map(
+    (kind) => candidateEvidenceByKind[kind],
+  );
+  if (
+    targetEvidence.some(
+      (evidence) =>
+        evidence &&
+        evidence.candidate_count > 0 &&
+        evidence.live_or_redirected_count === 0,
+    )
+  ) {
+    if (
+      targetEvidence.some(
+        (evidence) => evidence && evidence.stale_or_failed_count > 0,
+      )
+    ) {
+      return "replace-stale-evidence";
+    }
+    return "verify-existing-evidence";
+  }
+  if (
+    targetEvidence.some(
+      (evidence) => evidence && evidence.live_or_redirected_count > 0,
+    )
+  ) {
+    return "review-existing-evidence";
+  }
+  return "submit-new-evidence";
+}
+
+function staleCandidateCount(candidateEvidenceByKind) {
+  return Object.values(candidateEvidenceByKind).reduce(
+    (sum, evidence) => sum + (evidence.stale_or_failed_count || 0),
+    0,
+  );
 }
 
 function directSubmissionKindsForProfile(profile) {
@@ -1457,11 +1690,15 @@ function averageScore(profiles) {
 }
 
 function groupByNetuid(items) {
+  return groupBy(items, "netuid");
+}
+
+function groupBy(items, key) {
   const groups = new Map();
   for (const item of items) {
-    const group = groups.get(item.netuid) || [];
+    const group = groups.get(item[key]) || [];
     group.push(item);
-    groups.set(item.netuid, group);
+    groups.set(item[key], group);
   }
   return groups;
 }

--- a/scripts/curation-brief.mjs
+++ b/scripts/curation-brief.mjs
@@ -113,6 +113,7 @@ export function renderCurationBrief(snapshot) {
     "Submit one public-safe candidate at a time with `npm run candidate:new`. Official docs, websites, source repos, OpenAPI/schema URLs, public subnet APIs, dashboards, SDKs, examples, and data artifacts are the best auto-review candidates.",
     "",
     `- Enrichment queue lanes: ${formatCounts(enrichmentSummary.lane_counts)}`,
+    `- Evidence actions: ${formatCounts(enrichmentSummary.evidence_action_counts)}`,
     `- Direct-submission targets: ${enrichmentSummary.direct_submission_count ?? "unknown"}`,
     `- Maintainer-review targets: ${enrichmentSummary.maintainer_review_count ?? "unknown"}`,
     `- Manual-review-required targets: ${enrichmentSummary.manual_review_required_count ?? "unknown"}`,
@@ -120,7 +121,7 @@ export function renderCurationBrief(snapshot) {
     ...numberedRows(
       enrichmentQueue,
       (row) =>
-        `SN${row.netuid} ${row.name} - ${row.lane}; priority ${row.priority_score}; ${row.recommended_action}; target kinds: ${row.direct_submission_kinds.join(", ") || "n/a"}`,
+        `SN${row.netuid} ${row.name} - ${row.lane}; ${row.evidence_action || "unknown-action"}; priority ${row.priority_score}; ${row.recommended_action}; target kinds: ${row.direct_submission_kinds.join(", ") || "n/a"}`,
     ),
     "",
     "## Lowest Profile Completeness",
@@ -213,6 +214,7 @@ function enrichmentBriefRow(entry) {
     priority_score: entry.priority_score,
     completeness_score: entry.completeness_score,
     direct_submission_kinds: entry.direct_submission_kinds || [],
+    evidence_action: entry.evidence_action || null,
     manual_review_required: entry.manual_review_required,
     reason_codes: entry.reason_codes || [],
     recommended_action: entry.recommended_action,

--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -125,6 +125,7 @@ function buildCompactManifest(fullManifest) {
       "/metagraph/candidates.json",
       "/metagraph/health/latest.json",
       "/metagraph/review-queue.json",
+      "/metagraph/review/enrichment-evidence.json",
       "/metagraph/source-snapshots.json",
       "/metagraph/types.d.ts",
       "/metagraph/verification/latest.json",

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -170,6 +170,18 @@ const checks = [
     },
   ],
   [
+    "/api/v1/review/enrichment-evidence?evidence_action=replace-stale-evidence&limit=3",
+    (body) => {
+      assert.equal(body.data.entries.length <= 3, true);
+      assert.equal(
+        body.data.entries.every(
+          (entry) => entry.evidence_action === "replace-stale-evidence",
+        ),
+        true,
+      );
+    },
+  ],
+  [
     "/api/v1/health",
     (body) => assert.equal(Array.isArray(body.data.subnets), true),
   ],

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -24,6 +24,7 @@ const R2_ONLY_PATTERNS = [
   /^providers\/[^/]+\.json$/,
   /^providers\/[^/]+\/endpoints\.json$/,
   /^review-queue\.json$/,
+  /^review\/enrichment-evidence\.json$/,
   /^rpc\/pools\.json$/,
   /^rpc-endpoints\.json$/,
   /^schemas\/(?!index\.json$).+\.json$/,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -298,6 +298,28 @@ export const API_QUERY_COLLECTIONS = {
       "verified_candidate_count",
     ],
   }),
+  "enrichment-evidence": queryCollection("entries", {
+    filters: {
+      evidence_action: enumSchema([
+        "submit-new-evidence",
+        "verify-existing-evidence",
+        "replace-stale-evidence",
+        "review-existing-evidence",
+        "maintainer-review-existing-evidence",
+        "monitor",
+      ]),
+      lane: enumSchema([
+        "direct-submission",
+        "maintainer-review",
+        "adapter-candidate",
+        "monitoring-followup",
+        "baseline-monitoring",
+      ]),
+      netuid: integerSchema,
+    },
+    search: ["name", "slug", "evidence_action"],
+    sort: ["evidence_action", "lane", "name", "netuid", "priority_score"],
+  }),
   "health-subnets": queryCollection("subnets", {
     filters: {
       netuid: integerSchema,
@@ -674,6 +696,12 @@ export const PUBLIC_ARTIFACTS = [
     "ReviewEnrichmentQueueArtifact",
   ),
   artifact(
+    "review-enrichment-evidence",
+    "/metagraph/review/enrichment-evidence.json",
+    "Detailed candidate evidence by missing or contributor-target surface kind for enrichment work.",
+    "ReviewEnrichmentEvidenceArtifact",
+  ),
+  artifact(
     "review-decisions",
     "/metagraph/review/maintainer-decisions.json",
     "Public-safe maintainer review decision ledger.",
@@ -902,6 +930,16 @@ export const API_ROUTES = [
     "standard",
     ["registry", "review", "profiles"],
     listQuery("enrichment-queue"),
+  ),
+  route(
+    "review-enrichment-evidence",
+    "GET",
+    "/api/v1/review/enrichment-evidence",
+    "/metagraph/review/enrichment-evidence.json",
+    "Fetch detailed candidate evidence behind the enrichment queue.",
+    "standard",
+    ["registry", "review", "profiles"],
+    listQuery("enrichment-evidence"),
   ),
   route(
     "health",

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -370,6 +370,7 @@ test("public artifacts are internally consistent", () => {
   const profileCompleteness = readArtifact("review/profile-completeness.json");
   const adapterCandidates = readArtifact("review/adapter-candidates.json");
   const enrichmentQueue = readArtifact("review/enrichment-queue.json");
+  const enrichmentEvidence = readArtifact("review/enrichment-evidence.json");
   const reviewDecisions = readArtifact("review/maintainer-decisions.json");
   const generatedCandidateDiscovery = JSON.parse(
     readFileSync("registry/candidates/generated/public-sources.json", "utf8"),
@@ -608,6 +609,8 @@ test("public artifacts are internally consistent", () => {
   assert.equal(enrichmentQueue.summary.subnet_count, native.subnets.length);
   assert.equal(enrichmentQueue.summary.queue_count, native.subnets.length);
   assert.equal(enrichmentQueue.queue.length, native.subnets.length);
+  assert.equal(enrichmentEvidence.summary.subnet_count, native.subnets.length);
+  assert.equal(enrichmentEvidence.entries.length, native.subnets.length);
   assert.equal(
     enrichmentQueue.queue.some((entry) => entry.lane === "direct-submission"),
     true,
@@ -621,6 +624,46 @@ test("public artifacts are internally consistent", () => {
       Array.isArray(entry.direct_submission_kinds),
     ),
     true,
+  );
+  assert.equal(
+    enrichmentQueue.queue.every(
+      (entry) =>
+        entry.candidate_evidence_summary &&
+        typeof entry.candidate_evidence_summary === "object",
+    ),
+    true,
+  );
+  assert.equal(
+    enrichmentQueue.queue.some(
+      (entry) => entry.evidence_action === "replace-stale-evidence",
+    ),
+    true,
+  );
+  assert.equal(
+    enrichmentQueue.queue.every((entry) =>
+      Number.isInteger(entry.stale_candidate_count),
+    ),
+    true,
+  );
+  assert.equal(
+    enrichmentEvidence.entries.some(
+      (entry) => entry.candidate_evidence_by_kind["source-repo"],
+    ),
+    true,
+  );
+  assert.deepEqual(
+    Object.fromEntries(
+      enrichmentQueue.queue.map((entry) => [
+        entry.netuid,
+        entry.candidate_evidence_summary,
+      ]),
+    ),
+    Object.fromEntries(
+      enrichmentEvidence.entries.map((entry) => [
+        entry.netuid,
+        entry.candidate_evidence_summary,
+      ]),
+    ),
   );
   assert.deepEqual(
     profileCompleteness.summary.by_profile_level,


### PR DESCRIPTION
## Summary
Add detailed enrichment evidence behind the all-subnet enrichment queue so contributors and maintainers can tell whether a subnet needs new evidence, verification of existing evidence, replacement of stale candidates, or maintainer review.

## What changed
- Added compact `candidate_evidence_summary`, `stale_candidate_count`, and `evidence_action` fields to the tracked enrichment queue.
- Added R2-backed `/metagraph/review/enrichment-evidence.json` and `/api/v1/review/enrichment-evidence` for full per-kind candidate evidence.
- Added strict review evidence schemas, OpenAPI/types/client regeneration, artifact budget coverage, and Worker/API validation for the new route.
- Updated curation docs so contributors know how to interpret enrichment lanes versus evidence actions.
- Marked the new detailed evidence artifact as required in the compact R2 manifest.

## Why
The enrichment queue was useful, but too coarse: a contributor could not tell whether a missing website/repo/API needed a fresh submission or whether candidates already existed but were stale, unsupported, or awaiting review. This makes all-subnet enrichment more actionable without putting high-churn per-kind detail back into Git.

## Validation
- `npm run build`
- `npm run check`
- `npm run test:coverage`
- `npm run validate:artifact-budgets`
- `git diff --check`
- `node scripts/ci-verify-submitted-artifacts.mjs --changed-files /tmp/metagraphed-enrichment-changed-files.txt`

## Notes
- Full detailed evidence is R2-backed; Git keeps only the compact queue summary and public contract artifacts.
- Candidate discovery still reports unauthenticated GitHub API 403s for some upstream source crawls. That is an existing freshness/data-source issue and should be handled separately with read-only discovery auth.
