### PR TITLE
chore(health): refresh r2 manifest sizes

### DIFF
--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -214,7 +214,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1118,
-  "full_artifact_size_bytes": 28256354,
+  "full_artifact_size_bytes": 28451143,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -239,6 +239,6 @@
   "storage_tier_size_bytes": {
     "dual": 3885990,
     "git": 69198,
-    "r2": 24301166
+    "r2": 24495955
   }
 }


### PR DESCRIPTION
## Summary
- refreshes compact R2 manifest size totals after the write-enabled health probe pass

## What changed
- updates `public/metagraph/r2-manifest.json` full artifact and R2-tier byte totals

## Why
- the health probe results are stored in R2, and the public manifest should describe the current generated bundle

## Validation
- `METAGRAPH_WRITE_PROBE_RESULTS=1 npm run probes:smoke` - 855 surfaces probed, 649 ok, 206 degraded, 0 failed
- `npm run artifacts:prepare-local`
- `npm run r2:manifest`
- signed commit verified locally

## Notes
- this does not add expanded health artifacts to Git; it only updates compact manifest totals.