### PR TITLE
fix(discovery): use taopedia contents listing

### DIFF
--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -308,19 +308,21 @@ async function discoverFromTensorplexSubnetDocs() {
 }
 
 async function discoverFromTaopediaArticles() {
-  const treeUrl =
-    "https://api.github.com/repos/e35ventura/taopedia-articles/git/trees/main?recursive=1";
-  const tree = await fetchJson(treeUrl, githubHeaders());
-  if (!Array.isArray(tree?.tree)) {
-    warnings.push("taopedia-articles: failed to list repository tree");
+  const pagesUrl =
+    "https://api.github.com/repos/e35ventura/taopedia-articles/contents/content/pages?ref=main";
+  const pages = await fetchJson(pagesUrl, githubHeaders());
+  if (!Array.isArray(pages)) {
+    warnings.push("taopedia-articles: failed to list content pages");
     restoreExistingCandidatesForProvider("taopedia-articles");
     return;
   }
 
-  for (const entry of tree.tree) {
-    const match = /^content\/pages\/subnet_(\d+)[^/]*\/index\.mdx$/.exec(
-      entry.path || "",
-    );
+  for (const entry of pages) {
+    if (entry.type !== "dir") {
+      continue;
+    }
+
+    const match = /^subnet_(\d+)[^/]*$/.exec(entry.name || "");
     if (!match) {
       continue;
     }
@@ -330,7 +332,7 @@ async function discoverFromTaopediaArticles() {
       continue;
     }
 
-    const url = `https://github.com/e35ventura/taopedia-articles/blob/main/${entry.path}`;
+    const url = `https://github.com/e35ventura/taopedia-articles/blob/main/${entry.path}/index.mdx`;
     addCandidate({
       id: `sn-${netuid}-taopedia-article`,
       netuid,


### PR DESCRIPTION
## Summary
- replace Taopedia recursive Git tree discovery with the lower-cost GitHub contents listing
- keep existing Taopedia article candidate IDs and public URLs stable
- remove the local source-health warning caused by the recursive tree endpoint returning 403

## What changed
- `discoverFromTaopediaArticles` now reads `content/pages` through the GitHub contents API
- subnet article candidates are derived from matching subnet page directories

## Why
- the recursive tree endpoint can hit GitHub rate or secondary limits even when authenticated
- the shallow contents endpoint returns the same subnet article coverage without unnecessary API cost or discovery warnings

## Validation
- `GITHUB_TOKEN=... npm run discover:candidates:dry-run`
- `GITHUB_TOKEN=... npm run check`
- `git diff --check`

## Notes
- This is intentionally code-only; generated candidate counts and promotion counts stayed unchanged in dry-run validation.
