### PR TITLE
chore(storage): refresh r2 manifest after public source enrichment

### DIFF
--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 3795088,
+  "artifact_size_bytes": 3795030,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -61,8 +61,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "51aa14f1a76def4aabeb0d11ff59f2e30ce2f04fe5b6b290d00876c69591ffbf",
-      "size_bytes": 4407,
+      "sha256": "a7f52bbc0ef76132f8c487612ea35c7cd03a109ef81840fe06611cfc101806b8",
+      "size_bytes": 4349,
       "storage_tier": "dual"
     },
     {
@@ -214,7 +214,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1140,
-  "full_artifact_size_bytes": 25093463,
+  "full_artifact_size_bytes": 26242565,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -237,8 +237,8 @@
     "r2": 1117
   },
   "storage_tier_size_bytes": {
-    "dual": 3725480,
+    "dual": 3725422,
     "git": 69608,
-    "r2": 21298375
+    "r2": 22447535
   }
 }


### PR DESCRIPTION
## Summary
- refresh the compact R2 manifest after the official source enrichment merge
- keep publish hashes aligned without changing registry inputs or generated detail data

## What changed
- updated `public/metagraph/r2-manifest.json` sizes and checksums for the current compact artifact set

## Why
- R2 uploads verify local artifact hashes against the compact manifest before publishing; the enrichment merge changed compact artifacts, so the manifest needs a small follow-up refresh

## Validation
- `npm run validate`
- `METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload:dry-run`
- `git diff --check`
