### PR TITLE
feat(registry): add taostats metagraph discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ npm run probes:smoke
 
 `sync:subnets` uses the Bittensor Python SDK through `uvx` to fetch decoded native Finney subnet metadata without committing Python dependencies to this repo.
 
-`discover:candidates` reads public enrichment sources and writes unverified candidate surfaces into `registry/candidates/generated/public-sources.json`. Current sources include TaoMarketCap, Tensorplex subnet-docs, Taopedia articles, Backprop Finance dTAO dashboard routes, GitHub README links, and public project websites. Third-party dashboards are enrichment candidates only, not chain or identity authority. GitHub README-derived links are intentionally capped, de-duplicated by kind/domain, and limited to project-affiliated provenance so broad reference docs do not flood refresh PRs.
+`discover:candidates` reads public enrichment sources and writes unverified candidate surfaces into `registry/candidates/generated/public-sources.json`. Current sources include TaoMarketCap, Tensorplex subnet-docs, Taopedia articles, Backprop Finance dTAO dashboard routes, Taostats metagraph dashboard routes, GitHub README links, and public project websites. Third-party dashboards are enrichment candidates only, not chain or identity authority. GitHub README-derived links are intentionally capped, de-duplicated by kind/domain, and limited to project-affiliated provenance so broad reference docs do not flood refresh PRs.
 
 `verify:candidates` safely checks candidate URLs, writes a compact promotion snapshot to `registry/verification/promotions.json`, and stages the full volatile verification run outside Git for R2.
 

--- a/docs/all-subnet-registry.md
+++ b/docs/all-subnet-registry.md
@@ -75,7 +75,7 @@ Curation levels:
 
 Candidates are never treated as verified surfaces. They must pass verification and maintainer review before being treated as reviewed registry truth.
 
-`npm run discover:candidates` generates a public-source candidate bundle from enrichment sources such as TaoMarketCap, Tensorplex subnet-docs, Taopedia articles, Backprop Finance dashboard routes, GitHub README links, and public websites. Third-party directories and dashboards are enrichment only; native chain data remains canonical for active subnet existence and curated overlays remain canonical for reviewed public interfaces.
+`npm run discover:candidates` generates a public-source candidate bundle from enrichment sources such as TaoMarketCap, Tensorplex subnet-docs, Taopedia articles, Backprop Finance dashboard routes, Taostats metagraph dashboard routes, GitHub README links, and public websites. Third-party directories and dashboards are enrichment only; native chain data remains canonical for active subnet existence and curated overlays remain canonical for reviewed public interfaces.
 
 `npm run verify:candidates` writes a compact Git-reviewed promotion snapshot to `registry/verification/promotions.json` and stages the full volatile verification run for R2. Classification values include live, redirected, auth-required, dead, unsafe, unsupported, rate-limited, transient, timeout, and content-mismatch.
 

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -121,7 +121,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `npm run build`: regenerate deterministic public artifacts from current registry inputs.
 - `npm run validate`: validate native snapshot, overlays, candidates, review decisions, generated artifacts, and required schemas.
 - `npm run sync:subnets`: update the native Finney snapshot.
-- `npm run discover:candidates`: refresh public-source candidate discovery from chain-adjacent enrichment sources, third-party subnet dashboards, GitHub README links, and public project websites. GitHub README-derived links are capped, de-duplicated by kind/domain, and limited to project-affiliated provenance before they enter the generated candidate bundle.
+- `npm run discover:candidates`: refresh public-source candidate discovery from chain-adjacent enrichment sources, third-party subnet dashboards, subnet metagraph explorer pages, GitHub README links, and public project websites. GitHub README-derived links are capped, de-duplicated by kind/domain, and limited to project-affiliated provenance before they enter the generated candidate bundle.
 - `npm run verify:candidates`: safely verify public candidates.
 - `npm run curate:baseline`: derive generated overlays from verified candidates, commit only compact checksum metadata, and stage expanded generated overlays outside Git for R2.
 - `npm run review:promote`: apply public-safe maintainer review decisions to overlays.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -41,10 +41,11 @@ This updates native subnet data, candidates, verification, baseline curation, ad
 The refresh keeps Git reviewable: compact artifacts remain in `public/metagraph`, while per-subnet candidates, verification details, health detail/history, adapter snapshots, schema snapshots, and provider detail outputs are staged for R2 and should not be committed.
 
 Candidate discovery reads public enrichment sources such as TaoMarketCap,
-Backprop Finance dashboard routes, Tensorplex `subnet-docs`, and Taopedia
-articles. Set `GITHUB_TOKEN` or `GH_TOKEN` for authenticated read-only GitHub
-API requests during local refreshes; scheduled sync and publish workflows
-already pass `GITHUB_TOKEN` from GitHub Actions.
+Backprop Finance dashboard routes, Taostats metagraph dashboard routes,
+Tensorplex `subnet-docs`, and Taopedia articles. Set `GITHUB_TOKEN` or
+`GH_TOKEN` for authenticated read-only GitHub API requests during local
+refreshes; scheduled sync and publish workflows already pass `GITHUB_TOKEN`
+from GitHub Actions.
 
 Live health probes are only written when explicitly enabled:
 

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -2,12 +2,20 @@
   "adapter_count": 2,
   "artifact_budget_summary": {
     "fail_count": 0,
-    "ok_count": 1205,
-    "warn_count": 0
+    "ok_count": 1204,
+    "warn_count": 1
   },
-  "artifact_budgets": [],
+  "artifact_budgets": [
+    {
+      "fail_bytes": 5000000,
+      "path": "verification/latest.json",
+      "size_bytes": 2082761,
+      "status": "warn",
+      "warn_bytes": 2000000
+    }
+  ],
   "artifact_count": 22,
-  "artifact_size_bytes": 3556315,
+  "artifact_size_bytes": 3657528,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -17,8 +25,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "facd7c83e10a12ac9352f1e0f8245b16a58a0b464aa7d9e1a0d71baa7e091f96",
-      "size_bytes": 3285,
+      "sha256": "abedcf31acbfba3e8369cfdf8eacfe864fc692932b4cf4aa9308bdc07c317e90",
+      "size_bytes": 3022,
       "storage_tier": "dual"
     },
     {
@@ -29,25 +37,25 @@
     },
     {
       "path": "coverage.json",
-      "sha256": "1402a9028f242a682675c5c78cb5f1ad22d001cab90710a955a2b91e42fc7d4a",
+      "sha256": "e7a78ee6f755c1503f0c7f56aba8ea1122c825d61bebfc4bbe31cb9290609fd8",
       "size_bytes": 982,
       "storage_tier": "dual"
     },
     {
       "path": "curation.json",
-      "sha256": "9ab40c5a6fa57a6e68c181c125e32c918cf8bd8241d9b52527e6cfcbbdb082df",
-      "size_bytes": 156215,
+      "sha256": "4bc62f736c86bc4b3f13f89ced298ca613db5db61fcac5d968f7aac50cac5c55",
+      "size_bytes": 156220,
       "storage_tier": "dual"
     },
     {
       "path": "evidence-ledger.json",
-      "sha256": "59a0385881bd2c70461a79eb8bc230fc92580ac902f15e5cf1405a9570fdc3ae",
-      "size_bytes": 626942,
+      "sha256": "c12131906c10294d09898d8edc13e92f7b1d6595a9c7c67563a1f130a75338af",
+      "size_bytes": 651684,
       "storage_tier": "dual"
     },
     {
       "path": "freshness.json",
-      "sha256": "271463ce4e3e1d0fd39763086d86217a6ed10012e03d0cc31310dcb5213f4661",
+      "sha256": "9ad9982efae083a13b9eac2e6e6f1f9f9d82a1f9d77640d68f68d1009cca8e43",
       "size_bytes": 4323,
       "storage_tier": "dual"
     },
@@ -65,8 +73,8 @@
     },
     {
       "path": "profiles.json",
-      "sha256": "c736e8ec581d138871a63cb9936f6492ea1e144eea1b5502d69d012fe149322c",
-      "size_bytes": 339653,
+      "sha256": "72e06cf35e07f7c68c04ba7be1665f401ed480ef287f6002219a6204a10e4981",
+      "size_bytes": 342758,
       "storage_tier": "dual"
     },
     {
@@ -77,26 +85,26 @@
     },
     {
       "path": "review/adapter-candidates.json",
-      "sha256": "4deb266c1ed466582aec4573a27530ff6cc9b5afe231c1f6428c09f1af49314c",
-      "size_bytes": 26471,
+      "sha256": "e08c3502d16608f07585848a591e8f2ee55ef72a1bc03f95fb79c39e3d97ffc3",
+      "size_bytes": 26473,
       "storage_tier": "dual"
     },
     {
       "path": "review/curation.json",
-      "sha256": "a04ff02427e299f6686e0a356a2c9358c68c2fdf1a2531ffb32be7f4529983a0",
-      "size_bytes": 94825,
+      "sha256": "42268b9642fb806c2494bf364973b4f5a3c494c075ca27c3bfc91acdefd7c7b8",
+      "size_bytes": 94841,
       "storage_tier": "dual"
     },
     {
       "path": "review/enrichment-queue.json",
-      "sha256": "29c77a63197536d1e32529ec754a1a234891ade008582417e87ded87b87a2d6b",
-      "size_bytes": 330824,
+      "sha256": "6c401854d0cc761a3f330fd2351323519eec2d9cab86f52f1dda9f03b9628d27",
+      "size_bytes": 334085,
       "storage_tier": "dual"
     },
     {
       "path": "review/gap-priorities.json",
-      "sha256": "69a8b7d6bc616ca0484927113cde03f94433df226b4508e7407c3c832e8ccdf7",
-      "size_bytes": 66465,
+      "sha256": "1d113aaa1cf63c21026ba2826be32456bf0fcfee57f4db213a1351c7b59eb2bd",
+      "size_bytes": 66479,
       "storage_tier": "dual"
     },
     {
@@ -107,8 +115,8 @@
     },
     {
       "path": "review/profile-completeness.json",
-      "sha256": "bfc0bfba9a56354130f97b08f52bbc2d7dca53aa91f3d659acdc3b06ce48b7a0",
-      "size_bytes": 129947,
+      "sha256": "7dceea6ea4aa347793605030756c00343edf238a3bd13ee94297b244d824f82c",
+      "size_bytes": 129949,
       "storage_tier": "git"
     },
     {
@@ -125,28 +133,28 @@
     },
     {
       "path": "search.json",
-      "sha256": "9daba46103509c365c36b2daab07cd0d31caedfa48d6fac7edc7bb21706cda65",
-      "size_bytes": 414556,
+      "sha256": "159a273eddcf0bcc53e97760a0b801137369b4611258394514cbe86f594f1ec2",
+      "size_bytes": 435504,
       "storage_tier": "dual"
     },
     {
       "path": "subnets.json",
-      "sha256": "0fb7e7f331ba654df7dd4e40c88eac4b14cb4497dbc8f25012bb8988aea04de6",
-      "size_bytes": 120249,
+      "sha256": "0d8ad92161a5c542f3761e928a5ed9c9ecff203b4a2bb0d2516b31d6f11ad41f",
+      "size_bytes": 120258,
       "storage_tier": "dual"
     },
     {
       "path": "surfaces.json",
-      "sha256": "82cdb1fe3be88e37cbd43e08e6903fbaab02cb5e8a6321963ccb717142c96020",
-      "size_bytes": 697512,
+      "sha256": "12368d712a64db5c0a55d7f2526a665a9f8b891399dc7aeab8e54809e020b33a",
+      "size_bytes": 746884,
       "storage_tier": "dual"
     }
   ],
-  "candidate_count": 1753,
+  "candidate_count": 1880,
   "contract_version": "2026-06-06.1",
   "coverage": {
     "application_subnet_count": 128,
-    "candidate_count": 1753,
+    "candidate_count": 1880,
     "candidate_subnet_count": 129,
     "chain_subnet_count": 129,
     "curated_overlay_count": 129,
@@ -163,7 +171,7 @@
     "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
     "network": "finney",
     "probed_count": 129,
-    "probed_surface_count": 721,
+    "probed_surface_count": 766,
     "root_subnet_count": 1,
     "schema_version": 1,
     "source": {
@@ -177,11 +185,11 @@
       },
       "overlays": "registry/subnets"
     },
-    "surface_count": 725
+    "surface_count": 770
   },
-  "endpoint_count": 725,
+  "endpoint_count": 770,
   "full_artifact_count": 1205,
-  "full_artifact_size_bytes": 37398462,
+  "full_artifact_size_bytes": 39652528,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 67,
@@ -196,10 +204,10 @@
     "r2": 1183
   },
   "storage_tier_size_bytes": {
-    "dual": 3426368,
-    "git": 129947,
-    "r2": 33842147
+    "dual": 3527579,
+    "git": 129949,
+    "r2": 35995000
   },
   "subnet_count": 129,
-  "surface_count": 725
+  "surface_count": 770
 }

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -3,63 +3,55 @@
     "added": [],
     "modified": [
       {
-        "hash": "1402a9028f242a682675c5c78cb5f1ad22d001cab90710a955a2b91e42fc7d4a",
+        "hash": "e7a78ee6f755c1503f0c7f56aba8ea1122c825d61bebfc4bbe31cb9290609fd8",
         "path": "coverage.json"
       },
       {
-        "hash": "9ab40c5a6fa57a6e68c181c125e32c918cf8bd8241d9b52527e6cfcbbdb082df",
+        "hash": "4bc62f736c86bc4b3f13f89ced298ca613db5db61fcac5d968f7aac50cac5c55",
         "path": "curation.json"
       },
       {
-        "hash": "59a0385881bd2c70461a79eb8bc230fc92580ac902f15e5cf1405a9570fdc3ae",
+        "hash": "c12131906c10294d09898d8edc13e92f7b1d6595a9c7c67563a1f130a75338af",
         "path": "evidence-ledger.json"
       },
       {
-        "hash": "271463ce4e3e1d0fd39763086d86217a6ed10012e03d0cc31310dcb5213f4661",
+        "hash": "9ad9982efae083a13b9eac2e6e6f1f9f9d82a1f9d77640d68f68d1009cca8e43",
         "path": "freshness.json"
       },
       {
-        "hash": "9c313800098e52539f6651772b40477201c9ca48c010629bb51f9e49a38c3e88",
-        "path": "gaps.json"
-      },
-      {
-        "hash": "c736e8ec581d138871a63cb9936f6492ea1e144eea1b5502d69d012fe149322c",
+        "hash": "72e06cf35e07f7c68c04ba7be1665f401ed480ef287f6002219a6204a10e4981",
         "path": "profiles.json"
       },
       {
-        "hash": "9b7cbdb2a73de1d2780d6a6a10c33f4669e0383e02008f5b37eaababbc77546f",
-        "path": "providers.json"
-      },
-      {
-        "hash": "4deb266c1ed466582aec4573a27530ff6cc9b5afe231c1f6428c09f1af49314c",
+        "hash": "e08c3502d16608f07585848a591e8f2ee55ef72a1bc03f95fb79c39e3d97ffc3",
         "path": "review/adapter-candidates.json"
       },
       {
-        "hash": "a04ff02427e299f6686e0a356a2c9358c68c2fdf1a2531ffb32be7f4529983a0",
+        "hash": "42268b9642fb806c2494bf364973b4f5a3c494c075ca27c3bfc91acdefd7c7b8",
         "path": "review/curation.json"
       },
       {
-        "hash": "29c77a63197536d1e32529ec754a1a234891ade008582417e87ded87b87a2d6b",
+        "hash": "6c401854d0cc761a3f330fd2351323519eec2d9cab86f52f1dda9f03b9628d27",
         "path": "review/enrichment-queue.json"
       },
       {
-        "hash": "69a8b7d6bc616ca0484927113cde03f94433df226b4508e7407c3c832e8ccdf7",
+        "hash": "1d113aaa1cf63c21026ba2826be32456bf0fcfee57f4db213a1351c7b59eb2bd",
         "path": "review/gap-priorities.json"
       },
       {
-        "hash": "bfc0bfba9a56354130f97b08f52bbc2d7dca53aa91f3d659acdc3b06ce48b7a0",
+        "hash": "7dceea6ea4aa347793605030756c00343edf238a3bd13ee94297b244d824f82c",
         "path": "review/profile-completeness.json"
       },
       {
-        "hash": "9daba46103509c365c36b2daab07cd0d31caedfa48d6fac7edc7bb21706cda65",
+        "hash": "159a273eddcf0bcc53e97760a0b801137369b4611258394514cbe86f594f1ec2",
         "path": "search.json"
       },
       {
-        "hash": "0fb7e7f331ba654df7dd4e40c88eac4b14cb4497dbc8f25012bb8988aea04de6",
+        "hash": "0d8ad92161a5c542f3761e928a5ed9c9ecff203b4a2bb0d2516b31d6f11ad41f",
         "path": "subnets.json"
       },
       {
-        "hash": "82cdb1fe3be88e37cbd43e08e6903fbaab02cb5e8a6321963ccb717142c96020",
+        "hash": "12368d712a64db5c0a55d7f2526a665a9f8b891399dc7aeab8e54809e020b33a",
         "path": "surfaces.json"
       }
     ],
@@ -80,13 +72,13 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 15,
+    "artifact_modified_count": 13,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {
-        "after": 1753,
-        "before": 1624,
-        "delta": 129
+        "after": 1880,
+        "before": 1753,
+        "delta": 127
       },
       "curated_overlay_count": {
         "after": 129,
@@ -100,9 +92,9 @@
       },
       "provider_count": null,
       "surface_count": {
-        "after": 725,
-        "before": 662,
-        "delta": 63
+        "after": 770,
+        "before": 725,
+        "delta": 45
       }
     },
     "netuid_added_count": 0,

--- a/public/metagraph/coverage.json
+++ b/public/metagraph/coverage.json
@@ -1,6 +1,6 @@
 {
   "application_subnet_count": 128,
-  "candidate_count": 1753,
+  "candidate_count": 1880,
   "candidate_subnet_count": 129,
   "chain_subnet_count": 129,
   "curated_overlay_count": 129,
@@ -17,7 +17,7 @@
   "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
   "network": "finney",
   "probed_count": 129,
-  "probed_surface_count": 721,
+  "probed_surface_count": 766,
   "root_subnet_count": 1,
   "schema_version": 1,
   "source": {
@@ -31,5 +31,5 @@
     },
     "overlays": "registry/subnets"
   },
-  "surface_count": 725
+  "surface_count": 770
 }

--- a/public/metagraph/curation.json
+++ b/public/metagraph/curation.json
@@ -1,7 +1,7 @@
 {
   "curation": [
     {
-      "candidate_count": 3,
+      "candidate_count": 4,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -41,7 +41,7 @@
       "surface_count": 12
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -85,7 +85,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -125,7 +125,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -169,7 +169,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -213,7 +213,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -225,7 +225,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 4,
@@ -252,10 +252,10 @@
       "name": "Hone",
       "netuid": 5,
       "slug": "sn-5",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -297,7 +297,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -335,7 +335,7 @@
       "surface_count": 15
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -377,7 +377,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -421,49 +421,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 12,
-      "coverage_level": "probed",
-      "curation": {
-        "gap_notes": [
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
-          "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
-        ],
-        "level": "machine-verified",
-        "review_state": "machine-generated",
-        "reviewed_at": null,
-        "source_count": 4,
-        "verified_at": null
-      },
-      "gap_count": 4,
-      "gaps": {
-        "gap_notes": [
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
-          "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
-        ],
-        "missing_kinds": [
-          "openapi",
-          "subnet-api",
-          "sse",
-          "data-artifact"
-        ],
-        "supported_kinds": [
-          "dashboard",
-          "docs",
-          "source-repo",
-          "website"
-        ]
-      },
-      "name": "Swap",
-      "netuid": 10,
-      "slug": "sn-10",
-      "surface_count": 6
-    },
-    {
-      "candidate_count": 16,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -499,13 +457,55 @@
           "website"
         ]
       },
+      "name": "Swap",
+      "netuid": 10,
+      "slug": "sn-10",
+      "surface_count": 7
+    },
+    {
+      "candidate_count": 17,
+      "coverage_level": "probed",
+      "curation": {
+        "gap_notes": [
+          "No verified OpenAPI/Swagger surface yet.",
+          "No verified subnet API surface yet.",
+          "No verified SSE/event stream yet.",
+          "No verified data artifact yet."
+        ],
+        "level": "machine-verified",
+        "review_state": "machine-generated",
+        "reviewed_at": null,
+        "source_count": 6,
+        "verified_at": null
+      },
+      "gap_count": 4,
+      "gaps": {
+        "gap_notes": [
+          "No verified OpenAPI/Swagger surface yet.",
+          "No verified subnet API surface yet.",
+          "No verified SSE/event stream yet.",
+          "No verified data artifact yet."
+        ],
+        "missing_kinds": [
+          "openapi",
+          "subnet-api",
+          "sse",
+          "data-artifact"
+        ],
+        "supported_kinds": [
+          "dashboard",
+          "docs",
+          "source-repo",
+          "website"
+        ]
+      },
       "name": "TrajectoryRL",
       "netuid": 11,
       "slug": "sn-11",
       "surface_count": 8
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -549,7 +549,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -591,7 +591,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -633,7 +633,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -675,7 +675,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -686,7 +686,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -712,10 +712,10 @@
       "name": "BitAds",
       "netuid": 16,
       "slug": "sn-16",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -757,7 +757,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -769,7 +769,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -799,7 +799,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -841,7 +841,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -887,7 +887,7 @@
       "surface_count": 1
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -931,7 +931,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -969,7 +969,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1011,7 +1011,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1051,7 +1051,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1099,7 +1099,7 @@
       "surface_count": 1
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1111,7 +1111,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -1138,10 +1138,10 @@
       "name": "Perturb",
       "netuid": 26,
       "slug": "sn-26",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1155,7 +1155,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -1184,10 +1184,10 @@
       "name": "Nodexo",
       "netuid": 27,
       "slug": "sn-27",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1201,7 +1201,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -1230,10 +1230,10 @@
       "name": "gm",
       "netuid": 28,
       "slug": "sn-28",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1273,7 +1273,7 @@
       "surface_count": 6
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1317,7 +1317,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1331,7 +1331,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -1360,10 +1360,10 @@
       "name": "Recall",
       "netuid": 31,
       "slug": "sn-31",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1407,7 +1407,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1447,7 +1447,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1489,7 +1489,7 @@
       "surface_count": 4
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1501,7 +1501,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 4,
@@ -1528,10 +1528,10 @@
       "name": "OxMarkets",
       "netuid": 35,
       "slug": "sn-35",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1543,7 +1543,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -1573,7 +1573,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1585,7 +1585,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 4,
@@ -1612,10 +1612,10 @@
       "name": "Aurelius",
       "netuid": 37,
       "slug": "sn-37",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1627,7 +1627,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -1654,10 +1654,10 @@
       "name": "colosseum",
       "netuid": 38,
       "slug": "sn-38",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1703,7 +1703,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1717,7 +1717,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -1746,10 +1746,10 @@
       "name": "Chunking",
       "netuid": 40,
       "slug": "sn-40",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1760,7 +1760,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -1786,10 +1786,10 @@
       "name": "Almanac",
       "netuid": 41,
       "slug": "sn-41",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1835,7 +1835,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1879,7 +1879,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1891,7 +1891,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 4,
@@ -1918,10 +1918,10 @@
       "name": "Score",
       "netuid": 44,
       "slug": "sn-44",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1965,7 +1965,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2005,7 +2005,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2049,7 +2049,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2093,7 +2093,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2131,7 +2131,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2142,7 +2142,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -2168,10 +2168,10 @@
       "name": "Synth",
       "netuid": 50,
       "slug": "sn-50",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2182,7 +2182,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 6,
+        "source_count": 7,
         "verified_at": null
       },
       "gap_count": 3,
@@ -2208,10 +2208,10 @@
       "name": "lium.io",
       "netuid": 51,
       "slug": "sn-51",
-      "surface_count": 9
+      "surface_count": 10
     },
     {
-      "candidate_count": 9,
+      "candidate_count": 10,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2253,7 +2253,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2267,7 +2267,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -2296,10 +2296,10 @@
       "name": "EfficientFrontier",
       "netuid": 53,
       "slug": "sn-53",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2341,7 +2341,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2353,7 +2353,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 4,
@@ -2380,10 +2380,10 @@
       "name": "NIOME",
       "netuid": 55,
       "slug": "sn-55",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2393,7 +2393,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 2,
@@ -2418,10 +2418,10 @@
       "name": "Gradients",
       "netuid": 56,
       "slug": "sn-56",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2465,7 +2465,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2503,7 +2503,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2543,7 +2543,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2554,7 +2554,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 6,
+        "source_count": 7,
         "verified_at": null
       },
       "gap_count": 3,
@@ -2580,10 +2580,10 @@
       "name": "Bitsec.ai",
       "netuid": 60,
       "slug": "sn-60",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2625,7 +2625,7 @@
       "surface_count": 4
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2671,7 +2671,7 @@
       "surface_count": 1
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2715,7 +2715,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 27,
+      "candidate_count": 28,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2753,7 +2753,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2764,7 +2764,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -2790,10 +2790,10 @@
       "name": "TAO Private Network",
       "netuid": 65,
       "slug": "sn-65",
-      "surface_count": 9
+      "surface_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2833,7 +2833,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2875,7 +2875,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2886,7 +2886,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -2915,7 +2915,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2929,7 +2929,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -2958,10 +2958,10 @@
       "name": "ain",
       "netuid": 69,
       "slug": "sn-69",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2972,7 +2972,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -2998,10 +2998,10 @@
       "name": "NexisGen",
       "netuid": 70,
       "slug": "sn-70",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3012,7 +3012,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -3038,10 +3038,10 @@
       "name": "Leadpoet",
       "netuid": 71,
       "slug": "sn-71",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3081,7 +3081,7 @@
       "surface_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3095,7 +3095,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -3124,10 +3124,10 @@
       "name": "Parked",
       "netuid": 73,
       "slug": "sn-73",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3170,7 +3170,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3212,7 +3212,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3258,7 +3258,7 @@
       "surface_count": 1
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3269,7 +3269,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -3295,10 +3295,10 @@
       "name": "Liquidity",
       "netuid": 77,
       "slug": "sn-77",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3309,7 +3309,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -3335,10 +3335,10 @@
       "name": "Vocence",
       "netuid": 78,
       "slug": "sn-78",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3380,7 +3380,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3391,7 +3391,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -3417,10 +3417,10 @@
       "name": "dogelayer",
       "netuid": 80,
       "slug": "sn-80",
-      "surface_count": 10
+      "surface_count": 9
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3468,7 +3468,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3512,7 +3512,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3523,7 +3523,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -3549,10 +3549,10 @@
       "name": "CliqueAI",
       "netuid": 83,
       "slug": "sn-83",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3594,7 +3594,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3638,7 +3638,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3652,7 +3652,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -3681,10 +3681,10 @@
       "name": "Subnet 86",
       "netuid": 86,
       "slug": "sn-86",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3728,7 +3728,7 @@
       "surface_count": 6
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3768,7 +3768,7 @@
       "surface_count": 4
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3814,7 +3814,7 @@
       "surface_count": 1
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3828,7 +3828,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -3857,10 +3857,10 @@
       "name": "ogham",
       "netuid": 90,
       "slug": "sn-90",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3906,7 +3906,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3956,7 +3956,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3967,7 +3967,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -3996,7 +3996,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4008,7 +4008,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -4038,7 +4038,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4050,7 +4050,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -4077,10 +4077,10 @@
       "name": "Actual",
       "netuid": 95,
       "slug": "sn-95",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4118,7 +4118,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4129,7 +4129,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 6,
+        "source_count": 7,
         "verified_at": null
       },
       "gap_count": 3,
@@ -4155,10 +4155,10 @@
       "name": "Albedo",
       "netuid": 97,
       "slug": "sn-97",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4202,7 +4202,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4213,7 +4213,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 6,
+        "source_count": 7,
         "verified_at": null
       },
       "gap_count": 3,
@@ -4239,10 +4239,10 @@
       "name": "Leoma",
       "netuid": 99,
       "slug": "sn-99",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4254,7 +4254,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -4281,10 +4281,10 @@
       "name": "Plaτform",
       "netuid": 100,
       "slug": "sn-100",
-      "surface_count": 9
+      "surface_count": 10
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4298,7 +4298,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -4327,10 +4327,10 @@
       "name": "eni",
       "netuid": 101,
       "slug": "sn-101",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4374,7 +4374,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4418,7 +4418,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4432,7 +4432,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -4461,10 +4461,10 @@
       "name": "for sale (burn to uid1)",
       "netuid": 104,
       "slug": "sn-104",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4475,7 +4475,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -4501,10 +4501,10 @@
       "name": "Beam",
       "netuid": 105,
       "slug": "sn-105",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4516,7 +4516,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -4543,10 +4543,10 @@
       "name": "VoidAI",
       "netuid": 106,
       "slug": "sn-106",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4557,7 +4557,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 6,
+        "source_count": 7,
         "verified_at": null
       },
       "gap_count": 3,
@@ -4583,10 +4583,10 @@
       "name": "Minos",
       "netuid": 107,
       "slug": "sn-107",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4598,7 +4598,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 4,
@@ -4625,10 +4625,10 @@
       "name": "TalkHead",
       "netuid": 108,
       "slug": "sn-108",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4674,7 +4674,7 @@
       "surface_count": 1
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4714,7 +4714,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4758,7 +4758,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4770,7 +4770,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 4,
@@ -4797,10 +4797,10 @@
       "name": "minotaur",
       "netuid": 112,
       "slug": "sn-112",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4842,7 +4842,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4853,7 +4853,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -4882,7 +4882,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4928,7 +4928,7 @@
       "surface_count": 1
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4942,7 +4942,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -4971,10 +4971,10 @@
       "name": "hard_sign",
       "netuid": 116,
       "slug": "sn-116",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5022,7 +5022,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5034,7 +5034,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -5061,10 +5061,10 @@
       "name": "Ditto",
       "netuid": 118,
       "slug": "sn-118",
-      "surface_count": 9
+      "surface_count": 10
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5078,7 +5078,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -5107,10 +5107,10 @@
       "name": "Satori",
       "netuid": 119,
       "slug": "sn-119",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5152,7 +5152,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5196,7 +5196,7 @@
       "surface_count": 2
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5238,7 +5238,7 @@
       "surface_count": 3
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5284,7 +5284,7 @@
       "surface_count": 1
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5324,7 +5324,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5338,7 +5338,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 6,
@@ -5367,10 +5367,10 @@
       "name": "8 Ball",
       "netuid": 125,
       "slug": "sn-125",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5412,7 +5412,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5424,7 +5424,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 4,
+        "source_count": 5,
         "verified_at": null
       },
       "gap_count": 4,
@@ -5451,10 +5451,10 @@
       "name": "Astrid",
       "netuid": 127,
       "slug": "sn-127",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5465,7 +5465,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 3,
@@ -5491,7 +5491,7 @@
       "name": "ByteLeap",
       "netuid": 128,
       "slug": "sn-128",
-      "surface_count": 9
+      "surface_count": 10
     }
   ],
   "generated_at": "1970-01-01T00:00:00.000Z",

--- a/public/metagraph/evidence-ledger.json
+++ b/public/metagraph/evidence-ledger.json
@@ -34,6 +34,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "root Taostats metagraph is a candidate dashboard surface for SN0.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/0/metagraph",
+      "subject": "candidate:sn-0-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "root Tensorplex subnet docs is a candidate docs surface for SN0.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -108,6 +119,17 @@
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_1_apex/index.mdx",
       "subject": "candidate:sn-1-taopedia-article",
       "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Apex Taostats metagraph is a candidate dashboard surface for SN1.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/1/metagraph",
+      "subject": "candidate:sn-1-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -309,6 +331,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Swap Taostats metagraph is a candidate dashboard surface for SN10.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/10/metagraph",
+      "subject": "candidate:sn-10-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Swap Tensorplex subnet docs is a candidate docs surface for SN10.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -438,6 +471,17 @@
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
       "subject": "candidate:sn-11-taopedia-article",
       "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "TrajectoryRL Taostats metagraph is a candidate dashboard surface for SN11.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/11/metagraph",
+      "subject": "candidate:sn-11-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -617,6 +661,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Compute Horde Taostats metagraph is a candidate dashboard surface for SN12.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/12/metagraph",
+      "subject": "candidate:sn-12-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Compute Horde Tensorplex subnet docs is a candidate docs surface for SN12.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -713,6 +768,17 @@
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_13/index.mdx",
       "subject": "candidate:sn-13-taopedia-article",
       "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Data Universe Taostats metagraph is a candidate dashboard surface for SN13.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/13/metagraph",
+      "subject": "candidate:sn-13-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -947,6 +1013,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Cacheon Taostats metagraph is a candidate dashboard surface for SN14.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/14/metagraph",
+      "subject": "candidate:sn-14-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Cacheon Tensorplex subnet docs is a candidate docs surface for SN14.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -1145,6 +1222,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ORO Taostats metagraph is a candidate dashboard surface for SN15.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/15/metagraph",
+      "subject": "candidate:sn-15-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ORO Tensorplex subnet docs is a candidate docs surface for SN15.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -1207,182 +1295,6 @@
       "source_type": "project-website-common-path",
       "source_url": "https://oroagents.com/",
       "subject": "candidate:sn-15-website-common-swagger",
-      "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO Swagger JSON is a candidate openapi surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-common-path",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-common-swagger-json",
-      "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO dashboard is a candidate dashboard surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-link-oroagents-com-dashboard-4",
-      "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO docs is a candidate docs surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-link-oroagents-com-docs-1",
-      "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO docs is a candidate docs surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-link-oroagents-com-docs-3",
-      "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO docs is a candidate docs surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-link-oroagents-com-docs-5",
-      "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO website page is a candidate website surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-link-oroagents-com-website-2",
-      "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds Backprop Finance dashboard is a candidate dashboard surface for SN16.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "backprop-dashboard",
-      "source_url": "https://backprop.finance/dtao/subnets/16-bitads",
-      "subject": "candidate:sn-16-backprop-dashboard",
-      "support_summary": "Universal Backprop Finance dTAO subnet dashboard candidate. Third-party enrichment, not protocol authority.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds TaoMarketCap dashboard is a candidate dashboard surface for SN16.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "taomarketcap-dashboard",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/16",
-      "subject": "candidate:sn-16-taomarketcap-dashboard",
-      "support_summary": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds source repository is a candidate source-repo surface for SN16.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "taomarketcap-subnet-identity-v3",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/16",
-      "subject": "candidate:sn-16-taomarketcap-source-repo",
-      "support_summary": "Discovered from TaoMarketCap subnet identity metadata. Not probed or verified by Metagraphed.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds website is a candidate website surface for SN16.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "taomarketcap-subnet-identity-v3",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/16",
-      "subject": "candidate:sn-16-taomarketcap-website",
-      "support_summary": "Discovered from TaoMarketCap subnet identity metadata. Not probed or verified by Metagraphed.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds Taopedia article is a candidate docs surface for SN16.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "community-docs",
-      "source_type": "taopedia-article",
-      "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx",
-      "subject": "candidate:sn-16-taopedia-article",
-      "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds Tensorplex subnet docs is a candidate docs surface for SN16.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "community-docs",
-      "source_type": "tensorplex-subnet-docs",
-      "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
-      "subject": "candidate:sn-16-tensorplex-docs",
-      "support_summary": "Discovered from Tensorplex subnet-docs. Useful as documentation enrichment, not verified operational authority.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds API is a candidate subnet-api surface for SN16.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-common-path",
-      "source_url": "https://bitads.ai/",
-      "subject": "candidate:sn-16-website-common-api",
-      "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds docs is a candidate docs surface for SN16.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-common-path",
-      "source_url": "https://bitads.ai/",
-      "subject": "candidate:sn-16-website-common-docs",
-      "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds health endpoint is a candidate subnet-api surface for SN16.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-common-path",
-      "source_url": "https://bitads.ai/",
-      "subject": "candidate:sn-16-website-common-health",
-      "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds OpenAPI JSON is a candidate openapi surface for SN16.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-common-path",
-      "source_url": "https://bitads.ai/",
-      "subject": "candidate:sn-16-website-common-openapi-json",
       "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -1472,6 +1384,17 @@
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_2/index.mdx",
       "subject": "candidate:sn-2-taopedia-article",
       "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "DSperse Taostats metagraph is a candidate dashboard surface for SN2.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/2/metagraph",
+      "subject": "candidate:sn-2-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -1585,6 +1508,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "deprecated Taostats metagraph is a candidate dashboard surface for SN3.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/3/metagraph",
+      "subject": "candidate:sn-3-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "deprecated Tensorplex subnet docs is a candidate docs surface for SN3.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -1659,6 +1593,17 @@
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_4/index.mdx",
       "subject": "candidate:sn-4-taopedia-article",
       "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Targon Taostats metagraph is a candidate dashboard surface for SN4.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/4/metagraph",
+      "subject": "candidate:sn-4-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -1915,6 +1860,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Hone Taostats metagraph is a candidate dashboard surface for SN5.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/5/metagraph",
+      "subject": "candidate:sn-5-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Hone Tensorplex subnet docs is a candidate docs surface for SN5.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -2088,6 +2044,17 @@
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_6/index.mdx",
       "subject": "candidate:sn-6-taopedia-article",
       "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Numinous Taostats metagraph is a candidate dashboard surface for SN6.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/6/metagraph",
+      "subject": "candidate:sn-6-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -2267,6 +2234,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Allways Taostats metagraph is a candidate dashboard surface for SN7.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/7/metagraph",
+      "subject": "candidate:sn-7-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Allways Tensorplex subnet docs is a candidate docs surface for SN7.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -2396,6 +2374,17 @@
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx",
       "subject": "candidate:sn-8-taopedia-article",
       "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Vanta Taostats metagraph is a candidate dashboard surface for SN8.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/8/metagraph",
+      "subject": "candidate:sn-8-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -2583,6 +2572,17 @@
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_9/index.mdx",
       "subject": "candidate:sn-9-taopedia-article",
       "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "iota Taostats metagraph is a candidate dashboard surface for SN9.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/9/metagraph",
+      "subject": "candidate:sn-9-taostats-metagraph",
+      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -4632,6 +4632,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Swap Taostats metagraph is a public dashboard surface for SN10.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/10/metagraph",
+      "subject": "surface:sn-10-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-10.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Swap Tensorplex subnet docs is a public docs surface for SN10.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -4694,6 +4705,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx",
       "subject": "surface:sn-100-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-100.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Plaτform Taostats metagraph is a public dashboard surface for SN100.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/100/metagraph",
+      "subject": "surface:sn-100-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-100.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -4771,6 +4793,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx",
       "subject": "surface:sn-101-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-101.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "eni Taostats metagraph is a public dashboard surface for SN101.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/101/metagraph",
+      "subject": "surface:sn-101-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-101.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -4863,6 +4896,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "for sale (burn to uid1) Taostats metagraph is a public dashboard surface for SN104.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/104/metagraph",
+      "subject": "surface:sn-104-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-104.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "for sale (burn to uid1) Tensorplex subnet docs is a public docs surface for SN104.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -4925,6 +4969,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx",
       "subject": "surface:sn-105-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-105.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Beam Taostats metagraph is a public dashboard surface for SN105.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/105/metagraph",
+      "subject": "surface:sn-105-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-105.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5017,6 +5072,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "VoidAI Taostats metagraph is a public dashboard surface for SN106.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/106/metagraph",
+      "subject": "surface:sn-106-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-106.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "VoidAI Tensorplex subnet docs is a public docs surface for SN106.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5101,6 +5167,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
       "subject": "surface:sn-107-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-107.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Minos Taostats metagraph is a public dashboard surface for SN107.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/107/metagraph",
+      "subject": "surface:sn-107-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-107.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5204,6 +5281,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "TalkHead Taostats metagraph is a public dashboard surface for SN108.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/108/metagraph",
+      "subject": "surface:sn-108-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-108.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "TalkHead Tensorplex subnet docs is a public docs surface for SN108.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5281,6 +5369,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "TrajectoryRL Taostats metagraph is a public dashboard surface for SN11.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/11/metagraph",
+      "subject": "surface:sn-11-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-11.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "TrajectoryRL Tensorplex subnet docs is a public docs surface for SN11.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5299,17 +5398,6 @@
       "source_type": "registry-observed",
       "source_url": "https://trajrl.com/",
       "subject": "surface:sn-11-website-common-docs",
-      "support_summary": "Listed in curated overlay for sn-11.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "TrajectoryRL dashboard is a public dashboard surface for SN11.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://trajrl.com/",
-      "subject": "surface:sn-11-website-link-trajrl-com-dashboard-3",
       "support_summary": "Listed in curated overlay for sn-11.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5468,6 +5556,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "minotaur Taostats metagraph is a public dashboard surface for SN112.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/112/metagraph",
+      "subject": "surface:sn-112-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-112.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "minotaur Tensorplex subnet docs is a public docs surface for SN112.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5567,6 +5666,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "SOMA Taostats metagraph is a public dashboard surface for SN114.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/114/metagraph",
+      "subject": "surface:sn-114-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-114.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "SOMA Tensorplex subnet docs is a public docs surface for SN114.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5585,17 +5695,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/114/subnet.json",
       "subject": "surface:sn-114-tensorplex-source-repo-1",
-      "support_summary": "Listed in curated overlay for sn-114.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "SOMA dashboard is a public dashboard surface for SN114.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://thesoma.ai/",
-      "subject": "surface:sn-114-website-link-thesoma-ai-dashboard-6",
       "support_summary": "Listed in curated overlay for sn-114.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5651,6 +5750,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
       "subject": "surface:sn-116-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-116.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "hard_sign Taostats metagraph is a public dashboard surface for SN116.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/116/metagraph",
+      "subject": "surface:sn-116-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-116.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5743,6 +5853,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Ditto Taostats metagraph is a public dashboard surface for SN118.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/118/metagraph",
+      "subject": "surface:sn-118-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-118.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Ditto Tensorplex subnet docs is a public docs surface for SN118.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5816,6 +5937,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx",
       "subject": "surface:sn-119-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-119.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Satori Taostats metagraph is a public dashboard surface for SN119.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/119/metagraph",
+      "subject": "surface:sn-119-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-119.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6128,6 +6260,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "8 Ball Taostats metagraph is a public dashboard surface for SN125.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/125/metagraph",
+      "subject": "surface:sn-125-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-125.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "8 Ball Tensorplex subnet docs is a public docs surface for SN125.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6194,6 +6337,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Poker44 Taostats metagraph is a public dashboard surface for SN126.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/126/metagraph",
+      "subject": "surface:sn-126-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-126.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Poker44 Tensorplex subnet docs is a public docs surface for SN126.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6201,17 +6355,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/126/subnet.json",
       "subject": "surface:sn-126-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-126.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Poker44 dashboard is a public dashboard surface for SN126.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://poker44.net/",
-      "subject": "surface:sn-126-website-link-poker44-net-dashboard-1",
       "support_summary": "Listed in curated overlay for sn-126.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6267,6 +6410,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx",
       "subject": "surface:sn-127-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-127.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Astrid Taostats metagraph is a public dashboard surface for SN127.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/127/metagraph",
+      "subject": "surface:sn-127-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-127.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6333,6 +6487,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
       "subject": "surface:sn-128-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-128.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "ByteLeap Taostats metagraph is a public dashboard surface for SN128.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/128/metagraph",
+      "subject": "surface:sn-128-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-128.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6485,7 +6650,7 @@
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://github.com/latent-to/cacheon/blob/main/README.md",
+      "source_url": "https://cacheon.ai/",
       "subject": "surface:sn-14-github-readme-latent-to-cacheon-docs-1",
       "support_summary": "Listed in curated overlay for sn-14.",
       "verified_at": "1970-01-01T00:00:00.000Z"
@@ -6667,6 +6832,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "BitAds Taostats metagraph is a public dashboard surface for SN16.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/16/metagraph",
+      "subject": "surface:sn-16-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-16.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "BitAds Tensorplex subnet docs is a public docs surface for SN16.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6843,6 +7019,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Zeus Taostats metagraph is a public dashboard surface for SN18.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/18/metagraph",
+      "subject": "surface:sn-18-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-18.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Zeus Tensorplex subnet docs is a public docs surface for SN18.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6850,17 +7037,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/18/subnet.json",
       "subject": "surface:sn-18-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-18.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Zeus dashboard is a public dashboard surface for SN18.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://www.zeussubnet.com/",
-      "subject": "surface:sn-18-website-link-www-zeussubnet-com-dashboard-5",
       "support_summary": "Listed in curated overlay for sn-18.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7338,6 +7514,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Perturb Taostats metagraph is a public dashboard surface for SN26.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/26/metagraph",
+      "subject": "surface:sn-26-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-26.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Perturb Tensorplex subnet docs is a public docs surface for SN26.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7393,6 +7580,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Nodexo Taostats metagraph is a public dashboard surface for SN27.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/27/metagraph",
+      "subject": "surface:sn-27-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-27.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Nodexo Tensorplex subnet docs is a public docs surface for SN27.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7433,6 +7631,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx",
       "subject": "surface:sn-28-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-28.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "gm Taostats metagraph is a public dashboard surface for SN28.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/28/metagraph",
+      "subject": "surface:sn-28-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-28.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7624,6 +7833,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Recall Taostats metagraph is a public dashboard surface for SN31.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/31/metagraph",
+      "subject": "surface:sn-31-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-31.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Recall Tensorplex subnet docs is a public docs surface for SN31.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7811,6 +8031,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "OxMarkets Taostats metagraph is a public dashboard surface for SN35.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/35/metagraph",
+      "subject": "surface:sn-35-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-35.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "OxMarkets Tensorplex subnet docs is a public docs surface for SN35.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7888,6 +8119,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Eirel Taostats metagraph is a public dashboard surface for SN36.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/36/metagraph",
+      "subject": "surface:sn-36-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-36.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Eirel Tensorplex subnet docs is a public docs surface for SN36.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7906,17 +8148,6 @@
       "source_type": "registry-observed",
       "source_url": "https://eirel.ai/",
       "subject": "surface:sn-36-website-common-docs",
-      "support_summary": "Listed in curated overlay for sn-36.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Eirel dashboard is a public dashboard surface for SN36.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://eirel.ai/",
-      "subject": "surface:sn-36-website-link-eirel-ai-dashboard-3",
       "support_summary": "Listed in curated overlay for sn-36.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7972,6 +8203,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx",
       "subject": "surface:sn-37-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-37.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Aurelius Taostats metagraph is a public dashboard surface for SN37.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/37/metagraph",
+      "subject": "surface:sn-37-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-37.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8038,6 +8280,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
       "subject": "surface:sn-38-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-38.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "colosseum Taostats metagraph is a public dashboard surface for SN38.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/38/metagraph",
+      "subject": "surface:sn-38-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-38.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8152,6 +8405,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Chunking Taostats metagraph is a public dashboard surface for SN40.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/40/metagraph",
+      "subject": "surface:sn-40-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-40.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Chunking Tensorplex subnet docs is a public docs surface for SN40.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -8214,6 +8478,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx",
       "subject": "surface:sn-41-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-41.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Almanac Taostats metagraph is a public dashboard surface for SN41.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/41/metagraph",
+      "subject": "surface:sn-41-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-41.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8346,6 +8621,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_44/index.mdx",
       "subject": "surface:sn-44-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-44.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Score Taostats metagraph is a public dashboard surface for SN44.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/44/metagraph",
+      "subject": "surface:sn-44-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-44.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8713,6 +8999,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Hone Taostats metagraph is a public dashboard surface for SN5.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/5/metagraph",
+      "subject": "surface:sn-5-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-5.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Hone Tensorplex subnet docs is a public docs surface for SN5.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -8775,6 +9072,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx",
       "subject": "surface:sn-50-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-50.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Synth Taostats metagraph is a public dashboard surface for SN50.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/50/metagraph",
+      "subject": "surface:sn-50-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-50.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8874,6 +9182,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
       "subject": "surface:sn-51-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-51.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "lium.io Taostats metagraph is a public dashboard surface for SN51.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/51/metagraph",
+      "subject": "surface:sn-51-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-51.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8995,6 +9314,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
       "subject": "surface:sn-53-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-53.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "EfficientFrontier Taostats metagraph is a public dashboard surface for SN53.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/53/metagraph",
+      "subject": "surface:sn-53-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-53.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9142,6 +9472,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "NIOME Taostats metagraph is a public dashboard surface for SN55.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/55/metagraph",
+      "subject": "surface:sn-55-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-55.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "NIOME Tensorplex subnet docs is a public docs surface for SN55.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9204,6 +9545,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
       "subject": "surface:sn-56-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-56.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Gradients Taostats metagraph is a public dashboard surface for SN56.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/56/metagraph",
+      "subject": "surface:sn-56-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-56.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9461,6 +9813,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Babelbit Taostats metagraph is a public dashboard surface for SN59.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/59/metagraph",
+      "subject": "surface:sn-59-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-59.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Babelbit Tensorplex subnet docs is a public docs surface for SN59.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9468,17 +9831,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json",
       "subject": "surface:sn-59-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-59.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Babelbit dashboard is a public dashboard surface for SN59.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://babelbit.ai/",
-      "subject": "surface:sn-59-website-link-babelbit-ai-dashboard-1",
       "support_summary": "Listed in curated overlay for sn-59.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9622,6 +9974,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx",
       "subject": "surface:sn-60-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-60.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Bitsec.ai Taostats metagraph is a public dashboard surface for SN60.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/60/metagraph",
+      "subject": "surface:sn-60-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-60.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9923,6 +10286,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "TAO Private Network Taostats metagraph is a public dashboard surface for SN65.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/65/metagraph",
+      "subject": "surface:sn-65-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-65.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "TAO Private Network Tensorplex subnet docs is a public docs surface for SN65.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10198,6 +10572,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "NOVA Taostats metagraph is a public dashboard surface for SN68.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/68/metagraph",
+      "subject": "surface:sn-68-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-68.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "NOVA Tensorplex subnet docs is a public docs surface for SN68.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10205,17 +10590,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/68/subnet.json",
       "subject": "surface:sn-68-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-68.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "NOVA dashboard is a public dashboard surface for SN68.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://www.metanova-labs.ai/",
-      "subject": "surface:sn-68-website-link-www-metanova-labs-ai-dashboard-5",
       "support_summary": "Listed in curated overlay for sn-68.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10271,6 +10645,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx",
       "subject": "surface:sn-69-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-69.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "ain Taostats metagraph is a public dashboard surface for SN69.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/69/metagraph",
+      "subject": "surface:sn-69-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-69.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10337,6 +10722,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx",
       "subject": "surface:sn-70-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-70.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "NexisGen Taostats metagraph is a public dashboard surface for SN70.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/70/metagraph",
+      "subject": "surface:sn-70-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-70.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10425,6 +10821,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx",
       "subject": "surface:sn-71-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-71.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Leadpoet Taostats metagraph is a public dashboard surface for SN71.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/71/metagraph",
+      "subject": "surface:sn-71-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-71.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10561,6 +10968,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Parked Taostats metagraph is a public dashboard surface for SN73.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/73/metagraph",
+      "subject": "surface:sn-73-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-73.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Parked Tensorplex subnet docs is a public docs surface for SN73.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10693,6 +11111,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Liquidity Taostats metagraph is a public dashboard surface for SN77.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/77/metagraph",
+      "subject": "surface:sn-77-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-77.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Liquidity Tensorplex subnet docs is a public docs surface for SN77.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10777,6 +11206,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
       "subject": "surface:sn-78-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-78.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Vocence Taostats metagraph is a public dashboard surface for SN78.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/78/metagraph",
+      "subject": "surface:sn-78-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-78.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10924,6 +11364,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Vanta Taostats metagraph is a public dashboard surface for SN8.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/8/metagraph",
+      "subject": "surface:sn-8-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-8.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Vanta Tensorplex subnet docs is a public docs surface for SN8.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10931,17 +11382,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/8/subnet.json",
       "subject": "surface:sn-8-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-8.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Vanta dashboard is a public dashboard surface for SN8.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://www.vantanetwork.io/",
-      "subject": "surface:sn-8-website-link-www-vantanetwork-io-dashboard-1",
       "support_summary": "Listed in curated overlay for sn-8.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11001,6 +11441,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "dogelayer Taostats metagraph is a public dashboard surface for SN80.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/80/metagraph",
+      "subject": "surface:sn-80-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-80.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "dogelayer Tensorplex subnet docs is a public docs surface for SN80.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11030,28 +11481,6 @@
       "source_type": "registry-observed",
       "source_url": "https://dogelayer.ai/",
       "subject": "surface:sn-80-website-common-swagger",
-      "support_summary": "Listed in curated overlay for sn-80.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "dogelayer dashboard is a public dashboard surface for SN80.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://dogelayer.ai/",
-      "subject": "surface:sn-80-website-link-dogelayer-ai-dashboard-1",
-      "support_summary": "Listed in curated overlay for sn-80.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "dogelayer docs is a public docs surface for SN80.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://dogelayer.ai/",
-      "subject": "surface:sn-80-website-link-dogelayer-ai-docs-2",
       "support_summary": "Listed in curated overlay for sn-80.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11162,6 +11591,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx",
       "subject": "surface:sn-83-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-83.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "CliqueAI Taostats metagraph is a public dashboard surface for SN83.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/83/metagraph",
+      "subject": "surface:sn-83-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-83.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11283,6 +11723,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx",
       "subject": "surface:sn-86-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-86.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Subnet 86 Taostats metagraph is a public dashboard surface for SN86.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/86/metagraph",
+      "subject": "surface:sn-86-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-86.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11485,6 +11936,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ogham Taostats metagraph is a public dashboard surface for SN90.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/90/metagraph",
+      "subject": "surface:sn-90-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-90.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ogham Tensorplex subnet docs is a public docs surface for SN90.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11595,6 +12057,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Bitcast Taostats metagraph is a public dashboard surface for SN93.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/93/metagraph",
+      "subject": "surface:sn-93-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-93.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Bitcast Tensorplex subnet docs is a public docs surface for SN93.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11624,17 +12097,6 @@
       "source_type": "registry-observed",
       "source_url": "https://stats.bitcast.network/",
       "subject": "surface:sn-93-website-common-swagger",
-      "support_summary": "Listed in curated overlay for sn-93.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Bitcast dashboard is a public dashboard surface for SN93.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://stats.bitcast.network/",
-      "subject": "surface:sn-93-website-link-stats-bitcast-network-dashboard-1",
       "support_summary": "Listed in curated overlay for sn-93.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11694,6 +12156,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Bitsota Taostats metagraph is a public dashboard surface for SN94.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/94/metagraph",
+      "subject": "surface:sn-94-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-94.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Bitsota Tensorplex subnet docs is a public docs surface for SN94.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11712,17 +12185,6 @@
       "source_type": "registry-observed",
       "source_url": "https://bitsota.ai/",
       "subject": "surface:sn-94-website-common-docs",
-      "support_summary": "Listed in curated overlay for sn-94.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Bitsota dashboard is a public dashboard surface for SN94.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://bitsota.ai/",
-      "subject": "surface:sn-94-website-link-bitsota-ai-dashboard-3",
       "support_summary": "Listed in curated overlay for sn-94.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11767,6 +12229,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
       "subject": "surface:sn-95-taopedia-article",
+      "support_summary": "Listed in curated overlay for sn-95.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Actual Taostats metagraph is a public dashboard surface for SN95.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/95/metagraph",
+      "subject": "surface:sn-95-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-95.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11969,6 +12442,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Albedo Taostats metagraph is a public dashboard surface for SN97.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/97/metagraph",
+      "subject": "surface:sn-97-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-97.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Albedo Tensorplex subnet docs is a public docs surface for SN97.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12101,6 +12585,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Leoma Taostats metagraph is a public dashboard surface for SN99.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://taostats.io/subnets/99/metagraph",
+      "subject": "surface:sn-99-taostats-metagraph",
+      "support_summary": "Listed in curated overlay for sn-99.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Leoma Tensorplex subnet docs is a public docs surface for SN99.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12151,8 +12646,8 @@
   "schema_version": 1,
   "summary": {
     "candidate_claim_count": 250,
-    "claim_count": 1104,
+    "claim_count": 1149,
     "subnet_claim_count": 129,
-    "surface_claim_count": 725
+    "surface_claim_count": 770
   }
 }

--- a/public/metagraph/freshness.json
+++ b/public/metagraph/freshness.json
@@ -43,7 +43,7 @@
       "timestamp_field": null
     },
     {
-      "as_of": "2026-06-08T11:59:34.000Z",
+      "as_of": "2026-06-08T12:31:57.000Z",
       "id": "candidate-discovery",
       "lane": "candidate-discovery",
       "notes": "",
@@ -52,11 +52,11 @@
       "stale_after_hours": 24,
       "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-08T11:59:34.000Z",
+      "timestamp": "2026-06-08T12:31:57.000Z",
       "timestamp_field": "candidate_discovery_as_of"
     },
     {
-      "as_of": "2026-06-08T12:00:34.438Z",
+      "as_of": "2026-06-08T12:32:59.499Z",
       "id": "candidate-verification",
       "lane": "candidate-verification",
       "notes": "",
@@ -65,7 +65,7 @@
       "stale_after_hours": 24,
       "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-08T12:00:34.438Z",
+      "timestamp": "2026-06-08T12:32:59.499Z",
       "timestamp_field": "verification_as_of"
     },
     {
@@ -112,9 +112,9 @@
     "adapter_count": 2,
     "adapter_snapshot_as_of": "2026-06-07T21:52:49.513Z",
     "blocking_source_count": 5,
-    "candidate_discovery_as_of": "2026-06-08T11:59:34.000Z",
+    "candidate_discovery_as_of": "2026-06-08T12:31:57.000Z",
     "health_probe_as_of": "2026-06-08T07:59:37.947Z",
-    "health_surface_count": 721,
+    "health_surface_count": 766,
     "missing_blocking_source_count": 0,
     "native_data_as_of": "2026-06-07T21:51:54Z",
     "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
@@ -124,7 +124,7 @@
     "stale_window_warnings": [
       "schema-drift has no observed timestamp; review before relying on this lane."
     ],
-    "verification_as_of": "2026-06-08T12:00:34.438Z",
+    "verification_as_of": "2026-06-08T12:32:59.499Z",
     "verification_generated_at": "1970-01-01T00:00:00.000Z",
     "warning_source_count": 3
   }

--- a/public/metagraph/profiles.json
+++ b/public/metagraph/profiles.json
@@ -4,7 +4,7 @@
   "notes": "Public-safe subnet profiles derived from native chain data, curated overlays, verified surfaces, candidates, and explicit gaps.",
   "profiles": [
     {
-      "candidate_count": 3,
+      "candidate_count": 4,
       "categories": [
         "root",
         "system",
@@ -93,7 +93,7 @@
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -178,7 +178,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -262,7 +262,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "decentralized-training",
@@ -346,7 +346,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -427,7 +427,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -453,10 +453,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 6,
+      "monitored_endpoint_count": 7,
       "name": "Hone",
       "native_name": "Hone",
       "native_name_quality": "chain",
@@ -481,7 +481,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -490,6 +490,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx",
           "https://github.com/manifold-inc/hone",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/5/subnet.json",
+          "https://taostats.io/subnets/5/metagraph",
           "https://www.hone.training/"
         ]
       },
@@ -503,12 +504,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "ε",
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -590,7 +591,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "bitcoin",
         "subnet-api",
@@ -670,7 +671,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -724,7 +725,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -733,6 +734,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx",
           "https://github.com/taoshidev/vanta-network",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/8/subnet.json",
+          "https://taostats.io/subnets/8/metagraph",
           "https://www.vantanetwork.io/"
         ]
       },
@@ -751,7 +753,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -835,7 +837,7 @@
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -861,10 +863,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 6,
+      "monitored_endpoint_count": 7,
       "name": "Swap",
       "native_name": "Swap",
       "native_name_quality": "chain",
@@ -889,7 +891,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -898,6 +900,7 @@
           "https://github.com/Swap-Subnet/swap-subnet",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/10/subnet.json",
+          "https://taostats.io/subnets/10/metagraph",
           "https://www.taofi.com/pool"
         ]
       },
@@ -911,12 +914,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "κ",
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -970,7 +973,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -979,6 +982,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/11/subnet.json",
           "https://github.com/trajectoryRL/trajectoryRL",
+          "https://taostats.io/subnets/11/metagraph",
           "https://trajrl.com/"
         ]
       },
@@ -997,7 +1001,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "compute",
@@ -1080,7 +1084,7 @@
       "team": null
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-curated",
         "data",
@@ -1171,7 +1175,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -1255,7 +1259,7 @@
       "team": null
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1338,7 +1342,7 @@
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -1362,10 +1366,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "BitAds",
       "native_name": "BitAds",
       "native_name_quality": "chain",
@@ -1392,7 +1396,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -1401,7 +1405,8 @@
           "https://bitads.ai/",
           "https://github.com/FirstTensorLabs/BitAds",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
+          "https://taostats.io/subnets/16/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -1415,12 +1420,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "π",
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -1502,7 +1507,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -1556,7 +1561,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -1565,6 +1570,7 @@
           "https://github.com/Orpheus-AI/Zeus",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/18/subnet.json",
+          "https://taostats.io/subnets/18/metagraph",
           "https://www.zeussubnet.com/"
         ]
       },
@@ -1583,7 +1589,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1666,7 +1672,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated",
         "capital-markets",
@@ -1748,7 +1754,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "advertising",
         "baseline-curated",
@@ -1830,7 +1836,7 @@
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1923,7 +1929,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2007,7 +2013,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2096,7 +2102,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "compute",
@@ -2179,7 +2185,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -2205,10 +2211,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 8,
       "name": "Perturb",
       "native_name": "Perturb",
       "native_name_quality": "chain",
@@ -2233,7 +2239,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -2242,6 +2248,7 @@
           "https://github.com/0xsigurd/Perturb",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_26/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/26/subnet.json",
+          "https://taostats.io/subnets/26/metagraph",
           "https://www.perturbai.io/"
         ]
       },
@@ -2255,12 +2262,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ב",
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -2291,10 +2298,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "Nodexo",
       "native_name": "Nodexo",
       "native_name_quality": "chain",
@@ -2319,14 +2326,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/27",
           "https://backprop.finance/dtao/subnets/27-nodexo",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json",
+          "https://taostats.io/subnets/27/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -2337,12 +2345,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ג",
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -2373,10 +2381,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "gm",
       "native_name": "gm",
       "native_name_quality": "chain",
@@ -2401,14 +2409,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/28",
           "https://backprop.finance/dtao/subnets/28-gm",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/28/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/28/subnet.json",
+          "https://taostats.io/subnets/28/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -2419,12 +2428,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ד",
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "data",
@@ -2512,7 +2521,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated",
         "defi",
@@ -2597,7 +2606,7 @@
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -2628,10 +2637,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "Recall",
       "native_name": "Recall",
       "native_name_quality": "chain",
@@ -2656,14 +2665,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/31",
           "https://backprop.finance/dtao/subnets/31-recall",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json",
+          "https://taostats.io/subnets/31/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -2674,12 +2684,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ז",
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2760,7 +2770,7 @@
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-curated",
         "conversation-data",
@@ -2846,7 +2856,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "deepfake-detection",
@@ -2932,7 +2942,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -2958,10 +2968,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 8,
       "name": "OxMarkets",
       "native_name": "OxMarkets",
       "native_name_quality": "chain",
@@ -2986,7 +2996,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -2995,6 +3005,7 @@
           "https://github.com/General-Tao-Ventures/cartha-validator",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_35/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/35/subnet.json",
+          "https://taostats.io/subnets/35/metagraph",
           "https://www.0xmarkets.io/"
         ]
       },
@@ -3008,12 +3019,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ך",
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -3067,7 +3078,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -3076,7 +3087,8 @@
           "https://eirel.ai/",
           "https://github.com/RendixNetwork/eirel-ai",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/36/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/36/subnet.json",
+          "https://taostats.io/subnets/36/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -3094,7 +3106,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -3120,10 +3132,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 8,
       "name": "Aurelius",
       "native_name": "Aurelius",
       "native_name_quality": "chain",
@@ -3148,7 +3160,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -3157,7 +3169,8 @@
           "https://backprop.finance/dtao/subnets/37-aurelius",
           "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json",
+          "https://taostats.io/subnets/37/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -3170,12 +3183,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ל",
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -3202,10 +3215,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 8,
       "name": "colosseum",
       "native_name": "colosseum",
       "native_name_quality": "chain",
@@ -3232,7 +3245,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 5,
+        "interface_source_count": 6,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -3240,6 +3253,7 @@
           "https://backprop.finance/dtao/subnets/38-colosseum",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/38/subnet.json",
+          "https://taostats.io/subnets/38/metagraph",
           "https://www.taocolosseum.com/"
         ]
       },
@@ -3253,12 +3267,12 @@
         "openapi",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ם",
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "compute",
@@ -3341,7 +3355,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -3372,10 +3386,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "Chunking",
       "native_name": "Chunking",
       "native_name_quality": "chain",
@@ -3400,14 +3414,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/40",
           "https://backprop.finance/dtao/subnets/40-chunking",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_40/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json",
+          "https://taostats.io/subnets/40/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -3418,12 +3433,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ן",
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -3447,10 +3462,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "Almanac",
       "native_name": "Almanac",
       "native_name_quality": "chain",
@@ -3477,7 +3492,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -3486,7 +3501,8 @@
           "https://backprop.finance/dtao/subnets/41-almanac",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx",
           "https://github.com/sportstensor/sn41",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json",
+          "https://taostats.io/subnets/41/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -3500,12 +3516,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "נ",
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated",
         "data",
@@ -3592,7 +3608,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3676,7 +3692,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -3702,10 +3718,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 8,
       "name": "Score",
       "native_name": "Score",
       "native_name_quality": "chain",
@@ -3730,7 +3746,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -3739,6 +3755,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_44/index.mdx",
           "https://github.com/score-technologies/turbovision",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/44/subnet.json",
+          "https://taostats.io/subnets/44/metagraph",
           "https://www.wearescore.com/"
         ]
       },
@@ -3752,12 +3769,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ף",
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3838,7 +3855,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated"
       ],
@@ -3921,7 +3938,7 @@
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-curated",
         "data",
@@ -4005,7 +4022,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "compute",
@@ -4088,7 +4105,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -4181,7 +4198,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -4205,10 +4222,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "Synth",
       "native_name": "Synth",
       "native_name_quality": "chain",
@@ -4235,7 +4252,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -4244,7 +4261,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx",
           "https://github.com/mode-network/synth-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/50/subnet.json",
-          "https://synthdata.co/"
+          "https://synthdata.co/",
+          "https://taostats.io/subnets/50/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -4258,12 +4276,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ש",
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated"
       ],
@@ -4287,10 +4305,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 9,
+      "endpoint_count": 10,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 9,
+      "monitored_endpoint_count": 10,
       "name": "lium.io",
       "native_name": "lium.io",
       "native_name_quality": "chain",
@@ -4317,7 +4335,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 8,
+        "interface_source_count": 9,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -4328,7 +4346,8 @@
           "https://github.com/Datura-ai/lium-io/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
-          "https://lium.io/"
+          "https://lium.io/",
+          "https://taostats.io/subnets/51/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -4342,12 +4361,12 @@
         "subnet-api",
         "website"
       ],
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "ת",
       "team": null
     },
     {
-      "candidate_count": 9,
+      "candidate_count": 10,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -4433,7 +4452,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -4464,10 +4483,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "EfficientFrontier",
       "native_name": "EfficientFrontier",
       "native_name_quality": "chain",
@@ -4492,14 +4511,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/53",
           "https://backprop.finance/dtao/subnets/53-efficientfrontier",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
+          "https://taostats.io/subnets/53/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -4510,12 +4530,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ب",
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -4597,7 +4617,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -4623,10 +4643,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 6,
+      "monitored_endpoint_count": 7,
       "name": "NIOME",
       "native_name": "NIOME",
       "native_name_quality": "chain",
@@ -4651,7 +4671,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -4660,7 +4680,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_55/index.mdx",
           "https://github.com/genomesio/subnet-niome",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/55/subnet.json",
-          "https://niome.genomes.io/"
+          "https://niome.genomes.io/",
+          "https://taostats.io/subnets/55/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -4673,12 +4694,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "ث",
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated"
       ],
@@ -4700,10 +4721,10 @@
       "completeness_score": 73,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "interface_count": 6,
       "missing_critical_count": 2,
-      "monitored_endpoint_count": 10,
+      "monitored_endpoint_count": 11,
       "name": "Gradients",
       "native_name": "Gradients",
       "native_name_quality": "chain",
@@ -4731,7 +4752,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -4740,6 +4761,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
           "https://github.com/gradients-ai/G.O.D",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/56/subnet.json",
+          "https://taostats.io/subnets/56/metagraph",
           "https://www.gradients.io/"
         ]
       },
@@ -4755,12 +4777,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "ج",
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -4844,7 +4866,7 @@
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "ai-marketplace",
         "baseline-curated",
@@ -4937,7 +4959,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -4991,7 +5013,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -5001,7 +5023,8 @@
           "https://github.com/babelbit/babelbit_subnet",
           "https://github.com/babelbit/babelbit_subnet/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_59/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json",
+          "https://taostats.io/subnets/59/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -5020,7 +5043,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -5044,10 +5067,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 10,
+      "monitored_endpoint_count": 11,
       "name": "Bitsec.ai",
       "native_name": "Bitsec.ai",
       "native_name_quality": "chain",
@@ -5074,7 +5097,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 8,
+        "interface_source_count": 9,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -5085,7 +5108,8 @@
           "https://github.com/Bitsec-AI/sandbox",
           "https://github.com/Bitsec-AI/sandbox/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/60/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/60/subnet.json",
+          "https://taostats.io/subnets/60/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -5099,12 +5123,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "ذ",
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated",
         "cybersecurity",
@@ -5190,7 +5214,7 @@
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "agents",
         "baseline-curated",
@@ -5271,7 +5295,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -5353,7 +5377,7 @@
       "team": null
     },
     {
-      "candidate_count": 27,
+      "candidate_count": 28,
       "categories": [
         "baseline-curated",
         "compute",
@@ -5446,7 +5470,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -5470,10 +5494,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 9,
+      "endpoint_count": 10,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 9,
+      "monitored_endpoint_count": 10,
       "name": "TAO Private Network",
       "native_name": "TAO Private Network",
       "native_name_quality": "chain",
@@ -5500,7 +5524,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -5509,6 +5533,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx",
           "https://github.com/taofu-labs/tpn-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/65/subnet.json",
+          "https://taostats.io/subnets/65/metagraph",
           "https://tpn.taofu.xyz/"
         ]
       },
@@ -5523,12 +5548,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "ص",
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -5620,7 +5645,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -5702,7 +5727,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -5756,7 +5781,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -5765,6 +5790,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx",
           "https://github.com/metanova-labs/nova",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/68/subnet.json",
+          "https://taostats.io/subnets/68/metagraph",
           "https://www.metanova-labs.ai/"
         ]
       },
@@ -5784,7 +5810,7 @@
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -5815,10 +5841,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "ain",
       "native_name": "ain",
       "native_name_quality": "chain",
@@ -5843,14 +5869,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/69",
           "https://backprop.finance/dtao/subnets/69-ain",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/69/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/69/subnet.json",
+          "https://taostats.io/subnets/69/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -5861,12 +5888,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ع",
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -5890,10 +5917,10 @@
       "completeness_score": 58,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "NexisGen",
       "native_name": "NexisGen",
       "native_name_quality": "chain",
@@ -5920,7 +5947,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -5929,7 +5956,8 @@
           "https://github.com/RendixNetwork/nexisgen",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/70/subnet.json",
-          "https://nexisgen.ai/"
+          "https://nexisgen.ai/",
+          "https://taostats.io/subnets/70/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -5943,12 +5971,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "غ",
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -5972,10 +6000,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "Leadpoet",
       "native_name": "Leadpoet",
       "native_name_quality": "chain",
@@ -6002,7 +6030,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -6011,7 +6039,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx",
           "https://github.com/leadpoet/leadpoet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/71/subnet.json",
-          "https://leadpoet.com/"
+          "https://leadpoet.com/",
+          "https://taostats.io/subnets/71/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -6025,12 +6054,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ㄴ",
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated",
         "computer-vision",
@@ -6117,7 +6146,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -6148,10 +6177,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "Parked",
       "native_name": "Parked",
       "native_name_quality": "chain",
@@ -6176,14 +6205,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/73",
           "https://backprop.finance/dtao/subnets/73-parked",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json",
+          "https://taostats.io/subnets/73/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -6194,12 +6224,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ك",
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "developer-tools",
         "repositories",
@@ -6282,7 +6312,7 @@
       "team": null
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-curated",
         "depin",
@@ -6369,7 +6399,7 @@
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -6450,7 +6480,7 @@
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -6474,10 +6504,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "Liquidity",
       "native_name": "Liquidity",
       "native_name_quality": "chain",
@@ -6504,7 +6534,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -6513,7 +6543,8 @@
           "https://github.com/creativebuilds/sn77",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/77/subnet.json",
-          "https://sn77.xyz/"
+          "https://sn77.xyz/",
+          "https://taostats.io/subnets/77/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -6527,12 +6558,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ه",
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -6556,10 +6587,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 10,
+      "monitored_endpoint_count": 11,
       "name": "Vocence",
       "native_name": "Vocence",
       "native_name_quality": "chain",
@@ -6586,7 +6617,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -6595,6 +6626,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/78/subnet.json",
           "https://github.com/vocence-78/vocence",
+          "https://taostats.io/subnets/78/metagraph",
           "https://www.vocence.ai/"
         ]
       },
@@ -6609,12 +6641,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "و",
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -6698,7 +6730,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -6722,10 +6754,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 10,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 10,
+      "monitored_endpoint_count": 9,
       "name": "dogelayer",
       "native_name": "dogelayer",
       "native_name_quality": "chain",
@@ -6752,7 +6784,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -6761,7 +6793,8 @@
           "https://dogelayer.ai/",
           "https://github.com/dogelayer-ai/dogelayer",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/80/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/80/subnet.json",
+          "https://taostats.io/subnets/80/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -6775,12 +6808,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 10,
+      "surface_count": 9,
       "symbol": "ى",
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "decentralized-training",
@@ -6864,7 +6897,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -6945,7 +6978,7 @@
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -6969,10 +7002,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "CliqueAI",
       "native_name": "CliqueAI",
       "native_name_quality": "chain",
@@ -6999,7 +7032,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -7008,7 +7041,8 @@
           "https://cliqueai.toptensor.ai/",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/83/subnet.json",
-          "https://github.com/toptensor/CliqueAI"
+          "https://github.com/toptensor/CliqueAI",
+          "https://taostats.io/subnets/83/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -7022,12 +7056,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ᚦ",
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "chip-design",
@@ -7113,7 +7147,7 @@
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -7194,7 +7228,7 @@
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -7225,10 +7259,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "Subnet 86",
       "native_name": "⚒",
       "native_name_quality": "placeholder",
@@ -7253,14 +7287,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/86",
           "https://backprop.finance/dtao/subnets/86-subnet-86",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/86/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/86/subnet.json",
+          "https://taostats.io/subnets/86/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -7271,12 +7306,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ᚳ",
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -7365,7 +7400,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated",
         "data-artifact",
@@ -7451,7 +7486,7 @@
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -7532,7 +7567,7 @@
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -7563,10 +7598,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "ogham",
       "native_name": "ogham",
       "native_name_quality": "chain",
@@ -7591,14 +7626,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/90",
           "https://backprop.finance/dtao/subnets/90-ogham",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json",
+          "https://taostats.io/subnets/90/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -7609,12 +7645,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": " ",
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -7696,7 +7732,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "stale-source-cleanup"
@@ -7779,7 +7815,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -7833,7 +7869,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -7842,7 +7878,8 @@
           "https://github.com/bitcast-network/bitcast",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_93/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/93/subnet.json",
-          "https://stats.bitcast.network/"
+          "https://stats.bitcast.network/",
+          "https://taostats.io/subnets/93/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -7861,7 +7898,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -7915,7 +7952,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -7924,7 +7961,8 @@
           "https://bitsota.ai/",
           "https://github.com/AlveusLabs/SN94-BitSota",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json",
+          "https://taostats.io/subnets/94/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -7942,7 +7980,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -7969,10 +8007,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 8,
       "name": "Actual",
       "native_name": "Actual",
       "native_name_quality": "chain",
@@ -7999,7 +8037,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 5,
+        "interface_source_count": 6,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -8007,7 +8045,8 @@
           "https://api.taomarketcap.com/public/v1/subnets/95",
           "https://backprop.finance/dtao/subnets/95-actual",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json",
+          "https://taostats.io/subnets/95/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -8020,12 +8059,12 @@
         "openapi",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ᚅ",
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -8118,7 +8157,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -8142,10 +8181,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 10,
+      "monitored_endpoint_count": 11,
       "name": "Albedo",
       "native_name": "Albedo",
       "native_name_quality": "chain",
@@ -8172,7 +8211,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 8,
+        "interface_source_count": 9,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -8183,6 +8222,7 @@
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/97/subnet.json",
           "https://github.com/unarbos/albedo",
           "https://github.com/unitone-labs/FlameWire/blob/main/README.md",
+          "https://taostats.io/subnets/97/metagraph",
           "https://us-east-1.hippius.com/albedo/index.html"
         ]
       },
@@ -8197,12 +8237,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "ა",
       "team": null
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-curated",
         "finance",
@@ -8284,7 +8324,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -8308,10 +8348,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 10,
+      "monitored_endpoint_count": 11,
       "name": "Leoma",
       "native_name": "Leoma",
       "native_name_quality": "chain",
@@ -8338,7 +8378,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 8,
+        "interface_source_count": 9,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -8349,7 +8389,8 @@
           "https://github.com/RendixNetwork/leoma/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_99/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/99/subnet.json",
-          "https://leoma.ai/"
+          "https://leoma.ai/",
+          "https://taostats.io/subnets/99/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -8363,12 +8404,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "გ",
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -8394,10 +8435,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 9,
+      "endpoint_count": 10,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 9,
+      "monitored_endpoint_count": 10,
       "name": "Plaτform",
       "native_name": "Plaτform",
       "native_name_quality": "chain",
@@ -8422,7 +8463,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -8431,7 +8472,8 @@
           "https://github.com/PlatformNetwork/platform",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/100/subnet.json",
-          "https://platform.network/"
+          "https://platform.network/",
+          "https://taostats.io/subnets/100/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -8444,12 +8486,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "დ",
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -8480,10 +8522,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "eni",
       "native_name": "eni",
       "native_name_quality": "chain",
@@ -8508,14 +8550,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/101",
           "https://backprop.finance/dtao/subnets/101-eni",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/101/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/101/subnet.json",
+          "https://taostats.io/subnets/101/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -8526,12 +8569,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ე",
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -8612,7 +8655,7 @@
       "team": null
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -8693,7 +8736,7 @@
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -8724,10 +8767,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "for sale (burn to uid1)",
       "native_name": "for sale (burn to uid1)",
       "native_name_quality": "chain",
@@ -8752,14 +8795,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/104",
           "https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_104/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/104/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/104/subnet.json",
+          "https://taostats.io/subnets/104/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -8770,12 +8814,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "Բ",
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -8799,10 +8843,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "Beam",
       "native_name": "Beam",
       "native_name_quality": "chain",
@@ -8829,7 +8873,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -8838,7 +8882,8 @@
           "https://backprop.finance/dtao/subnets/105-beam",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx",
           "https://github.com/orgs/Beam-Network/repositories",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json",
+          "https://taostats.io/subnets/105/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -8852,12 +8897,178 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "Գ",
       "team": null
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
+      "categories": [
+        "baseline-curated"
+      ],
+      "completeness": {
+        "confidence": "medium",
+        "gap_reasons": [
+          "missing-openapi",
+          "missing-subnet-api",
+          "missing-sse",
+          "missing-data-artifact"
+        ],
+        "missing_critical_count": 4,
+        "missing_operational": [
+          "openapi",
+          "subnet-api",
+          "sse",
+          "data-artifact"
+        ],
+        "missing_required": [],
+        "profile_level": "identity-complete",
+        "score": 50
+      },
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "endpoint_count": 8,
+      "interface_count": 4,
+      "missing_critical_count": 4,
+      "monitored_endpoint_count": 8,
+      "name": "VoidAI",
+      "native_name": "VoidAI",
+      "native_name_quality": "chain",
+      "netuid": 106,
+      "operational_interface_count": 0,
+      "operational_interface_kinds": [],
+      "primary_app_surface": {
+        "id": "sn-106-taomarketcap-website",
+        "kind": "website",
+        "name": "VoidAI website",
+        "provider": "taomarketcap",
+        "url": "https://voidai.com/"
+      },
+      "primary_links": {
+        "dashboard_url": "https://backprop.finance/dtao/subnets/106-voidai",
+        "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx",
+        "source_repo": "https://github.com/v0idai/SN106",
+        "website_url": "https://voidai.com/"
+      },
+      "profile_level": "identity-complete",
+      "project_name": "VoidAI",
+      "provenance": {
+        "curation_level": "machine-verified",
+        "identity_source": "curated-overlay",
+        "interface_source_count": 7,
+        "review_state": "machine-generated",
+        "reviewed_at": null,
+        "source_urls": [
+          "https://api.taomarketcap.com/public/v1/subnets/106",
+          "https://backprop.finance/dtao/subnets/106-voidai",
+          "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx",
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/106/subnet.json",
+          "https://github.com/v0idai/SN106",
+          "https://taostats.io/subnets/106/metagraph",
+          "https://voidai.com/"
+        ]
+      },
+      "review_state": "machine-generated",
+      "slug": "sn-106",
+      "status": "active",
+      "subnet_type": "application",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ],
+      "surface_count": 8,
+      "symbol": "Դ",
+      "team": null
+    },
+    {
+      "candidate_count": 20,
+      "categories": [
+        "baseline-curated"
+      ],
+      "completeness": {
+        "confidence": "medium",
+        "gap_reasons": [
+          "missing-openapi",
+          "missing-sse",
+          "missing-data-artifact"
+        ],
+        "missing_critical_count": 3,
+        "missing_operational": [
+          "openapi",
+          "sse",
+          "data-artifact"
+        ],
+        "missing_required": [],
+        "profile_level": "operational",
+        "score": 65
+      },
+      "completeness_score": 65,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "endpoint_count": 11,
+      "interface_count": 5,
+      "missing_critical_count": 3,
+      "monitored_endpoint_count": 11,
+      "name": "Minos",
+      "native_name": "Minos",
+      "native_name_quality": "chain",
+      "netuid": 107,
+      "operational_interface_count": 1,
+      "operational_interface_kinds": [
+        "subnet-api"
+      ],
+      "primary_app_surface": {
+        "id": "sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-1",
+        "kind": "subnet-api",
+        "name": "Minos API surface",
+        "provider": "taomarketcap",
+        "url": "https://api.theminos.ai/"
+      },
+      "primary_links": {
+        "dashboard_url": "https://backprop.finance/dtao/subnets/107-minos",
+        "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
+        "source_repo": "https://github.com/minos-protocol/minos_subnet",
+        "website_url": "https://theminos.ai/"
+      },
+      "profile_level": "operational",
+      "project_name": "Minos",
+      "provenance": {
+        "curation_level": "machine-verified",
+        "identity_source": "curated-overlay",
+        "interface_source_count": 8,
+        "review_state": "machine-generated",
+        "reviewed_at": null,
+        "source_urls": [
+          "https://api.taomarketcap.com/public/v1/subnets/107",
+          "https://backprop.finance/dtao/subnets/107-minos",
+          "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
+          "https://github.com/minos-protocol/minos_subnet",
+          "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/107/subnet.json",
+          "https://taostats.io/subnets/107/metagraph",
+          "https://theminos.ai/"
+        ]
+      },
+      "review_state": "machine-generated",
+      "slug": "sn-107",
+      "status": "active",
+      "subnet_type": "application",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "subnet-api",
+        "website"
+      ],
+      "surface_count": 11,
+      "symbol": "ミ",
+      "team": null
+    },
+    {
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -8887,170 +9098,6 @@
       "interface_count": 4,
       "missing_critical_count": 4,
       "monitored_endpoint_count": 7,
-      "name": "VoidAI",
-      "native_name": "VoidAI",
-      "native_name_quality": "chain",
-      "netuid": 106,
-      "operational_interface_count": 0,
-      "operational_interface_kinds": [],
-      "primary_app_surface": {
-        "id": "sn-106-taomarketcap-website",
-        "kind": "website",
-        "name": "VoidAI website",
-        "provider": "taomarketcap",
-        "url": "https://voidai.com/"
-      },
-      "primary_links": {
-        "dashboard_url": "https://backprop.finance/dtao/subnets/106-voidai",
-        "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx",
-        "source_repo": "https://github.com/v0idai/SN106",
-        "website_url": "https://voidai.com/"
-      },
-      "profile_level": "identity-complete",
-      "project_name": "VoidAI",
-      "provenance": {
-        "curation_level": "machine-verified",
-        "identity_source": "curated-overlay",
-        "interface_source_count": 6,
-        "review_state": "machine-generated",
-        "reviewed_at": null,
-        "source_urls": [
-          "https://api.taomarketcap.com/public/v1/subnets/106",
-          "https://backprop.finance/dtao/subnets/106-voidai",
-          "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/106/subnet.json",
-          "https://github.com/v0idai/SN106",
-          "https://voidai.com/"
-        ]
-      },
-      "review_state": "machine-generated",
-      "slug": "sn-106",
-      "status": "active",
-      "subnet_type": "application",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ],
-      "surface_count": 7,
-      "symbol": "Դ",
-      "team": null
-    },
-    {
-      "candidate_count": 19,
-      "categories": [
-        "baseline-curated"
-      ],
-      "completeness": {
-        "confidence": "medium",
-        "gap_reasons": [
-          "missing-openapi",
-          "missing-sse",
-          "missing-data-artifact"
-        ],
-        "missing_critical_count": 3,
-        "missing_operational": [
-          "openapi",
-          "sse",
-          "data-artifact"
-        ],
-        "missing_required": [],
-        "profile_level": "operational",
-        "score": 65
-      },
-      "completeness_score": 65,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "endpoint_count": 10,
-      "interface_count": 5,
-      "missing_critical_count": 3,
-      "monitored_endpoint_count": 10,
-      "name": "Minos",
-      "native_name": "Minos",
-      "native_name_quality": "chain",
-      "netuid": 107,
-      "operational_interface_count": 1,
-      "operational_interface_kinds": [
-        "subnet-api"
-      ],
-      "primary_app_surface": {
-        "id": "sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-1",
-        "kind": "subnet-api",
-        "name": "Minos API surface",
-        "provider": "taomarketcap",
-        "url": "https://api.theminos.ai/"
-      },
-      "primary_links": {
-        "dashboard_url": "https://backprop.finance/dtao/subnets/107-minos",
-        "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
-        "source_repo": "https://github.com/minos-protocol/minos_subnet",
-        "website_url": "https://theminos.ai/"
-      },
-      "profile_level": "operational",
-      "project_name": "Minos",
-      "provenance": {
-        "curation_level": "machine-verified",
-        "identity_source": "curated-overlay",
-        "interface_source_count": 7,
-        "review_state": "machine-generated",
-        "reviewed_at": null,
-        "source_urls": [
-          "https://api.taomarketcap.com/public/v1/subnets/107",
-          "https://backprop.finance/dtao/subnets/107-minos",
-          "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
-          "https://github.com/minos-protocol/minos_subnet",
-          "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/107/subnet.json",
-          "https://theminos.ai/"
-        ]
-      },
-      "review_state": "machine-generated",
-      "slug": "sn-107",
-      "status": "active",
-      "subnet_type": "application",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "subnet-api",
-        "website"
-      ],
-      "surface_count": 10,
-      "symbol": "ミ",
-      "team": null
-    },
-    {
-      "candidate_count": 18,
-      "categories": [
-        "baseline-curated"
-      ],
-      "completeness": {
-        "confidence": "medium",
-        "gap_reasons": [
-          "missing-openapi",
-          "missing-subnet-api",
-          "missing-sse",
-          "missing-data-artifact"
-        ],
-        "missing_critical_count": 4,
-        "missing_operational": [
-          "openapi",
-          "subnet-api",
-          "sse",
-          "data-artifact"
-        ],
-        "missing_required": [],
-        "profile_level": "identity-complete",
-        "score": 50
-      },
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "endpoint_count": 6,
-      "interface_count": 4,
-      "missing_critical_count": 4,
-      "monitored_endpoint_count": 6,
       "name": "TalkHead",
       "native_name": "TalkHead",
       "native_name_quality": "chain",
@@ -9075,7 +9122,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -9084,6 +9131,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx",
           "https://github.com/talkheadai/talkhead-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/108/subnet.json",
+          "https://taostats.io/subnets/108/metagraph",
           "https://www.talkhead.ai/"
         ]
       },
@@ -9097,12 +9145,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "Զ",
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -9184,7 +9232,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -9270,7 +9318,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "data",
@@ -9354,7 +9402,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -9380,10 +9428,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 6,
+      "monitored_endpoint_count": 7,
       "name": "minotaur",
       "native_name": "minotaur",
       "native_name_quality": "chain",
@@ -9408,7 +9456,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -9417,7 +9465,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_112/index.mdx",
           "https://github.com/subnet112/minotaur_subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/112/subnet.json",
-          "https://minotaursubnet.com/"
+          "https://minotaursubnet.com/",
+          "https://taostats.io/subnets/112/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -9430,12 +9479,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "Ђ",
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -9520,7 +9569,7 @@
       "team": null
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-curated"
       ],
@@ -9574,7 +9623,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -9583,6 +9632,7 @@
           "https://github.com/DendriteHQ/SOMA",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_114/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/114/subnet.json",
+          "https://taostats.io/subnets/114/metagraph",
           "https://thesoma.ai/"
         ]
       },
@@ -9602,7 +9652,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -9684,7 +9734,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -9715,10 +9765,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "hard_sign",
       "native_name": "hard_sign",
       "native_name_quality": "chain",
@@ -9743,14 +9793,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/116",
           "https://backprop.finance/dtao/subnets/116-hard-sign",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json",
+          "https://taostats.io/subnets/116/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -9761,12 +9812,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ъ",
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "identity-dispute",
@@ -9848,7 +9899,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated"
       ],
@@ -9874,10 +9925,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 9,
+      "endpoint_count": 10,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 9,
+      "monitored_endpoint_count": 10,
       "name": "Ditto",
       "native_name": "Ditto",
       "native_name_quality": "chain",
@@ -9902,7 +9953,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -9911,7 +9962,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_118/index.mdx",
           "https://github.com/orgs/ditto-assistant/repositories",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/118/subnet.json",
-          "https://heyditto.ai/"
+          "https://heyditto.ai/",
+          "https://taostats.io/subnets/118/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -9924,12 +9976,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "ⲁ",
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -9960,10 +10012,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "Satori",
       "native_name": "Satori",
       "native_name_quality": "chain",
@@ -9988,14 +10040,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/119",
           "https://backprop.finance/dtao/subnets/119-satori",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/119/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/119/subnet.json",
+          "https://taostats.io/subnets/119/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -10006,12 +10059,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "Ⲃ",
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -10093,7 +10146,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -10174,7 +10227,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -10259,7 +10312,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -10341,7 +10394,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -10424,7 +10477,7 @@
       "team": null
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -10455,10 +10508,10 @@
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
-      "monitored_endpoint_count": 4,
+      "monitored_endpoint_count": 5,
       "name": "8 Ball",
       "native_name": "8 Ball",
       "native_name_quality": "chain",
@@ -10483,14 +10536,15 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 4,
+        "interface_source_count": 5,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/125",
           "https://backprop.finance/dtao/subnets/125-8-ball",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_125/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/125/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/125/subnet.json",
+          "https://taostats.io/subnets/125/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -10501,12 +10555,12 @@
         "dashboard",
         "docs"
       ],
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "𑀂",
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -10560,7 +10614,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -10569,7 +10623,8 @@
           "https://github.com/Poker44/Poker44-subnet",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_126/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/126/subnet.json",
-          "https://poker44.net/"
+          "https://poker44.net/",
+          "https://taostats.io/subnets/126/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -10587,7 +10642,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -10613,10 +10668,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 6,
+      "monitored_endpoint_count": 7,
       "name": "Astrid",
       "native_name": "Astrid",
       "native_name_quality": "chain",
@@ -10641,7 +10696,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -10650,6 +10705,7 @@
           "https://github.com/astridintelligence/sn-127",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/127/subnet.json",
+          "https://taostats.io/subnets/127/metagraph",
           "https://www.astrid.global/"
         ]
       },
@@ -10663,12 +10719,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "𑀅",
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -10692,10 +10748,10 @@
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 9,
+      "endpoint_count": 10,
       "interface_count": 5,
       "missing_critical_count": 3,
-      "monitored_endpoint_count": 9,
+      "monitored_endpoint_count": 10,
       "name": "ByteLeap",
       "native_name": "ByteLeap",
       "native_name_quality": "chain",
@@ -10722,7 +10778,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -10731,7 +10787,8 @@
           "https://byteleap.ai/",
           "https://github.com/byteleapai/byteleap-Miner",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json",
+          "https://taostats.io/subnets/128/metagraph"
         ]
       },
       "review_state": "machine-generated",
@@ -10745,7 +10802,7 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "න",
       "team": null
     }

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 3743392,
+  "artifact_size_bytes": 3844605,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "facd7c83e10a12ac9352f1e0f8245b16a58a0b464aa7d9e1a0d71baa7e091f96",
-      "size_bytes": 3285,
+      "sha256": "abedcf31acbfba3e8369cfdf8eacfe864fc692932b4cf4aa9308bdc07c317e90",
+      "size_bytes": 3022,
       "storage_tier": "dual"
     },
     {
@@ -34,7 +34,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/coverage.json",
       "latest_key": "latest/coverage.json",
       "path": "/metagraph/coverage.json",
-      "sha256": "1402a9028f242a682675c5c78cb5f1ad22d001cab90710a955a2b91e42fc7d4a",
+      "sha256": "e7a78ee6f755c1503f0c7f56aba8ea1122c825d61bebfc4bbe31cb9290609fd8",
       "size_bytes": 982,
       "storage_tier": "dual"
     },
@@ -43,8 +43,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/curation.json",
       "latest_key": "latest/curation.json",
       "path": "/metagraph/curation.json",
-      "sha256": "9ab40c5a6fa57a6e68c181c125e32c918cf8bd8241d9b52527e6cfcbbdb082df",
-      "size_bytes": 156215,
+      "sha256": "4bc62f736c86bc4b3f13f89ced298ca613db5db61fcac5d968f7aac50cac5c55",
+      "size_bytes": 156220,
       "storage_tier": "dual"
     },
     {
@@ -52,8 +52,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/evidence-ledger.json",
       "latest_key": "latest/evidence-ledger.json",
       "path": "/metagraph/evidence-ledger.json",
-      "sha256": "59a0385881bd2c70461a79eb8bc230fc92580ac902f15e5cf1405a9570fdc3ae",
-      "size_bytes": 626942,
+      "sha256": "c12131906c10294d09898d8edc13e92f7b1d6595a9c7c67563a1f130a75338af",
+      "size_bytes": 651684,
       "storage_tier": "dual"
     },
     {
@@ -61,7 +61,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "271463ce4e3e1d0fd39763086d86217a6ed10012e03d0cc31310dcb5213f4661",
+      "sha256": "9ad9982efae083a13b9eac2e6e6f1f9f9d82a1f9d77640d68f68d1009cca8e43",
       "size_bytes": 4323,
       "storage_tier": "dual"
     },
@@ -88,8 +88,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/profiles.json",
       "latest_key": "latest/profiles.json",
       "path": "/metagraph/profiles.json",
-      "sha256": "c736e8ec581d138871a63cb9936f6492ea1e144eea1b5502d69d012fe149322c",
-      "size_bytes": 339653,
+      "sha256": "72e06cf35e07f7c68c04ba7be1665f401ed480ef287f6002219a6204a10e4981",
+      "size_bytes": 342758,
       "storage_tier": "dual"
     },
     {
@@ -106,8 +106,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/adapter-candidates.json",
       "latest_key": "latest/review/adapter-candidates.json",
       "path": "/metagraph/review/adapter-candidates.json",
-      "sha256": "4deb266c1ed466582aec4573a27530ff6cc9b5afe231c1f6428c09f1af49314c",
-      "size_bytes": 26471,
+      "sha256": "e08c3502d16608f07585848a591e8f2ee55ef72a1bc03f95fb79c39e3d97ffc3",
+      "size_bytes": 26473,
       "storage_tier": "dual"
     },
     {
@@ -115,8 +115,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/curation.json",
       "latest_key": "latest/review/curation.json",
       "path": "/metagraph/review/curation.json",
-      "sha256": "a04ff02427e299f6686e0a356a2c9358c68c2fdf1a2531ffb32be7f4529983a0",
-      "size_bytes": 94825,
+      "sha256": "42268b9642fb806c2494bf364973b4f5a3c494c075ca27c3bfc91acdefd7c7b8",
+      "size_bytes": 94841,
       "storage_tier": "dual"
     },
     {
@@ -124,8 +124,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
       "latest_key": "latest/review/enrichment-queue.json",
       "path": "/metagraph/review/enrichment-queue.json",
-      "sha256": "29c77a63197536d1e32529ec754a1a234891ade008582417e87ded87b87a2d6b",
-      "size_bytes": 330824,
+      "sha256": "6c401854d0cc761a3f330fd2351323519eec2d9cab86f52f1dda9f03b9628d27",
+      "size_bytes": 334085,
       "storage_tier": "dual"
     },
     {
@@ -133,8 +133,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/gap-priorities.json",
       "latest_key": "latest/review/gap-priorities.json",
       "path": "/metagraph/review/gap-priorities.json",
-      "sha256": "69a8b7d6bc616ca0484927113cde03f94433df226b4508e7407c3c832e8ccdf7",
-      "size_bytes": 66465,
+      "sha256": "1d113aaa1cf63c21026ba2826be32456bf0fcfee57f4db213a1351c7b59eb2bd",
+      "size_bytes": 66479,
       "storage_tier": "dual"
     },
     {
@@ -151,8 +151,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/profile-completeness.json",
       "latest_key": "latest/review/profile-completeness.json",
       "path": "/metagraph/review/profile-completeness.json",
-      "sha256": "bfc0bfba9a56354130f97b08f52bbc2d7dca53aa91f3d659acdc3b06ce48b7a0",
-      "size_bytes": 129947,
+      "sha256": "7dceea6ea4aa347793605030756c00343edf238a3bd13ee94297b244d824f82c",
+      "size_bytes": 129949,
       "storage_tier": "git"
     },
     {
@@ -178,8 +178,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/search.json",
       "latest_key": "latest/search.json",
       "path": "/metagraph/search.json",
-      "sha256": "9daba46103509c365c36b2daab07cd0d31caedfa48d6fac7edc7bb21706cda65",
-      "size_bytes": 414556,
+      "sha256": "159a273eddcf0bcc53e97760a0b801137369b4611258394514cbe86f594f1ec2",
+      "size_bytes": 435504,
       "storage_tier": "dual"
     },
     {
@@ -187,8 +187,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/subnets.json",
       "latest_key": "latest/subnets.json",
       "path": "/metagraph/subnets.json",
-      "sha256": "0fb7e7f331ba654df7dd4e40c88eac4b14cb4497dbc8f25012bb8988aea04de6",
-      "size_bytes": 120249,
+      "sha256": "0d8ad92161a5c542f3761e928a5ed9c9ecff203b4a2bb0d2516b31d6f11ad41f",
+      "size_bytes": 120258,
       "storage_tier": "dual"
     },
     {
@@ -196,8 +196,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/surfaces.json",
       "latest_key": "latest/surfaces.json",
       "path": "/metagraph/surfaces.json",
-      "sha256": "82cdb1fe3be88e37cbd43e08e6903fbaab02cb5e8a6321963ccb717142c96020",
-      "size_bytes": 697512,
+      "sha256": "12368d712a64db5c0a55d7f2526a665a9f8b891399dc7aeab8e54809e020b33a",
+      "size_bytes": 746884,
       "storage_tier": "dual"
     },
     {
@@ -214,7 +214,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1206,
-  "full_artifact_size_bytes": 37585539,
+  "full_artifact_size_bytes": 39839605,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -237,8 +237,8 @@
     "r2": 1183
   },
   "storage_tier_size_bytes": {
-    "dual": 3613445,
-    "git": 129947,
-    "r2": 33842147
+    "dual": 3714656,
+    "git": 129949,
+    "r2": 35995000
   }
 }

--- a/public/metagraph/review/adapter-candidates.json
+++ b/public/metagraph/review/adapter-candidates.json
@@ -37,7 +37,7 @@
         "openapi"
       ],
       "operational_surface_count": 2,
-      "priority_score": 50,
+      "priority_score": 51,
       "slug": "sn-56"
     },
     {
@@ -129,6 +129,18 @@
       "slug": "sn-46"
     },
     {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Bitsec.ai",
+      "netuid": 60,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 31,
+      "slug": "sn-60"
+    },
+    {
       "candidate_api_count": 11,
       "curation_level": "maintainer-reviewed",
       "name": "Chutes",
@@ -143,50 +155,14 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "DSperse",
-      "netuid": 2,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 30,
-      "slug": "sn-2"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Bitsec.ai",
-      "netuid": 60,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 30,
-      "slug": "sn-60"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
       "name": "Vocence",
       "netuid": 78,
       "operational_kinds": [
         "openapi"
       ],
       "operational_surface_count": 1,
-      "priority_score": 30,
+      "priority_score": 31,
       "slug": "sn-78"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "dogelayer",
-      "netuid": 80,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 30,
-      "slug": "sn-80"
     },
     {
       "candidate_api_count": 6,
@@ -197,7 +173,7 @@
         "openapi"
       ],
       "operational_surface_count": 1,
-      "priority_score": 30,
+      "priority_score": 31,
       "slug": "sn-97"
     },
     {
@@ -209,7 +185,7 @@
         "openapi"
       ],
       "operational_surface_count": 1,
-      "priority_score": 30,
+      "priority_score": 31,
       "slug": "sn-99"
     },
     {
@@ -221,8 +197,20 @@
         "subnet-api"
       ],
       "operational_surface_count": 1,
-      "priority_score": 30,
+      "priority_score": 31,
       "slug": "sn-107"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "DSperse",
+      "netuid": 2,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 30,
+      "slug": "sn-2"
     },
     {
       "candidate_api_count": 6,
@@ -233,7 +221,7 @@
         "subnet-api"
       ],
       "operational_surface_count": 1,
-      "priority_score": 29,
+      "priority_score": 30,
       "slug": "sn-51"
     },
     {
@@ -245,8 +233,56 @@
         "openapi"
       ],
       "operational_surface_count": 1,
-      "priority_score": 29,
+      "priority_score": 30,
       "slug": "sn-65"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "ByteLeap",
+      "netuid": 128,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 30,
+      "slug": "sn-128"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "BitAds",
+      "netuid": 16,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-16"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Almanac",
+      "netuid": 41,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-41"
+    },
+    {
+      "candidate_api_count": 6,
+      "curation_level": "machine-verified",
+      "name": "Synth",
+      "netuid": 50,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-50"
     },
     {
       "candidate_api_count": 5,
@@ -273,6 +309,66 @@
       "slug": "sn-68"
     },
     {
+      "candidate_api_count": 6,
+      "curation_level": "machine-verified",
+      "name": "NexisGen",
+      "netuid": 70,
+      "operational_kinds": [
+        "data-artifact"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-70"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Leadpoet",
+      "netuid": 71,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-71"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Liquidity",
+      "netuid": 77,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-77"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "dogelayer",
+      "netuid": 80,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-80"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "CliqueAI",
+      "netuid": 83,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-83"
+    },
+    {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
       "name": "Bitcast",
@@ -283,6 +379,18 @@
       "operational_surface_count": 1,
       "priority_score": 29,
       "slug": "sn-93"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Beam",
+      "netuid": 105,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-105"
     },
     {
       "candidate_api_count": 7,
@@ -311,50 +419,14 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "ByteLeap",
-      "netuid": 128,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 29,
-      "slug": "sn-128"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "BitAds",
-      "netuid": 16,
+      "name": "colosseum",
+      "netuid": 38,
       "operational_kinds": [
         "openapi"
       ],
       "operational_surface_count": 1,
       "priority_score": 28,
-      "slug": "sn-16"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Almanac",
-      "netuid": 41,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-41"
-    },
-    {
-      "candidate_api_count": 6,
-      "curation_level": "machine-verified",
-      "name": "Synth",
-      "netuid": 50,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-50"
+      "slug": "sn-38"
     },
     {
       "candidate_api_count": 6,
@@ -369,76 +441,16 @@
       "slug": "sn-59"
     },
     {
-      "candidate_api_count": 6,
-      "curation_level": "machine-verified",
-      "name": "NexisGen",
-      "netuid": 70,
-      "operational_kinds": [
-        "data-artifact"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-70"
-    },
-    {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "Leadpoet",
-      "netuid": 71,
+      "name": "Actual",
+      "netuid": 95,
       "operational_kinds": [
         "openapi"
       ],
       "operational_surface_count": 1,
       "priority_score": 28,
-      "slug": "sn-71"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Liquidity",
-      "netuid": 77,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-77"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "CliqueAI",
-      "netuid": 83,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-83"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Beam",
-      "netuid": 105,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-105"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "colosseum",
-      "netuid": 38,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 27,
-      "slug": "sn-38"
+      "slug": "sn-95"
     },
     {
       "candidate_api_count": 6,
@@ -451,18 +463,6 @@
       "operational_surface_count": 1,
       "priority_score": 27,
       "slug": "gittensor"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Actual",
-      "netuid": 95,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 27,
-      "slug": "sn-95"
     },
     {
       "candidate_api_count": 0,
@@ -553,7 +553,7 @@
       "netuid": 100,
       "operational_kinds": [],
       "operational_surface_count": 0,
-      "priority_score": 9,
+      "priority_score": 10,
       "slug": "sn-100"
     },
     {
@@ -563,7 +563,7 @@
       "netuid": 118,
       "operational_kinds": [],
       "operational_surface_count": 0,
-      "priority_score": 9,
+      "priority_score": 10,
       "slug": "sn-118"
     },
     {
@@ -609,6 +609,26 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "Perturb",
+      "netuid": 26,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-26"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "OxMarkets",
+      "netuid": 35,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-35"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Eirel",
       "netuid": 36,
       "operational_kinds": [],
@@ -619,12 +639,52 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "Aurelius",
+      "netuid": 37,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-37"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Score",
+      "netuid": 44,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-44"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Bitsota",
       "netuid": 94,
       "operational_kinds": [],
       "operational_surface_count": 0,
       "priority_score": 8,
       "slug": "sn-94"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "VoidAI",
+      "netuid": 106,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-106"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Hone",
+      "netuid": 5,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 7,
+      "slug": "sn-5"
     },
     {
       "candidate_api_count": 6,
@@ -649,42 +709,12 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "Perturb",
-      "netuid": 26,
+      "name": "Swap",
+      "netuid": 10,
       "operational_kinds": [],
       "operational_surface_count": 0,
       "priority_score": 7,
-      "slug": "sn-26"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "OxMarkets",
-      "netuid": 35,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-35"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Aurelius",
-      "netuid": 37,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-37"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Score",
-      "netuid": 44,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-44"
+      "slug": "sn-10"
     },
     {
       "candidate_api_count": 5,
@@ -699,6 +729,16 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "NIOME",
+      "netuid": 55,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 7,
+      "slug": "sn-55"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Harnyx",
       "netuid": 67,
       "operational_kinds": [],
@@ -709,12 +749,22 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "VoidAI",
-      "netuid": 106,
+      "name": "TalkHead",
+      "netuid": 108,
       "operational_kinds": [],
       "operational_surface_count": 0,
       "priority_score": 7,
-      "slug": "sn-106"
+      "slug": "sn-108"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "minotaur",
+      "netuid": 112,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 7,
+      "slug": "sn-112"
     },
     {
       "candidate_api_count": 5,
@@ -739,62 +789,22 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "Hone",
-      "netuid": 5,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-5"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Swap",
-      "netuid": 10,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-10"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "NIOME",
-      "netuid": 55,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-55"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "TalkHead",
-      "netuid": 108,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-108"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "minotaur",
-      "netuid": 112,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-112"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
       "name": "Astrid",
       "netuid": 127,
       "operational_kinds": [],
       "operational_surface_count": 0,
-      "priority_score": 6,
+      "priority_score": 7,
       "slug": "sn-127"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Nodexo",
+      "netuid": 27,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 5,
+      "slug": "sn-27"
     },
     {
       "candidate_api_count": 6,
@@ -805,16 +815,6 @@
       "operational_surface_count": 0,
       "priority_score": 5,
       "slug": "sn-75"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Nodexo",
-      "netuid": 27,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 4,
-      "slug": "sn-27"
     },
     {
       "candidate_api_count": 5,

--- a/public/metagraph/review/curation.json
+++ b/public/metagraph/review/curation.json
@@ -37,7 +37,7 @@
         "openapi"
       ],
       "operational_surface_count": 2,
-      "priority_score": 50,
+      "priority_score": 51,
       "slug": "sn-56"
     },
     {
@@ -129,6 +129,18 @@
       "slug": "sn-46"
     },
     {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Bitsec.ai",
+      "netuid": 60,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 31,
+      "slug": "sn-60"
+    },
+    {
       "candidate_api_count": 11,
       "curation_level": "maintainer-reviewed",
       "name": "Chutes",
@@ -143,50 +155,14 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "DSperse",
-      "netuid": 2,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 30,
-      "slug": "sn-2"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Bitsec.ai",
-      "netuid": 60,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 30,
-      "slug": "sn-60"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
       "name": "Vocence",
       "netuid": 78,
       "operational_kinds": [
         "openapi"
       ],
       "operational_surface_count": 1,
-      "priority_score": 30,
+      "priority_score": 31,
       "slug": "sn-78"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "dogelayer",
-      "netuid": 80,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 30,
-      "slug": "sn-80"
     },
     {
       "candidate_api_count": 6,
@@ -197,7 +173,7 @@
         "openapi"
       ],
       "operational_surface_count": 1,
-      "priority_score": 30,
+      "priority_score": 31,
       "slug": "sn-97"
     },
     {
@@ -209,7 +185,7 @@
         "openapi"
       ],
       "operational_surface_count": 1,
-      "priority_score": 30,
+      "priority_score": 31,
       "slug": "sn-99"
     },
     {
@@ -221,8 +197,20 @@
         "subnet-api"
       ],
       "operational_surface_count": 1,
-      "priority_score": 30,
+      "priority_score": 31,
       "slug": "sn-107"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "DSperse",
+      "netuid": 2,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 30,
+      "slug": "sn-2"
     },
     {
       "candidate_api_count": 6,
@@ -233,7 +221,7 @@
         "subnet-api"
       ],
       "operational_surface_count": 1,
-      "priority_score": 29,
+      "priority_score": 30,
       "slug": "sn-51"
     },
     {
@@ -245,8 +233,56 @@
         "openapi"
       ],
       "operational_surface_count": 1,
-      "priority_score": 29,
+      "priority_score": 30,
       "slug": "sn-65"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "ByteLeap",
+      "netuid": 128,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 30,
+      "slug": "sn-128"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "BitAds",
+      "netuid": 16,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-16"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Almanac",
+      "netuid": 41,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-41"
+    },
+    {
+      "candidate_api_count": 6,
+      "curation_level": "machine-verified",
+      "name": "Synth",
+      "netuid": 50,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-50"
     },
     {
       "candidate_api_count": 5,
@@ -273,6 +309,66 @@
       "slug": "sn-68"
     },
     {
+      "candidate_api_count": 6,
+      "curation_level": "machine-verified",
+      "name": "NexisGen",
+      "netuid": 70,
+      "operational_kinds": [
+        "data-artifact"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-70"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Leadpoet",
+      "netuid": 71,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-71"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Liquidity",
+      "netuid": 77,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-77"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "dogelayer",
+      "netuid": 80,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-80"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "CliqueAI",
+      "netuid": 83,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-83"
+    },
+    {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
       "name": "Bitcast",
@@ -283,6 +379,18 @@
       "operational_surface_count": 1,
       "priority_score": 29,
       "slug": "sn-93"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Beam",
+      "netuid": 105,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-105"
     },
     {
       "candidate_api_count": 7,
@@ -311,50 +419,14 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "ByteLeap",
-      "netuid": 128,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 29,
-      "slug": "sn-128"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "BitAds",
-      "netuid": 16,
+      "name": "colosseum",
+      "netuid": 38,
       "operational_kinds": [
         "openapi"
       ],
       "operational_surface_count": 1,
       "priority_score": 28,
-      "slug": "sn-16"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Almanac",
-      "netuid": 41,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-41"
-    },
-    {
-      "candidate_api_count": 6,
-      "curation_level": "machine-verified",
-      "name": "Synth",
-      "netuid": 50,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-50"
+      "slug": "sn-38"
     },
     {
       "candidate_api_count": 6,
@@ -369,76 +441,16 @@
       "slug": "sn-59"
     },
     {
-      "candidate_api_count": 6,
-      "curation_level": "machine-verified",
-      "name": "NexisGen",
-      "netuid": 70,
-      "operational_kinds": [
-        "data-artifact"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-70"
-    },
-    {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "Leadpoet",
-      "netuid": 71,
+      "name": "Actual",
+      "netuid": 95,
       "operational_kinds": [
         "openapi"
       ],
       "operational_surface_count": 1,
       "priority_score": 28,
-      "slug": "sn-71"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Liquidity",
-      "netuid": 77,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-77"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "CliqueAI",
-      "netuid": 83,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-83"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Beam",
-      "netuid": 105,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-105"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "colosseum",
-      "netuid": 38,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 27,
-      "slug": "sn-38"
+      "slug": "sn-95"
     },
     {
       "candidate_api_count": 6,
@@ -451,18 +463,6 @@
       "operational_surface_count": 1,
       "priority_score": 27,
       "slug": "gittensor"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Actual",
-      "netuid": 95,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 27,
-      "slug": "sn-95"
     },
     {
       "candidate_api_count": 0,
@@ -553,7 +553,7 @@
       "netuid": 100,
       "operational_kinds": [],
       "operational_surface_count": 0,
-      "priority_score": 9,
+      "priority_score": 10,
       "slug": "sn-100"
     },
     {
@@ -563,7 +563,7 @@
       "netuid": 118,
       "operational_kinds": [],
       "operational_surface_count": 0,
-      "priority_score": 9,
+      "priority_score": 10,
       "slug": "sn-118"
     },
     {
@@ -609,6 +609,26 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "Perturb",
+      "netuid": 26,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-26"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "OxMarkets",
+      "netuid": 35,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-35"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Eirel",
       "netuid": 36,
       "operational_kinds": [],
@@ -619,12 +639,52 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "Aurelius",
+      "netuid": 37,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-37"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Score",
+      "netuid": 44,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-44"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Bitsota",
       "netuid": 94,
       "operational_kinds": [],
       "operational_surface_count": 0,
       "priority_score": 8,
       "slug": "sn-94"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "VoidAI",
+      "netuid": 106,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-106"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Hone",
+      "netuid": 5,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 7,
+      "slug": "sn-5"
     },
     {
       "candidate_api_count": 6,
@@ -649,42 +709,12 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "Perturb",
-      "netuid": 26,
+      "name": "Swap",
+      "netuid": 10,
       "operational_kinds": [],
       "operational_surface_count": 0,
       "priority_score": 7,
-      "slug": "sn-26"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "OxMarkets",
-      "netuid": 35,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-35"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Aurelius",
-      "netuid": 37,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-37"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Score",
-      "netuid": 44,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-44"
+      "slug": "sn-10"
     },
     {
       "candidate_api_count": 5,
@@ -699,6 +729,16 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "NIOME",
+      "netuid": 55,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 7,
+      "slug": "sn-55"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Harnyx",
       "netuid": 67,
       "operational_kinds": [],
@@ -709,12 +749,22 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "VoidAI",
-      "netuid": 106,
+      "name": "TalkHead",
+      "netuid": 108,
       "operational_kinds": [],
       "operational_surface_count": 0,
       "priority_score": 7,
-      "slug": "sn-106"
+      "slug": "sn-108"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "minotaur",
+      "netuid": 112,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 7,
+      "slug": "sn-112"
     },
     {
       "candidate_api_count": 5,
@@ -739,62 +789,22 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "Hone",
-      "netuid": 5,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-5"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Swap",
-      "netuid": 10,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-10"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "NIOME",
-      "netuid": 55,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-55"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "TalkHead",
-      "netuid": 108,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-108"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "minotaur",
-      "netuid": 112,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 6,
-      "slug": "sn-112"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
       "name": "Astrid",
       "netuid": 127,
       "operational_kinds": [],
       "operational_surface_count": 0,
-      "priority_score": 6,
+      "priority_score": 7,
       "slug": "sn-127"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "Nodexo",
+      "netuid": 27,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 5,
+      "slug": "sn-27"
     },
     {
       "candidate_api_count": 6,
@@ -805,16 +815,6 @@
       "operational_surface_count": 0,
       "priority_score": 5,
       "slug": "sn-75"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Nodexo",
-      "netuid": 27,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 4,
-      "slug": "sn-27"
     },
     {
       "candidate_api_count": 5,
@@ -1080,7 +1080,7 @@
   "contract_version": "2026-06-06.1",
   "gap_priorities": [
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "dashboard",
@@ -1088,15 +1088,15 @@
       ],
       "name": "Allways",
       "netuid": 7,
-      "priority_score": 84,
+      "priority_score": 85,
       "review_state": "maintainer-reviewed",
       "slug": "allways",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 15,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1108,15 +1108,15 @@
       ],
       "name": "Nodexo",
       "netuid": 27,
-      "priority_score": 80,
+      "priority_score": 81,
       "review_state": "machine-generated",
       "slug": "sn-27",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1128,15 +1128,15 @@
       ],
       "name": "Grail",
       "netuid": 81,
-      "priority_score": 74,
+      "priority_score": 75,
       "review_state": "needs-review",
       "slug": "sn-81",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 3,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1148,15 +1148,15 @@
       ],
       "name": "Chunking",
       "netuid": 40,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-40",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1168,15 +1168,15 @@
       ],
       "name": "EfficientFrontier",
       "netuid": 53,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-53",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1188,15 +1188,15 @@
       ],
       "name": "Parked",
       "netuid": 73,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-73",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1208,15 +1208,15 @@
       ],
       "name": "luis",
       "netuid": 92,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "stale",
       "slug": "sn-92",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 2,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1228,15 +1228,15 @@
       ],
       "name": "hard_sign",
       "netuid": 116,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-116",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1248,15 +1248,15 @@
       ],
       "name": "Satori",
       "netuid": 119,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-119",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1265,15 +1265,15 @@
       ],
       "name": "SOMA",
       "netuid": 114,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-114",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1285,15 +1285,15 @@
       ],
       "name": "gm",
       "netuid": 28,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-28",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1305,15 +1305,15 @@
       ],
       "name": "Recall",
       "netuid": 31,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-31",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1325,15 +1325,15 @@
       ],
       "name": "ain",
       "netuid": 69,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-69",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1345,15 +1345,15 @@
       ],
       "name": "Subnet 86",
       "netuid": 86,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-86",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1365,15 +1365,15 @@
       ],
       "name": "ogham",
       "netuid": 90,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-90",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1385,15 +1385,15 @@
       ],
       "name": "eni",
       "netuid": 101,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-101",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1405,15 +1405,15 @@
       ],
       "name": "for sale (burn to uid1)",
       "netuid": 104,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-104",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1425,15 +1425,15 @@
       ],
       "name": "8 Ball",
       "netuid": 125,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-125",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1441,15 +1441,15 @@
       ],
       "name": "Gradients",
       "netuid": 56,
-      "priority_score": 71,
+      "priority_score": 72,
       "review_state": "machine-generated",
       "slug": "sn-56",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 21
+      "surface_count": 11,
+      "verified_candidate_count": 22
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1458,15 +1458,15 @@
       ],
       "name": "NOVA",
       "netuid": 68,
-      "priority_score": 69,
+      "priority_score": 70,
       "review_state": "machine-generated",
       "slug": "sn-68",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1475,15 +1475,15 @@
       ],
       "name": "NexisGen",
       "netuid": 70,
-      "priority_score": 69,
+      "priority_score": 70,
       "review_state": "machine-generated",
       "slug": "sn-70",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 12
+      "surface_count": 9,
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1493,15 +1493,15 @@
       ],
       "name": "Ditto",
       "netuid": 118,
-      "priority_score": 67,
+      "priority_score": 68,
       "review_state": "machine-generated",
       "slug": "sn-118",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 17
+      "surface_count": 10,
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1511,15 +1511,15 @@
       ],
       "name": "Actual",
       "netuid": 95,
-      "priority_score": 66,
+      "priority_score": 67,
       "review_state": "machine-generated",
       "slug": "sn-95",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 11
+      "surface_count": 8,
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1529,15 +1529,15 @@
       ],
       "name": "colosseum",
       "netuid": 38,
-      "priority_score": 64,
+      "priority_score": 65,
       "review_state": "machine-generated",
       "slug": "sn-38",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 9
+      "surface_count": 8,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1546,15 +1546,15 @@
       ],
       "name": "lium.io",
       "netuid": 51,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-51",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 18
+      "surface_count": 10,
+      "verified_candidate_count": 19
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1563,15 +1563,15 @@
       ],
       "name": "Zipcode",
       "netuid": 46,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-46",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1581,15 +1581,15 @@
       ],
       "name": "Cacheon",
       "netuid": 14,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-14",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1599,15 +1599,15 @@
       ],
       "name": "404—GEN",
       "netuid": 17,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-17",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1617,15 +1617,15 @@
       ],
       "name": "Plaτform",
       "netuid": 100,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-100",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 13
+      "surface_count": 10,
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1635,15 +1635,15 @@
       ],
       "name": "TalkHead",
       "netuid": 108,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-108",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 8
+      "surface_count": 7,
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1654,15 +1654,15 @@
       ],
       "name": "Basilica",
       "netuid": 39,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "needs-review",
       "slug": "sn-39",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1673,15 +1673,15 @@
       ],
       "name": "BrainPlay",
       "netuid": 117,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "needs-review",
       "slug": "sn-117",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 2,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1691,15 +1691,15 @@
       ],
       "name": "Numinous",
       "netuid": 6,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-6",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1709,9 +1709,27 @@
       ],
       "name": "Zeus",
       "netuid": 18,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-18",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 13
+    },
+    {
+      "candidate_count": 18,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Aurelius",
+      "netuid": 37,
+      "priority_score": 62,
+      "review_state": "machine-generated",
+      "slug": "sn-37",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
       "verified_candidate_count": 12
@@ -1725,35 +1743,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Aurelius",
-      "netuid": 37,
-      "priority_score": 61,
-      "review_state": "machine-generated",
-      "slug": "sn-37",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 16,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "TrajectoryRL",
       "netuid": 11,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-11",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1763,15 +1763,15 @@
       ],
       "name": "Perturb",
       "netuid": 26,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-26",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 9
+      "surface_count": 8,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1781,15 +1781,15 @@
       ],
       "name": "Eirel",
       "netuid": 36,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-36",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1799,15 +1799,15 @@
       ],
       "name": "NIOME",
       "netuid": 55,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-55",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 8
+      "surface_count": 7,
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1817,15 +1817,15 @@
       ],
       "name": "Poker44",
       "netuid": 126,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-126",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -1836,15 +1836,15 @@
       ],
       "name": "Gopher",
       "netuid": 42,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "needs-review",
       "slug": "sn-42",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 2,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1853,15 +1853,15 @@
       ],
       "name": "Minos",
       "netuid": 107,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-107",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 13
+      "surface_count": 11,
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1871,15 +1871,15 @@
       ],
       "name": "Hone",
       "netuid": 5,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-5",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 9
+      "surface_count": 7,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1889,15 +1889,15 @@
       ],
       "name": "Vanta",
       "netuid": 8,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-8",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1907,15 +1907,15 @@
       ],
       "name": "Yanez MIID",
       "netuid": 54,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-54",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1925,15 +1925,15 @@
       ],
       "name": "Harnyx",
       "netuid": 67,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-67",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1943,15 +1943,15 @@
       ],
       "name": "Bitsota",
       "netuid": 94,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-94",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1961,15 +1961,15 @@
       ],
       "name": "Astrid",
       "netuid": 127,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-127",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 9
+      "surface_count": 7,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1978,15 +1978,15 @@
       ],
       "name": "TAO Private Network",
       "netuid": 65,
-      "priority_score": 58,
+      "priority_score": 59,
       "review_state": "machine-generated",
       "slug": "sn-65",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 16
+      "surface_count": 10,
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1995,15 +1995,15 @@
       ],
       "name": "Bitcast",
       "netuid": 93,
-      "priority_score": 58,
+      "priority_score": 59,
       "review_state": "machine-generated",
       "slug": "sn-93",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -2013,15 +2013,15 @@
       ],
       "name": "Score",
       "netuid": 44,
-      "priority_score": 58,
+      "priority_score": 59,
       "review_state": "machine-generated",
       "slug": "sn-44",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 8
+      "surface_count": 8,
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -2030,15 +2030,15 @@
       ],
       "name": "Babelbit",
       "netuid": 59,
-      "priority_score": 57,
+      "priority_score": 58,
       "review_state": "machine-generated",
       "slug": "sn-59",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -2048,15 +2048,15 @@
       ],
       "name": "OxMarkets",
       "netuid": 35,
-      "priority_score": 57,
+      "priority_score": 58,
       "review_state": "machine-generated",
       "slug": "sn-35",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 7
+      "surface_count": 8,
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -2066,11 +2066,64 @@
       ],
       "name": "minotaur",
       "netuid": 112,
-      "priority_score": 57,
+      "priority_score": 58,
       "review_state": "machine-generated",
       "slug": "sn-112",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
+      "surface_count": 7,
+      "verified_candidate_count": 8
+    },
+    {
+      "candidate_count": 14,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Affine",
+      "netuid": 120,
+      "priority_score": 58,
+      "review_state": "machine-generated",
+      "slug": "sn-120",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 7,
+      "verified_candidate_count": 8
+    },
+    {
+      "candidate_count": 17,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Albedo",
+      "netuid": 97,
+      "priority_score": 57,
+      "review_state": "machine-generated",
+      "slug": "sn-97",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "candidate_count": 13,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Swap",
+      "netuid": 10,
+      "priority_score": 57,
+      "review_state": "machine-generated",
+      "slug": "sn-10",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 7,
       "verified_candidate_count": 7
     },
     {
@@ -2082,14 +2135,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Affine",
-      "netuid": 120,
+      "name": "VoidAI",
+      "netuid": 106,
       "priority_score": 57,
       "review_state": "machine-generated",
-      "slug": "sn-120",
+      "slug": "sn-106",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 7
+      "surface_count": 8,
+      "verified_candidate_count": 8
     },
     {
       "candidate_count": 16,
@@ -2099,70 +2152,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Albedo",
-      "netuid": 97,
-      "priority_score": 56,
-      "review_state": "machine-generated",
-      "slug": "sn-97",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 13
-    },
-    {
-      "candidate_count": 12,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Swap",
-      "netuid": 10,
-      "priority_score": 56,
-      "review_state": "machine-generated",
-      "slug": "sn-10",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 6
-    },
-    {
-      "candidate_count": 12,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "VoidAI",
-      "netuid": 106,
-      "priority_score": 56,
-      "review_state": "machine-generated",
-      "slug": "sn-106",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 15,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "DSperse",
       "netuid": 2,
-      "priority_score": 55,
+      "priority_score": 56,
       "review_state": "machine-generated",
       "slug": "sn-2",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2171,11 +2171,45 @@
       ],
       "name": "Leoma",
       "netuid": 99,
-      "priority_score": 55,
+      "priority_score": 56,
       "review_state": "machine-generated",
       "slug": "sn-99",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
+      "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Bitsec.ai",
+      "netuid": 60,
+      "priority_score": 55,
+      "review_state": "machine-generated",
+      "slug": "sn-60",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 11,
+      "verified_candidate_count": 12
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Vocence",
+      "netuid": 78,
+      "priority_score": 55,
+      "review_state": "machine-generated",
+      "slug": "sn-78",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 11,
       "verified_candidate_count": 13
     },
     {
@@ -2186,30 +2220,13 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Bitsec.ai",
-      "netuid": 60,
+      "name": "Almanac",
+      "netuid": 41,
       "priority_score": 54,
       "review_state": "machine-generated",
-      "slug": "sn-60",
+      "slug": "sn-41",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 14,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Vocence",
-      "netuid": 78,
-      "priority_score": 54,
-      "review_state": "machine-generated",
-      "slug": "sn-78",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
+      "surface_count": 9,
       "verified_candidate_count": 12
     },
     {
@@ -2220,51 +2237,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "dogelayer",
-      "netuid": 80,
-      "priority_score": 54,
-      "review_state": "machine-generated",
-      "slug": "sn-80",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Almanac",
-      "netuid": 41,
-      "priority_score": 53,
-      "review_state": "machine-generated",
-      "slug": "sn-41",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Synth",
       "netuid": 50,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-50",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 11
+      "surface_count": 9,
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2273,9 +2256,43 @@
       ],
       "name": "Swarm",
       "netuid": 124,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-124",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 9,
+      "verified_candidate_count": 12
+    },
+    {
+      "candidate_count": 14,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ByteLeap",
+      "netuid": 128,
+      "priority_score": 54,
+      "review_state": "machine-generated",
+      "slug": "sn-128",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 10,
+      "verified_candidate_count": 12
+    },
+    {
+      "candidate_count": 13,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "BitAds",
+      "netuid": 16,
+      "priority_score": 53,
+      "review_state": "machine-generated",
+      "slug": "sn-16",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
       "verified_candidate_count": 11
@@ -2288,51 +2305,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ByteLeap",
-      "netuid": 128,
+      "name": "Leadpoet",
+      "netuid": 71,
       "priority_score": 53,
       "review_state": "machine-generated",
-      "slug": "sn-128",
+      "slug": "sn-71",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
       "verified_candidate_count": 11
     },
     {
-      "candidate_count": 12,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "BitAds",
-      "netuid": 16,
-      "priority_score": 52,
-      "review_state": "machine-generated",
-      "slug": "sn-16",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 12,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Leadpoet",
-      "netuid": 71,
-      "priority_score": 52,
-      "review_state": "machine-generated",
-      "slug": "sn-71",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2341,15 +2324,32 @@
       ],
       "name": "Liquidity",
       "netuid": 77,
-      "priority_score": 52,
+      "priority_score": 53,
       "review_state": "machine-generated",
       "slug": "sn-77",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
+      "surface_count": 9,
+      "verified_candidate_count": 11
+    },
+    {
+      "candidate_count": 13,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "dogelayer",
+      "netuid": 80,
+      "priority_score": 53,
+      "review_state": "machine-generated",
+      "slug": "sn-80",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 9,
       "verified_candidate_count": 10
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2358,15 +2358,15 @@
       ],
       "name": "CliqueAI",
       "netuid": 83,
-      "priority_score": 52,
+      "priority_score": 53,
       "review_state": "machine-generated",
       "slug": "sn-83",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "surface_count": 9,
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2375,15 +2375,15 @@
       ],
       "name": "Beam",
       "netuid": 105,
-      "priority_score": 52,
+      "priority_score": 53,
       "review_state": "machine-generated",
       "slug": "sn-105",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "surface_count": 9,
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2393,15 +2393,15 @@
       ],
       "name": "Templar",
       "netuid": 3,
-      "priority_score": 49,
+      "priority_score": 50,
       "review_state": "needs-review",
       "slug": "sn-3",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2413,15 +2413,15 @@
       ],
       "name": "Mainframe",
       "netuid": 25,
-      "priority_score": 45,
+      "priority_score": 46,
       "review_state": "maintainer-reviewed",
       "slug": "sn-25",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2433,15 +2433,15 @@
       ],
       "name": "Bitstarter #1",
       "netuid": 91,
-      "priority_score": 39,
+      "priority_score": 40,
       "review_state": "maintainer-reviewed",
       "slug": "sn-91",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 2,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2452,15 +2452,15 @@
       ],
       "name": "EvolAI",
       "netuid": 47,
-      "priority_score": 38,
+      "priority_score": 39,
       "review_state": "maintainer-reviewed",
       "slug": "sn-47",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2472,15 +2472,15 @@
       ],
       "name": "GroundLayer",
       "netuid": 20,
-      "priority_score": 37,
+      "priority_score": 38,
       "review_state": "maintainer-reviewed",
       "slug": "sn-20",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 1,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2490,15 +2490,15 @@
       ],
       "name": "Investing",
       "netuid": 88,
-      "priority_score": 36,
+      "priority_score": 37,
       "review_state": "maintainer-reviewed",
       "slug": "sn-88",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 4,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2510,15 +2510,15 @@
       ],
       "name": "Byzantium",
       "netuid": 76,
-      "priority_score": 35,
+      "priority_score": 36,
       "review_state": "maintainer-reviewed",
       "slug": "sn-76",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 1,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2530,15 +2530,15 @@
       ],
       "name": "InfiniteHash",
       "netuid": 89,
-      "priority_score": 35,
+      "priority_score": 36,
       "review_state": "maintainer-reviewed",
       "slug": "sn-89",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2549,9 +2549,85 @@
       ],
       "name": "Targon",
       "netuid": 4,
-      "priority_score": 34,
+      "priority_score": 35,
       "review_state": "maintainer-reviewed",
       "slug": "sn-4",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 18
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Compelle",
+      "netuid": 82,
+      "priority_score": 35,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-82",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 18
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "iota",
+      "netuid": 9,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-9",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 3,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "AdTAO",
+      "netuid": 21,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-21",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 15
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ItsAI",
+      "netuid": 32,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-32",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
       "verified_candidate_count": 17
@@ -2566,11 +2642,68 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Compelle",
-      "netuid": 82,
+      "name": "Talisman AI",
+      "netuid": 45,
       "priority_score": 34,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-82",
+      "slug": "sn-45",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 17
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Quantum Compute",
+      "netuid": 48,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-48",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Enigma",
+      "netuid": 63,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-63",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "sundae_bar",
+      "netuid": 121,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-121",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
       "verified_candidate_count": 17
@@ -2585,128 +2718,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "iota",
-      "netuid": 9,
+      "name": "Djinn",
+      "netuid": 103,
       "priority_score": 33,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-9",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "AdTAO",
-      "netuid": 21,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-21",
+      "slug": "sn-103",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "ItsAI",
-      "netuid": 32,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-32",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 16
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Talisman AI",
-      "netuid": 45,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-45",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 16
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Quantum Compute",
-      "netuid": 48,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-48",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Enigma",
-      "netuid": 63,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-63",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "sundae_bar",
-      "netuid": 121,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-121",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
       "candidate_count": 21,
@@ -2718,14 +2737,66 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Djinn",
-      "netuid": 103,
+      "name": "ForeverMoney",
+      "netuid": 98,
       "priority_score": 32,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-103",
+      "slug": "sn-98",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
+      "verified_candidate_count": 15
+    },
+    {
+      "candidate_count": 17,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "Quasar",
+      "netuid": 24,
+      "priority_score": 32,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-24",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 8,
+      "verified_candidate_count": 11
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "dashboard",
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "StreetVision by NATIX",
+      "netuid": 72,
+      "priority_score": 31,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-72",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 6,
       "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "MVTRX",
+      "netuid": 79,
+      "priority_score": 31,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-79",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 3,
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 20,
@@ -2737,88 +2808,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ForeverMoney",
-      "netuid": 98,
-      "priority_score": 31,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-98",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 16,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "name": "Quasar",
-      "netuid": 24,
-      "priority_score": 31,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-24",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "dashboard",
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "name": "StreetVision by NATIX",
-      "netuid": 72,
-      "priority_score": 30,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-72",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 6,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "name": "MVTRX",
-      "netuid": 79,
-      "priority_score": 30,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-79",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 17
-    },
-    {
-      "candidate_count": 19,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Vidaio",
       "netuid": 85,
-      "priority_score": 30,
+      "priority_score": 31,
       "review_state": "maintainer-reviewed",
       "slug": "sn-85",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2829,15 +2829,15 @@
       ],
       "name": "ConnitoAI",
       "netuid": 102,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-102",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2849,15 +2849,15 @@
       ],
       "name": "Academia",
       "netuid": 109,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-109",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2869,15 +2869,15 @@
       ],
       "name": "HashiChain",
       "netuid": 115,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-115",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2889,15 +2889,15 @@
       ],
       "name": "MANTIS",
       "netuid": 123,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2905,15 +2905,15 @@
       ],
       "name": "Green Compute",
       "netuid": 110,
-      "priority_score": 25,
+      "priority_score": 26,
       "review_state": "maintainer-reviewed",
       "slug": "sn-110",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 7,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2923,15 +2923,15 @@
       ],
       "name": "Trishool",
       "netuid": 23,
-      "priority_score": 24,
+      "priority_score": 25,
       "review_state": "maintainer-reviewed",
       "slug": "sn-23",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 3,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -2942,15 +2942,15 @@
       ],
       "name": "Endure Network",
       "netuid": 30,
-      "priority_score": 24,
+      "priority_score": 25,
       "review_state": "maintainer-reviewed",
       "slug": "sn-30",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 2,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2960,15 +2960,15 @@
       ],
       "name": "Hippius",
       "netuid": 75,
-      "priority_score": 23,
+      "priority_score": 24,
       "review_state": "maintainer-reviewed",
       "slug": "sn-75",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 5,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2979,15 +2979,15 @@
       ],
       "name": "Ridges",
       "netuid": 62,
-      "priority_score": 23,
+      "priority_score": 24,
       "review_state": "maintainer-reviewed",
       "slug": "sn-62",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 27,
+      "candidate_count": 28,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2996,15 +2996,15 @@
       ],
       "name": "Chutes",
       "netuid": 64,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-64",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 21
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "dashboard",
@@ -3014,15 +3014,15 @@
       ],
       "name": "Gittensor",
       "netuid": 74,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "gittensor",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "dashboard",
@@ -3032,12 +3032,30 @@
       ],
       "name": "ReadyAI",
       "netuid": 33,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-33",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 5,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "blockmachine",
+      "netuid": 19,
+      "priority_score": 22,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-19",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 3,
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 22,
@@ -3048,14 +3066,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "blockmachine",
-      "netuid": 19,
+      "name": "Data Universe",
+      "netuid": 13,
       "priority_score": 21,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-19",
+      "slug": "sn-13",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 17
+      "surface_count": 8,
+      "verified_candidate_count": 14
     },
     {
       "candidate_count": 21,
@@ -3066,14 +3084,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Data Universe",
-      "netuid": 13,
+      "name": "ORO",
+      "netuid": 15,
       "priority_score": 20,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-13",
+      "slug": "sn-15",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 8,
-      "verified_candidate_count": 13
+      "surface_count": 3,
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 20,
@@ -3084,14 +3102,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ORO",
-      "netuid": 15,
+      "name": "Apex",
+      "netuid": 1,
       "priority_score": 19,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-15",
+      "slug": "sn-1",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 3,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 19,
@@ -3102,35 +3120,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Apex",
-      "netuid": 1,
+      "name": "TensorUSD",
+      "netuid": 113,
       "priority_score": 18,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-1",
+      "slug": "sn-113",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 3,
       "verified_candidate_count": 12
     },
     {
-      "candidate_count": 18,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "TensorUSD",
-      "netuid": 113,
-      "priority_score": 17,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-113",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -3141,15 +3141,15 @@
       ],
       "name": "Compute Horde",
       "netuid": 12,
-      "priority_score": 17,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
       "slug": "sn-12",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -3160,15 +3160,15 @@
       ],
       "name": "Graphite",
       "netuid": 43,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-43",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -3179,15 +3179,15 @@
       ],
       "name": "Sparket",
       "netuid": 57,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-57",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -3198,15 +3198,15 @@
       ],
       "name": "oneoneone",
       "netuid": 111,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-111",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -3217,15 +3217,15 @@
       ],
       "name": "Luminar Network",
       "netuid": 87,
-      "priority_score": 15,
+      "priority_score": 16,
       "review_state": "maintainer-reviewed",
       "slug": "sn-87",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 6,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3235,15 +3235,15 @@
       ],
       "name": "RedTeam",
       "netuid": 61,
-      "priority_score": 13,
+      "priority_score": 14,
       "review_state": "maintainer-reviewed",
       "slug": "sn-61",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 4,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3252,15 +3252,15 @@
       ],
       "name": "Coldint",
       "netuid": 29,
-      "priority_score": 13,
+      "priority_score": 14,
       "review_state": "maintainer-reviewed",
       "slug": "sn-29",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3269,15 +3269,15 @@
       ],
       "name": "ninja",
       "netuid": 66,
-      "priority_score": 10,
+      "priority_score": 11,
       "review_state": "maintainer-reviewed",
       "slug": "sn-66",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 9,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 9,
+      "candidate_count": 10,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3287,15 +3287,15 @@
       ],
       "name": "Dojo",
       "netuid": 52,
-      "priority_score": 8,
+      "priority_score": 9,
       "review_state": "maintainer-reviewed",
       "slug": "sn-52",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 5,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -3303,15 +3303,15 @@
       ],
       "name": "Handshake58",
       "netuid": 58,
-      "priority_score": 6,
+      "priority_score": 7,
       "review_state": "maintainer-reviewed",
       "slug": "sn-58",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 10,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -3319,15 +3319,15 @@
       ],
       "name": "Nepher Robotics",
       "netuid": 49,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-49",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 9,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -3335,12 +3335,30 @@
       ],
       "name": "Verathos",
       "netuid": 96,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-96",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
+    },
+    {
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ansuz",
+      "netuid": 84,
+      "priority_score": 6,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-84",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 3,
+      "verified_candidate_count": 7
     },
     {
       "candidate_count": 6,
@@ -3351,35 +3369,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ansuz",
-      "netuid": 84,
-      "priority_score": 5,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-84",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 6
-    },
-    {
-      "candidate_count": 5,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "BitMind",
       "netuid": 34,
-      "priority_score": 4,
+      "priority_score": 5,
       "review_state": "maintainer-reviewed",
       "slug": "sn-34",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 4,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3389,15 +3389,15 @@
       ],
       "name": "Bitrecs",
       "netuid": 122,
-      "priority_score": 4,
+      "priority_score": 5,
       "review_state": "maintainer-reviewed",
       "slug": "sn-122",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 3,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -3405,15 +3405,15 @@
       ],
       "name": "Desearch",
       "netuid": 22,
-      "priority_score": 3,
+      "priority_score": 4,
       "review_state": "maintainer-reviewed",
       "slug": "sn-22",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 3,
+      "candidate_count": 4,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3423,12 +3423,12 @@
       ],
       "name": "root",
       "netuid": 0,
-      "priority_score": 2,
+      "priority_score": 3,
       "review_state": "maintainer-reviewed",
       "slug": "root",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 12,
-      "verified_candidate_count": 3
+      "verified_candidate_count": 4
     }
   ],
   "generated_at": "1970-01-01T00:00:00.000Z",

--- a/public/metagraph/review/enrichment-queue.json
+++ b/public/metagraph/review/enrichment-queue.json
@@ -5,17 +5,17 @@
   "queue": [
     {
       "adapter_score": 255,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
-        "candidate_count": 2,
+        "candidate_count": 3,
         "kinds_with_candidates": [
           "dashboard"
         ],
         "live_kinds": [
           "dashboard"
         ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
+        "live_or_redirected_count": 3,
+        "reviewable_count": 3,
         "stale_kinds": [],
         "stale_or_failed_count": 0,
         "unverified_count": 0,
@@ -36,7 +36,7 @@
       "name": "Allways",
       "netuid": 7,
       "operational_interface_count": 3,
-      "priority_score": 195,
+      "priority_score": 196,
       "profile_level": "adapter-backed",
       "reason_codes": [
         "adapter-candidate"
@@ -52,12 +52,14 @@
       ],
       "sample_live_candidate_ids": [
         "sn-7-backprop-dashboard",
-        "sn-7-taomarketcap-dashboard"
+        "sn-7-taomarketcap-dashboard",
+        "sn-7-taostats-metagraph"
       ],
       "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [
         "sn-7-backprop-dashboard",
-        "sn-7-taomarketcap-dashboard"
+        "sn-7-taomarketcap-dashboard",
+        "sn-7-taostats-metagraph"
       ],
       "slug": "allways",
       "source_urls": [
@@ -67,11 +69,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 15,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "adapter_score": 4,
-      "candidate_count": 12,
+      "adapter_score": 5,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 7,
         "kinds_with_candidates": [
@@ -100,7 +102,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -115,7 +117,7 @@
       "name": "Nodexo",
       "netuid": 27,
       "operational_interface_count": 0,
-      "priority_score": 164,
+      "priority_score": 165,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -146,15 +148,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/27",
         "https://backprop.finance/dtao/subnets/27-nodexo",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json",
+        "https://taostats.io/subnets/27/metagraph"
       ],
       "stale_candidate_count": 7,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -177,7 +180,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -192,7 +195,7 @@
       "name": "Chunking",
       "netuid": 40,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -207,7 +210,7 @@
         "sn-40-taomarketcap-dashboard",
         "sn-40-taomarketcap-source-repo",
         "sn-40-taopedia-article",
-        "sn-40-tensorplex-docs"
+        "sn-40-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -221,15 +224,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/40",
         "https://backprop.finance/dtao/subnets/40-chunking",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_40/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json",
+        "https://taostats.io/subnets/40/metagraph"
       ],
       "stale_candidate_count": 1,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -252,7 +256,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -267,7 +271,7 @@
       "name": "EfficientFrontier",
       "netuid": 53,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -282,7 +286,7 @@
         "sn-53-taomarketcap-dashboard",
         "sn-53-taomarketcap-source-repo",
         "sn-53-taopedia-article",
-        "sn-53-tensorplex-docs"
+        "sn-53-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -296,15 +300,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/53",
         "https://backprop.finance/dtao/subnets/53-efficientfrontier",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
+        "https://taostats.io/subnets/53/metagraph"
       ],
       "stale_candidate_count": 1,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -327,7 +332,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -342,7 +347,7 @@
       "name": "Parked",
       "netuid": 73,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -356,8 +361,8 @@
         "sn-73-backprop-dashboard",
         "sn-73-taomarketcap-dashboard",
         "sn-73-taopedia-article",
-        "sn-73-tensorplex-docs",
-        "sn-73-tensorplex-source-repo-1"
+        "sn-73-taostats-metagraph",
+        "sn-73-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -371,15 +376,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/73",
         "https://backprop.finance/dtao/subnets/73-parked",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json",
+        "https://taostats.io/subnets/73/metagraph"
       ],
       "stale_candidate_count": 1,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -417,7 +423,7 @@
       "name": "luis",
       "netuid": 92,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -431,8 +437,8 @@
         "sn-92-backprop-dashboard",
         "sn-92-taomarketcap-dashboard",
         "sn-92-taopedia-article",
-        "sn-92-tensorplex-docs",
-        "sn-92-tensorplex-source-repo-1"
+        "sn-92-taostats-metagraph",
+        "sn-92-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -450,11 +456,11 @@
       ],
       "stale_candidate_count": 1,
       "surface_count": 2,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -477,7 +483,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -492,7 +498,7 @@
       "name": "hard_sign",
       "netuid": 116,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -506,8 +512,8 @@
         "sn-116-backprop-dashboard",
         "sn-116-taomarketcap-dashboard",
         "sn-116-taopedia-article",
-        "sn-116-tensorplex-docs",
-        "sn-116-tensorplex-source-repo-1"
+        "sn-116-taostats-metagraph",
+        "sn-116-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -521,15 +527,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/116",
         "https://backprop.finance/dtao/subnets/116-hard-sign",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json",
+        "https://taostats.io/subnets/116/metagraph"
       ],
       "stale_candidate_count": 1,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -552,7 +559,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -567,7 +574,7 @@
       "name": "Satori",
       "netuid": 119,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -582,7 +589,7 @@
         "sn-119-taomarketcap-dashboard",
         "sn-119-taomarketcap-source-repo",
         "sn-119-taopedia-article",
-        "sn-119-tensorplex-docs"
+        "sn-119-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -596,15 +603,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/119",
         "https://backprop.finance/dtao/subnets/119-satori",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/119/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/119/subnet.json",
+        "https://taostats.io/subnets/119/metagraph"
       ],
       "stale_candidate_count": 1,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -623,7 +631,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -638,7 +646,7 @@
       "name": "gm",
       "netuid": 28,
       "operational_interface_count": 0,
-      "priority_score": 150,
+      "priority_score": 151,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -652,6 +660,7 @@
         "sn-28-backprop-dashboard",
         "sn-28-taomarketcap-dashboard",
         "sn-28-taopedia-article",
+        "sn-28-taostats-metagraph",
         "sn-28-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -662,15 +671,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/28",
         "https://backprop.finance/dtao/subnets/28-gm",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/28/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/28/subnet.json",
+        "https://taostats.io/subnets/28/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -689,7 +699,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -704,7 +714,7 @@
       "name": "Recall",
       "netuid": 31,
       "operational_interface_count": 0,
-      "priority_score": 150,
+      "priority_score": 151,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -718,6 +728,7 @@
         "sn-31-backprop-dashboard",
         "sn-31-taomarketcap-dashboard",
         "sn-31-taopedia-article",
+        "sn-31-taostats-metagraph",
         "sn-31-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -728,15 +739,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/31",
         "https://backprop.finance/dtao/subnets/31-recall",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json",
+        "https://taostats.io/subnets/31/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -755,7 +767,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -770,7 +782,7 @@
       "name": "ain",
       "netuid": 69,
       "operational_interface_count": 0,
-      "priority_score": 150,
+      "priority_score": 151,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -784,6 +796,7 @@
         "sn-69-backprop-dashboard",
         "sn-69-taomarketcap-dashboard",
         "sn-69-taopedia-article",
+        "sn-69-taostats-metagraph",
         "sn-69-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -794,15 +807,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/69",
         "https://backprop.finance/dtao/subnets/69-ain",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/69/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/69/subnet.json",
+        "https://taostats.io/subnets/69/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -821,7 +835,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -836,7 +850,7 @@
       "name": "Subnet 86",
       "netuid": 86,
       "operational_interface_count": 0,
-      "priority_score": 150,
+      "priority_score": 151,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -850,6 +864,7 @@
         "sn-86-backprop-dashboard",
         "sn-86-taomarketcap-dashboard",
         "sn-86-taopedia-article",
+        "sn-86-taostats-metagraph",
         "sn-86-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -860,15 +875,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/86",
         "https://backprop.finance/dtao/subnets/86-subnet-86",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/86/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/86/subnet.json",
+        "https://taostats.io/subnets/86/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -887,7 +903,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -902,7 +918,7 @@
       "name": "ogham",
       "netuid": 90,
       "operational_interface_count": 0,
-      "priority_score": 150,
+      "priority_score": 151,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -916,6 +932,7 @@
         "sn-90-backprop-dashboard",
         "sn-90-taomarketcap-dashboard",
         "sn-90-taopedia-article",
+        "sn-90-taostats-metagraph",
         "sn-90-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -926,15 +943,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/90",
         "https://backprop.finance/dtao/subnets/90-ogham",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json",
+        "https://taostats.io/subnets/90/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -953,7 +971,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -968,7 +986,7 @@
       "name": "eni",
       "netuid": 101,
       "operational_interface_count": 0,
-      "priority_score": 150,
+      "priority_score": 151,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -982,6 +1000,7 @@
         "sn-101-backprop-dashboard",
         "sn-101-taomarketcap-dashboard",
         "sn-101-taopedia-article",
+        "sn-101-taostats-metagraph",
         "sn-101-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -992,15 +1011,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/101",
         "https://backprop.finance/dtao/subnets/101-eni",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/101/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/101/subnet.json",
+        "https://taostats.io/subnets/101/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -1019,7 +1039,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -1034,7 +1054,7 @@
       "name": "for sale (burn to uid1)",
       "netuid": 104,
       "operational_interface_count": 0,
-      "priority_score": 150,
+      "priority_score": 151,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1048,6 +1068,7 @@
         "sn-104-backprop-dashboard",
         "sn-104-taomarketcap-dashboard",
         "sn-104-taopedia-article",
+        "sn-104-taostats-metagraph",
         "sn-104-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -1058,15 +1079,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/104",
         "https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_104/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/104/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/104/subnet.json",
+        "https://taostats.io/subnets/104/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -1085,7 +1107,7 @@
         "website",
         "source-repo"
       ],
-      "endpoint_count": 4,
+      "endpoint_count": 5,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -1100,7 +1122,7 @@
       "name": "8 Ball",
       "netuid": 125,
       "operational_interface_count": 0,
-      "priority_score": 150,
+      "priority_score": 151,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1114,6 +1136,7 @@
         "sn-125-backprop-dashboard",
         "sn-125-taomarketcap-dashboard",
         "sn-125-taopedia-article",
+        "sn-125-taostats-metagraph",
         "sn-125-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -1124,15 +1147,16 @@
         "https://api.taomarketcap.com/public/v1/subnets/125",
         "https://backprop.finance/dtao/subnets/125-8-ball",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_125/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/125/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/125/subnet.json",
+        "https://taostats.io/subnets/125/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 1,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "candidate_evidence_summary": {
         "candidate_count": 18,
         "kinds_with_candidates": [
@@ -1177,7 +1201,7 @@
       "name": "Mainframe",
       "netuid": 25,
       "operational_interface_count": 0,
-      "priority_score": 144,
+      "priority_score": 146,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1214,11 +1238,11 @@
       ],
       "stale_candidate_count": 8,
       "surface_count": 1,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -1255,7 +1279,7 @@
       "name": "Grail",
       "netuid": 81,
       "operational_interface_count": 0,
-      "priority_score": 143,
+      "priority_score": 144,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1269,7 +1293,7 @@
         "sn-81-taomarketcap-dashboard",
         "sn-81-taomarketcap-source-repo",
         "sn-81-taopedia-article",
-        "sn-81-tensorplex-docs"
+        "sn-81-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -1282,11 +1306,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 3,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 2,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 8,
         "kinds_with_candidates": [
@@ -1329,7 +1353,7 @@
       "name": "Bitstarter #1",
       "netuid": 91,
       "operational_interface_count": 0,
-      "priority_score": 136,
+      "priority_score": 138,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1342,7 +1366,7 @@
         "sn-91-taomarketcap-dashboard",
         "sn-91-taomarketcap-website",
         "sn-91-taopedia-article",
-        "sn-91-tensorplex-docs"
+        "sn-91-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -1355,11 +1379,11 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 1,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 9,
         "kinds_with_candidates": [
@@ -1404,7 +1428,7 @@
       "name": "GroundLayer",
       "netuid": 20,
       "operational_interface_count": 0,
-      "priority_score": 132,
+      "priority_score": 134,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1434,86 +1458,11 @@
       ],
       "stale_candidate_count": 7,
       "surface_count": 1,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "adapter_score": 27,
-      "candidate_count": 14,
-      "candidate_evidence_summary": {
-        "candidate_count": 3,
-        "kinds_with_candidates": [
-          "source-repo",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 3,
-        "stale_kinds": [
-          "source-repo"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "source-repo"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "source-repo",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Actual",
-      "netuid": 95,
-      "operational_interface_count": 1,
-      "priority_score": 130,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "missing-source-repo",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-95-backprop-dashboard",
-        "sn-95-taomarketcap-dashboard",
-        "sn-95-taomarketcap-source-repo",
-        "sn-95-taomarketcap-website",
-        "sn-95-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-95-taomarketcap-source-repo"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-95-taomarketcap-source-repo"
-      ],
-      "slug": "sn-95",
-      "source_urls": [
-        "https://actual.inc/",
-        "https://api.taomarketcap.com/public/v1/subnets/95",
-        "https://backprop.finance/dtao/subnets/95-actual",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 7,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 9,
-      "candidate_count": 23,
+      "adapter_score": 10,
+      "candidate_count": 24,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -1539,7 +1488,7 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 9,
+      "endpoint_count": 10,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -1552,7 +1501,7 @@
       "name": "Ditto",
       "netuid": 118,
       "operational_interface_count": 0,
-      "priority_score": 130,
+      "priority_score": 133,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -1591,15 +1540,92 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_118/index.mdx",
         "https://github.com/orgs/ditto-assistant/repositories",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/118/subnet.json",
-        "https://heyditto.ai/"
+        "https://heyditto.ai/",
+        "https://taostats.io/subnets/118/metagraph"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 9,
-      "verified_candidate_count": 17
+      "surface_count": 10,
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "source-repo",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Actual",
+      "netuid": 95,
+      "operational_interface_count": 1,
+      "priority_score": 132,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-source-repo",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-95-backprop-dashboard",
+        "sn-95-taomarketcap-dashboard",
+        "sn-95-taomarketcap-source-repo",
+        "sn-95-taomarketcap-website",
+        "sn-95-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-95-taomarketcap-source-repo"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-95-taomarketcap-source-repo"
+      ],
+      "slug": "sn-95",
+      "source_urls": [
+        "https://actual.inc/",
+        "https://api.taomarketcap.com/public/v1/subnets/95",
+        "https://backprop.finance/dtao/subnets/95-actual",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json",
+        "https://taostats.io/subnets/95/metagraph"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 8,
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 1,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 8,
         "kinds_with_candidates": [
@@ -1642,7 +1668,7 @@
       "name": "Byzantium",
       "netuid": 76,
       "operational_interface_count": 0,
-      "priority_score": 129,
+      "priority_score": 131,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1655,7 +1681,7 @@
         "sn-76-taomarketcap-dashboard",
         "sn-76-taomarketcap-website",
         "sn-76-taopedia-article",
-        "sn-76-tensorplex-docs"
+        "sn-76-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -1667,11 +1693,11 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 1,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 1,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 9,
         "kinds_with_candidates": [
@@ -1716,7 +1742,7 @@
       "name": "InfiniteHash",
       "netuid": 89,
       "operational_interface_count": 0,
-      "priority_score": 129,
+      "priority_score": 131,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1745,11 +1771,11 @@
       ],
       "stale_candidate_count": 7,
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "adapter_score": 27,
-      "candidate_count": 12,
+      "adapter_score": 28,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -1774,7 +1800,7 @@
       "direct_submission_kinds": [
         "source-repo"
       ],
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -1787,7 +1813,7 @@
       "name": "colosseum",
       "netuid": 38,
       "operational_interface_count": 1,
-      "priority_score": 127,
+      "priority_score": 129,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -1816,15 +1842,16 @@
         "https://backprop.finance/dtao/subnets/38-colosseum",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/38/subnet.json",
+        "https://taostats.io/subnets/38/metagraph",
         "https://www.taocolosseum.com/"
       ],
       "stale_candidate_count": 1,
-      "surface_count": 7,
-      "verified_candidate_count": 9
+      "surface_count": 8,
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 29,
-      "candidate_count": 20,
+      "candidate_count": 21,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -1863,7 +1890,7 @@
       "name": "SOMA",
       "netuid": 114,
       "operational_interface_count": 1,
-      "priority_score": 127,
+      "priority_score": 128,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -1904,15 +1931,16 @@
         "https://github.com/DendriteHQ/SOMA",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_114/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/114/subnet.json",
+        "https://taostats.io/subnets/114/metagraph",
         "https://thesoma.ai/"
       ],
       "stale_candidate_count": 4,
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 10,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -1953,7 +1981,7 @@
       "name": "Cacheon",
       "netuid": 14,
       "operational_interface_count": 0,
-      "priority_score": 124,
+      "priority_score": 125,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -2000,11 +2028,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 22,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -2040,7 +2068,7 @@
       "name": "EvolAI",
       "netuid": 47,
       "operational_interface_count": 1,
-      "priority_score": 124,
+      "priority_score": 125,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -2066,11 +2094,98 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 2,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 10,
+      "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 10,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Plaτform",
+      "netuid": 100,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-100-backprop-dashboard",
+        "sn-100-taomarketcap-dashboard",
+        "sn-100-taomarketcap-source-repo",
+        "sn-100-taomarketcap-website",
+        "sn-100-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-100-website-common-openapi-json",
+        "sn-100-website-common-swagger",
+        "sn-100-website-common-swagger-json",
+        "sn-100-website-common-api",
+        "sn-100-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-100-website-common-openapi-json",
+        "sn-100-website-common-swagger",
+        "sn-100-website-common-swagger-json",
+        "sn-100-website-common-api",
+        "sn-100-website-common-health"
+      ],
+      "slug": "sn-100",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/100",
+        "https://backprop.finance/dtao/subnets/100-pla-form",
+        "https://github.com/PlatformNetwork/platform",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/100/subnet.json",
+        "https://platform.network/",
+        "https://taostats.io/subnets/100/metagraph"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 10,
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 8,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -2109,7 +2224,7 @@
       "name": "404—GEN",
       "netuid": 17,
       "operational_interface_count": 0,
-      "priority_score": 123,
+      "priority_score": 124,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -2153,97 +2268,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 12
-    },
-    {
-      "adapter_score": 9,
-      "candidate_count": 18,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 9,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Plaτform",
-      "netuid": 100,
-      "operational_interface_count": 0,
-      "priority_score": 123,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-100-backprop-dashboard",
-        "sn-100-taomarketcap-dashboard",
-        "sn-100-taomarketcap-source-repo",
-        "sn-100-taomarketcap-website",
-        "sn-100-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-100-website-common-openapi-json",
-        "sn-100-website-common-swagger",
-        "sn-100-website-common-swagger-json",
-        "sn-100-website-common-api",
-        "sn-100-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-100-website-common-openapi-json",
-        "sn-100-website-common-swagger",
-        "sn-100-website-common-swagger-json",
-        "sn-100-website-common-api",
-        "sn-100-website-common-health"
-      ],
-      "slug": "sn-100",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/100",
-        "https://backprop.finance/dtao/subnets/100-pla-form",
-        "https://github.com/PlatformNetwork/platform",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/100/subnet.json",
-        "https://platform.network/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 9,
       "verified_candidate_count": 13
     },
     {
       "adapter_score": 29,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -2280,7 +2309,7 @@
       "name": "NOVA",
       "netuid": 68,
       "operational_interface_count": 1,
-      "priority_score": 122,
+      "priority_score": 124,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -2319,15 +2348,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx",
         "https://github.com/metanova-labs/nova",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/68/subnet.json",
+        "https://taostats.io/subnets/68/metagraph",
         "https://www.metanova-labs.ai/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "adapter_score": 28,
-      "candidate_count": 17,
+      "adapter_score": 29,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -2352,7 +2382,7 @@
         "openapi",
         "subnet-api"
       ],
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -2364,7 +2394,7 @@
       "name": "NexisGen",
       "netuid": 70,
       "operational_interface_count": 1,
-      "priority_score": 122,
+      "priority_score": 124,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -2403,14 +2433,105 @@
         "https://github.com/RendixNetwork/nexisgen",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/70/subnet.json",
-        "https://nexisgen.ai/"
+        "https://nexisgen.ai/",
+        "https://taostats.io/subnets/70/metagraph"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 12
+      "surface_count": 9,
+      "verified_candidate_count": 13
     },
     {
-      "adapter_score": 6,
+      "adapter_score": 8,
+      "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 4,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Zeus",
+      "netuid": 18,
+      "operational_interface_count": 0,
+      "priority_score": 123,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-18-backprop-dashboard",
+        "sn-18-taomarketcap-dashboard",
+        "sn-18-taomarketcap-source-repo",
+        "sn-18-taomarketcap-website",
+        "sn-18-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-18-website-common-api"
+      ],
+      "sample_stale_candidate_ids": [
+        "sn-18-website-common-openapi-json",
+        "sn-18-website-common-swagger",
+        "sn-18-website-common-swagger-json",
+        "sn-18-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-18-website-common-api",
+        "sn-18-website-common-openapi-json",
+        "sn-18-website-common-swagger",
+        "sn-18-website-common-swagger-json",
+        "sn-18-website-common-health"
+      ],
+      "slug": "sn-18",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/18",
+        "https://backprop.finance/dtao/subnets/18-zeus",
+        "https://github.com/Orpheus-AI/Zeus",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/18/subnet.json",
+        "https://taostats.io/subnets/18/metagraph",
+        "https://www.zeussubnet.com/"
+      ],
+      "stale_candidate_count": 4,
+      "surface_count": 8,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 8,
       "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 5,
@@ -2437,7 +2558,94 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 6,
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Aurelius",
+      "netuid": 37,
+      "operational_interface_count": 0,
+      "priority_score": 123,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-37-backprop-dashboard",
+        "sn-37-taomarketcap-dashboard",
+        "sn-37-taomarketcap-source-repo",
+        "sn-37-taomarketcap-website",
+        "sn-37-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-37-website-common-openapi-json",
+        "sn-37-website-common-swagger",
+        "sn-37-website-common-swagger-json",
+        "sn-37-website-common-api",
+        "sn-37-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-37-website-common-openapi-json",
+        "sn-37-website-common-swagger",
+        "sn-37-website-common-swagger-json",
+        "sn-37-website-common-api",
+        "sn-37-website-common-health"
+      ],
+      "slug": "sn-37",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/37",
+        "https://aureliusaligned.ai/",
+        "https://backprop.finance/dtao/subnets/37-aurelius",
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json",
+        "https://taostats.io/subnets/37/metagraph"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 8,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -2450,7 +2658,7 @@
       "name": "TalkHead",
       "netuid": 108,
       "operational_interface_count": 0,
-      "priority_score": 122,
+      "priority_score": 123,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -2489,15 +2697,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx",
         "https://github.com/talkheadai/talkhead-subnet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/108/subnet.json",
+        "https://taostats.io/subnets/108/metagraph",
         "https://www.talkhead.ai/"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 6,
-      "verified_candidate_count": 8
+      "surface_count": 7,
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 2,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "candidate_evidence_summary": {
         "candidate_count": 11,
         "kinds_with_candidates": [
@@ -2541,7 +2750,7 @@
       "name": "Targon",
       "netuid": 4,
       "operational_interface_count": 0,
-      "priority_score": 121,
+      "priority_score": 122,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -2580,7 +2789,335 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 6,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "verify-existing-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Numinous",
+      "netuid": 6,
+      "operational_interface_count": 0,
+      "priority_score": 122,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-6-backprop-dashboard",
+        "sn-6-github-readme-numinouslabs-numinous-dashboard-1",
+        "sn-6-taomarketcap-dashboard",
+        "sn-6-taomarketcap-source-repo",
+        "sn-6-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-6-website-link-numinouslabs-io-subnet-api-2"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-6-website-link-numinouslabs-io-subnet-api-2",
+        "sn-6-website-common-openapi-json",
+        "sn-6-website-common-swagger",
+        "sn-6-website-common-swagger-json",
+        "sn-6-website-common-api"
+      ],
+      "slug": "sn-6",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/6",
+        "https://backprop.finance/dtao/subnets/6-numinous",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_6/index.mdx",
+        "https://github.com/numinouslabs/numinous",
+        "https://github.com/numinouslabs/numinous/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/6/subnet.json",
+        "https://numinouslabs.io/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 2,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 8,
+        "kinds_with_candidates": [
+          "docs",
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "docs"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 8,
+        "stale_kinds": [
+          "docs",
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 2,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "docs",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Compelle",
+      "netuid": 82,
+      "operational_interface_count": 0,
+      "priority_score": 122,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-82-backprop-dashboard",
+        "sn-82-taomarketcap-dashboard",
+        "sn-82-taomarketcap-source-repo",
+        "sn-82-taomarketcap-website",
+        "sn-82-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-82-website-common-openapi-json",
+        "sn-82-website-common-swagger",
+        "sn-82-website-common-swagger-json",
+        "sn-82-website-common-api",
+        "sn-82-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-82-website-common-openapi-json",
+        "sn-82-website-common-swagger",
+        "sn-82-website-common-swagger-json",
+        "sn-82-website-common-api",
+        "sn-82-website-common-health"
+      ],
+      "slug": "sn-82",
+      "source_urls": [
+        "https://compelle.com/",
+        "https://github.com/compelle/compelle-validator",
+        "https://taomarketcap.com/subnets/82"
+      ],
+      "stale_candidate_count": 6,
+      "surface_count": 2,
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 51,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 73,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Gradients",
+      "netuid": 56,
+      "operational_interface_count": 2,
+      "priority_score": 122,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-56-backprop-dashboard",
+        "sn-56-taomarketcap-dashboard",
+        "sn-56-taomarketcap-source-repo",
+        "sn-56-taomarketcap-website",
+        "sn-56-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-56-website-common-api",
+        "sn-56-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-56-website-common-api",
+        "sn-56-website-common-health"
+      ],
+      "slug": "sn-56",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/56",
+        "https://backprop.finance/dtao/subnets/56-gradients",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
+        "https://github.com/gradients-ai/G.O.D",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/56/subnet.json",
+        "https://taostats.io/subnets/56/metagraph",
+        "https://www.gradients.io/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 11,
+      "verified_candidate_count": 22
+    },
+    {
+      "adapter_score": 3,
+      "candidate_count": 23,
+      "candidate_evidence_summary": {
+        "candidate_count": 12,
+        "kinds_with_candidates": [
+          "docs",
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "docs"
+        ],
+        "live_or_redirected_count": 6,
+        "reviewable_count": 12,
+        "stale_kinds": [
+          "docs",
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 3,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "docs",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "iota",
+      "netuid": 9,
+      "operational_interface_count": 0,
+      "priority_score": 121,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-9-backprop-dashboard",
+        "sn-9-github-readme-macrocosm-os-iota-dashboard-1",
+        "sn-9-github-readme-macrocosm-os-iota-docs-2",
+        "sn-9-taomarketcap-dashboard",
+        "sn-9-taomarketcap-source-repo"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-9-website-common-openapi-json",
+        "sn-9-website-common-swagger",
+        "sn-9-website-common-swagger-json",
+        "sn-9-website-common-api",
+        "sn-9-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-9-website-common-openapi-json",
+        "sn-9-website-common-swagger",
+        "sn-9-website-common-swagger-json",
+        "sn-9-website-common-api",
+        "sn-9-website-common-health"
+      ],
+      "slug": "sn-9",
+      "source_urls": [
+        "https://github.com/macrocosm-os/iota",
+        "https://github.com/macrocosm-os/iota/blob/main/README.md",
+        "https://iota.macrocosmos.ai/",
+        "https://iota.macrocosmos.ai/dashboard/mainnet"
+      ],
+      "stale_candidate_count": 6,
+      "surface_count": 3,
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 8,
@@ -2591,16 +3128,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 4,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -2622,8 +3157,8 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Zeus",
-      "netuid": 18,
+      "name": "TrajectoryRL",
+      "netuid": 11,
       "operational_interface_count": 0,
       "priority_score": 121,
       "profile_level": "identity-complete",
@@ -2636,38 +3171,38 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-18-backprop-dashboard",
-        "sn-18-taomarketcap-dashboard",
-        "sn-18-taomarketcap-source-repo",
-        "sn-18-taomarketcap-website",
-        "sn-18-taopedia-article"
+        "sn-11-backprop-dashboard",
+        "sn-11-taomarketcap-dashboard",
+        "sn-11-taomarketcap-source-repo",
+        "sn-11-taomarketcap-website",
+        "sn-11-taopedia-article"
       ],
-      "sample_live_candidate_ids": [
-        "sn-18-website-common-api"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
-        "sn-18-website-common-openapi-json",
-        "sn-18-website-common-swagger",
-        "sn-18-website-common-swagger-json",
-        "sn-18-website-common-health"
+        "sn-11-website-common-openapi-json",
+        "sn-11-website-common-swagger",
+        "sn-11-website-common-swagger-json",
+        "sn-11-website-common-api",
+        "sn-11-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-18-website-common-api",
-        "sn-18-website-common-openapi-json",
-        "sn-18-website-common-swagger",
-        "sn-18-website-common-swagger-json",
-        "sn-18-website-common-health"
+        "sn-11-website-common-openapi-json",
+        "sn-11-website-common-swagger",
+        "sn-11-website-common-swagger-json",
+        "sn-11-website-common-api",
+        "sn-11-website-common-health"
       ],
-      "slug": "sn-18",
+      "slug": "sn-11",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/18",
-        "https://backprop.finance/dtao/subnets/18-zeus",
-        "https://github.com/Orpheus-AI/Zeus",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/18/subnet.json",
-        "https://www.zeussubnet.com/"
+        "https://api.taomarketcap.com/public/v1/subnets/11",
+        "https://backprop.finance/dtao/subnets/11-trajectoryrl",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/11/subnet.json",
+        "https://github.com/trajectoryRL/trajectoryRL",
+        "https://taostats.io/subnets/11/metagraph",
+        "https://trajrl.com/"
       ],
-      "stale_candidate_count": 4,
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 12
     },
@@ -2714,595 +3249,10 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Compelle",
-      "netuid": 82,
-      "operational_interface_count": 0,
-      "priority_score": 121,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-82-backprop-dashboard",
-        "sn-82-taomarketcap-dashboard",
-        "sn-82-taomarketcap-source-repo",
-        "sn-82-taomarketcap-website",
-        "sn-82-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-82-website-common-openapi-json",
-        "sn-82-website-common-swagger",
-        "sn-82-website-common-swagger-json",
-        "sn-82-website-common-api",
-        "sn-82-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-82-website-common-openapi-json",
-        "sn-82-website-common-swagger",
-        "sn-82-website-common-swagger-json",
-        "sn-82-website-common-api",
-        "sn-82-website-common-health"
-      ],
-      "slug": "sn-82",
-      "source_urls": [
-        "https://compelle.com/",
-        "https://github.com/compelle/compelle-validator",
-        "https://taomarketcap.com/subnets/82"
-      ],
-      "stale_candidate_count": 6,
-      "surface_count": 2,
-      "verified_candidate_count": 17
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 17,
-      "candidate_evidence_summary": {
-        "candidate_count": 6,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 6,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "verify-existing-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Numinous",
-      "netuid": 6,
-      "operational_interface_count": 0,
-      "priority_score": 120,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-6-backprop-dashboard",
-        "sn-6-github-readme-numinouslabs-numinous-dashboard-1",
-        "sn-6-taomarketcap-dashboard",
-        "sn-6-taomarketcap-source-repo",
-        "sn-6-taomarketcap-website"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-6-website-link-numinouslabs-io-subnet-api-2"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-6-website-link-numinouslabs-io-subnet-api-2",
-        "sn-6-website-common-openapi-json",
-        "sn-6-website-common-swagger",
-        "sn-6-website-common-swagger-json",
-        "sn-6-website-common-api"
-      ],
-      "slug": "sn-6",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/6",
-        "https://backprop.finance/dtao/subnets/6-numinous",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_6/index.mdx",
-        "https://github.com/numinouslabs/numinous",
-        "https://github.com/numinouslabs/numinous/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/6/subnet.json",
-        "https://numinouslabs.io/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 7,
-      "verified_candidate_count": 10
-    },
-    {
-      "adapter_score": 8,
-      "candidate_count": 16,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "TrajectoryRL",
-      "netuid": 11,
-      "operational_interface_count": 0,
-      "priority_score": 120,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-11-backprop-dashboard",
-        "sn-11-taomarketcap-dashboard",
-        "sn-11-taomarketcap-source-repo",
-        "sn-11-taomarketcap-website",
-        "sn-11-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
-      "slug": "sn-11",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/11",
-        "https://backprop.finance/dtao/subnets/11-trajectoryrl",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/11/subnet.json",
-        "https://github.com/trajectoryRL/trajectoryRL",
-        "https://trajrl.com/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 8,
-      "candidate_count": 16,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Eirel",
-      "netuid": 36,
-      "operational_interface_count": 0,
-      "priority_score": 120,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-36-backprop-dashboard",
-        "sn-36-taomarketcap-dashboard",
-        "sn-36-taomarketcap-source-repo",
-        "sn-36-taomarketcap-website",
-        "sn-36-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-36-website-common-openapi-json",
-        "sn-36-website-common-swagger",
-        "sn-36-website-common-swagger-json",
-        "sn-36-website-common-api",
-        "sn-36-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-36-website-common-openapi-json",
-        "sn-36-website-common-swagger",
-        "sn-36-website-common-swagger-json",
-        "sn-36-website-common-api",
-        "sn-36-website-common-health"
-      ],
-      "slug": "sn-36",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/36",
-        "https://backprop.finance/dtao/subnets/36-eirel",
-        "https://eirel.ai/",
-        "https://github.com/RendixNetwork/eirel-ai",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/36/subnet.json"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 17,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Aurelius",
-      "netuid": 37,
-      "operational_interface_count": 0,
-      "priority_score": 120,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-37-backprop-dashboard",
-        "sn-37-taomarketcap-dashboard",
-        "sn-37-taomarketcap-source-repo",
-        "sn-37-taomarketcap-website",
-        "sn-37-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-37-website-common-openapi-json",
-        "sn-37-website-common-swagger",
-        "sn-37-website-common-swagger-json",
-        "sn-37-website-common-api",
-        "sn-37-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-37-website-common-openapi-json",
-        "sn-37-website-common-swagger",
-        "sn-37-website-common-swagger-json",
-        "sn-37-website-common-api",
-        "sn-37-website-common-health"
-      ],
-      "slug": "sn-37",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/37",
-        "https://aureliusaligned.ai/",
-        "https://backprop.finance/dtao/subnets/37-aurelius",
-        "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 50,
-      "candidate_count": 23,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 73,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 10,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Gradients",
-      "netuid": 56,
-      "operational_interface_count": 2,
-      "priority_score": 120,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-56-backprop-dashboard",
-        "sn-56-taomarketcap-dashboard",
-        "sn-56-taomarketcap-source-repo",
-        "sn-56-taomarketcap-website",
-        "sn-56-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-56-website-common-api",
-        "sn-56-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-56-website-common-api",
-        "sn-56-website-common-health"
-      ],
-      "slug": "sn-56",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/56",
-        "https://backprop.finance/dtao/subnets/56-gradients",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
-        "https://github.com/gradients-ai/G.O.D",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/56/subnet.json",
-        "https://www.gradients.io/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 10,
-      "verified_candidate_count": 21
-    },
-    {
-      "adapter_score": 3,
-      "candidate_count": 22,
-      "candidate_evidence_summary": {
-        "candidate_count": 12,
-        "kinds_with_candidates": [
-          "docs",
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "docs"
-        ],
-        "live_or_redirected_count": 6,
-        "reviewable_count": 12,
-        "stale_kinds": [
-          "docs",
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 6,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 3,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "docs",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "iota",
-      "netuid": 9,
-      "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-9-backprop-dashboard",
-        "sn-9-github-readme-macrocosm-os-iota-dashboard-1",
-        "sn-9-github-readme-macrocosm-os-iota-docs-2",
-        "sn-9-taomarketcap-dashboard",
-        "sn-9-taomarketcap-source-repo"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-9-website-common-openapi-json",
-        "sn-9-website-common-swagger",
-        "sn-9-website-common-swagger-json",
-        "sn-9-website-common-api",
-        "sn-9-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-9-website-common-openapi-json",
-        "sn-9-website-common-swagger",
-        "sn-9-website-common-swagger-json",
-        "sn-9-website-common-api",
-        "sn-9-website-common-health"
-      ],
-      "slug": "sn-9",
-      "source_urls": [
-        "https://github.com/macrocosm-os/iota",
-        "https://github.com/macrocosm-os/iota/blob/main/README.md",
-        "https://iota.macrocosmos.ai/",
-        "https://iota.macrocosmos.ai/dashboard/mainnet"
-      ],
-      "stale_candidate_count": 6,
-      "surface_count": 3,
-      "verified_candidate_count": 15
-    },
-    {
-      "adapter_score": 2,
-      "candidate_count": 22,
-      "candidate_evidence_summary": {
-        "candidate_count": 8,
-        "kinds_with_candidates": [
-          "docs",
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "docs"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 8,
-        "stale_kinds": [
-          "docs",
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 6,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 2,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "docs",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
       "name": "AdTAO",
       "netuid": 21,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 121,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3341,11 +3291,11 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "adapter_score": 7,
-      "candidate_count": 16,
+      "adapter_score": 8,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -3371,7 +3321,7 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -3384,7 +3334,7 @@
       "name": "Perturb",
       "netuid": 26,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 121,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3423,15 +3373,16 @@
         "https://github.com/0xsigurd/Perturb",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_26/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/26/subnet.json",
+        "https://taostats.io/subnets/26/metagraph",
         "https://www.perturbai.io/"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 9
+      "surface_count": 8,
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 2,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "candidate_evidence_summary": {
         "candidate_count": 9,
         "kinds_with_candidates": [
@@ -3476,7 +3427,7 @@
       "name": "ItsAI",
       "netuid": 32,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 121,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3517,74 +3468,98 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "adapter_score": 0,
-      "candidate_count": 4,
+      "adapter_score": 8,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
       "direct_submission_kinds": [
-        "website"
+        "openapi",
+        "subnet-api",
+        "data-artifact"
       ],
-      "endpoint_count": 2,
-      "evidence_action": "submit-new-evidence",
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
         "data-artifact",
         "openapi",
         "sse",
-        "subnet-api",
-        "website"
+        "subnet-api"
       ],
-      "name": "Gopher",
-      "netuid": 42,
+      "name": "Eirel",
+      "netuid": 36,
       "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "directory-only",
+      "priority_score": 121,
+      "profile_level": "identity-complete",
       "reason_codes": [
-        "directory-only-profile",
-        "missing-website",
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
         "needs-maintainer-review"
       ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "needs-review",
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-42-backprop-dashboard",
-        "sn-42-taomarketcap-dashboard",
-        "sn-42-taopedia-article",
-        "sn-42-tensorplex-docs"
+        "sn-36-backprop-dashboard",
+        "sn-36-taomarketcap-dashboard",
+        "sn-36-taomarketcap-source-repo",
+        "sn-36-taomarketcap-website",
+        "sn-36-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-42",
-      "source_urls": [
-        "https://developers.gopher-ai.com/docs/subnet/intro",
-        "https://developers.gopher-ai.com/docs/subnet/miners",
-        "https://github.com/gopher-lab/subnet-42",
-        "https://taomarketcap.com/subnets/42"
+      "sample_stale_candidate_ids": [
+        "sn-36-website-common-openapi-json",
+        "sn-36-website-common-swagger",
+        "sn-36-website-common-swagger-json",
+        "sn-36-website-common-api",
+        "sn-36-website-common-health"
       ],
-      "stale_candidate_count": 0,
-      "surface_count": 2,
-      "verified_candidate_count": 4
+      "sample_target_candidate_ids": [
+        "sn-36-website-common-openapi-json",
+        "sn-36-website-common-swagger",
+        "sn-36-website-common-swagger-json",
+        "sn-36-website-common-api",
+        "sn-36-website-common-health"
+      ],
+      "slug": "sn-36",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/36",
+        "https://backprop.finance/dtao/subnets/36-eirel",
+        "https://eirel.ai/",
+        "https://github.com/RendixNetwork/eirel-ai",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/36/subnet.json",
+        "https://taostats.io/subnets/36/metagraph"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 8,
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 2,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "candidate_evidence_summary": {
         "candidate_count": 11,
         "kinds_with_candidates": [
@@ -3628,7 +3603,7 @@
       "name": "Talisman AI",
       "netuid": 45,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 121,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3667,11 +3642,11 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
       "adapter_score": 2,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "candidate_evidence_summary": {
         "candidate_count": 8,
         "kinds_with_candidates": [
@@ -3715,7 +3690,7 @@
       "name": "Quantum Compute",
       "netuid": 48,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 121,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3754,97 +3729,11 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 15
-    },
-    {
-      "adapter_score": 6,
-      "candidate_count": 16,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 6,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "NIOME",
-      "netuid": 55,
-      "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-55-backprop-dashboard",
-        "sn-55-taomarketcap-dashboard",
-        "sn-55-taomarketcap-source-repo",
-        "sn-55-taomarketcap-website",
-        "sn-55-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-55-website-common-openapi-json",
-        "sn-55-website-common-swagger",
-        "sn-55-website-common-swagger-json",
-        "sn-55-website-common-api",
-        "sn-55-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-55-website-common-openapi-json",
-        "sn-55-website-common-swagger",
-        "sn-55-website-common-swagger-json",
-        "sn-55-website-common-api",
-        "sn-55-website-common-health"
-      ],
-      "slug": "sn-55",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/55",
-        "https://backprop.finance/dtao/subnets/55-niome",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_55/index.mdx",
-        "https://github.com/genomesio/subnet-niome",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/55/subnet.json",
-        "https://niome.genomes.io/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 6,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 2,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "candidate_evidence_summary": {
         "candidate_count": 8,
         "kinds_with_candidates": [
@@ -3888,7 +3777,7 @@
       "name": "Enigma",
       "netuid": 63,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 121,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3927,145 +3816,11 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 15
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 5,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "docs"
-        ],
-        "live_kinds": [
-          "docs"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 25,
-      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "website"
-      ],
-      "endpoint_count": 1,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "docs",
-        "openapi",
-        "sse",
-        "subnet-api",
-        "website"
-      ],
-      "name": "Academia",
-      "netuid": 109,
-      "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-website"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-109-backprop-dashboard",
-        "sn-109-taomarketcap-dashboard",
-        "sn-109-taomarketcap-source-repo",
-        "sn-109-taopedia-article",
-        "sn-109-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-109",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/109",
-        "https://github.com/fx-integral/academia",
-        "https://taomarketcap.com/subnets/109"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 1,
-      "verified_candidate_count": 5
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 5,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "docs"
-        ],
-        "live_kinds": [
-          "docs"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 25,
-      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "website"
-      ],
-      "endpoint_count": 1,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "docs",
-        "openapi",
-        "sse",
-        "subnet-api",
-        "website"
-      ],
-      "name": "HashiChain",
-      "netuid": 115,
-      "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-website"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-115-backprop-dashboard",
-        "sn-115-taomarketcap-dashboard",
-        "sn-115-taomarketcap-source-repo",
-        "sn-115-taopedia-article",
-        "sn-115-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-115",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/115",
-        "https://github.com/hashi115/hashichain",
-        "https://taomarketcap.com/subnets/115"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 2,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "candidate_evidence_summary": {
         "candidate_count": 8,
         "kinds_with_candidates": [
@@ -4109,7 +3864,7 @@
       "name": "sundae_bar",
       "netuid": 121,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 121,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -4148,11 +3903,458 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
+    },
+    {
+      "adapter_score": 30,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "lium.io",
+      "netuid": 51,
+      "operational_interface_count": 1,
+      "priority_score": 121,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-51-backprop-dashboard",
+        "sn-51-github-readme-datura-ai-lium-io-docs-1",
+        "sn-51-taomarketcap-dashboard",
+        "sn-51-taomarketcap-source-repo",
+        "sn-51-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-51-website-common-openapi-json",
+        "sn-51-website-common-swagger",
+        "sn-51-website-common-swagger-json"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-51-website-common-openapi-json",
+        "sn-51-website-common-swagger",
+        "sn-51-website-common-swagger-json"
+      ],
+      "slug": "sn-51",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/51",
+        "https://backprop.finance/dtao/subnets/51-lium-io",
+        "https://docs.lium.io/bittensor-subnet/overview",
+        "https://github.com/Datura-ai/lium-io",
+        "https://github.com/Datura-ai/lium-io/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
+        "https://lium.io/"
+      ],
+      "stale_candidate_count": 3,
+      "surface_count": 10,
+      "verified_candidate_count": 19
     },
     {
       "adapter_score": 0,
       "candidate_count": 5,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 2,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Gopher",
+      "netuid": 42,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "needs-review",
+      "sample_candidate_ids": [
+        "sn-42-backprop-dashboard",
+        "sn-42-taomarketcap-dashboard",
+        "sn-42-taopedia-article",
+        "sn-42-taostats-metagraph",
+        "sn-42-tensorplex-docs"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-42",
+      "source_urls": [
+        "https://developers.gopher-ai.com/docs/subnet/intro",
+        "https://developers.gopher-ai.com/docs/subnet/miners",
+        "https://github.com/gopher-lab/subnet-42",
+        "https://taomarketcap.com/subnets/42"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 2,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "NIOME",
+      "netuid": 55,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-55-backprop-dashboard",
+        "sn-55-taomarketcap-dashboard",
+        "sn-55-taomarketcap-source-repo",
+        "sn-55-taomarketcap-website",
+        "sn-55-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-55-website-common-openapi-json",
+        "sn-55-website-common-swagger",
+        "sn-55-website-common-swagger-json",
+        "sn-55-website-common-api",
+        "sn-55-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-55-website-common-openapi-json",
+        "sn-55-website-common-swagger",
+        "sn-55-website-common-swagger-json",
+        "sn-55-website-common-api",
+        "sn-55-website-common-health"
+      ],
+      "slug": "sn-55",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/55",
+        "https://backprop.finance/dtao/subnets/55-niome",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_55/index.mdx",
+        "https://github.com/genomesio/subnet-niome",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/55/subnet.json",
+        "https://niome.genomes.io/",
+        "https://taostats.io/subnets/55/metagraph"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Bitsota",
+      "netuid": 94,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-94-backprop-dashboard",
+        "sn-94-taomarketcap-dashboard",
+        "sn-94-taomarketcap-source-repo",
+        "sn-94-taomarketcap-website",
+        "sn-94-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-94-website-common-openapi-json",
+        "sn-94-website-common-swagger",
+        "sn-94-website-common-swagger-json",
+        "sn-94-website-common-api",
+        "sn-94-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-94-website-common-openapi-json",
+        "sn-94-website-common-swagger",
+        "sn-94-website-common-swagger-json",
+        "sn-94-website-common-api",
+        "sn-94-website-common-health"
+      ],
+      "slug": "sn-94",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/94",
+        "https://backprop.finance/dtao/subnets/94-bitsota",
+        "https://bitsota.ai/",
+        "https://github.com/AlveusLabs/SN94-BitSota",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json",
+        "https://taostats.io/subnets/94/metagraph"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 8,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 6,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "docs"
+        ],
+        "live_kinds": [
+          "docs"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 25,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 1,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "docs",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Academia",
+      "netuid": 109,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-109-backprop-dashboard",
+        "sn-109-taomarketcap-dashboard",
+        "sn-109-taomarketcap-source-repo",
+        "sn-109-taopedia-article",
+        "sn-109-taostats-metagraph"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-109",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/109",
+        "https://github.com/fx-integral/academia",
+        "https://taomarketcap.com/subnets/109"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 1,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 6,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "docs"
+        ],
+        "live_kinds": [
+          "docs"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 25,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 1,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "docs",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "HashiChain",
+      "netuid": 115,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-115-backprop-dashboard",
+        "sn-115-taomarketcap-dashboard",
+        "sn-115-taomarketcap-source-repo",
+        "sn-115-taopedia-article",
+        "sn-115-taostats-metagraph"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-115",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/115",
+        "https://github.com/hashi115/hashichain",
+        "https://taomarketcap.com/subnets/115"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 1,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -4189,7 +4391,7 @@
       "name": "MANTIS",
       "netuid": 123,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 120,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -4202,7 +4404,7 @@
         "sn-123-taomarketcap-dashboard",
         "sn-123-taomarketcap-source-repo",
         "sn-123-taopedia-article",
-        "sn-123-tensorplex-docs"
+        "sn-123-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -4215,7 +4417,94 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Poker44",
+      "netuid": 126,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-126-backprop-dashboard",
+        "sn-126-taomarketcap-dashboard",
+        "sn-126-taomarketcap-source-repo",
+        "sn-126-taomarketcap-website",
+        "sn-126-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-126-website-common-openapi-json",
+        "sn-126-website-common-swagger",
+        "sn-126-website-common-swagger-json",
+        "sn-126-website-common-api",
+        "sn-126-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-126-website-common-openapi-json",
+        "sn-126-website-common-swagger",
+        "sn-126-website-common-swagger-json",
+        "sn-126-website-common-api",
+        "sn-126-website-common-health"
+      ],
+      "slug": "sn-126",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/126",
+        "https://backprop.finance/dtao/subnets/126-poker44",
+        "https://github.com/Poker44/Poker44-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_126/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/126/subnet.json",
+        "https://poker44.net/",
+        "https://taostats.io/subnets/126/metagraph"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 7,
@@ -4255,420 +4544,10 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Poker44",
-      "netuid": 126,
-      "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-126-backprop-dashboard",
-        "sn-126-taomarketcap-dashboard",
-        "sn-126-taomarketcap-source-repo",
-        "sn-126-taomarketcap-website",
-        "sn-126-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-126-website-common-openapi-json",
-        "sn-126-website-common-swagger",
-        "sn-126-website-common-swagger-json",
-        "sn-126-website-common-api",
-        "sn-126-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-126-website-common-openapi-json",
-        "sn-126-website-common-swagger",
-        "sn-126-website-common-swagger-json",
-        "sn-126-website-common-api",
-        "sn-126-website-common-health"
-      ],
-      "slug": "sn-126",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/126",
-        "https://backprop.finance/dtao/subnets/126-poker44",
-        "https://github.com/Poker44/Poker44-subnet",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_126/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/126/subnet.json",
-        "https://poker44.net/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 10
-    },
-    {
-      "adapter_score": 8,
-      "candidate_count": 15,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Bitsota",
-      "netuid": 94,
-      "operational_interface_count": 0,
-      "priority_score": 118,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-94-backprop-dashboard",
-        "sn-94-taomarketcap-dashboard",
-        "sn-94-taomarketcap-source-repo",
-        "sn-94-taomarketcap-website",
-        "sn-94-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-94-website-common-openapi-json",
-        "sn-94-website-common-swagger",
-        "sn-94-website-common-swagger-json",
-        "sn-94-website-common-api",
-        "sn-94-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-94-website-common-openapi-json",
-        "sn-94-website-common-swagger",
-        "sn-94-website-common-swagger-json",
-        "sn-94-website-common-api",
-        "sn-94-website-common-health"
-      ],
-      "slug": "sn-94",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/94",
-        "https://backprop.finance/dtao/subnets/94-bitsota",
-        "https://bitsota.ai/",
-        "https://github.com/AlveusLabs/SN94-BitSota",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "adapter_score": 2,
-      "candidate_count": 21,
-      "candidate_evidence_summary": {
-        "candidate_count": 8,
-        "kinds_with_candidates": [
-          "docs",
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "docs"
-        ],
-        "live_or_redirected_count": 3,
-        "reviewable_count": 8,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 2,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "docs",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Djinn",
-      "netuid": 103,
-      "operational_interface_count": 0,
-      "priority_score": 118,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-103-backprop-dashboard",
-        "sn-103-taomarketcap-dashboard",
-        "sn-103-taomarketcap-source-repo",
-        "sn-103-taomarketcap-website",
-        "sn-103-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-103-website-common-openapi-json",
-        "sn-103-website-common-swagger",
-        "sn-103-website-common-swagger-json",
-        "sn-103-website-common-api",
-        "sn-103-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-103-website-common-openapi-json",
-        "sn-103-website-common-swagger",
-        "sn-103-website-common-swagger-json",
-        "sn-103-website-common-api",
-        "sn-103-website-common-health"
-      ],
-      "slug": "sn-103",
-      "source_urls": [
-        "https://github.com/Djinn-Inc/djinn",
-        "https://taomarketcap.com/subnets/103",
-        "https://www.djinn.gg/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 2,
-      "verified_candidate_count": 16
-    },
-    {
-      "adapter_score": 31,
-      "candidate_count": 22,
-      "candidate_evidence_summary": {
-        "candidate_count": 4,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 4,
-        "stale_kinds": [
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 11,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Zipcode",
-      "netuid": 46,
-      "operational_interface_count": 1,
-      "priority_score": 118,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-46-backprop-dashboard",
-        "sn-46-github-readme-resi-labs-ai-resi-dashboard-1",
-        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
-        "sn-46-github-readme-resi-labs-ai-resi-models-dashboard-1",
-        "sn-46-taomarketcap-dashboard"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-46-website-link-zipcode-ai-subnet-api-3"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-46-website-link-zipcode-ai-subnet-api-3",
-        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
-        "sn-46-website-common-api",
-        "sn-46-website-common-health"
-      ],
-      "slug": "sn-46",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/46",
-        "https://backprop.finance/dtao/subnets/46-zipcode",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_46/index.mdx",
-        "https://github.com/resi-labs-ai/RESI-models",
-        "https://github.com/resi-labs-ai/RESI-models/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/46/subnet.json",
-        "https://zipcode.ai/"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 11,
-      "verified_candidate_count": 15
-    },
-    {
-      "adapter_score": 29,
-      "candidate_count": 23,
-      "candidate_evidence_summary": {
-        "candidate_count": 3,
-        "kinds_with_candidates": [
-          "openapi"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "stale_kinds": [
-          "openapi"
-        ],
-        "stale_or_failed_count": 3,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 9,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse"
-      ],
-      "name": "lium.io",
-      "netuid": 51,
-      "operational_interface_count": 1,
-      "priority_score": 118,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-51-backprop-dashboard",
-        "sn-51-github-readme-datura-ai-lium-io-docs-1",
-        "sn-51-taomarketcap-dashboard",
-        "sn-51-taomarketcap-source-repo",
-        "sn-51-taomarketcap-website"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-51-website-common-openapi-json",
-        "sn-51-website-common-swagger",
-        "sn-51-website-common-swagger-json"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-51-website-common-openapi-json",
-        "sn-51-website-common-swagger",
-        "sn-51-website-common-swagger-json"
-      ],
-      "slug": "sn-51",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/51",
-        "https://backprop.finance/dtao/subnets/51-lium-io",
-        "https://docs.lium.io/bittensor-subnet/overview",
-        "https://github.com/Datura-ai/lium-io",
-        "https://github.com/Datura-ai/lium-io/blob/main/README.md",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
-        "https://lium.io/"
-      ],
-      "stale_candidate_count": 3,
-      "surface_count": 9,
-      "verified_candidate_count": 18
-    },
-    {
-      "adapter_score": 6,
-      "candidate_count": 15,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 6,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
       "name": "Hone",
       "netuid": 5,
       "operational_interface_count": 0,
-      "priority_score": 117,
+      "priority_score": 119,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -4707,15 +4586,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx",
         "https://github.com/manifold-inc/hone",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/5/subnet.json",
+        "https://taostats.io/subnets/5/metagraph",
         "https://www.hone.training/"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 6,
-      "verified_candidate_count": 9
+      "surface_count": 7,
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 7,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -4754,7 +4634,7 @@
       "name": "Vanta",
       "netuid": 8,
       "operational_interface_count": 0,
-      "priority_score": 117,
+      "priority_score": 119,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -4793,86 +4673,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx",
         "https://github.com/taoshidev/vanta-network",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/8/subnet.json",
+        "https://taostats.io/subnets/8/metagraph",
         "https://www.vantanetwork.io/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 9
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 6,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "docs"
-        ],
-        "live_kinds": [
-          "docs"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 2,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "docs",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Basilica",
-      "netuid": 39,
-      "operational_interface_count": 0,
-      "priority_score": 117,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "needs-review",
-      "sample_candidate_ids": [
-        "sn-39-backprop-dashboard",
-        "sn-39-taomarketcap-dashboard",
-        "sn-39-taomarketcap-source-repo",
-        "sn-39-taopedia-article",
-        "sn-39-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-39",
-      "source_urls": [
-        "https://github.com/one-covenant/basilica",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/39/subnet.json",
-        "https://taomarketcap.com/subnets/39",
-        "https://www.basilica.ai/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 7,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -4911,7 +4721,7 @@
       "name": "Yanez MIID",
       "netuid": 54,
       "operational_interface_count": 0,
-      "priority_score": 117,
+      "priority_score": 119,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -4955,11 +4765,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 7,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -4998,7 +4808,7 @@
       "name": "Harnyx",
       "netuid": 67,
       "operational_interface_count": 0,
-      "priority_score": 117,
+      "priority_score": 119,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -5042,23 +4852,28 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "adapter_score": 0,
-      "candidate_count": 6,
+      "adapter_score": 2,
+      "candidate_count": 22,
       "candidate_evidence_summary": {
-        "candidate_count": 2,
+        "candidate_count": 8,
         "kinds_with_candidates": [
-          "docs"
+          "docs",
+          "openapi",
+          "subnet-api"
         ],
         "live_kinds": [
           "docs"
         ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
+        "live_or_redirected_count": 3,
+        "reviewable_count": 8,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -5071,7 +4886,7 @@
         "data-artifact"
       ],
       "endpoint_count": 2,
-      "evidence_action": "submit-new-evidence",
+      "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -5081,43 +4896,53 @@
         "sse",
         "subnet-api"
       ],
-      "name": "BrainPlay",
-      "netuid": 117,
+      "name": "Djinn",
+      "netuid": 103,
       "operational_interface_count": 0,
-      "priority_score": 117,
+      "priority_score": 119,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
         "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
+        "missing-subnet-api"
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "needs-review",
+      "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-117-backprop-dashboard",
-        "sn-117-taomarketcap-dashboard",
-        "sn-117-taomarketcap-source-repo",
-        "sn-117-taopedia-article",
-        "sn-117-tensorplex-docs"
+        "sn-103-backprop-dashboard",
+        "sn-103-taomarketcap-dashboard",
+        "sn-103-taomarketcap-source-repo",
+        "sn-103-taomarketcap-website",
+        "sn-103-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-117",
-      "source_urls": [
-        "https://github.com/shiftlayer-llc/brainplay-subnet",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/117/subnet.json",
-        "https://play.shiftlayer.ai/",
-        "https://taomarketcap.com/subnets/117"
+      "sample_stale_candidate_ids": [
+        "sn-103-website-common-openapi-json",
+        "sn-103-website-common-swagger",
+        "sn-103-website-common-swagger-json",
+        "sn-103-website-common-api",
+        "sn-103-website-common-health"
       ],
-      "stale_candidate_count": 0,
+      "sample_target_candidate_ids": [
+        "sn-103-website-common-openapi-json",
+        "sn-103-website-common-swagger",
+        "sn-103-website-common-swagger-json",
+        "sn-103-website-common-api",
+        "sn-103-website-common-health"
+      ],
+      "slug": "sn-103",
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn",
+        "https://taomarketcap.com/subnets/103",
+        "https://www.djinn.gg/"
+      ],
+      "stale_candidate_count": 5,
       "surface_count": 2,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 17
     },
     {
-      "adapter_score": 6,
-      "candidate_count": 15,
+      "adapter_score": 7,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -5143,7 +4968,7 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -5156,7 +4981,7 @@
       "name": "Astrid",
       "netuid": 127,
       "operational_interface_count": 0,
-      "priority_score": 117,
+      "priority_score": 119,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -5195,15 +5020,164 @@
         "https://github.com/astridintelligence/sn-127",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/127/subnet.json",
+        "https://taostats.io/subnets/127/metagraph",
         "https://www.astrid.global/"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 6,
-      "verified_candidate_count": 9
+      "surface_count": 7,
+      "verified_candidate_count": 10
     },
     {
-      "adapter_score": 7,
-      "candidate_count": 14,
+      "adapter_score": 31,
+      "candidate_count": 23,
+      "candidate_evidence_summary": {
+        "candidate_count": 4,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 4,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Zipcode",
+      "netuid": 46,
+      "operational_interface_count": 1,
+      "priority_score": 119,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-46-backprop-dashboard",
+        "sn-46-github-readme-resi-labs-ai-resi-dashboard-1",
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
+        "sn-46-github-readme-resi-labs-ai-resi-models-dashboard-1",
+        "sn-46-taomarketcap-dashboard"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-46-website-link-zipcode-ai-subnet-api-3"
+      ],
+      "sample_stale_candidate_ids": [
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-46-website-link-zipcode-ai-subnet-api-3",
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
+        "sn-46-website-common-api",
+        "sn-46-website-common-health"
+      ],
+      "slug": "sn-46",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/46",
+        "https://backprop.finance/dtao/subnets/46-zipcode",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_46/index.mdx",
+        "https://github.com/resi-labs-ai/RESI-models",
+        "https://github.com/resi-labs-ai/RESI-models/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/46/subnet.json",
+        "https://zipcode.ai/"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 11,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "docs"
+        ],
+        "live_kinds": [
+          "docs"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 2,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "docs",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Basilica",
+      "netuid": 39,
+      "operational_interface_count": 0,
+      "priority_score": 118,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "needs-review",
+      "sample_candidate_ids": [
+        "sn-39-backprop-dashboard",
+        "sn-39-taomarketcap-dashboard",
+        "sn-39-taomarketcap-source-repo",
+        "sn-39-taopedia-article",
+        "sn-39-taostats-metagraph"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-39",
+      "source_urls": [
+        "https://github.com/one-covenant/basilica",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/39/subnet.json",
+        "https://taomarketcap.com/subnets/39",
+        "https://www.basilica.ai/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 2,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -5229,7 +5203,7 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -5242,7 +5216,7 @@
       "name": "Score",
       "netuid": 44,
       "operational_interface_count": 0,
-      "priority_score": 116,
+      "priority_score": 118,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -5281,15 +5255,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_44/index.mdx",
         "https://github.com/score-technologies/turbovision",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/44/subnet.json",
+        "https://taostats.io/subnets/44/metagraph",
         "https://www.wearescore.com/"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 8
+      "surface_count": 8,
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 2,
-      "candidate_count": 20,
+      "candidate_count": 21,
       "candidate_evidence_summary": {
         "candidate_count": 9,
         "kinds_with_candidates": [
@@ -5333,7 +5308,7 @@
       "name": "ForeverMoney",
       "netuid": 98,
       "operational_interface_count": 0,
-      "priority_score": 116,
+      "priority_score": 118,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -5372,11 +5347,169 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "docs"
+        ],
+        "live_kinds": [
+          "docs"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 2,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "docs",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "BrainPlay",
+      "netuid": 117,
+      "operational_interface_count": 0,
+      "priority_score": 118,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "needs-review",
+      "sample_candidate_ids": [
+        "sn-117-backprop-dashboard",
+        "sn-117-taomarketcap-dashboard",
+        "sn-117-taomarketcap-source-repo",
+        "sn-117-taopedia-article",
+        "sn-117-taostats-metagraph"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-117",
+      "source_urls": [
+        "https://github.com/shiftlayer-llc/brainplay-subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/117/subnet.json",
+        "https://play.shiftlayer.ai/",
+        "https://taomarketcap.com/subnets/117"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 2,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "OxMarkets",
+      "netuid": 35,
+      "operational_interface_count": 0,
+      "priority_score": 117,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-35-backprop-dashboard",
+        "sn-35-taomarketcap-dashboard",
+        "sn-35-taomarketcap-source-repo",
+        "sn-35-taomarketcap-website",
+        "sn-35-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-35-website-common-openapi-json",
+        "sn-35-website-common-swagger",
+        "sn-35-website-common-swagger-json",
+        "sn-35-website-common-api",
+        "sn-35-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-35-website-common-openapi-json",
+        "sn-35-website-common-swagger",
+        "sn-35-website-common-swagger-json",
+        "sn-35-website-common-api",
+        "sn-35-website-common-health"
+      ],
+      "slug": "sn-35",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/35",
+        "https://backprop.finance/dtao/subnets/35-oxmarkets",
+        "https://github.com/General-Tao-Ventures/cartha-validator",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_35/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/35/subnet.json",
+        "https://taostats.io/subnets/35/metagraph",
+        "https://www.0xmarkets.io/"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 8,
+      "verified_candidate_count": 8
     },
     {
       "adapter_score": 2,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "candidate_evidence_summary": {
         "candidate_count": 8,
         "kinds_with_candidates": [
@@ -5420,7 +5553,7 @@
       "name": "Vidaio",
       "netuid": 85,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -5461,11 +5594,11 @@
       ],
       "stale_candidate_count": 2,
       "surface_count": 2,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
       "adapter_score": 7,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -5501,185 +5634,10 @@
         "sse",
         "subnet-api"
       ],
-      "name": "OxMarkets",
-      "netuid": 35,
-      "operational_interface_count": 0,
-      "priority_score": 114,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-35-backprop-dashboard",
-        "sn-35-taomarketcap-dashboard",
-        "sn-35-taomarketcap-source-repo",
-        "sn-35-taomarketcap-website",
-        "sn-35-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-35-website-common-openapi-json",
-        "sn-35-website-common-swagger",
-        "sn-35-website-common-swagger-json",
-        "sn-35-website-common-api",
-        "sn-35-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-35-website-common-openapi-json",
-        "sn-35-website-common-swagger",
-        "sn-35-website-common-swagger-json",
-        "sn-35-website-common-api",
-        "sn-35-website-common-health"
-      ],
-      "slug": "sn-35",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/35",
-        "https://backprop.finance/dtao/subnets/35-oxmarkets",
-        "https://github.com/General-Tao-Ventures/cartha-validator",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_35/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/35/subnet.json",
-        "https://www.0xmarkets.io/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 7
-    },
-    {
-      "adapter_score": 24,
-      "candidate_count": 17,
-      "candidate_evidence_summary": {
-        "candidate_count": 9,
-        "kinds_with_candidates": [
-          "docs",
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "docs",
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 3,
-        "reviewable_count": 9,
-        "stale_kinds": [
-          "docs",
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 6,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 48,
-      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api"
-      ],
-      "endpoint_count": 4,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Investing",
-      "netuid": 88,
-      "operational_interface_count": 1,
-      "priority_score": 114,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-88-backprop-dashboard",
-        "sn-88-github-readme-mobiusfund-investing-dashboard-1",
-        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
-        "sn-88-taomarketcap-dashboard",
-        "sn-88-taomarketcap-source-repo"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-88-github-readme-mobiusfund-investing-subnet-api-2"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-88-website-common-openapi-json",
-        "sn-88-website-common-swagger",
-        "sn-88-website-common-swagger-json",
-        "sn-88-website-common-api",
-        "sn-88-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
-        "sn-88-website-common-openapi-json",
-        "sn-88-website-common-swagger",
-        "sn-88-website-common-swagger-json",
-        "sn-88-website-common-api"
-      ],
-      "slug": "sn-88",
-      "source_urls": [
-        "https://db.investing88.ai/",
-        "https://github.com/mobiusfund/investing",
-        "https://github.com/mobiusfund/investing/blob/main/README.md",
-        "https://investing88.ai/"
-      ],
-      "stale_candidate_count": 6,
-      "surface_count": 4,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 6,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 6,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
       "name": "minotaur",
       "netuid": 112,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 116,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -5718,15 +5676,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_112/index.mdx",
         "https://github.com/subnet112/minotaur_subnet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/112/subnet.json",
-        "https://minotaursubnet.com/"
+        "https://minotaursubnet.com/",
+        "https://taostats.io/subnets/112/metagraph"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 6,
-      "verified_candidate_count": 7
+      "surface_count": 7,
+      "verified_candidate_count": 8
     },
     {
       "adapter_score": 7,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -5765,7 +5724,7 @@
       "name": "Affine",
       "netuid": 120,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 116,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -5809,97 +5768,100 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "adapter_score": 6,
-      "candidate_count": 12,
+      "adapter_score": 24,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
+        "candidate_count": 9,
         "kinds_with_candidates": [
+          "docs",
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
+        "live_kinds": [
+          "docs",
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 3,
+        "reviewable_count": 9,
         "stale_kinds": [
+          "docs",
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 5,
+        "stale_or_failed_count": 6,
         "unverified_count": 0,
         "unverified_kinds": []
       },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
+      "completeness_score": 48,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
       "direct_submission_kinds": [
         "openapi",
-        "subnet-api",
-        "data-artifact"
+        "subnet-api"
       ],
-      "endpoint_count": 6,
+      "endpoint_count": 4,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
-        "data-artifact",
+        "docs",
         "openapi",
         "sse",
         "subnet-api"
       ],
-      "name": "Swap",
-      "netuid": 10,
-      "operational_interface_count": 0,
-      "priority_score": 113,
-      "profile_level": "identity-complete",
+      "name": "Investing",
+      "netuid": 88,
+      "operational_interface_count": 1,
+      "priority_score": 115,
+      "profile_level": "operational",
       "reason_codes": [
-        "missing-data-artifact",
+        "adapter-candidate",
         "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
+        "missing-subnet-api"
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
+      "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-10-backprop-dashboard",
-        "sn-10-taomarketcap-dashboard",
-        "sn-10-taomarketcap-source-repo",
-        "sn-10-taomarketcap-website",
-        "sn-10-taopedia-article"
+        "sn-88-backprop-dashboard",
+        "sn-88-github-readme-mobiusfund-investing-dashboard-1",
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
+        "sn-88-taomarketcap-dashboard",
+        "sn-88-taomarketcap-source-repo"
       ],
-      "sample_live_candidate_ids": [],
+      "sample_live_candidate_ids": [
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-2"
+      ],
       "sample_stale_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
+        "sn-88-website-common-openapi-json",
+        "sn-88-website-common-swagger",
+        "sn-88-website-common-swagger-json",
+        "sn-88-website-common-api",
+        "sn-88-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
+        "sn-88-website-common-openapi-json",
+        "sn-88-website-common-swagger",
+        "sn-88-website-common-swagger-json",
+        "sn-88-website-common-api"
       ],
-      "slug": "sn-10",
+      "slug": "sn-88",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/10",
-        "https://backprop.finance/dtao/subnets/10-swap",
-        "https://github.com/Swap-Subnet/swap-subnet",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/10/subnet.json",
-        "https://www.taofi.com/pool"
+        "https://db.investing88.ai/",
+        "https://github.com/mobiusfund/investing",
+        "https://github.com/mobiusfund/investing/blob/main/README.md",
+        "https://investing88.ai/"
       ],
-      "stale_candidate_count": 5,
-      "surface_count": 6,
-      "verified_candidate_count": 6
+      "stale_candidate_count": 6,
+      "surface_count": 4,
+      "verified_candidate_count": 12
     },
     {
-      "adapter_score": 7,
-      "candidate_count": 12,
+      "adapter_score": 8,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -5925,7 +5887,7 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -5938,7 +5900,7 @@
       "name": "VoidAI",
       "netuid": 106,
       "operational_interface_count": 0,
-      "priority_score": 113,
+      "priority_score": 115,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -5977,15 +5939,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/106/subnet.json",
         "https://github.com/v0idai/SN106",
+        "https://taostats.io/subnets/106/metagraph",
         "https://voidai.com/"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 7
+      "surface_count": 8,
+      "verified_candidate_count": 8
     },
     {
-      "adapter_score": 30,
-      "candidate_count": 19,
+      "adapter_score": 31,
+      "candidate_count": 20,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -6005,7 +5968,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -6017,7 +5980,7 @@
       "name": "Minos",
       "netuid": 107,
       "operational_interface_count": 1,
-      "priority_score": 113,
+      "priority_score": 115,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -6051,15 +6014,103 @@
         "https://github.com/minos-protocol/minos_subnet",
         "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/107/subnet.json",
+        "https://taostats.io/subnets/107/metagraph",
         "https://theminos.ai/"
       ],
       "stale_candidate_count": 3,
-      "surface_count": 10,
-      "verified_candidate_count": 13
+      "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Swap",
+      "netuid": 10,
+      "operational_interface_count": 0,
+      "priority_score": 114,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-10-backprop-dashboard",
+        "sn-10-taomarketcap-dashboard",
+        "sn-10-taomarketcap-source-repo",
+        "sn-10-taomarketcap-website",
+        "sn-10-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-10-website-common-openapi-json",
+        "sn-10-website-common-swagger",
+        "sn-10-website-common-swagger-json",
+        "sn-10-website-common-api",
+        "sn-10-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-10-website-common-openapi-json",
+        "sn-10-website-common-swagger",
+        "sn-10-website-common-swagger-json",
+        "sn-10-website-common-api",
+        "sn-10-website-common-health"
+      ],
+      "slug": "sn-10",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/10",
+        "https://backprop.finance/dtao/subnets/10-swap",
+        "https://github.com/Swap-Subnet/swap-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/10/subnet.json",
+        "https://taostats.io/subnets/10/metagraph",
+        "https://www.taofi.com/pool"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 2,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 11,
         "kinds_with_candidates": [
@@ -6103,7 +6154,7 @@
       "name": "ConnitoAI",
       "netuid": 102,
       "operational_interface_count": 0,
-      "priority_score": 112,
+      "priority_score": 113,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -6142,11 +6193,83 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 2,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 30,
+      "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TAO Private Network",
+      "netuid": 65,
+      "operational_interface_count": 1,
+      "priority_score": 113,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-65-backprop-dashboard",
+        "sn-65-taomarketcap-dashboard",
+        "sn-65-taomarketcap-source-repo",
+        "sn-65-taomarketcap-website",
+        "sn-65-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-65-website-common-api",
+        "sn-65-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-65-website-common-api",
+        "sn-65-website-common-health"
+      ],
+      "slug": "sn-65",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/65",
+        "https://backprop.finance/dtao/subnets/65-tao-private-network",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx",
+        "https://github.com/taofu-labs/tpn-subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/65/subnet.json",
+        "https://taostats.io/subnets/65/metagraph",
+        "https://tpn.taofu.xyz/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 10,
+      "verified_candidate_count": 17
     },
     {
       "adapter_score": 2,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -6184,7 +6307,7 @@
       "name": "Endure Network",
       "netuid": 30,
       "operational_interface_count": 0,
-      "priority_score": 111,
+      "priority_score": 112,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -6197,7 +6320,7 @@
         "sn-30-taomarketcap-dashboard",
         "sn-30-taomarketcap-website",
         "sn-30-taopedia-article",
-        "sn-30-tensorplex-docs"
+        "sn-30-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -6210,82 +6333,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 2,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 29,
-      "candidate_count": 18,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 9,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "TAO Private Network",
-      "netuid": 65,
-      "operational_interface_count": 1,
-      "priority_score": 111,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-65-backprop-dashboard",
-        "sn-65-taomarketcap-dashboard",
-        "sn-65-taomarketcap-source-repo",
-        "sn-65-taomarketcap-website",
-        "sn-65-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-65-website-common-api",
-        "sn-65-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-65-website-common-api",
-        "sn-65-website-common-health"
-      ],
-      "slug": "sn-65",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/65",
-        "https://backprop.finance/dtao/subnets/65-tao-private-network",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx",
-        "https://github.com/taofu-labs/tpn-subnet",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/65/subnet.json",
-        "https://tpn.taofu.xyz/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 16
-    },
-    {
-      "adapter_score": 29,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -6317,7 +6369,7 @@
       "name": "Bitcast",
       "netuid": 93,
       "operational_interface_count": 1,
-      "priority_score": 111,
+      "priority_score": 112,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -6348,15 +6400,16 @@
         "https://github.com/bitcast-network/bitcast",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_93/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/93/subnet.json",
-        "https://stats.bitcast.network/"
+        "https://stats.bitcast.network/",
+        "https://taostats.io/subnets/93/metagraph"
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 28,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -6388,7 +6441,7 @@
       "name": "Babelbit",
       "netuid": 59,
       "operational_interface_count": 1,
-      "priority_score": 109,
+      "priority_score": 111,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -6422,15 +6475,16 @@
         "https://github.com/babelbit/babelbit_subnet",
         "https://github.com/babelbit/babelbit_subnet/blob/main/README.md",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_59/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json",
+        "https://taostats.io/subnets/59/metagraph"
       ],
       "stale_candidate_count": 3,
       "surface_count": 8,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "adapter_score": 30,
-      "candidate_count": 16,
+      "adapter_score": 31,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -6452,7 +6506,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -6464,7 +6518,7 @@
       "name": "Albedo",
       "netuid": 97,
       "operational_interface_count": 1,
-      "priority_score": 109,
+      "priority_score": 110,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -6500,101 +6554,15 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/97/subnet.json",
         "https://github.com/unarbos/albedo",
         "https://github.com/unitone-labs/FlameWire/blob/main/README.md",
-        "https://us-east-1.hippius.com/albedo/index.html"
+        "https://taostats.io/subnets/97/metagraph"
       ],
       "stale_candidate_count": 1,
-      "surface_count": 10,
-      "verified_candidate_count": 13
-    },
-    {
-      "adapter_score": 26,
-      "candidate_count": 23,
-      "candidate_evidence_summary": {
-        "candidate_count": 7,
-        "kinds_with_candidates": [
-          "dashboard",
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "dashboard"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 7,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 58,
-      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api"
-      ],
-      "endpoint_count": 6,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "dashboard",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "StreetVision by NATIX",
-      "netuid": 72,
-      "operational_interface_count": 1,
-      "priority_score": 108,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-72-backprop-dashboard",
-        "sn-72-github-readme-natixnetwork-streetvision-subnet-data-artifact-1",
-        "sn-72-taomarketcap-dashboard",
-        "sn-72-taomarketcap-source-repo",
-        "sn-72-taomarketcap-website"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-72-website-common-openapi-json",
-        "sn-72-website-common-swagger",
-        "sn-72-website-common-swagger-json",
-        "sn-72-website-common-api",
-        "sn-72-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-72-website-common-openapi-json",
-        "sn-72-website-common-swagger",
-        "sn-72-website-common-swagger-json",
-        "sn-72-website-common-api",
-        "sn-72-website-common-health"
-      ],
-      "slug": "sn-72",
-      "source_urls": [
-        "https://docs.natix.network/whitepaper",
-        "https://github.com/natixnetwork/streetvision-subnet",
-        "https://huggingface.co/natix-network-org",
-        "https://www.natix.network/",
-        "https://www.natix.network/vx360-depin-dashcam"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 6,
-      "verified_candidate_count": 15
+      "surface_count": 11,
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 48,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -6631,7 +6599,7 @@
       "name": "Quasar",
       "netuid": 24,
       "operational_interface_count": 1,
-      "priority_score": 107,
+      "priority_score": 109,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -6674,11 +6642,97 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 26,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 8,
+        "kinds_with_candidates": [
+          "dashboard",
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "dashboard"
+        ],
+        "live_or_redirected_count": 3,
+        "reviewable_count": 8,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 58,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "dashboard",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "StreetVision by NATIX",
+      "netuid": 72,
+      "operational_interface_count": 1,
+      "priority_score": 109,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-72-backprop-dashboard",
+        "sn-72-github-readme-natixnetwork-streetvision-subnet-data-artifact-1",
+        "sn-72-taomarketcap-dashboard",
+        "sn-72-taomarketcap-source-repo",
+        "sn-72-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-72-website-common-openapi-json",
+        "sn-72-website-common-swagger",
+        "sn-72-website-common-swagger-json",
+        "sn-72-website-common-api",
+        "sn-72-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-72-website-common-openapi-json",
+        "sn-72-website-common-swagger",
+        "sn-72-website-common-swagger-json",
+        "sn-72-website-common-api",
+        "sn-72-website-common-health"
+      ],
+      "slug": "sn-72",
+      "source_urls": [
+        "https://docs.natix.network/whitepaper",
+        "https://github.com/natixnetwork/streetvision-subnet",
+        "https://huggingface.co/natix-network-org",
+        "https://www.natix.network/",
+        "https://www.natix.network/vx360-depin-dashcam"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 6,
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 30,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -6710,7 +6764,7 @@
       "name": "DSperse",
       "netuid": 2,
       "operational_interface_count": 1,
-      "priority_score": 107,
+      "priority_score": 109,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -6747,11 +6801,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "adapter_score": 30,
-      "candidate_count": 15,
+      "adapter_score": 31,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -6771,7 +6825,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -6783,7 +6837,7 @@
       "name": "Leoma",
       "netuid": 99,
       "operational_interface_count": 1,
-      "priority_score": 107,
+      "priority_score": 109,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -6821,12 +6875,12 @@
         "https://leoma.ai/"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 10,
-      "verified_candidate_count": 13
+      "surface_count": 11,
+      "verified_candidate_count": 14
     },
     {
-      "adapter_score": 30,
-      "candidate_count": 14,
+      "adapter_score": 31,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -6848,7 +6902,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -6860,7 +6914,7 @@
       "name": "Bitsec.ai",
       "netuid": 60,
       "operational_interface_count": 1,
-      "priority_score": 106,
+      "priority_score": 107,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -6897,8 +6951,80 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/60/subnet.json"
       ],
       "stale_candidate_count": 1,
-      "surface_count": 10,
-      "verified_candidate_count": 11
+      "surface_count": 11,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 31,
+      "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Vocence",
+      "netuid": 78,
+      "operational_interface_count": 1,
+      "priority_score": 107,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-78-backprop-dashboard",
+        "sn-78-taomarketcap-dashboard",
+        "sn-78-taomarketcap-source-repo",
+        "sn-78-taomarketcap-website",
+        "sn-78-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-78-website-common-api",
+        "sn-78-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-78-website-common-api",
+        "sn-78-website-common-health"
+      ],
+      "slug": "sn-78",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/78",
+        "https://backprop.finance/dtao/subnets/78-vocence",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/78/subnet.json",
+        "https://github.com/vocence-78/vocence",
+        "https://taostats.io/subnets/78/metagraph",
+        "https://www.vocence.ai/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 11,
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 30,
@@ -6931,8 +7057,8 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Vocence",
-      "netuid": 78,
+      "name": "ByteLeap",
+      "netuid": 128,
       "operational_interface_count": 1,
       "priority_score": 106,
       "profile_level": "operational",
@@ -6943,111 +7069,38 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-78-backprop-dashboard",
-        "sn-78-taomarketcap-dashboard",
-        "sn-78-taomarketcap-source-repo",
-        "sn-78-taomarketcap-website",
-        "sn-78-taopedia-article"
+        "sn-128-backprop-dashboard",
+        "sn-128-taomarketcap-dashboard",
+        "sn-128-taomarketcap-source-repo",
+        "sn-128-taomarketcap-website",
+        "sn-128-taopedia-article"
       ],
       "sample_live_candidate_ids": [
-        "sn-78-website-common-api",
-        "sn-78-website-common-health"
+        "sn-128-website-common-api",
+        "sn-128-website-common-health"
       ],
       "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [
-        "sn-78-website-common-api",
-        "sn-78-website-common-health"
+        "sn-128-website-common-api",
+        "sn-128-website-common-health"
       ],
-      "slug": "sn-78",
+      "slug": "sn-128",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/78",
-        "https://backprop.finance/dtao/subnets/78-vocence",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/78/subnet.json",
-        "https://github.com/vocence-78/vocence",
-        "https://www.vocence.ai/"
+        "https://api.taomarketcap.com/public/v1/subnets/128",
+        "https://backprop.finance/dtao/subnets/128-byteleap",
+        "https://byteleap.ai/",
+        "https://github.com/byteleapai/byteleap-Miner",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json",
+        "https://taostats.io/subnets/128/metagraph"
       ],
       "stale_candidate_count": 0,
       "surface_count": 10,
       "verified_candidate_count": 12
     },
     {
-      "adapter_score": 30,
-      "candidate_count": 14,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 2,
-        "stale_kinds": [
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 10,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "dogelayer",
-      "netuid": 80,
-      "operational_interface_count": 1,
-      "priority_score": 106,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-80-backprop-dashboard",
-        "sn-80-taomarketcap-dashboard",
-        "sn-80-taomarketcap-source-repo",
-        "sn-80-taomarketcap-website",
-        "sn-80-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-80-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-80-website-common-api"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-80-website-common-health",
-        "sn-80-website-common-api"
-      ],
-      "slug": "sn-80",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/80",
-        "https://backprop.finance/dtao/subnets/80-dogelayer",
-        "https://dogelayer.ai/",
-        "https://github.com/dogelayer-ai/dogelayer",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/80/subnet.json"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 10,
-      "verified_candidate_count": 11
-    },
-    {
       "adapter_score": 1,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 8,
         "kinds_with_candidates": [
@@ -7087,7 +7140,7 @@
       "name": "Ridges",
       "netuid": 62,
       "operational_interface_count": 0,
-      "priority_score": 103,
+      "priority_score": 105,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -7120,11 +7173,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "adapter_score": 28,
-      "candidate_count": 13,
+      "adapter_score": 29,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -7144,7 +7197,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -7156,7 +7209,7 @@
       "name": "Almanac",
       "netuid": 41,
       "operational_interface_count": 1,
-      "priority_score": 103,
+      "priority_score": 105,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7187,15 +7240,16 @@
         "https://backprop.finance/dtao/subnets/41-almanac",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx",
         "https://github.com/sportstensor/sn41",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json",
+        "https://taostats.io/subnets/41/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 11
+      "surface_count": 9,
+      "verified_candidate_count": 12
     },
     {
-      "adapter_score": 28,
-      "candidate_count": 13,
+      "adapter_score": 29,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -7215,7 +7269,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -7227,7 +7281,7 @@
       "name": "Synth",
       "netuid": 50,
       "operational_interface_count": 1,
-      "priority_score": 103,
+      "priority_score": 105,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7260,15 +7314,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx",
         "https://github.com/mode-network/synth-subnet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/50/subnet.json",
-        "https://synthdata.co/"
+        "https://synthdata.co/",
+        "https://taostats.io/subnets/50/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 11
+      "surface_count": 9,
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 29,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -7300,7 +7355,7 @@
       "name": "Swarm",
       "netuid": 124,
       "operational_interface_count": 1,
-      "priority_score": 103,
+      "priority_score": 105,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7336,82 +7391,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 29,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 9,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "ByteLeap",
-      "netuid": 128,
-      "operational_interface_count": 1,
-      "priority_score": 103,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-128-backprop-dashboard",
-        "sn-128-taomarketcap-dashboard",
-        "sn-128-taomarketcap-source-repo",
-        "sn-128-taomarketcap-website",
-        "sn-128-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-128-website-common-api",
-        "sn-128-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-128-website-common-api",
-        "sn-128-website-common-health"
-      ],
-      "slug": "sn-128",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/128",
-        "https://backprop.finance/dtao/subnets/128-byteleap",
-        "https://byteleap.ai/",
-        "https://github.com/byteleapai/byteleap-Miner",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 5,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -7452,7 +7436,7 @@
       "name": "Hippius",
       "netuid": 75,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 104,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -7496,11 +7480,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 5,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
     },
     {
-      "adapter_score": 28,
-      "candidate_count": 12,
+      "adapter_score": 29,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -7520,7 +7504,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -7532,7 +7516,7 @@
       "name": "BitAds",
       "netuid": 16,
       "operational_interface_count": 1,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7563,15 +7547,16 @@
         "https://bitads.ai/",
         "https://github.com/FirstTensorLabs/BitAds",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
+        "https://taostats.io/subnets/16/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "surface_count": 9,
+      "verified_candidate_count": 11
     },
     {
-      "adapter_score": 28,
-      "candidate_count": 12,
+      "adapter_score": 29,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -7591,7 +7576,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -7603,7 +7588,7 @@
       "name": "Leadpoet",
       "netuid": 71,
       "operational_interface_count": 1,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7634,15 +7619,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx",
         "https://github.com/leadpoet/leadpoet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/71/subnet.json",
-        "https://leadpoet.com/"
+        "https://leadpoet.com/",
+        "https://taostats.io/subnets/71/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "surface_count": 9,
+      "verified_candidate_count": 11
     },
     {
-      "adapter_score": 28,
-      "candidate_count": 12,
+      "adapter_score": 29,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -7662,7 +7648,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -7674,7 +7660,7 @@
       "name": "Liquidity",
       "netuid": 77,
       "operational_interface_count": 1,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7705,15 +7691,91 @@
         "https://github.com/creativebuilds/sn77",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/77/subnet.json",
-        "https://sn77.xyz/"
+        "https://sn77.xyz/",
+        "https://taostats.io/subnets/77/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
+      "surface_count": 9,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 13,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 2,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "dogelayer",
+      "netuid": 80,
+      "operational_interface_count": 1,
+      "priority_score": 103,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-80-backprop-dashboard",
+        "sn-80-taomarketcap-dashboard",
+        "sn-80-taomarketcap-source-repo",
+        "sn-80-taomarketcap-website",
+        "sn-80-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-80-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [
+        "sn-80-website-common-api"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-80-website-common-health",
+        "sn-80-website-common-api"
+      ],
+      "slug": "sn-80",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/80",
+        "https://backprop.finance/dtao/subnets/80-dogelayer",
+        "https://dogelayer.ai/",
+        "https://github.com/dogelayer-ai/dogelayer",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/80/subnet.json",
+        "https://taostats.io/subnets/80/metagraph"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 9,
       "verified_candidate_count": 10
     },
     {
-      "adapter_score": 28,
-      "candidate_count": 12,
+      "adapter_score": 29,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -7733,7 +7795,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -7745,7 +7807,7 @@
       "name": "CliqueAI",
       "netuid": 83,
       "operational_interface_count": 1,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7776,15 +7838,16 @@
         "https://cliqueai.toptensor.ai/",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/83/subnet.json",
-        "https://github.com/toptensor/CliqueAI"
+        "https://github.com/toptensor/CliqueAI",
+        "https://taostats.io/subnets/83/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "surface_count": 9,
+      "verified_candidate_count": 11
     },
     {
-      "adapter_score": 28,
-      "candidate_count": 12,
+      "adapter_score": 29,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -7804,7 +7867,7 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
       "manual_review_required": true,
@@ -7816,7 +7879,7 @@
       "name": "Beam",
       "netuid": 105,
       "operational_interface_count": 1,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7847,15 +7910,16 @@
         "https://backprop.finance/dtao/subnets/105-beam",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx",
         "https://github.com/orgs/Beam-Network/repositories",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json",
+        "https://taostats.io/subnets/105/metagraph"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "surface_count": 9,
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 23,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -7892,7 +7956,7 @@
       "name": "MVTRX",
       "netuid": 79,
       "operational_interface_count": 1,
-      "priority_score": 101,
+      "priority_score": 102,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -7933,11 +7997,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 3,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
       "adapter_score": 23,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 8,
         "kinds_with_candidates": [
@@ -7974,7 +8038,7 @@
       "name": "Trishool",
       "netuid": 23,
       "operational_interface_count": 1,
-      "priority_score": 100,
+      "priority_score": 101,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -8016,11 +8080,11 @@
       ],
       "stale_candidate_count": 4,
       "surface_count": 3,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 8,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -8059,7 +8123,7 @@
       "name": "Data Universe",
       "netuid": 13,
       "operational_interface_count": 0,
-      "priority_score": 100,
+      "priority_score": 101,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -8103,11 +8167,11 @@
       ],
       "stale_candidate_count": 6,
       "surface_count": 8,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 3,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -8146,7 +8210,7 @@
       "name": "blockmachine",
       "netuid": 19,
       "operational_interface_count": 0,
-      "priority_score": 98,
+      "priority_score": 100,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -8186,13 +8250,13 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 3,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
       "adapter_score": 45,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "candidate_evidence_summary": {
-        "candidate_count": 3,
+        "candidate_count": 4,
         "kinds_with_candidates": [
           "dashboard",
           "subnet-api"
@@ -8200,8 +8264,8 @@
         "live_kinds": [
           "dashboard"
         ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 3,
+        "live_or_redirected_count": 3,
+        "reviewable_count": 4,
         "stale_kinds": [
           "subnet-api"
         ],
@@ -8229,7 +8293,7 @@
       "name": "ReadyAI",
       "netuid": 33,
       "operational_interface_count": 1,
-      "priority_score": 97,
+      "priority_score": 98,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -8262,11 +8326,236 @@
       ],
       "stale_candidate_count": 1,
       "surface_count": 5,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 5,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 6,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Luminar Network",
+      "netuid": 87,
+      "operational_interface_count": 0,
+      "priority_score": 98,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-87-backprop-dashboard",
+        "sn-87-taomarketcap-dashboard",
+        "sn-87-taopedia-article",
+        "sn-87-taostats-metagraph",
+        "sn-87-tensorplex-docs"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-87",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/87",
+        "https://demo.luminar.network/",
+        "https://docs.luminar.network/",
+        "https://docs.luminar.network/introduction.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/87/subnet.json",
+        "https://luminar.network/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 6,
+      "verified_candidate_count": 5
+    },
+    {
+      "adapter_score": 2,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "docs",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "docs",
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 3,
+        "reviewable_count": 3,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 2,
+      "evidence_action": "review-existing-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "docs",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Compute Horde",
+      "netuid": 12,
+      "operational_interface_count": 0,
+      "priority_score": 97,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-12-backprop-dashboard",
+        "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1",
+        "sn-12-taomarketcap-dashboard",
+        "sn-12-taomarketcap-source-repo",
+        "sn-12-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1"
+      ],
+      "slug": "sn-12",
+      "source_urls": [
+        "https://computehorde.io/",
+        "https://github.com/backend-developers-ltd/ComputeHorde",
+        "https://learnbittensor.org/subnets/12",
+        "https://taomarketcap.com/subnets/12"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 2,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 3,
+      "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 3,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ORO",
+      "netuid": 15,
+      "operational_interface_count": 0,
+      "priority_score": 97,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-15-backprop-dashboard",
+        "sn-15-github-readme-oro-ai-oro-dashboard-1",
+        "sn-15-github-readme-oro-ai-oro-docs-2",
+        "sn-15-github-readme-oro-ai-oro-subnet-api-3",
+        "sn-15-taomarketcap-dashboard"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-15-website-common-openapi-json",
+        "sn-15-website-common-swagger",
+        "sn-15-website-common-swagger-json",
+        "sn-15-github-readme-oro-ai-oro-subnet-api-3",
+        "sn-15-website-common-api"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-15-website-common-openapi-json",
+        "sn-15-website-common-swagger",
+        "sn-15-website-common-swagger-json",
+        "sn-15-github-readme-oro-ai-oro-subnet-api-3",
+        "sn-15-website-common-api"
+      ],
+      "slug": "sn-15",
+      "source_urls": [
+        "https://docs.oroagents.com/docs/miners/quick-start",
+        "https://github.com/ORO-AI/oro",
+        "https://github.com/ORO-AI/oro/blob/main/README.md",
+        "https://oroagents.com/"
+      ],
+      "stale_candidate_count": 6,
+      "surface_count": 3,
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 31,
-      "candidate_count": 27,
+      "candidate_count": 28,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -8344,11 +8633,11 @@
       ],
       "stale_candidate_count": 3,
       "surface_count": 11,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 21
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -8360,153 +8649,6 @@
         "unverified_count": 0,
         "unverified_kinds": []
       },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "source-repo"
-      ],
-      "endpoint_count": 6,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "source-repo",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Luminar Network",
-      "netuid": 87,
-      "operational_interface_count": 0,
-      "priority_score": 96,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-source-repo"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-87-backprop-dashboard",
-        "sn-87-taomarketcap-dashboard",
-        "sn-87-taopedia-article",
-        "sn-87-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-87",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/87",
-        "https://demo.luminar.network/",
-        "https://docs.luminar.network/",
-        "https://docs.luminar.network/introduction.md",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/87/subnet.json",
-        "https://luminar.network/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 6,
-      "verified_candidate_count": 4
-    },
-    {
-      "adapter_score": 2,
-      "candidate_count": 6,
-      "candidate_evidence_summary": {
-        "candidate_count": 3,
-        "kinds_with_candidates": [
-          "docs",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "docs",
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 3,
-        "reviewable_count": 3,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 2,
-      "evidence_action": "review-existing-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "docs",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Compute Horde",
-      "netuid": 12,
-      "operational_interface_count": 0,
-      "priority_score": 95,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-12-backprop-dashboard",
-        "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1",
-        "sn-12-taomarketcap-dashboard",
-        "sn-12-taomarketcap-source-repo",
-        "sn-12-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1"
-      ],
-      "slug": "sn-12",
-      "source_urls": [
-        "https://computehorde.io/",
-        "https://github.com/backend-developers-ltd/ComputeHorde",
-        "https://learnbittensor.org/subnets/12",
-        "https://taomarketcap.com/subnets/12"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 2,
-      "verified_candidate_count": 6
-    },
-    {
-      "adapter_score": 3,
-      "candidate_count": 20,
-      "candidate_evidence_summary": {
-        "candidate_count": 6,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 6,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 6,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
       "completeness_score": 55,
       "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "maintainer-reviewed",
@@ -8515,8 +8657,8 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 3,
-      "evidence_action": "replace-stale-evidence",
+      "endpoint_count": 5,
+      "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
@@ -8525,54 +8667,44 @@
         "sse",
         "subnet-api"
       ],
-      "name": "ORO",
-      "netuid": 15,
+      "name": "Templar",
+      "netuid": 3,
       "operational_interface_count": 0,
-      "priority_score": 95,
+      "priority_score": 96,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
         "missing-openapi",
-        "missing-subnet-api"
+        "missing-subnet-api",
+        "needs-maintainer-review"
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
+      "review_state": "needs-review",
       "sample_candidate_ids": [
-        "sn-15-backprop-dashboard",
-        "sn-15-github-readme-oro-ai-oro-dashboard-1",
-        "sn-15-github-readme-oro-ai-oro-docs-2",
-        "sn-15-github-readme-oro-ai-oro-subnet-api-3",
-        "sn-15-taomarketcap-dashboard"
+        "sn-3-backprop-dashboard",
+        "sn-3-taomarketcap-dashboard",
+        "sn-3-taopedia-article",
+        "sn-3-taostats-metagraph",
+        "sn-3-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-15-website-common-openapi-json",
-        "sn-15-website-common-swagger",
-        "sn-15-website-common-swagger-json",
-        "sn-15-github-readme-oro-ai-oro-subnet-api-3",
-        "sn-15-website-common-api"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-15-website-common-openapi-json",
-        "sn-15-website-common-swagger",
-        "sn-15-website-common-swagger-json",
-        "sn-15-github-readme-oro-ai-oro-subnet-api-3",
-        "sn-15-website-common-api"
-      ],
-      "slug": "sn-15",
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-3",
       "source_urls": [
-        "https://docs.oroagents.com/docs/miners/quick-start",
-        "https://github.com/ORO-AI/oro",
-        "https://github.com/ORO-AI/oro/blob/main/README.md",
-        "https://oroagents.com/"
+        "https://docs.tplr.ai/",
+        "https://github.com/one-covenant/templar",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/3/subnet.json",
+        "https://wandb.ai/tplr/templar",
+        "https://www.tplr.ai/"
       ],
-      "stale_candidate_count": 6,
-      "surface_count": 3,
-      "verified_candidate_count": 14
+      "stale_candidate_count": 0,
+      "surface_count": 5,
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 3,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -8611,7 +8743,7 @@
       "name": "Apex",
       "netuid": 1,
       "operational_interface_count": 0,
-      "priority_score": 94,
+      "priority_score": 95,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -8652,78 +8784,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 3,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
-      "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 5,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Templar",
-      "netuid": 3,
-      "operational_interface_count": 0,
-      "priority_score": 94,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "needs-review",
-      "sample_candidate_ids": [
-        "sn-3-backprop-dashboard",
-        "sn-3-taomarketcap-dashboard",
-        "sn-3-taopedia-article",
-        "sn-3-tensorplex-docs",
-        "sn-3-tensorplex-source-repo-1"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-3",
-      "source_urls": [
-        "https://docs.tplr.ai/",
-        "https://github.com/one-covenant/templar",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/3/subnet.json",
-        "https://wandb.ai/tplr/templar",
-        "https://www.tplr.ai/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -8761,7 +8826,7 @@
       "name": "Graphite",
       "netuid": 43,
       "operational_interface_count": 0,
-      "priority_score": 93,
+      "priority_score": 94,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -8775,7 +8840,7 @@
         "sn-43-taomarketcap-dashboard",
         "sn-43-taomarketcap-source-repo",
         "sn-43-taopedia-article",
-        "sn-43-tensorplex-docs"
+        "sn-43-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -8789,11 +8854,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -8831,7 +8896,7 @@
       "name": "Sparket",
       "netuid": 57,
       "operational_interface_count": 0,
-      "priority_score": 93,
+      "priority_score": 94,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -8844,8 +8909,8 @@
         "sn-57-backprop-dashboard",
         "sn-57-taomarketcap-dashboard",
         "sn-57-taopedia-article",
-        "sn-57-tensorplex-docs",
-        "sn-57-tensorplex-source-repo-1"
+        "sn-57-taostats-metagraph",
+        "sn-57-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -8859,11 +8924,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -8901,7 +8966,7 @@
       "name": "oneoneone",
       "netuid": 111,
       "operational_interface_count": 0,
-      "priority_score": 93,
+      "priority_score": 94,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -8915,7 +8980,7 @@
         "sn-111-taomarketcap-dashboard",
         "sn-111-taomarketcap-source-repo",
         "sn-111-taopedia-article",
-        "sn-111-tensorplex-docs"
+        "sn-111-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -8929,11 +8994,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 3,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -8972,7 +9037,7 @@
       "name": "TensorUSD",
       "netuid": 113,
       "operational_interface_count": 0,
-      "priority_score": 92,
+      "priority_score": 94,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9013,13 +9078,13 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 3,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 27,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
-        "candidate_count": 8,
+        "candidate_count": 9,
         "kinds_with_candidates": [
           "dashboard",
           "openapi",
@@ -9030,8 +9095,8 @@
           "openapi",
           "subnet-api"
         ],
-        "live_or_redirected_count": 6,
-        "reviewable_count": 8,
+        "live_or_redirected_count": 7,
+        "reviewable_count": 9,
         "stale_kinds": [
           "openapi"
         ],
@@ -9059,7 +9124,7 @@
       "name": "Gittensor",
       "netuid": 74,
       "operational_interface_count": 1,
-      "priority_score": 91,
+      "priority_score": 92,
       "profile_level": "adapter-backed",
       "reason_codes": [
         "adapter-candidate",
@@ -9102,11 +9167,11 @@
       ],
       "stale_candidate_count": 2,
       "surface_count": 7,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 47,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -9137,7 +9202,7 @@
       "name": "Green Compute",
       "netuid": 110,
       "operational_interface_count": 2,
-      "priority_score": 89,
+      "priority_score": 91,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9149,7 +9214,7 @@
         "sn-110-taomarketcap-dashboard",
         "sn-110-taomarketcap-website",
         "sn-110-taopedia-article",
-        "sn-110-tensorplex-docs"
+        "sn-110-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -9173,11 +9238,11 @@
       ],
       "stale_candidate_count": 3,
       "surface_count": 7,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
       "adapter_score": 4,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -9216,7 +9281,7 @@
       "name": "RedTeam",
       "netuid": 61,
       "operational_interface_count": 0,
-      "priority_score": 87,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9257,11 +9322,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 4,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 29,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -9295,7 +9360,7 @@
       "name": "ninja",
       "netuid": 66,
       "operational_interface_count": 1,
-      "priority_score": 79,
+      "priority_score": 80,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9334,11 +9399,76 @@
       ],
       "stale_candidate_count": 2,
       "surface_count": 9,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 26,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 63,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 6,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Coldint",
+      "netuid": 29,
+      "operational_interface_count": 1,
+      "priority_score": 79,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-29-backprop-dashboard",
+        "sn-29-taomarketcap-dashboard",
+        "sn-29-taomarketcap-source-repo",
+        "sn-29-taopedia-article",
+        "sn-29-taostats-metagraph"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-29",
+      "source_urls": [
+        "https://coldint.io/",
+        "https://github.com/coldint/coldint_validator",
+        "https://github.com/coldint/coldint_validator/blob/main/README.md",
+        "https://github.com/coldint/sn29",
+        "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2",
+        "https://taostats.io/subnets/netuid-29"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 6,
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 0,
-      "candidate_count": 9,
+      "candidate_count": 10,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9371,7 +9501,7 @@
       "name": "Dojo",
       "netuid": 52,
       "operational_interface_count": 0,
-      "priority_score": 78,
+      "priority_score": 79,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9401,76 +9531,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 5,
-      "verified_candidate_count": 8
-    },
-    {
-      "adapter_score": 26,
-      "candidate_count": 6,
-      "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 63,
-      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api"
-      ],
-      "endpoint_count": 6,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Coldint",
-      "netuid": 29,
-      "operational_interface_count": 1,
-      "priority_score": 77,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-29-backprop-dashboard",
-        "sn-29-taomarketcap-dashboard",
-        "sn-29-taomarketcap-source-repo",
-        "sn-29-taopedia-article",
-        "sn-29-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-29",
-      "source_urls": [
-        "https://coldint.io/",
-        "https://github.com/coldint/coldint_validator",
-        "https://github.com/coldint/coldint_validator/blob/main/README.md",
-        "https://github.com/coldint/sn29",
-        "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2",
-        "https://taostats.io/subnets/netuid-29"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9503,7 +9568,7 @@
       "name": "ansuz",
       "netuid": 84,
       "operational_interface_count": 0,
-      "priority_score": 73,
+      "priority_score": 75,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9516,8 +9581,8 @@
         "sn-84-backprop-dashboard",
         "sn-84-taomarketcap-dashboard",
         "sn-84-taopedia-article",
-        "sn-84-tensorplex-docs",
-        "sn-84-tensorplex-source-repo-1"
+        "sn-84-taostats-metagraph",
+        "sn-84-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9532,11 +9597,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 3,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9569,7 +9634,7 @@
       "name": "BitMind",
       "netuid": 34,
       "operational_interface_count": 0,
-      "priority_score": 72,
+      "priority_score": 73,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9583,7 +9648,7 @@
         "sn-34-taomarketcap-dashboard",
         "sn-34-taomarketcap-source-repo",
         "sn-34-taopedia-article",
-        "sn-34-tensorplex-docs"
+        "sn-34-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9598,11 +9663,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 4,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9635,7 +9700,7 @@
       "name": "Bitrecs",
       "netuid": 122,
       "operational_interface_count": 0,
-      "priority_score": 72,
+      "priority_score": 73,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9648,8 +9713,8 @@
         "sn-122-backprop-dashboard",
         "sn-122-taomarketcap-dashboard",
         "sn-122-taopedia-article",
-        "sn-122-tensorplex-docs",
-        "sn-122-tensorplex-source-repo-1"
+        "sn-122-taostats-metagraph",
+        "sn-122-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9664,11 +9729,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 3,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 70,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9695,7 +9760,7 @@
       "name": "Handshake58",
       "netuid": 58,
       "operational_interface_count": 2,
-      "priority_score": 70,
+      "priority_score": 71,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9725,11 +9790,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 10,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
       "adapter_score": 0,
-      "candidate_count": 3,
+      "candidate_count": 4,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9762,7 +9827,7 @@
       "name": "root",
       "netuid": 0,
       "operational_interface_count": 0,
-      "priority_score": 69,
+      "priority_score": 70,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9774,6 +9839,7 @@
       "sample_candidate_ids": [
         "sn-0-backprop-dashboard",
         "sn-0-taomarketcap-dashboard",
+        "sn-0-taostats-metagraph",
         "sn-0-tensorplex-docs"
       ],
       "sample_live_candidate_ids": [],
@@ -9792,11 +9858,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 12,
-      "verified_candidate_count": 3
+      "verified_candidate_count": 4
     },
     {
       "adapter_score": 49,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9823,7 +9889,7 @@
       "name": "Nepher Robotics",
       "netuid": 49,
       "operational_interface_count": 2,
-      "priority_score": 65,
+      "priority_score": 67,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9853,11 +9919,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 49,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9884,7 +9950,7 @@
       "name": "Verathos",
       "netuid": 96,
       "operational_interface_count": 2,
-      "priority_score": 65,
+      "priority_score": 67,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9914,11 +9980,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 49,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9945,7 +10011,7 @@
       "name": "Desearch",
       "netuid": 22,
       "operational_interface_count": 2,
-      "priority_score": 62,
+      "priority_score": 64,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9975,7 +10041,7 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     }
   ],
   "schema_version": 1,

--- a/public/metagraph/review/gap-priorities.json
+++ b/public/metagraph/review/gap-priorities.json
@@ -3,7 +3,7 @@
   "generated_at": "1970-01-01T00:00:00.000Z",
   "priorities": [
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "dashboard",
@@ -11,15 +11,15 @@
       ],
       "name": "Allways",
       "netuid": 7,
-      "priority_score": 84,
+      "priority_score": 85,
       "review_state": "maintainer-reviewed",
       "slug": "allways",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 15,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -31,15 +31,15 @@
       ],
       "name": "Nodexo",
       "netuid": 27,
-      "priority_score": 80,
+      "priority_score": 81,
       "review_state": "machine-generated",
       "slug": "sn-27",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -51,15 +51,15 @@
       ],
       "name": "Grail",
       "netuid": 81,
-      "priority_score": 74,
+      "priority_score": 75,
       "review_state": "needs-review",
       "slug": "sn-81",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 3,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -71,15 +71,15 @@
       ],
       "name": "Chunking",
       "netuid": 40,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-40",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -91,15 +91,15 @@
       ],
       "name": "EfficientFrontier",
       "netuid": 53,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-53",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -111,15 +111,15 @@
       ],
       "name": "Parked",
       "netuid": 73,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-73",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -131,15 +131,15 @@
       ],
       "name": "luis",
       "netuid": 92,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "stale",
       "slug": "sn-92",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 2,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -151,15 +151,15 @@
       ],
       "name": "hard_sign",
       "netuid": 116,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-116",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -171,15 +171,15 @@
       ],
       "name": "Satori",
       "netuid": 119,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-119",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -188,15 +188,15 @@
       ],
       "name": "SOMA",
       "netuid": 114,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-114",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -208,15 +208,15 @@
       ],
       "name": "gm",
       "netuid": 28,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-28",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -228,15 +228,15 @@
       ],
       "name": "Recall",
       "netuid": 31,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-31",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -248,15 +248,15 @@
       ],
       "name": "ain",
       "netuid": 69,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-69",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -268,15 +268,15 @@
       ],
       "name": "Subnet 86",
       "netuid": 86,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-86",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -288,15 +288,15 @@
       ],
       "name": "ogham",
       "netuid": 90,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-90",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -308,15 +308,15 @@
       ],
       "name": "eni",
       "netuid": 101,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-101",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -328,15 +328,15 @@
       ],
       "name": "for sale (burn to uid1)",
       "netuid": 104,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-104",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -348,15 +348,15 @@
       ],
       "name": "8 Ball",
       "netuid": 125,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-125",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 4,
-      "verified_candidate_count": 4
+      "surface_count": 5,
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -364,15 +364,15 @@
       ],
       "name": "Gradients",
       "netuid": 56,
-      "priority_score": 71,
+      "priority_score": 72,
       "review_state": "machine-generated",
       "slug": "sn-56",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 21
+      "surface_count": 11,
+      "verified_candidate_count": 22
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -381,15 +381,15 @@
       ],
       "name": "NOVA",
       "netuid": 68,
-      "priority_score": 69,
+      "priority_score": 70,
       "review_state": "machine-generated",
       "slug": "sn-68",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -398,15 +398,15 @@
       ],
       "name": "NexisGen",
       "netuid": 70,
-      "priority_score": 69,
+      "priority_score": 70,
       "review_state": "machine-generated",
       "slug": "sn-70",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 12
+      "surface_count": 9,
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -416,15 +416,15 @@
       ],
       "name": "Ditto",
       "netuid": 118,
-      "priority_score": 67,
+      "priority_score": 68,
       "review_state": "machine-generated",
       "slug": "sn-118",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 17
+      "surface_count": 10,
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -434,15 +434,15 @@
       ],
       "name": "Actual",
       "netuid": 95,
-      "priority_score": 66,
+      "priority_score": 67,
       "review_state": "machine-generated",
       "slug": "sn-95",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 11
+      "surface_count": 8,
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -452,15 +452,15 @@
       ],
       "name": "colosseum",
       "netuid": 38,
-      "priority_score": 64,
+      "priority_score": 65,
       "review_state": "machine-generated",
       "slug": "sn-38",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 9
+      "surface_count": 8,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -469,15 +469,15 @@
       ],
       "name": "lium.io",
       "netuid": 51,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-51",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 18
+      "surface_count": 10,
+      "verified_candidate_count": 19
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -486,15 +486,15 @@
       ],
       "name": "Zipcode",
       "netuid": 46,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-46",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -504,15 +504,15 @@
       ],
       "name": "Cacheon",
       "netuid": 14,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-14",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -522,15 +522,15 @@
       ],
       "name": "404—GEN",
       "netuid": 17,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-17",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -540,15 +540,15 @@
       ],
       "name": "Plaτform",
       "netuid": 100,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-100",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 13
+      "surface_count": 10,
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -558,15 +558,15 @@
       ],
       "name": "TalkHead",
       "netuid": 108,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-108",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 8
+      "surface_count": 7,
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -577,15 +577,15 @@
       ],
       "name": "Basilica",
       "netuid": 39,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "needs-review",
       "slug": "sn-39",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -596,15 +596,15 @@
       ],
       "name": "BrainPlay",
       "netuid": 117,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "needs-review",
       "slug": "sn-117",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 2,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -614,15 +614,15 @@
       ],
       "name": "Numinous",
       "netuid": 6,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-6",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -632,9 +632,27 @@
       ],
       "name": "Zeus",
       "netuid": 18,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-18",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 13
+    },
+    {
+      "candidate_count": 18,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Aurelius",
+      "netuid": 37,
+      "priority_score": 62,
+      "review_state": "machine-generated",
+      "slug": "sn-37",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
       "verified_candidate_count": 12
@@ -648,35 +666,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Aurelius",
-      "netuid": 37,
-      "priority_score": 61,
-      "review_state": "machine-generated",
-      "slug": "sn-37",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 16,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "TrajectoryRL",
       "netuid": 11,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-11",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -686,15 +686,15 @@
       ],
       "name": "Perturb",
       "netuid": 26,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-26",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 9
+      "surface_count": 8,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -704,15 +704,15 @@
       ],
       "name": "Eirel",
       "netuid": 36,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-36",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -722,15 +722,15 @@
       ],
       "name": "NIOME",
       "netuid": 55,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-55",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 8
+      "surface_count": 7,
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -740,15 +740,15 @@
       ],
       "name": "Poker44",
       "netuid": 126,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-126",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -759,15 +759,15 @@
       ],
       "name": "Gopher",
       "netuid": 42,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "needs-review",
       "slug": "sn-42",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 2,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -776,15 +776,15 @@
       ],
       "name": "Minos",
       "netuid": 107,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-107",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 13
+      "surface_count": 11,
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -794,15 +794,15 @@
       ],
       "name": "Hone",
       "netuid": 5,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-5",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 9
+      "surface_count": 7,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -812,15 +812,15 @@
       ],
       "name": "Vanta",
       "netuid": 8,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-8",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -830,15 +830,15 @@
       ],
       "name": "Yanez MIID",
       "netuid": 54,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-54",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -848,15 +848,15 @@
       ],
       "name": "Harnyx",
       "netuid": 67,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-67",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -866,15 +866,15 @@
       ],
       "name": "Bitsota",
       "netuid": 94,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-94",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -884,15 +884,15 @@
       ],
       "name": "Astrid",
       "netuid": 127,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-127",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 9
+      "surface_count": 7,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -901,15 +901,15 @@
       ],
       "name": "TAO Private Network",
       "netuid": 65,
-      "priority_score": 58,
+      "priority_score": 59,
       "review_state": "machine-generated",
       "slug": "sn-65",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 16
+      "surface_count": 10,
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -918,15 +918,15 @@
       ],
       "name": "Bitcast",
       "netuid": 93,
-      "priority_score": 58,
+      "priority_score": 59,
       "review_state": "machine-generated",
       "slug": "sn-93",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -936,15 +936,15 @@
       ],
       "name": "Score",
       "netuid": 44,
-      "priority_score": 58,
+      "priority_score": 59,
       "review_state": "machine-generated",
       "slug": "sn-44",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 8
+      "surface_count": 8,
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -953,15 +953,15 @@
       ],
       "name": "Babelbit",
       "netuid": 59,
-      "priority_score": 57,
+      "priority_score": 58,
       "review_state": "machine-generated",
       "slug": "sn-59",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -971,15 +971,15 @@
       ],
       "name": "OxMarkets",
       "netuid": 35,
-      "priority_score": 57,
+      "priority_score": 58,
       "review_state": "machine-generated",
       "slug": "sn-35",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 7
+      "surface_count": 8,
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -989,11 +989,64 @@
       ],
       "name": "minotaur",
       "netuid": 112,
-      "priority_score": 57,
+      "priority_score": 58,
       "review_state": "machine-generated",
       "slug": "sn-112",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
+      "surface_count": 7,
+      "verified_candidate_count": 8
+    },
+    {
+      "candidate_count": 14,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Affine",
+      "netuid": 120,
+      "priority_score": 58,
+      "review_state": "machine-generated",
+      "slug": "sn-120",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 7,
+      "verified_candidate_count": 8
+    },
+    {
+      "candidate_count": 17,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Albedo",
+      "netuid": 97,
+      "priority_score": 57,
+      "review_state": "machine-generated",
+      "slug": "sn-97",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "candidate_count": 13,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Swap",
+      "netuid": 10,
+      "priority_score": 57,
+      "review_state": "machine-generated",
+      "slug": "sn-10",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 7,
       "verified_candidate_count": 7
     },
     {
@@ -1005,14 +1058,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Affine",
-      "netuid": 120,
+      "name": "VoidAI",
+      "netuid": 106,
       "priority_score": 57,
       "review_state": "machine-generated",
-      "slug": "sn-120",
+      "slug": "sn-106",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 7
+      "surface_count": 8,
+      "verified_candidate_count": 8
     },
     {
       "candidate_count": 16,
@@ -1022,70 +1075,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Albedo",
-      "netuid": 97,
-      "priority_score": 56,
-      "review_state": "machine-generated",
-      "slug": "sn-97",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 13
-    },
-    {
-      "candidate_count": 12,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Swap",
-      "netuid": 10,
-      "priority_score": 56,
-      "review_state": "machine-generated",
-      "slug": "sn-10",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 6,
-      "verified_candidate_count": 6
-    },
-    {
-      "candidate_count": 12,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "VoidAI",
-      "netuid": 106,
-      "priority_score": 56,
-      "review_state": "machine-generated",
-      "slug": "sn-106",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 15,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "DSperse",
       "netuid": 2,
-      "priority_score": 55,
+      "priority_score": 56,
       "review_state": "machine-generated",
       "slug": "sn-2",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1094,11 +1094,45 @@
       ],
       "name": "Leoma",
       "netuid": 99,
-      "priority_score": 55,
+      "priority_score": 56,
       "review_state": "machine-generated",
       "slug": "sn-99",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
+      "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Bitsec.ai",
+      "netuid": 60,
+      "priority_score": 55,
+      "review_state": "machine-generated",
+      "slug": "sn-60",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 11,
+      "verified_candidate_count": 12
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Vocence",
+      "netuid": 78,
+      "priority_score": 55,
+      "review_state": "machine-generated",
+      "slug": "sn-78",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 11,
       "verified_candidate_count": 13
     },
     {
@@ -1109,30 +1143,13 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Bitsec.ai",
-      "netuid": 60,
+      "name": "Almanac",
+      "netuid": 41,
       "priority_score": 54,
       "review_state": "machine-generated",
-      "slug": "sn-60",
+      "slug": "sn-41",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 14,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Vocence",
-      "netuid": 78,
-      "priority_score": 54,
-      "review_state": "machine-generated",
-      "slug": "sn-78",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
+      "surface_count": 9,
       "verified_candidate_count": 12
     },
     {
@@ -1143,51 +1160,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "dogelayer",
-      "netuid": 80,
-      "priority_score": 54,
-      "review_state": "machine-generated",
-      "slug": "sn-80",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Almanac",
-      "netuid": 41,
-      "priority_score": 53,
-      "review_state": "machine-generated",
-      "slug": "sn-41",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Synth",
       "netuid": 50,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-50",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 11
+      "surface_count": 9,
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1196,9 +1179,43 @@
       ],
       "name": "Swarm",
       "netuid": 124,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-124",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 9,
+      "verified_candidate_count": 12
+    },
+    {
+      "candidate_count": 14,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ByteLeap",
+      "netuid": 128,
+      "priority_score": 54,
+      "review_state": "machine-generated",
+      "slug": "sn-128",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 10,
+      "verified_candidate_count": 12
+    },
+    {
+      "candidate_count": 13,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "BitAds",
+      "netuid": 16,
+      "priority_score": 53,
+      "review_state": "machine-generated",
+      "slug": "sn-16",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
       "verified_candidate_count": 11
@@ -1211,51 +1228,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ByteLeap",
-      "netuid": 128,
+      "name": "Leadpoet",
+      "netuid": 71,
       "priority_score": 53,
       "review_state": "machine-generated",
-      "slug": "sn-128",
+      "slug": "sn-71",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
       "verified_candidate_count": 11
     },
     {
-      "candidate_count": 12,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "BitAds",
-      "netuid": 16,
-      "priority_score": 52,
-      "review_state": "machine-generated",
-      "slug": "sn-16",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 12,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Leadpoet",
-      "netuid": 71,
-      "priority_score": 52,
-      "review_state": "machine-generated",
-      "slug": "sn-71",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1264,15 +1247,32 @@
       ],
       "name": "Liquidity",
       "netuid": 77,
-      "priority_score": 52,
+      "priority_score": 53,
       "review_state": "machine-generated",
       "slug": "sn-77",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
+      "surface_count": 9,
+      "verified_candidate_count": 11
+    },
+    {
+      "candidate_count": 13,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "dogelayer",
+      "netuid": 80,
+      "priority_score": 53,
+      "review_state": "machine-generated",
+      "slug": "sn-80",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 9,
       "verified_candidate_count": 10
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1281,15 +1281,15 @@
       ],
       "name": "CliqueAI",
       "netuid": 83,
-      "priority_score": 52,
+      "priority_score": 53,
       "review_state": "machine-generated",
       "slug": "sn-83",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "surface_count": 9,
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1298,15 +1298,15 @@
       ],
       "name": "Beam",
       "netuid": 105,
-      "priority_score": 52,
+      "priority_score": 53,
       "review_state": "machine-generated",
       "slug": "sn-105",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "surface_count": 9,
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1316,15 +1316,15 @@
       ],
       "name": "Templar",
       "netuid": 3,
-      "priority_score": 49,
+      "priority_score": 50,
       "review_state": "needs-review",
       "slug": "sn-3",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1336,15 +1336,15 @@
       ],
       "name": "Mainframe",
       "netuid": 25,
-      "priority_score": 45,
+      "priority_score": 46,
       "review_state": "maintainer-reviewed",
       "slug": "sn-25",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1356,15 +1356,15 @@
       ],
       "name": "Bitstarter #1",
       "netuid": 91,
-      "priority_score": 39,
+      "priority_score": 40,
       "review_state": "maintainer-reviewed",
       "slug": "sn-91",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 2,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1375,15 +1375,15 @@
       ],
       "name": "EvolAI",
       "netuid": 47,
-      "priority_score": 38,
+      "priority_score": 39,
       "review_state": "maintainer-reviewed",
       "slug": "sn-47",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1395,15 +1395,15 @@
       ],
       "name": "GroundLayer",
       "netuid": 20,
-      "priority_score": 37,
+      "priority_score": 38,
       "review_state": "maintainer-reviewed",
       "slug": "sn-20",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 1,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1413,15 +1413,15 @@
       ],
       "name": "Investing",
       "netuid": 88,
-      "priority_score": 36,
+      "priority_score": 37,
       "review_state": "maintainer-reviewed",
       "slug": "sn-88",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 4,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1433,15 +1433,15 @@
       ],
       "name": "Byzantium",
       "netuid": 76,
-      "priority_score": 35,
+      "priority_score": 36,
       "review_state": "maintainer-reviewed",
       "slug": "sn-76",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 1,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1453,15 +1453,15 @@
       ],
       "name": "InfiniteHash",
       "netuid": 89,
-      "priority_score": 35,
+      "priority_score": 36,
       "review_state": "maintainer-reviewed",
       "slug": "sn-89",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1472,9 +1472,85 @@
       ],
       "name": "Targon",
       "netuid": 4,
-      "priority_score": 34,
+      "priority_score": 35,
       "review_state": "maintainer-reviewed",
       "slug": "sn-4",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 18
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Compelle",
+      "netuid": 82,
+      "priority_score": 35,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-82",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 18
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "iota",
+      "netuid": 9,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-9",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 3,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "AdTAO",
+      "netuid": 21,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-21",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 15
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ItsAI",
+      "netuid": 32,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-32",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
       "verified_candidate_count": 17
@@ -1489,11 +1565,68 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Compelle",
-      "netuid": 82,
+      "name": "Talisman AI",
+      "netuid": 45,
       "priority_score": 34,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-82",
+      "slug": "sn-45",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 17
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Quantum Compute",
+      "netuid": 48,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-48",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Enigma",
+      "netuid": 63,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-63",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 2,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "docs",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "sundae_bar",
+      "netuid": 121,
+      "priority_score": 34,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-121",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
       "verified_candidate_count": 17
@@ -1508,128 +1641,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "iota",
-      "netuid": 9,
+      "name": "Djinn",
+      "netuid": 103,
       "priority_score": 33,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-9",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "AdTAO",
-      "netuid": 21,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-21",
+      "slug": "sn-103",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "ItsAI",
-      "netuid": 32,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-32",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 16
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Talisman AI",
-      "netuid": 45,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-45",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 16
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Quantum Compute",
-      "netuid": 48,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-48",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Enigma",
-      "netuid": 63,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-63",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 22,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "sundae_bar",
-      "netuid": 121,
-      "priority_score": 33,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-121",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
       "candidate_count": 21,
@@ -1641,14 +1660,66 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Djinn",
-      "netuid": 103,
+      "name": "ForeverMoney",
+      "netuid": 98,
       "priority_score": 32,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-103",
+      "slug": "sn-98",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
+      "verified_candidate_count": 15
+    },
+    {
+      "candidate_count": 17,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "Quasar",
+      "netuid": 24,
+      "priority_score": 32,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-24",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 8,
+      "verified_candidate_count": 11
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "dashboard",
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "StreetVision by NATIX",
+      "netuid": 72,
+      "priority_score": 31,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-72",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 6,
       "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "MVTRX",
+      "netuid": 79,
+      "priority_score": 31,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-79",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 3,
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 20,
@@ -1660,88 +1731,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ForeverMoney",
-      "netuid": 98,
-      "priority_score": 31,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-98",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 2,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 16,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "name": "Quasar",
-      "netuid": 24,
-      "priority_score": 31,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-24",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "dashboard",
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "name": "StreetVision by NATIX",
-      "netuid": 72,
-      "priority_score": 30,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-72",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 6,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "name": "MVTRX",
-      "netuid": 79,
-      "priority_score": 30,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-79",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 17
-    },
-    {
-      "candidate_count": 19,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "docs",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Vidaio",
       "netuid": 85,
-      "priority_score": 30,
+      "priority_score": 31,
       "review_state": "maintainer-reviewed",
       "slug": "sn-85",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1752,15 +1752,15 @@
       ],
       "name": "ConnitoAI",
       "netuid": 102,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-102",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1772,15 +1772,15 @@
       ],
       "name": "Academia",
       "netuid": 109,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-109",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1792,15 +1792,15 @@
       ],
       "name": "HashiChain",
       "netuid": 115,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-115",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1812,15 +1812,15 @@
       ],
       "name": "MANTIS",
       "netuid": 123,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1828,15 +1828,15 @@
       ],
       "name": "Green Compute",
       "netuid": 110,
-      "priority_score": 25,
+      "priority_score": 26,
       "review_state": "maintainer-reviewed",
       "slug": "sn-110",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 7,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1846,15 +1846,15 @@
       ],
       "name": "Trishool",
       "netuid": 23,
-      "priority_score": 24,
+      "priority_score": 25,
       "review_state": "maintainer-reviewed",
       "slug": "sn-23",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 3,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -1865,15 +1865,15 @@
       ],
       "name": "Endure Network",
       "netuid": 30,
-      "priority_score": 24,
+      "priority_score": 25,
       "review_state": "maintainer-reviewed",
       "slug": "sn-30",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 2,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1883,15 +1883,15 @@
       ],
       "name": "Hippius",
       "netuid": 75,
-      "priority_score": 23,
+      "priority_score": 24,
       "review_state": "maintainer-reviewed",
       "slug": "sn-75",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 5,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -1902,15 +1902,15 @@
       ],
       "name": "Ridges",
       "netuid": 62,
-      "priority_score": 23,
+      "priority_score": 24,
       "review_state": "maintainer-reviewed",
       "slug": "sn-62",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 1,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 27,
+      "candidate_count": 28,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1919,15 +1919,15 @@
       ],
       "name": "Chutes",
       "netuid": 64,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-64",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 21
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "dashboard",
@@ -1937,15 +1937,15 @@
       ],
       "name": "Gittensor",
       "netuid": 74,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "gittensor",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "dashboard",
@@ -1955,12 +1955,30 @@
       ],
       "name": "ReadyAI",
       "netuid": 33,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-33",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 5,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
+    },
+    {
+      "candidate_count": 23,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "blockmachine",
+      "netuid": 19,
+      "priority_score": 22,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-19",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 3,
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 22,
@@ -1971,14 +1989,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "blockmachine",
-      "netuid": 19,
+      "name": "Data Universe",
+      "netuid": 13,
       "priority_score": 21,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-19",
+      "slug": "sn-13",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 17
+      "surface_count": 8,
+      "verified_candidate_count": 14
     },
     {
       "candidate_count": 21,
@@ -1989,14 +2007,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Data Universe",
-      "netuid": 13,
+      "name": "ORO",
+      "netuid": 15,
       "priority_score": 20,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-13",
+      "slug": "sn-15",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 8,
-      "verified_candidate_count": 13
+      "surface_count": 3,
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 20,
@@ -2007,14 +2025,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ORO",
-      "netuid": 15,
+      "name": "Apex",
+      "netuid": 1,
       "priority_score": 19,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-15",
+      "slug": "sn-1",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 3,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 19,
@@ -2025,35 +2043,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Apex",
-      "netuid": 1,
+      "name": "TensorUSD",
+      "netuid": 113,
       "priority_score": 18,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-1",
+      "slug": "sn-113",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 3,
       "verified_candidate_count": 12
     },
     {
-      "candidate_count": 18,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "TensorUSD",
-      "netuid": 113,
-      "priority_score": 17,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-113",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2064,15 +2064,15 @@
       ],
       "name": "Compute Horde",
       "netuid": 12,
-      "priority_score": 17,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
       "slug": "sn-12",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2083,15 +2083,15 @@
       ],
       "name": "Graphite",
       "netuid": 43,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-43",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2102,15 +2102,15 @@
       ],
       "name": "Sparket",
       "netuid": 57,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-57",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "docs",
@@ -2121,15 +2121,15 @@
       ],
       "name": "oneoneone",
       "netuid": 111,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-111",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 2,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -2140,15 +2140,15 @@
       ],
       "name": "Luminar Network",
       "netuid": 87,
-      "priority_score": 15,
+      "priority_score": 16,
       "review_state": "maintainer-reviewed",
       "slug": "sn-87",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 6,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2158,15 +2158,15 @@
       ],
       "name": "RedTeam",
       "netuid": 61,
-      "priority_score": 13,
+      "priority_score": 14,
       "review_state": "maintainer-reviewed",
       "slug": "sn-61",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 4,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2175,15 +2175,15 @@
       ],
       "name": "Coldint",
       "netuid": 29,
-      "priority_score": 13,
+      "priority_score": 14,
       "review_state": "maintainer-reviewed",
       "slug": "sn-29",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2192,15 +2192,15 @@
       ],
       "name": "ninja",
       "netuid": 66,
-      "priority_score": 10,
+      "priority_score": 11,
       "review_state": "maintainer-reviewed",
       "slug": "sn-66",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 9,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 9,
+      "candidate_count": 10,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2210,15 +2210,15 @@
       ],
       "name": "Dojo",
       "netuid": 52,
-      "priority_score": 8,
+      "priority_score": 9,
       "review_state": "maintainer-reviewed",
       "slug": "sn-52",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 5,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -2226,15 +2226,15 @@
       ],
       "name": "Handshake58",
       "netuid": 58,
-      "priority_score": 6,
+      "priority_score": 7,
       "review_state": "maintainer-reviewed",
       "slug": "sn-58",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 10,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -2242,15 +2242,15 @@
       ],
       "name": "Nepher Robotics",
       "netuid": 49,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-49",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 9,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -2258,12 +2258,30 @@
       ],
       "name": "Verathos",
       "netuid": 96,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-96",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
+    },
+    {
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ansuz",
+      "netuid": 84,
+      "priority_score": 6,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-84",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 3,
+      "verified_candidate_count": 7
     },
     {
       "candidate_count": 6,
@@ -2274,35 +2292,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ansuz",
-      "netuid": 84,
-      "priority_score": 5,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-84",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 3,
-      "verified_candidate_count": 6
-    },
-    {
-      "candidate_count": 5,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "BitMind",
       "netuid": 34,
-      "priority_score": 4,
+      "priority_score": 5,
       "review_state": "maintainer-reviewed",
       "slug": "sn-34",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 4,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2312,15 +2312,15 @@
       ],
       "name": "Bitrecs",
       "netuid": 122,
-      "priority_score": 4,
+      "priority_score": 5,
       "review_state": "maintainer-reviewed",
       "slug": "sn-122",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 3,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -2328,15 +2328,15 @@
       ],
       "name": "Desearch",
       "netuid": 22,
-      "priority_score": 3,
+      "priority_score": 4,
       "review_state": "maintainer-reviewed",
       "slug": "sn-22",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 3,
+      "candidate_count": 4,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2346,12 +2346,12 @@
       ],
       "name": "root",
       "netuid": 0,
-      "priority_score": 2,
+      "priority_score": 3,
       "review_state": "maintainer-reviewed",
       "slug": "root",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 12,
-      "verified_candidate_count": 3
+      "verified_candidate_count": 4
     }
   ],
   "schema_version": 1

--- a/public/metagraph/review/profile-completeness.json
+++ b/public/metagraph/review/profile-completeness.json
@@ -3,7 +3,7 @@
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profiles": [
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -30,11 +30,11 @@
       "native_name_quality": "chain",
       "netuid": 27,
       "operational_interface_count": 0,
-      "priority_score": 122,
+      "priority_score": 123,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-27",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -42,7 +42,7 @@
       ]
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "completeness_score": 25,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -68,7 +68,7 @@
       "native_name_quality": "chain",
       "netuid": 25,
       "operational_interface_count": 0,
-      "priority_score": 122,
+      "priority_score": 123,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-25",
@@ -80,7 +80,7 @@
       ]
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "completeness_score": 25,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -106,7 +106,7 @@
       "native_name_quality": "chain",
       "netuid": 91,
       "operational_interface_count": 0,
-      "priority_score": 116,
+      "priority_score": 117,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-91",
@@ -118,7 +118,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -145,11 +145,11 @@
       "native_name_quality": "chain",
       "netuid": 40,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-40",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -157,7 +157,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -184,11 +184,11 @@
       "native_name_quality": "chain",
       "netuid": 53,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-53",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -196,7 +196,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -223,11 +223,11 @@
       "native_name_quality": "chain",
       "netuid": 73,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-73",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -235,7 +235,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -262,7 +262,7 @@
       "native_name_quality": "chain",
       "netuid": 92,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "stale",
       "slug": "sn-92",
@@ -274,7 +274,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -301,11 +301,11 @@
       "native_name_quality": "chain",
       "netuid": 116,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-116",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -313,7 +313,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -340,11 +340,11 @@
       "native_name_quality": "chain",
       "netuid": 119,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-119",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -352,7 +352,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -379,11 +379,11 @@
       "native_name_quality": "chain",
       "netuid": 28,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-28",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -391,7 +391,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -418,11 +418,11 @@
       "native_name_quality": "chain",
       "netuid": 31,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-31",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -430,7 +430,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -457,11 +457,11 @@
       "native_name_quality": "chain",
       "netuid": 69,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-69",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -469,7 +469,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -496,11 +496,11 @@
       "native_name_quality": "placeholder",
       "netuid": 86,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-86",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -508,7 +508,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -535,11 +535,11 @@
       "native_name_quality": "chain",
       "netuid": 90,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-90",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -547,7 +547,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -574,11 +574,11 @@
       "native_name_quality": "chain",
       "netuid": 101,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-101",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -586,7 +586,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -613,11 +613,11 @@
       "native_name_quality": "chain",
       "netuid": 104,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-104",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -625,7 +625,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -652,11 +652,11 @@
       "native_name_quality": "chain",
       "netuid": 125,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-125",
-      "source_count": 4,
+      "source_count": 5,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -664,7 +664,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 25,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -690,7 +690,7 @@
       "native_name_quality": "chain",
       "netuid": 20,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 115,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-20",
@@ -702,7 +702,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 25,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -728,7 +728,7 @@
       "native_name_quality": "chain",
       "netuid": 76,
       "operational_interface_count": 0,
-      "priority_score": 112,
+      "priority_score": 113,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-76",
@@ -740,7 +740,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 25,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -766,7 +766,7 @@
       "native_name_quality": "chain",
       "netuid": 89,
       "operational_interface_count": 0,
-      "priority_score": 112,
+      "priority_score": 113,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-89",
@@ -778,7 +778,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 25,
       "confidence": "low",
       "curation_level": "maintainer-reviewed",
@@ -804,7 +804,7 @@
       "native_name_quality": "chain",
       "netuid": 81,
       "operational_interface_count": 0,
-      "priority_score": 106,
+      "priority_score": 107,
       "profile_level": "directory-only",
       "review_state": "needs-review",
       "slug": "sn-81",
@@ -816,7 +816,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 25,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -842,7 +842,7 @@
       "native_name_quality": "chain",
       "netuid": 109,
       "operational_interface_count": 0,
-      "priority_score": 105,
+      "priority_score": 106,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-109",
@@ -854,7 +854,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 25,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -880,7 +880,7 @@
       "native_name_quality": "chain",
       "netuid": 115,
       "operational_interface_count": 0,
-      "priority_score": 105,
+      "priority_score": 106,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-115",
@@ -892,7 +892,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 25,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -918,7 +918,7 @@
       "native_name_quality": "chain",
       "netuid": 123,
       "operational_interface_count": 0,
-      "priority_score": 105,
+      "priority_score": 106,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
@@ -930,7 +930,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -953,10 +953,46 @@
       "native_name_quality": "chain",
       "netuid": 4,
       "operational_interface_count": 0,
-      "priority_score": 103,
+      "priority_score": 104,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-4",
+      "source_count": 3,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 24,
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-docs",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Compelle",
+      "native_name_quality": "chain",
+      "netuid": 82,
+      "operational_interface_count": 0,
+      "priority_score": 104,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-82",
       "source_count": 3,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -985,47 +1021,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Compelle",
-      "native_name_quality": "chain",
-      "netuid": 82,
-      "operational_interface_count": 0,
-      "priority_score": 103,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-82",
-      "source_count": 3,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 22,
-      "completeness_score": 40,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-docs",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "iota",
       "native_name_quality": "chain",
       "netuid": 9,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-9",
@@ -1038,7 +1038,7 @@
       ]
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1061,7 +1061,7 @@
       "native_name_quality": "chain",
       "netuid": 21,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-21",
@@ -1074,7 +1074,7 @@
       ]
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1097,7 +1097,7 @@
       "native_name_quality": "chain",
       "netuid": 32,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-32",
@@ -1110,7 +1110,7 @@
       ]
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1133,7 +1133,7 @@
       "native_name_quality": "chain",
       "netuid": 45,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-45",
@@ -1146,7 +1146,7 @@
       ]
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1169,7 +1169,7 @@
       "native_name_quality": "chain",
       "netuid": 48,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-48",
@@ -1182,7 +1182,7 @@
       ]
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1205,10 +1205,46 @@
       "native_name_quality": "chain",
       "netuid": 63,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-63",
+      "source_count": 3,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 23,
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-docs",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "sundae_bar",
+      "native_name_quality": "chain",
+      "netuid": 121,
+      "operational_interface_count": 0,
+      "priority_score": 103,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-121",
       "source_count": 3,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1237,14 +1273,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "sundae_bar",
+      "name": "Djinn",
       "native_name_quality": "chain",
-      "netuid": 121,
+      "netuid": 103,
       "operational_interface_count": 0,
       "priority_score": 102,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
-      "slug": "sn-121",
+      "slug": "sn-103",
       "source_count": 3,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1273,14 +1309,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Djinn",
+      "name": "ForeverMoney",
       "native_name_quality": "chain",
-      "netuid": 103,
+      "netuid": 98,
       "operational_interface_count": 0,
       "priority_score": 101,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
-      "slug": "sn-103",
+      "slug": "sn-98",
       "source_count": 3,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1309,47 +1345,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "ForeverMoney",
-      "native_name_quality": "chain",
-      "netuid": 98,
-      "operational_interface_count": 0,
-      "priority_score": 100,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-98",
-      "source_count": 3,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 19,
-      "completeness_score": 40,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-docs",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "Vidaio",
       "native_name_quality": "chain",
       "netuid": 85,
       "operational_interface_count": 0,
-      "priority_score": 99,
+      "priority_score": 100,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-85",
@@ -1362,7 +1362,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1387,7 +1387,7 @@
       "native_name_quality": "chain",
       "netuid": 30,
       "operational_interface_count": 0,
-      "priority_score": 98,
+      "priority_score": 99,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-30",
@@ -1400,7 +1400,7 @@
       ]
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1423,7 +1423,7 @@
       "native_name_quality": "chain",
       "netuid": 102,
       "operational_interface_count": 0,
-      "priority_score": 97,
+      "priority_score": 98,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-102",
@@ -1436,7 +1436,7 @@
       ]
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "completeness_score": 33,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1460,7 +1460,7 @@
       "native_name_quality": "chain",
       "netuid": 47,
       "operational_interface_count": 1,
-      "priority_score": 94,
+      "priority_score": 95,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-47",
@@ -1473,7 +1473,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -1495,11 +1495,11 @@
       "native_name_quality": "chain",
       "netuid": 118,
       "operational_interface_count": 0,
-      "priority_score": 93,
+      "priority_score": 94,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-118",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -1509,7 +1509,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1532,7 +1532,7 @@
       "native_name_quality": "chain",
       "netuid": 62,
       "operational_interface_count": 0,
-      "priority_score": 92,
+      "priority_score": 93,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-62",
@@ -1545,7 +1545,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 40,
       "confidence": "low",
       "curation_level": "maintainer-reviewed",
@@ -1570,7 +1570,7 @@
       "native_name_quality": "placeholder",
       "netuid": 42,
       "operational_interface_count": 0,
-      "priority_score": 89,
+      "priority_score": 90,
       "profile_level": "directory-only",
       "review_state": "needs-review",
       "slug": "sn-42",
@@ -1583,7 +1583,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1608,7 +1608,7 @@
       "native_name_quality": "placeholder",
       "netuid": 87,
       "operational_interface_count": 0,
-      "priority_score": 89,
+      "priority_score": 90,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-87",
@@ -1621,7 +1621,7 @@
       ]
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1643,7 +1643,7 @@
       "native_name_quality": "chain",
       "netuid": 75,
       "operational_interface_count": 0,
-      "priority_score": 89,
+      "priority_score": 90,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-75",
@@ -1657,7 +1657,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -1679,7 +1679,7 @@
       "native_name_quality": "chain",
       "netuid": 14,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-14",
@@ -1693,7 +1693,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -1715,7 +1715,7 @@
       "native_name_quality": "chain",
       "netuid": 17,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-17",
@@ -1729,7 +1729,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -1751,11 +1751,47 @@
       "native_name_quality": "chain",
       "netuid": 100,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-100",
-      "source_count": 6,
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 19,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "TalkHead",
+      "native_name_quality": "chain",
+      "netuid": 108,
+      "operational_interface_count": 0,
+      "priority_score": 89,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-108",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -1783,19 +1819,235 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "TalkHead",
+      "name": "Numinous",
       "native_name_quality": "chain",
-      "netuid": 108,
+      "netuid": 6,
       "operational_interface_count": 0,
       "priority_score": 88,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-108",
-      "source_count": 6,
+      "slug": "sn-6",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
         "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Zeus",
+      "native_name_quality": "chain",
+      "netuid": 18,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-18",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Aurelius",
+      "native_name_quality": "chain",
+      "netuid": 37,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-37",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 23,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "blockmachine",
+      "native_name_quality": "chain",
+      "netuid": 19,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-19",
+      "source_count": 4,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 7,
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-docs",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Compute Horde",
+      "native_name_quality": "chain",
+      "netuid": 12,
+      "operational_interface_count": 0,
+      "priority_score": 87,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-12",
+      "source_count": 4,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 7,
+      "completeness_score": 40,
+      "confidence": "low",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-docs",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Basilica",
+      "native_name_quality": "chain",
+      "netuid": 39,
+      "operational_interface_count": 0,
+      "priority_score": 87,
+      "profile_level": "identity-complete",
+      "review_state": "needs-review",
+      "slug": "sn-39",
+      "source_count": 4,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 7,
+      "completeness_score": 40,
+      "confidence": "low",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-docs",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "BrainPlay",
+      "native_name_quality": "placeholder",
+      "netuid": 117,
+      "operational_interface_count": 0,
+      "priority_score": 87,
+      "profile_level": "identity-complete",
+      "review_state": "needs-review",
+      "slug": "sn-117",
+      "source_count": 4,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
         "source-repo",
         "website"
       ]
@@ -1819,14 +2071,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Numinous",
+      "name": "TrajectoryRL",
       "native_name_quality": "chain",
-      "netuid": 6,
+      "netuid": 11,
       "operational_interface_count": 0,
       "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-6",
+      "slug": "sn-11",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1855,15 +2107,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Zeus",
+      "name": "Perturb",
       "native_name_quality": "chain",
-      "netuid": 18,
+      "netuid": 26,
       "operational_interface_count": 0,
       "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-18",
-      "source_count": 6,
+      "slug": "sn-26",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -1891,15 +2143,87 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Aurelius",
+      "name": "Eirel",
       "native_name_quality": "chain",
-      "netuid": 37,
+      "netuid": 36,
       "operational_interface_count": 0,
       "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-37",
-      "source_count": 6,
+      "slug": "sn-36",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "NIOME",
+      "native_name_quality": "chain",
+      "netuid": 55,
+      "operational_interface_count": 0,
+      "priority_score": 87,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-55",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Poker44",
+      "native_name_quality": "chain",
+      "netuid": 126,
+      "operational_interface_count": 0,
+      "priority_score": 87,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-126",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -1927,15 +2251,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "blockmachine",
+      "name": "Data Universe",
       "native_name_quality": "chain",
-      "netuid": 19,
+      "netuid": 13,
       "operational_interface_count": 0,
       "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
-      "slug": "sn-19",
-      "source_count": 4,
+      "slug": "sn-13",
+      "source_count": 10,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -1964,14 +2288,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Compute Horde",
+      "name": "Graphite",
       "native_name_quality": "chain",
-      "netuid": 12,
+      "netuid": 43,
       "operational_interface_count": 0,
       "priority_score": 86,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
-      "slug": "sn-12",
+      "slug": "sn-43",
       "source_count": 4,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1983,7 +2307,7 @@
     {
       "candidate_count": 6,
       "completeness_score": 40,
-      "confidence": "low",
+      "confidence": "high",
       "curation_level": "maintainer-reviewed",
       "gap_reasons": [
         "missing-docs",
@@ -2000,14 +2324,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Basilica",
+      "name": "Sparket",
       "native_name_quality": "chain",
-      "netuid": 39,
+      "netuid": 57,
       "operational_interface_count": 0,
       "priority_score": 86,
       "profile_level": "identity-complete",
-      "review_state": "needs-review",
-      "slug": "sn-39",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-57",
       "source_count": 4,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -2019,7 +2343,7 @@
     {
       "candidate_count": 6,
       "completeness_score": 40,
-      "confidence": "low",
+      "confidence": "high",
       "curation_level": "maintainer-reviewed",
       "gap_reasons": [
         "missing-docs",
@@ -2036,14 +2360,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "BrainPlay",
-      "native_name_quality": "placeholder",
-      "netuid": 117,
+      "name": "oneoneone",
+      "native_name_quality": "chain",
+      "netuid": 111,
       "operational_interface_count": 0,
       "priority_score": 86,
       "profile_level": "identity-complete",
-      "review_state": "needs-review",
-      "slug": "sn-117",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-111",
       "source_count": 4,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -2071,15 +2395,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "TrajectoryRL",
+      "name": "Hone",
       "native_name_quality": "chain",
-      "netuid": 11,
+      "netuid": 5,
       "operational_interface_count": 0,
       "priority_score": 86,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-11",
-      "source_count": 6,
+      "slug": "sn-5",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -2107,15 +2431,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Perturb",
+      "name": "Vanta",
       "native_name_quality": "chain",
-      "netuid": 26,
+      "netuid": 8,
       "operational_interface_count": 0,
       "priority_score": 86,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-26",
-      "source_count": 6,
+      "slug": "sn-8",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -2143,15 +2467,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Eirel",
+      "name": "Yanez MIID",
       "native_name_quality": "chain",
-      "netuid": 36,
+      "netuid": 54,
       "operational_interface_count": 0,
       "priority_score": 86,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-36",
-      "source_count": 6,
+      "slug": "sn-54",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -2179,15 +2503,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "NIOME",
+      "name": "Harnyx",
       "native_name_quality": "chain",
-      "netuid": 55,
+      "netuid": 67,
       "operational_interface_count": 0,
       "priority_score": 86,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-55",
-      "source_count": 6,
+      "slug": "sn-67",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -2215,15 +2539,51 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Poker44",
+      "name": "Bitsota",
       "native_name_quality": "chain",
-      "netuid": 126,
+      "netuid": 94,
       "operational_interface_count": 0,
       "priority_score": 86,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-126",
-      "source_count": 6,
+      "slug": "sn-94",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 16,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Astrid",
+      "native_name_quality": "chain",
+      "netuid": 127,
+      "operational_interface_count": 0,
+      "priority_score": 86,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-127",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -2251,371 +2611,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Data Universe",
-      "native_name_quality": "chain",
-      "netuid": 13,
-      "operational_interface_count": 0,
-      "priority_score": 86,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-13",
-      "source_count": 10,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 5,
-      "completeness_score": 40,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-docs",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Graphite",
-      "native_name_quality": "chain",
-      "netuid": 43,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-43",
-      "source_count": 4,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 5,
-      "completeness_score": 40,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-docs",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Sparket",
-      "native_name_quality": "chain",
-      "netuid": 57,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-57",
-      "source_count": 4,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 5,
-      "completeness_score": 40,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-docs",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "oneoneone",
-      "native_name_quality": "chain",
-      "netuid": 111,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-111",
-      "source_count": 4,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 15,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Hone",
-      "native_name_quality": "chain",
-      "netuid": 5,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-5",
-      "source_count": 6,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 15,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Vanta",
-      "native_name_quality": "chain",
-      "netuid": 8,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-8",
-      "source_count": 6,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 15,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Yanez MIID",
-      "native_name_quality": "chain",
-      "netuid": 54,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-54",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 15,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Harnyx",
-      "native_name_quality": "chain",
-      "netuid": 67,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-67",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 15,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Bitsota",
-      "native_name_quality": "chain",
-      "netuid": 94,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-94",
-      "source_count": 6,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 15,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Astrid",
-      "native_name_quality": "chain",
-      "netuid": 127,
-      "operational_interface_count": 0,
-      "priority_score": 85,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-127",
-      "source_count": 6,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 20,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "ORO",
       "native_name_quality": "chain",
       "netuid": 15,
       "operational_interface_count": 0,
-      "priority_score": 85,
+      "priority_score": 86,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-15",
@@ -2629,7 +2629,7 @@
       ]
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "completeness_score": 48,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -2650,7 +2650,7 @@
       "native_name_quality": "chain",
       "netuid": 88,
       "operational_interface_count": 1,
-      "priority_score": 84,
+      "priority_score": 85,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-88",
@@ -2664,7 +2664,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -2686,11 +2686,11 @@
       "native_name_quality": "chain",
       "netuid": 44,
       "operational_interface_count": 0,
-      "priority_score": 84,
+      "priority_score": 85,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-44",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -2700,7 +2700,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -2723,16 +2723,160 @@
       "native_name_quality": "chain",
       "netuid": 95,
       "operational_interface_count": 1,
-      "priority_score": 84,
+      "priority_score": 85,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-95",
-      "source_count": 5,
+      "source_count": 6,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
         "docs",
         "openapi",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 20,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Apex",
+      "native_name_quality": "chain",
+      "netuid": 1,
+      "operational_interface_count": 0,
+      "priority_score": 85,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-1",
+      "source_count": 5,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 14,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "OxMarkets",
+      "native_name_quality": "chain",
+      "netuid": 35,
+      "operational_interface_count": 0,
+      "priority_score": 84,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-35",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 14,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "minotaur",
+      "native_name_quality": "chain",
+      "netuid": 112,
+      "operational_interface_count": 0,
+      "priority_score": 84,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-112",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 14,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Affine",
+      "native_name_quality": "chain",
+      "netuid": 120,
+      "operational_interface_count": 0,
+      "priority_score": 84,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-120",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
         "website"
       ]
     },
@@ -2755,155 +2899,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Apex",
-      "native_name_quality": "chain",
-      "netuid": 1,
-      "operational_interface_count": 0,
-      "priority_score": 84,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-1",
-      "source_count": 5,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 13,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "OxMarkets",
-      "native_name_quality": "chain",
-      "netuid": 35,
-      "operational_interface_count": 0,
-      "priority_score": 83,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-35",
-      "source_count": 6,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 13,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "minotaur",
-      "native_name_quality": "chain",
-      "netuid": 112,
-      "operational_interface_count": 0,
-      "priority_score": 83,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-112",
-      "source_count": 6,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 13,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Affine",
-      "native_name_quality": "chain",
-      "netuid": 120,
-      "operational_interface_count": 0,
-      "priority_score": 83,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-120",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 18,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "TensorUSD",
       "native_name_quality": "chain",
       "netuid": 113,
       "operational_interface_count": 0,
-      "priority_score": 83,
+      "priority_score": 84,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-113",
@@ -2917,7 +2917,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -2939,11 +2939,11 @@
       "native_name_quality": "chain",
       "netuid": 10,
       "operational_interface_count": 0,
-      "priority_score": 82,
+      "priority_score": 83,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-10",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -2953,7 +2953,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -2976,11 +2976,11 @@
       "native_name_quality": "chain",
       "netuid": 38,
       "operational_interface_count": 1,
-      "priority_score": 82,
+      "priority_score": 83,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-38",
-      "source_count": 5,
+      "source_count": 6,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -2990,7 +2990,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3012,11 +3012,11 @@
       "native_name_quality": "chain",
       "netuid": 106,
       "operational_interface_count": 0,
-      "priority_score": 82,
+      "priority_score": 83,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-106",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3026,7 +3026,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 58,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3046,7 +3046,7 @@
       "native_name_quality": "chain",
       "netuid": 72,
       "operational_interface_count": 1,
-      "priority_score": 80,
+      "priority_score": 81,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-72",
@@ -3060,7 +3060,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3082,7 +3082,7 @@
       "native_name_quality": "chain",
       "netuid": 61,
       "operational_interface_count": 0,
-      "priority_score": 79,
+      "priority_score": 80,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-61",
@@ -3096,7 +3096,7 @@
       ]
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3117,7 +3117,7 @@
       "native_name_quality": "chain",
       "netuid": 23,
       "operational_interface_count": 1,
-      "priority_score": 77,
+      "priority_score": 78,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-23",
@@ -3131,7 +3131,7 @@
       ]
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "completeness_score": 58,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3151,11 +3151,11 @@
       "native_name_quality": "chain",
       "netuid": 114,
       "operational_interface_count": 1,
-      "priority_score": 77,
+      "priority_score": 78,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-114",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3166,7 +3166,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 63,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3186,7 +3186,7 @@
       "native_name_quality": "chain",
       "netuid": 79,
       "operational_interface_count": 1,
-      "priority_score": 75,
+      "priority_score": 76,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-79",
@@ -3201,7 +3201,7 @@
       ]
     },
     {
-      "candidate_count": 9,
+      "candidate_count": 10,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3223,7 +3223,7 @@
       "native_name_quality": "chain",
       "netuid": 52,
       "operational_interface_count": 0,
-      "priority_score": 74,
+      "priority_score": 75,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-52",
@@ -3237,7 +3237,7 @@
       ]
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "completeness_score": 58,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3257,11 +3257,11 @@
       "native_name_quality": "chain",
       "netuid": 68,
       "operational_interface_count": 1,
-      "priority_score": 74,
+      "priority_score": 75,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-68",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3272,7 +3272,7 @@
       ]
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "completeness_score": 58,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3292,11 +3292,11 @@
       "native_name_quality": "chain",
       "netuid": 70,
       "operational_interface_count": 1,
-      "priority_score": 74,
+      "priority_score": 75,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-70",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3307,7 +3307,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3327,11 +3327,11 @@
       "native_name_quality": "chain",
       "netuid": 51,
       "operational_interface_count": 1,
-      "priority_score": 73,
+      "priority_score": 74,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-51",
-      "source_count": 8,
+      "source_count": 9,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3342,7 +3342,7 @@
       ]
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3362,7 +3362,7 @@
       "native_name_quality": "chain",
       "netuid": 46,
       "operational_interface_count": 1,
-      "priority_score": 72,
+      "priority_score": 73,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-46",
@@ -3372,6 +3372,78 @@
         "dashboard",
         "docs",
         "openapi",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 7,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "ansuz",
+      "native_name_quality": "chain",
+      "netuid": 84,
+      "operational_interface_count": 0,
+      "priority_score": 72,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-84",
+      "source_count": 5,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 6,
+      "completeness_score": 55,
+      "confidence": "low",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Templar",
+      "native_name_quality": "chain",
+      "netuid": 3,
+      "operational_interface_count": 0,
+      "priority_score": 71,
+      "profile_level": "identity-complete",
+      "review_state": "needs-review",
+      "slug": "sn-3",
+      "source_count": 5,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
         "source-repo",
         "website"
       ]
@@ -3395,83 +3467,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "ansuz",
-      "native_name_quality": "chain",
-      "netuid": 84,
-      "operational_interface_count": 0,
-      "priority_score": 71,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-84",
-      "source_count": 5,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 5,
-      "completeness_score": 55,
-      "confidence": "low",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Templar",
-      "native_name_quality": "chain",
-      "netuid": 3,
-      "operational_interface_count": 0,
-      "priority_score": 70,
-      "profile_level": "identity-complete",
-      "review_state": "needs-review",
-      "slug": "sn-3",
-      "source_count": 5,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 5,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "BitMind",
       "native_name_quality": "chain",
       "netuid": 34,
       "operational_interface_count": 0,
-      "priority_score": 70,
+      "priority_score": 71,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-34",
@@ -3485,7 +3485,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3507,7 +3507,7 @@
       "native_name_quality": "chain",
       "netuid": 122,
       "operational_interface_count": 0,
-      "priority_score": 70,
+      "priority_score": 71,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-122",
@@ -3521,7 +3521,42 @@
       ]
     },
     {
-      "candidate_count": 27,
+      "candidate_count": 20,
+      "completeness_score": 65,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "openapi",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Minos",
+      "native_name_quality": "chain",
+      "netuid": 107,
+      "operational_interface_count": 1,
+      "priority_score": 70,
+      "profile_level": "operational",
+      "review_state": "machine-generated",
+      "slug": "sn-107",
+      "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "subnet-api",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 28,
       "completeness_score": 70,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3556,42 +3591,7 @@
       ]
     },
     {
-      "candidate_count": 19,
-      "completeness_score": 65,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 3,
-      "missing_operational": [
-        "openapi",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Minos",
-      "native_name_quality": "chain",
-      "netuid": 107,
-      "operational_interface_count": 1,
-      "priority_score": 69,
-      "profile_level": "operational",
-      "review_state": "machine-generated",
-      "slug": "sn-107",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "subnet-api",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 3,
+      "candidate_count": 4,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3613,7 +3613,7 @@
       "native_name_quality": "chain",
       "netuid": 0,
       "operational_interface_count": 0,
-      "priority_score": 68,
+      "priority_score": 69,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "root",
@@ -3629,7 +3629,7 @@
       ]
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "completeness_score": 63,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3649,7 +3649,7 @@
       "native_name_quality": "chain",
       "netuid": 24,
       "operational_interface_count": 1,
-      "priority_score": 68,
+      "priority_score": 69,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-24",
@@ -3664,7 +3664,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3684,11 +3684,11 @@
       "native_name_quality": "chain",
       "netuid": 65,
       "operational_interface_count": 1,
-      "priority_score": 68,
+      "priority_score": 69,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-65",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3699,7 +3699,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3719,11 +3719,11 @@
       "native_name_quality": "chain",
       "netuid": 93,
       "operational_interface_count": 1,
-      "priority_score": 68,
+      "priority_score": 69,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-93",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3734,7 +3734,7 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "completeness_score": 63,
       "confidence": "high",
       "curation_level": "adapter-backed",
@@ -3754,7 +3754,7 @@
       "native_name_quality": "chain",
       "netuid": 74,
       "operational_interface_count": 1,
-      "priority_score": 67,
+      "priority_score": 68,
       "profile_level": "adapter-backed",
       "review_state": "maintainer-reviewed",
       "slug": "gittensor",
@@ -3769,7 +3769,7 @@
       ]
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3789,17 +3789,52 @@
       "native_name_quality": "chain",
       "netuid": 59,
       "operational_interface_count": 1,
-      "priority_score": 67,
+      "priority_score": 68,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-59",
-      "source_count": 7,
+      "source_count": 8,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
         "docs",
         "source-repo",
         "subnet-api",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 17,
+      "completeness_score": 65,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Albedo",
+      "native_name_quality": "chain",
+      "netuid": 97,
+      "operational_interface_count": 1,
+      "priority_score": 67,
+      "profile_level": "operational",
+      "review_state": "machine-generated",
+      "slug": "sn-97",
+      "source_count": 9,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "openapi",
+        "source-repo",
         "website"
       ]
     },
@@ -3820,46 +3855,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Albedo",
-      "native_name_quality": "chain",
-      "netuid": 97,
-      "operational_interface_count": 1,
-      "priority_score": 66,
-      "profile_level": "operational",
-      "review_state": "machine-generated",
-      "slug": "sn-97",
-      "source_count": 8,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "openapi",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 15,
-      "completeness_score": 65,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 3,
-      "missing_operational": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "DSperse",
       "native_name_quality": "chain",
       "netuid": 2,
       "operational_interface_count": 1,
-      "priority_score": 65,
+      "priority_score": 66,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-2",
@@ -3874,7 +3874,7 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3894,11 +3894,11 @@
       "native_name_quality": "chain",
       "netuid": 99,
       "operational_interface_count": 1,
-      "priority_score": 65,
+      "priority_score": 66,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-99",
-      "source_count": 8,
+      "source_count": 9,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3909,7 +3909,7 @@
       ]
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "completeness_score": 58,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3929,7 +3929,7 @@
       "native_name_quality": "chain",
       "netuid": 33,
       "operational_interface_count": 1,
-      "priority_score": 64,
+      "priority_score": 65,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-33",
@@ -3943,7 +3943,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3963,11 +3963,11 @@
       "native_name_quality": "chain",
       "netuid": 60,
       "operational_interface_count": 1,
-      "priority_score": 64,
+      "priority_score": 65,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-60",
-      "source_count": 8,
+      "source_count": 9,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3978,7 +3978,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3998,11 +3998,11 @@
       "native_name_quality": "chain",
       "netuid": 78,
       "operational_interface_count": 1,
-      "priority_score": 64,
+      "priority_score": 65,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-78",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4029,50 +4029,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "dogelayer",
-      "native_name_quality": "chain",
-      "netuid": 80,
-      "operational_interface_count": 1,
-      "priority_score": 64,
-      "profile_level": "operational",
-      "review_state": "machine-generated",
-      "slug": "sn-80",
-      "source_count": 6,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "openapi",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 13,
-      "completeness_score": 65,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 3,
-      "missing_operational": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "Almanac",
       "native_name_quality": "chain",
       "netuid": 41,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-41",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4083,7 +4048,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4103,11 +4068,11 @@
       "native_name_quality": "chain",
       "netuid": 50,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-50",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4118,7 +4083,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4138,10 +4103,45 @@
       "native_name_quality": "chain",
       "netuid": 124,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-124",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "openapi",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 14,
+      "completeness_score": 65,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "ByteLeap",
+      "native_name_quality": "chain",
+      "netuid": 128,
+      "operational_interface_count": 1,
+      "priority_score": 64,
+      "profile_level": "operational",
+      "review_state": "machine-generated",
+      "slug": "sn-128",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -4169,50 +4169,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "ByteLeap",
-      "native_name_quality": "chain",
-      "netuid": 128,
-      "operational_interface_count": 1,
-      "priority_score": 63,
-      "profile_level": "operational",
-      "review_state": "machine-generated",
-      "slug": "sn-128",
-      "source_count": 6,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "openapi",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 12,
-      "completeness_score": 65,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 3,
-      "missing_operational": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "BitAds",
       "native_name_quality": "chain",
       "netuid": 16,
       "operational_interface_count": 1,
-      "priority_score": 62,
+      "priority_score": 63,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-16",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4223,7 +4188,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4243,11 +4208,11 @@
       "native_name_quality": "chain",
       "netuid": 71,
       "operational_interface_count": 1,
-      "priority_score": 62,
+      "priority_score": 63,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-71",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4258,7 +4223,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4278,11 +4243,11 @@
       "native_name_quality": "chain",
       "netuid": 77,
       "operational_interface_count": 1,
-      "priority_score": 62,
+      "priority_score": 63,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-77",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4293,7 +4258,42 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
+      "completeness_score": 65,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "dogelayer",
+      "native_name_quality": "chain",
+      "netuid": 80,
+      "operational_interface_count": 1,
+      "priority_score": 63,
+      "profile_level": "operational",
+      "review_state": "machine-generated",
+      "slug": "sn-80",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "openapi",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 13,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4313,11 +4313,11 @@
       "native_name_quality": "chain",
       "netuid": 83,
       "operational_interface_count": 1,
-      "priority_score": 62,
+      "priority_score": 63,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-83",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4328,7 +4328,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4348,11 +4348,11 @@
       "native_name_quality": "chain",
       "netuid": 105,
       "operational_interface_count": 1,
-      "priority_score": 62,
+      "priority_score": 63,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-105",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4363,7 +4363,7 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "completeness_score": 70,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4383,7 +4383,7 @@
       "native_name_quality": "chain",
       "netuid": 66,
       "operational_interface_count": 1,
-      "priority_score": 60,
+      "priority_score": 61,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-66",
@@ -4398,7 +4398,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 73,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4416,11 +4416,11 @@
       "native_name_quality": "chain",
       "netuid": 56,
       "operational_interface_count": 2,
-      "priority_score": 60,
+      "priority_score": 61,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-56",
-      "source_count": 6,
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4432,7 +4432,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 63,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4452,7 +4452,7 @@
       "native_name_quality": "chain",
       "netuid": 29,
       "operational_interface_count": 1,
-      "priority_score": 58,
+      "priority_score": 59,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-29",
@@ -4467,7 +4467,7 @@
       ]
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "completeness_score": 78,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4485,7 +4485,7 @@
       "native_name_quality": "chain",
       "netuid": 110,
       "operational_interface_count": 2,
-      "priority_score": 54,
+      "priority_score": 55,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-110",
@@ -4501,7 +4501,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 85,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4519,7 +4519,7 @@
       "native_name_quality": "chain",
       "netuid": 49,
       "operational_interface_count": 2,
-      "priority_score": 39,
+      "priority_score": 40,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-49",
@@ -4535,7 +4535,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 85,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4553,7 +4553,7 @@
       "native_name_quality": "chain",
       "netuid": 96,
       "operational_interface_count": 2,
-      "priority_score": 39,
+      "priority_score": 40,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-96",
@@ -4569,7 +4569,7 @@
       ]
     },
     {
-      "candidate_count": 12,
+      "candidate_count": 13,
       "completeness_score": 85,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4587,7 +4587,7 @@
       "native_name_quality": "chain",
       "netuid": 22,
       "operational_interface_count": 2,
-      "priority_score": 37,
+      "priority_score": 38,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-22",
@@ -4603,7 +4603,7 @@
       ]
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "completeness_score": 85,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4621,7 +4621,7 @@
       "native_name_quality": "chain",
       "netuid": 58,
       "operational_interface_count": 2,
-      "priority_score": 32,
+      "priority_score": 33,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-58",
@@ -4637,7 +4637,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 92,
       "confidence": "high",
       "curation_level": "adapter-backed",
@@ -4653,7 +4653,7 @@
       "native_name_quality": "chain",
       "netuid": 7,
       "operational_interface_count": 3,
-      "priority_score": 26,
+      "priority_score": 27,
       "profile_level": "adapter-backed",
       "review_state": "maintainer-reviewed",
       "slug": "allways",

--- a/public/metagraph/search.json
+++ b/public/metagraph/search.json
@@ -1,6 +1,6 @@
 {
   "contract_version": "2026-06-06.1",
-  "document_count": 921,
+  "document_count": 966,
   "documents": [
     {
       "artifact_path": "/metagraph/providers.json",
@@ -3848,6 +3848,25 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-125-taostats-metagraph",
+      "netuid": 125,
+      "slug": "sn-125",
+      "subtitle": "dashboard / taostats",
+      "title": "8 Ball Taostats metagraph",
+      "tokens": [
+        "125",
+        "8",
+        "ball",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/125/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-125-tensorplex-docs",
       "netuid": 125,
       "slug": "sn-125",
@@ -3972,6 +3991,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-95-taostats-metagraph",
+      "netuid": 95,
+      "slug": "sn-95",
+      "subtitle": "dashboard / taostats",
+      "title": "Actual Taostats metagraph",
+      "tokens": [
+        "95",
+        "actual",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/95/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -4223,6 +4260,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-69-taostats-metagraph",
+      "netuid": 69,
+      "slug": "sn-69",
+      "subtitle": "dashboard / taostats",
+      "title": "ain Taostats metagraph",
+      "tokens": [
+        "69",
+        "ain",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/69/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-69-tensorplex-docs",
       "netuid": 69,
       "slug": "sn-69",
@@ -4385,6 +4440,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_97/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-97-taostats-metagraph",
+      "netuid": 97,
+      "slug": "sn-97",
+      "subtitle": "dashboard / taostats",
+      "title": "Albedo Taostats metagraph",
+      "tokens": [
+        "97",
+        "albedo",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/97/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -4775,6 +4848,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-41-taostats-metagraph",
+      "netuid": 41,
+      "slug": "sn-41",
+      "subtitle": "dashboard / taostats",
+      "title": "Almanac Taostats metagraph",
+      "tokens": [
+        "41",
+        "almanac",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/41/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-41-tensorplex-docs",
       "netuid": 41,
       "slug": "sn-41",
@@ -4936,6 +5027,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-127-taostats-metagraph",
+      "netuid": 127,
+      "slug": "sn-127",
+      "subtitle": "dashboard / taostats",
+      "title": "Astrid Taostats metagraph",
+      "tokens": [
+        "127",
+        "astrid",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/127/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-127-tensorplex-docs",
       "netuid": 127,
       "slug": "sn-127",
@@ -5065,6 +5174,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-37-taostats-metagraph",
+      "netuid": 37,
+      "slug": "sn-37",
+      "subtitle": "dashboard / taostats",
+      "title": "Aurelius Taostats metagraph",
+      "tokens": [
+        "37",
+        "aurelius",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/37/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-37-tensorplex-docs",
       "netuid": 37,
       "slug": "sn-37",
@@ -5137,23 +5264,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-59-website-link-babelbit-ai-dashboard-1",
-      "netuid": 59,
-      "slug": "sn-59",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Babelbit dashboard",
-      "tokens": [
-        "59",
-        "babelbit",
-        "dashboard",
-        "sn",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://babelbit.ai/main/dashboard"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-59-taomarketcap-source-repo",
       "netuid": 59,
       "slug": "sn-59",
@@ -5206,6 +5316,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_59/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-59-taostats-metagraph",
+      "netuid": 59,
+      "slug": "sn-59",
+      "subtitle": "dashboard / taostats",
+      "title": "Babelbit Taostats metagraph",
+      "tokens": [
+        "59",
+        "babelbit",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/59/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5391,6 +5519,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-105-taostats-metagraph",
+      "netuid": 105,
+      "slug": "sn-105",
+      "subtitle": "dashboard / taostats",
+      "title": "Beam Taostats metagraph",
+      "tokens": [
+        "105",
+        "beam",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/105/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-105-tensorplex-docs",
       "netuid": 105,
       "slug": "sn-105",
@@ -5535,6 +5681,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-16-taostats-metagraph",
+      "netuid": 16,
+      "slug": "sn-16",
+      "subtitle": "dashboard / taostats",
+      "title": "BitAds Taostats metagraph",
+      "tokens": [
+        "16",
+        "bitads",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/16/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-16-tensorplex-docs",
       "netuid": 16,
       "slug": "sn-16",
@@ -5585,23 +5749,6 @@
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/93-bitcast"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-93-website-link-stats-bitcast-network-dashboard-1",
-      "netuid": 93,
-      "slug": "sn-93",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Bitcast dashboard",
-      "tokens": [
-        "93",
-        "bitcast",
-        "dashboard",
-        "sn",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://stats.bitcast.network/bitcast"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5693,6 +5840,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_93/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-93-taostats-metagraph",
+      "netuid": 93,
+      "slug": "sn-93",
+      "subtitle": "dashboard / taostats",
+      "title": "Bitcast Taostats metagraph",
+      "tokens": [
+        "93",
+        "bitcast",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/93/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6006,6 +6171,25 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-60-taostats-metagraph",
+      "netuid": 60,
+      "slug": "sn-60",
+      "subtitle": "dashboard / taostats",
+      "title": "Bitsec.ai Taostats metagraph",
+      "tokens": [
+        "60",
+        "ai",
+        "bitsec",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/60/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-60-tensorplex-docs",
       "netuid": 60,
       "slug": "sn-60",
@@ -6058,23 +6242,6 @@
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/94-bitsota"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-94-website-link-bitsota-ai-dashboard-3",
-      "netuid": 94,
-      "slug": "sn-94",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Bitsota dashboard",
-      "tokens": [
-        "94",
-        "bitsota",
-        "dashboard",
-        "sn",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://bitsota.ai/leaderboard"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6147,6 +6314,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-94-taostats-metagraph",
+      "netuid": 94,
+      "slug": "sn-94",
+      "subtitle": "dashboard / taostats",
+      "title": "Bitsota Taostats metagraph",
+      "tokens": [
+        "94",
+        "bitsota",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/94/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6491,6 +6676,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-128-taostats-metagraph",
+      "netuid": 128,
+      "slug": "sn-128",
+      "subtitle": "dashboard / taostats",
+      "title": "ByteLeap Taostats metagraph",
+      "tokens": [
+        "128",
+        "byteleap",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/128/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-128-tensorplex-docs",
       "netuid": 128,
       "slug": "sn-128",
@@ -6832,6 +7035,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-40-taostats-metagraph",
+      "netuid": 40,
+      "slug": "sn-40",
+      "subtitle": "dashboard / taostats",
+      "title": "Chunking Taostats metagraph",
+      "tokens": [
+        "40",
+        "chunking",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/40/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-40-tensorplex-docs",
       "netuid": 40,
       "slug": "sn-40",
@@ -7158,6 +7379,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-83-taostats-metagraph",
+      "netuid": 83,
+      "slug": "sn-83",
+      "subtitle": "dashboard / taostats",
+      "title": "CliqueAI Taostats metagraph",
+      "tokens": [
+        "83",
+        "cliqueai",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/83/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-83-tensorplex-docs",
       "netuid": 83,
       "slug": "sn-83",
@@ -7369,6 +7608,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-38-taostats-metagraph",
+      "netuid": 38,
+      "slug": "sn-38",
+      "subtitle": "dashboard / taostats",
+      "title": "colosseum Taostats metagraph",
+      "tokens": [
+        "38",
+        "colosseum",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/38/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -7892,6 +8149,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-118-taostats-metagraph",
+      "netuid": 118,
+      "slug": "sn-118",
+      "subtitle": "dashboard / taostats",
+      "title": "Ditto Taostats metagraph",
+      "tokens": [
+        "118",
+        "dashboard",
+        "ditto",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/118/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-118-tensorplex-docs",
       "netuid": 118,
       "slug": "sn-118",
@@ -7979,23 +8254,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-80-website-link-dogelayer-ai-dashboard-1",
-      "netuid": 80,
-      "slug": "sn-80",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "dogelayer dashboard",
-      "tokens": [
-        "80",
-        "dashboard",
-        "dogelayer",
-        "sn",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://dogelayer.ai/en/dashboard"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-80-website-common-docs",
       "netuid": 80,
       "slug": "sn-80",
@@ -8010,23 +8268,6 @@
       ],
       "type": "surface",
       "url": "https://dogelayer.ai/docs"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-80-website-link-dogelayer-ai-docs-2",
-      "netuid": 80,
-      "slug": "sn-80",
-      "subtitle": "docs / taomarketcap",
-      "title": "dogelayer docs",
-      "tokens": [
-        "80",
-        "docs",
-        "dogelayer",
-        "sn",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://dogelayer.ai/en/docs"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8101,6 +8342,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-80-taostats-metagraph",
+      "netuid": 80,
+      "slug": "sn-80",
+      "subtitle": "dashboard / taostats",
+      "title": "dogelayer Taostats metagraph",
+      "tokens": [
+        "80",
+        "dashboard",
+        "dogelayer",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/80/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8450,6 +8709,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-53-taostats-metagraph",
+      "netuid": 53,
+      "slug": "sn-53",
+      "subtitle": "dashboard / taostats",
+      "title": "EfficientFrontier Taostats metagraph",
+      "tokens": [
+        "53",
+        "dashboard",
+        "efficientfrontier",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/53/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-53-tensorplex-docs",
       "netuid": 53,
       "slug": "sn-53",
@@ -8483,23 +8760,6 @@
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/36-eirel"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-36-website-link-eirel-ai-dashboard-3",
-      "netuid": 36,
-      "slug": "sn-36",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Eirel dashboard",
-      "tokens": [
-        "36",
-        "dashboard",
-        "eirel",
-        "sn",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://leaderboard.eirel.ai/"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8572,6 +8832,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-36-taostats-metagraph",
+      "netuid": 36,
+      "slug": "sn-36",
+      "subtitle": "dashboard / taostats",
+      "title": "Eirel Taostats metagraph",
+      "tokens": [
+        "36",
+        "dashboard",
+        "eirel",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/36/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8696,6 +8974,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-101-taostats-metagraph",
+      "netuid": 101,
+      "slug": "sn-101",
+      "subtitle": "dashboard / taostats",
+      "title": "eni Taostats metagraph",
+      "tokens": [
+        "101",
+        "dashboard",
+        "eni",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/101/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8860,6 +9156,28 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_104/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-104-taostats-metagraph",
+      "netuid": 104,
+      "slug": "sn-104",
+      "subtitle": "dashboard / taostats",
+      "title": "for sale (burn to uid1) Taostats metagraph",
+      "tokens": [
+        "104",
+        "burn",
+        "dashboard",
+        "for",
+        "metagraph",
+        "sale",
+        "sn",
+        "taostats",
+        "to",
+        "uid1"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/104/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -9084,6 +9402,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-28-taostats-metagraph",
+      "netuid": 28,
+      "slug": "sn-28",
+      "subtitle": "dashboard / taostats",
+      "title": "gm Taostats metagraph",
+      "tokens": [
+        "28",
+        "dashboard",
+        "gm",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/28/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-28-tensorplex-docs",
       "netuid": 28,
       "slug": "sn-28",
@@ -9286,6 +9622,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-56-taostats-metagraph",
+      "netuid": 56,
+      "slug": "sn-56",
+      "subtitle": "dashboard / taostats",
+      "title": "Gradients Taostats metagraph",
+      "tokens": [
+        "56",
+        "dashboard",
+        "gradients",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/56/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -9827,6 +10181,25 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-116-taostats-metagraph",
+      "netuid": 116,
+      "slug": "sn-116",
+      "subtitle": "dashboard / taostats",
+      "title": "hard_sign Taostats metagraph",
+      "tokens": [
+        "116",
+        "dashboard",
+        "hard",
+        "metagraph",
+        "sign",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/116/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-116-tensorplex-docs",
       "netuid": 116,
       "slug": "sn-116",
@@ -10152,6 +10525,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-5-taostats-metagraph",
+      "netuid": 5,
+      "slug": "sn-5",
+      "subtitle": "dashboard / taostats",
+      "title": "Hone Taostats metagraph",
+      "tokens": [
+        "5",
+        "dashboard",
+        "hone",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/5/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -10481,6 +10872,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-71-taostats-metagraph",
+      "netuid": 71,
+      "slug": "sn-71",
+      "subtitle": "dashboard / taostats",
+      "title": "Leadpoet Taostats metagraph",
+      "tokens": [
+        "71",
+        "dashboard",
+        "leadpoet",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/71/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-71-tensorplex-docs",
       "netuid": 71,
       "slug": "sn-71",
@@ -10663,6 +11072,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-99-taostats-metagraph",
+      "netuid": 99,
+      "slug": "sn-99",
+      "subtitle": "dashboard / taostats",
+      "title": "Leoma Taostats metagraph",
+      "tokens": [
+        "99",
+        "dashboard",
+        "leoma",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/99/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-99-tensorplex-docs",
       "netuid": 99,
       "slug": "sn-99",
@@ -10804,6 +11231,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-77-taostats-metagraph",
+      "netuid": 77,
+      "slug": "sn-77",
+      "subtitle": "dashboard / taostats",
+      "title": "Liquidity Taostats metagraph",
+      "tokens": [
+        "77",
+        "dashboard",
+        "liquidity",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/77/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -10971,6 +11416,25 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-51-taostats-metagraph",
+      "netuid": 51,
+      "slug": "sn-51",
+      "subtitle": "dashboard / taostats",
+      "title": "lium.io Taostats metagraph",
+      "tokens": [
+        "51",
+        "dashboard",
+        "io",
+        "lium",
+        "metagraph",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/51/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -11345,6 +11809,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-107-taostats-metagraph",
+      "netuid": 107,
+      "slug": "sn-107",
+      "subtitle": "dashboard / taostats",
+      "title": "Minos Taostats metagraph",
+      "tokens": [
+        "107",
+        "dashboard",
+        "metagraph",
+        "minos",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/107/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-107-tensorplex-docs",
       "netuid": 107,
       "slug": "sn-107",
@@ -11450,6 +11932,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_112/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-112-taostats-metagraph",
+      "netuid": 112,
+      "slug": "sn-112",
+      "subtitle": "dashboard / taostats",
+      "title": "minotaur Taostats metagraph",
+      "tokens": [
+        "112",
+        "dashboard",
+        "metagraph",
+        "minotaur",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/112/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -11862,6 +12362,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-70-taostats-metagraph",
+      "netuid": 70,
+      "slug": "sn-70",
+      "subtitle": "dashboard / taostats",
+      "title": "NexisGen Taostats metagraph",
+      "tokens": [
+        "70",
+        "dashboard",
+        "metagraph",
+        "nexisgen",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/70/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-70-tensorplex-docs",
       "netuid": 70,
       "slug": "sn-70",
@@ -12139,6 +12657,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-55-taostats-metagraph",
+      "netuid": 55,
+      "slug": "sn-55",
+      "subtitle": "dashboard / taostats",
+      "title": "NIOME Taostats metagraph",
+      "tokens": [
+        "55",
+        "dashboard",
+        "metagraph",
+        "niome",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/55/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-55-tensorplex-docs",
       "netuid": 55,
       "slug": "sn-55",
@@ -12228,6 +12764,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-27-taostats-metagraph",
+      "netuid": 27,
+      "slug": "sn-27",
+      "subtitle": "dashboard / taostats",
+      "title": "Nodexo Taostats metagraph",
+      "tokens": [
+        "27",
+        "dashboard",
+        "metagraph",
+        "nodexo",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/27/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-27-tensorplex-docs",
       "netuid": 27,
       "slug": "sn-27",
@@ -12279,23 +12833,6 @@
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/68-nova"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-68-website-link-www-metanova-labs-ai-dashboard-5",
-      "netuid": 68,
-      "slug": "sn-68",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "NOVA dashboard",
-      "tokens": [
-        "68",
-        "dashboard",
-        "nova",
-        "sn",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://www.metanova-labs.ai/dashboard"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12386,6 +12923,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-68-taostats-metagraph",
+      "netuid": 68,
+      "slug": "sn-68",
+      "subtitle": "dashboard / taostats",
+      "title": "NOVA Taostats metagraph",
+      "tokens": [
+        "68",
+        "dashboard",
+        "metagraph",
+        "nova",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/68/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12600,6 +13155,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-90-taostats-metagraph",
+      "netuid": 90,
+      "slug": "sn-90",
+      "subtitle": "dashboard / taostats",
+      "title": "ogham Taostats metagraph",
+      "tokens": [
+        "90",
+        "dashboard",
+        "metagraph",
+        "ogham",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/90/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12888,6 +13461,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-35-taostats-metagraph",
+      "netuid": 35,
+      "slug": "sn-35",
+      "subtitle": "dashboard / taostats",
+      "title": "OxMarkets Taostats metagraph",
+      "tokens": [
+        "35",
+        "dashboard",
+        "metagraph",
+        "oxmarkets",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/35/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-35-tensorplex-docs",
       "netuid": 35,
       "slug": "sn-35",
@@ -12974,6 +13565,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-73-taostats-metagraph",
+      "netuid": 73,
+      "slug": "sn-73",
+      "subtitle": "dashboard / taostats",
+      "title": "Parked Taostats metagraph",
+      "tokens": [
+        "73",
+        "dashboard",
+        "metagraph",
+        "parked",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/73/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -13082,6 +13691,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_26/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-26-taostats-metagraph",
+      "netuid": 26,
+      "slug": "sn-26",
+      "subtitle": "dashboard / taostats",
+      "title": "Perturb Taostats metagraph",
+      "tokens": [
+        "26",
+        "dashboard",
+        "metagraph",
+        "perturb",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/26/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -13259,6 +13886,25 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-100-taostats-metagraph",
+      "netuid": 100,
+      "slug": "sn-100",
+      "subtitle": "dashboard / taostats",
+      "title": "Plaτform Taostats metagraph",
+      "tokens": [
+        "100",
+        "dashboard",
+        "form",
+        "metagraph",
+        "pla",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/100/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-100-tensorplex-docs",
       "netuid": 100,
       "slug": "sn-100",
@@ -13314,23 +13960,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-126-website-link-poker44-net-dashboard-1",
-      "netuid": 126,
-      "slug": "sn-126",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Poker44 dashboard",
-      "tokens": [
-        "126",
-        "dashboard",
-        "poker44",
-        "sn",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://poker44.net/dashboard"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-126-taomarketcap-source-repo",
       "netuid": 126,
       "slug": "sn-126",
@@ -13383,6 +14012,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_126/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-126-taostats-metagraph",
+      "netuid": 126,
+      "slug": "sn-126",
+      "subtitle": "dashboard / taostats",
+      "title": "Poker44 Taostats metagraph",
+      "tokens": [
+        "126",
+        "dashboard",
+        "metagraph",
+        "poker44",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/126/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -13779,6 +14426,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-31-taostats-metagraph",
+      "netuid": 31,
+      "slug": "sn-31",
+      "subtitle": "dashboard / taostats",
+      "title": "Recall Taostats metagraph",
+      "tokens": [
+        "31",
+        "dashboard",
+        "metagraph",
+        "recall",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/31/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-31-tensorplex-docs",
       "netuid": 31,
       "slug": "sn-31",
@@ -13966,6 +14631,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-119-taostats-metagraph",
+      "netuid": 119,
+      "slug": "sn-119",
+      "subtitle": "dashboard / taostats",
+      "title": "Satori Taostats metagraph",
+      "tokens": [
+        "119",
+        "dashboard",
+        "metagraph",
+        "satori",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/119/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-119-tensorplex-docs",
       "netuid": 119,
       "slug": "sn-119",
@@ -14078,6 +14761,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-44-taostats-metagraph",
+      "netuid": 44,
+      "slug": "sn-44",
+      "subtitle": "dashboard / taostats",
+      "title": "Score Taostats metagraph",
+      "tokens": [
+        "44",
+        "dashboard",
+        "metagraph",
+        "score",
+        "sn",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/44/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-44-tensorplex-docs",
       "netuid": 44,
       "slug": "sn-44",
@@ -14166,23 +14867,6 @@
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/114-soma"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-114-website-link-thesoma-ai-dashboard-6",
-      "netuid": 114,
-      "slug": "sn-114",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "SOMA dashboard",
-      "tokens": [
-        "114",
-        "dashboard",
-        "sn",
-        "soma",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://thesoma.ai/dashboard"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14277,6 +14961,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_114/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-114-taostats-metagraph",
+      "netuid": 114,
+      "slug": "sn-114",
+      "subtitle": "dashboard / taostats",
+      "title": "SOMA Taostats metagraph",
+      "tokens": [
+        "114",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "soma",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/114/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14442,6 +15144,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-86-taostats-metagraph",
+      "netuid": 86,
+      "slug": "sn-86",
+      "subtitle": "dashboard / taostats",
+      "title": "Subnet 86 Taostats metagraph",
+      "tokens": [
+        "86",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "subnet",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/86/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-86-tensorplex-docs",
       "netuid": 86,
       "slug": "sn-86",
@@ -14583,6 +15303,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-10-taostats-metagraph",
+      "netuid": 10,
+      "slug": "sn-10",
+      "subtitle": "dashboard / taostats",
+      "title": "Swap Taostats metagraph",
+      "tokens": [
+        "10",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "swap",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/10/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14891,6 +15629,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-50-taostats-metagraph",
+      "netuid": 50,
+      "slug": "sn-50",
+      "subtitle": "dashboard / taostats",
+      "title": "Synth Taostats metagraph",
+      "tokens": [
+        "50",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "synth",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/50/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-50-tensorplex-docs",
       "netuid": 50,
       "slug": "sn-50",
@@ -15032,6 +15788,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-108-taostats-metagraph",
+      "netuid": 108,
+      "slug": "sn-108",
+      "subtitle": "dashboard / taostats",
+      "title": "TalkHead Taostats metagraph",
+      "tokens": [
+        "108",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "talkhead",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/108/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15207,6 +15981,26 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-65-taostats-metagraph",
+      "netuid": 65,
+      "slug": "sn-65",
+      "subtitle": "dashboard / taostats",
+      "title": "TAO Private Network Taostats metagraph",
+      "tokens": [
+        "65",
+        "dashboard",
+        "metagraph",
+        "network",
+        "private",
+        "sn",
+        "tao",
+        "taostats"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/65/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15502,23 +16296,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-11-website-link-trajrl-com-dashboard-3",
-      "netuid": 11,
-      "slug": "sn-11",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "TrajectoryRL dashboard",
-      "tokens": [
-        "11",
-        "dashboard",
-        "sn",
-        "taomarketcap",
-        "trajectoryrl"
-      ],
-      "type": "surface",
-      "url": "https://trajrl.com/leaderboard"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-11-website-common-docs",
       "netuid": 11,
       "slug": "sn-11",
@@ -15588,6 +16365,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-11-taostats-metagraph",
+      "netuid": 11,
+      "slug": "sn-11",
+      "subtitle": "dashboard / taostats",
+      "title": "TrajectoryRL Taostats metagraph",
+      "tokens": [
+        "11",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats",
+        "trajectoryrl"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/11/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15698,23 +16493,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-8-website-link-www-vantanetwork-io-dashboard-1",
-      "netuid": 8,
-      "slug": "sn-8",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Vanta dashboard",
-      "tokens": [
-        "8",
-        "dashboard",
-        "sn",
-        "taomarketcap",
-        "vanta"
-      ],
-      "type": "surface",
-      "url": "https://www.vantanetwork.io/dashboard"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-8-taomarketcap-source-repo",
       "netuid": 8,
       "slug": "sn-8",
@@ -15767,6 +16545,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-8-taostats-metagraph",
+      "netuid": 8,
+      "slug": "sn-8",
+      "subtitle": "dashboard / taostats",
+      "title": "Vanta Taostats metagraph",
+      "tokens": [
+        "8",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats",
+        "vanta"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/8/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16147,6 +16943,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-78-taostats-metagraph",
+      "netuid": 78,
+      "slug": "sn-78",
+      "subtitle": "dashboard / taostats",
+      "title": "Vocence Taostats metagraph",
+      "tokens": [
+        "78",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats",
+        "vocence"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/78/metagraph"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-78-tensorplex-docs",
       "netuid": 78,
       "slug": "sn-78",
@@ -16269,6 +17083,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-106-taostats-metagraph",
+      "netuid": 106,
+      "slug": "sn-106",
+      "subtitle": "dashboard / taostats",
+      "title": "VoidAI Taostats metagraph",
+      "tokens": [
+        "106",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats",
+        "voidai"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/106/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16457,23 +17289,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-18-website-link-www-zeussubnet-com-dashboard-5",
-      "netuid": 18,
-      "slug": "sn-18",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Zeus dashboard",
-      "tokens": [
-        "18",
-        "dashboard",
-        "sn",
-        "taomarketcap",
-        "zeus"
-      ],
-      "type": "surface",
-      "url": "https://www.zeussubnet.com/dashboard"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-18-website-link-www-zeussubnet-com-docs-4",
       "netuid": 18,
       "slug": "sn-18",
@@ -16543,6 +17358,24 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-18-taostats-metagraph",
+      "netuid": 18,
+      "slug": "sn-18",
+      "subtitle": "dashboard / taostats",
+      "title": "Zeus Taostats metagraph",
+      "tokens": [
+        "18",
+        "dashboard",
+        "metagraph",
+        "sn",
+        "taostats",
+        "zeus"
+      ],
+      "type": "surface",
+      "url": "https://taostats.io/subnets/18/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",

--- a/public/metagraph/subnets.json
+++ b/public/metagraph/subnets.json
@@ -13,7 +13,7 @@
   "subnets": [
     {
       "block": 8357554,
-      "candidate_count": 3,
+      "candidate_count": 4,
       "categories": [
         "root",
         "system",
@@ -43,7 +43,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -76,7 +76,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -104,7 +104,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "decentralized-training",
@@ -136,7 +136,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -167,7 +167,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -182,20 +182,20 @@
       "native_name_quality": "chain",
       "netuid": 5,
       "participant_count": 256,
-      "probed_surface_count": 6,
+      "probed_surface_count": 7,
       "registered_at_block": 2491604,
       "slug": "sn-5",
       "source_repo": "https://github.com/manifold-inc/hone",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "ε",
       "tempo": 360,
       "website_url": "https://www.hone.training/"
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -223,7 +223,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "bitcoin",
         "subnet-api",
@@ -253,7 +253,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -281,7 +281,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -314,7 +314,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -329,20 +329,20 @@
       "native_name_quality": "chain",
       "netuid": 10,
       "participant_count": 256,
-      "probed_surface_count": 6,
+      "probed_surface_count": 7,
       "registered_at_block": 2869647,
       "slug": "sn-10",
       "source_repo": "https://github.com/Swap-Subnet/swap-subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "κ",
       "tempo": 360,
       "website_url": "https://www.taofi.com/pool"
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -370,7 +370,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "compute",
@@ -402,7 +402,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-curated",
         "data",
@@ -436,7 +436,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -464,7 +464,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -496,7 +496,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -511,20 +511,20 @@
       "native_name_quality": "chain",
       "netuid": 16,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 2765446,
       "slug": "sn-16",
       "source_repo": "https://github.com/FirstTensorLabs/BitAds",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "π",
       "tempo": 360,
       "website_url": "https://bitads.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -552,7 +552,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -580,7 +580,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -612,7 +612,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated",
         "capital-markets",
@@ -642,7 +642,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "advertising",
         "baseline-curated",
@@ -674,7 +674,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -710,7 +710,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -742,7 +742,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -776,7 +776,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "compute",
@@ -808,7 +808,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -823,20 +823,20 @@
       "native_name_quality": "chain",
       "netuid": 26,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 8123781,
       "slug": "sn-26",
       "source_repo": "https://github.com/0xsigurd/Perturb",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ב",
       "tempo": 360,
       "website_url": "https://www.perturbai.io/"
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -851,20 +851,20 @@
       "native_name_quality": "chain",
       "netuid": 27,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 1727132,
       "slug": "sn-27",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ג",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -879,20 +879,20 @@
       "native_name_quality": "chain",
       "netuid": 28,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 4878363,
       "slug": "sn-28",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ד",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "data",
@@ -926,7 +926,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated",
         "defi",
@@ -959,7 +959,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -974,20 +974,20 @@
       "native_name_quality": "chain",
       "netuid": 31,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 7173591,
       "slug": "sn-31",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ז",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1018,7 +1018,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-curated",
         "conversation-data",
@@ -1052,7 +1052,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "deepfake-detection",
@@ -1086,7 +1086,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -1101,20 +1101,20 @@
       "native_name_quality": "chain",
       "netuid": 35,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 3037158,
       "slug": "sn-35",
       "source_repo": "https://github.com/General-Tao-Ventures/cartha-validator",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ך",
       "tempo": 360,
       "website_url": "https://www.0xmarkets.io/"
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -1142,7 +1142,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -1157,20 +1157,20 @@
       "native_name_quality": "chain",
       "netuid": 37,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 3212175,
       "slug": "sn-37",
       "source_repo": "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ל",
       "tempo": 360,
       "website_url": "https://aureliusaligned.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -1185,20 +1185,20 @@
       "native_name_quality": "chain",
       "netuid": 38,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 7284230,
       "slug": "sn-38",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ם",
       "tempo": 360,
       "website_url": "https://www.taocolosseum.com/"
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "compute",
@@ -1230,7 +1230,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -1245,20 +1245,20 @@
       "native_name_quality": "chain",
       "netuid": 40,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 3372582,
       "slug": "sn-40",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ן",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -1273,20 +1273,20 @@
       "native_name_quality": "chain",
       "netuid": 41,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 3394182,
       "slug": "sn-41",
       "source_repo": "https://github.com/sportstensor/sn41",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "נ",
       "tempo": 360,
       "website_url": "https://almanac.market/"
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated",
         "data",
@@ -1320,7 +1320,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1353,7 +1353,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -1368,20 +1368,20 @@
       "native_name_quality": "chain",
       "netuid": 44,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 3550319,
       "slug": "sn-44",
       "source_repo": "https://github.com/score-technologies/turbovision",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ף",
       "tempo": 360,
       "website_url": "https://www.wearescore.com/"
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1412,7 +1412,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated"
       ],
@@ -1440,7 +1440,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-curated",
         "data",
@@ -1471,7 +1471,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "compute",
@@ -1504,7 +1504,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1540,7 +1540,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -1555,20 +1555,20 @@
       "native_name_quality": "chain",
       "netuid": 50,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 4763204,
       "slug": "sn-50",
       "source_repo": "https://github.com/mode-network/synth-subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ש",
       "tempo": 360,
       "website_url": "https://synthdata.co/"
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated"
       ],
@@ -1583,20 +1583,20 @@
       "native_name_quality": "chain",
       "netuid": 51,
       "participant_count": 256,
-      "probed_surface_count": 9,
+      "probed_surface_count": 10,
       "registered_at_block": 3966206,
       "slug": "sn-51",
       "source_repo": "https://github.com/Datura-ai/lium-io",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "ת",
       "tempo": 360,
       "website_url": "https://lium.io/"
     },
     {
       "block": 8357554,
-      "candidate_count": 9,
+      "candidate_count": 10,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1629,7 +1629,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -1644,20 +1644,20 @@
       "native_name_quality": "chain",
       "netuid": 53,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 4203869,
       "slug": "sn-53",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ب",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -1685,7 +1685,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -1700,20 +1700,20 @@
       "native_name_quality": "chain",
       "netuid": 55,
       "participant_count": 256,
-      "probed_surface_count": 6,
+      "probed_surface_count": 7,
       "registered_at_block": 4703386,
       "slug": "sn-55",
       "source_repo": "https://github.com/genomesio/subnet-niome",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "ث",
       "tempo": 360,
       "website_url": "https://niome.genomes.io/"
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated"
       ],
@@ -1728,20 +1728,20 @@
       "native_name_quality": "chain",
       "netuid": 56,
       "participant_count": 256,
-      "probed_surface_count": 10,
+      "probed_surface_count": 11,
       "registered_at_block": 4312927,
       "slug": "sn-56",
       "source_repo": "https://github.com/gradients-ai/G.O.D",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "ج",
       "tempo": 360,
       "website_url": "https://www.gradients.io/"
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1774,7 +1774,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "ai-marketplace",
         "baseline-curated",
@@ -1809,7 +1809,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -1837,7 +1837,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -1852,20 +1852,20 @@
       "native_name_quality": "chain",
       "netuid": 60,
       "participant_count": 256,
-      "probed_surface_count": 10,
+      "probed_surface_count": 11,
       "registered_at_block": 4796992,
       "slug": "sn-60",
       "source_repo": "https://github.com/Bitsec-AI/sandbox",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "ذ",
       "tempo": 360,
       "website_url": "https://bitsec.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated",
         "cybersecurity",
@@ -1899,7 +1899,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "agents",
         "baseline-curated",
@@ -1930,7 +1930,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -1962,7 +1962,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 27,
+      "candidate_count": 28,
       "categories": [
         "baseline-curated",
         "compute",
@@ -1997,7 +1997,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -2012,20 +2012,20 @@
       "native_name_quality": "chain",
       "netuid": 65,
       "participant_count": 256,
-      "probed_surface_count": 9,
+      "probed_surface_count": 10,
       "registered_at_block": 4950813,
       "slug": "sn-65",
       "source_repo": "https://github.com/taofu-labs/tpn-subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "ص",
       "tempo": 360,
       "website_url": "https://tpn.taofu.xyz/"
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2060,7 +2060,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -2088,7 +2088,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -2116,7 +2116,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -2131,20 +2131,20 @@
       "native_name_quality": "chain",
       "netuid": 69,
       "participant_count": 162,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 8138182,
       "slug": "sn-69",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ع",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -2159,20 +2159,20 @@
       "native_name_quality": "chain",
       "netuid": 70,
       "participant_count": 236,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 7787562,
       "slug": "sn-70",
       "source_repo": "https://github.com/RendixNetwork/nexisgen",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "غ",
       "tempo": 360,
       "website_url": "https://nexisgen.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -2187,20 +2187,20 @@
       "native_name_quality": "chain",
       "netuid": 71,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 5048438,
       "slug": "sn-71",
       "source_repo": "https://github.com/leadpoet/leadpoet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ㄴ",
       "tempo": 360,
       "website_url": "https://leadpoet.com/"
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated",
         "computer-vision",
@@ -2235,7 +2235,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -2250,20 +2250,20 @@
       "native_name_quality": "chain",
       "netuid": 73,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 5160047,
       "slug": "sn-73",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ك",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "developer-tools",
         "repositories",
@@ -2293,7 +2293,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-curated",
         "depin",
@@ -2327,7 +2327,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2357,7 +2357,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -2372,20 +2372,20 @@
       "native_name_quality": "chain",
       "netuid": 77,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 5128460,
       "slug": "sn-77",
       "source_repo": "https://github.com/creativebuilds/sn77",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ه",
       "tempo": 360,
       "website_url": "https://sn77.xyz/"
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -2400,20 +2400,20 @@
       "native_name_quality": "chain",
       "netuid": 78,
       "participant_count": 256,
-      "probed_surface_count": 10,
+      "probed_surface_count": 11,
       "registered_at_block": 7966145,
       "slug": "sn-78",
       "source_repo": "https://github.com/vocence-78/vocence",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "و",
       "tempo": 360,
       "website_url": "https://www.vocence.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2444,7 +2444,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -2459,20 +2459,20 @@
       "native_name_quality": "chain",
       "netuid": 80,
       "participant_count": 256,
-      "probed_surface_count": 10,
+      "probed_surface_count": 9,
       "registered_at_block": 7151800,
       "slug": "sn-80",
       "source_repo": "https://github.com/dogelayer-ai/dogelayer",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 10,
+      "surface_count": 9,
       "symbol": "ى",
       "tempo": 360,
       "website_url": "https://dogelayer.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "decentralized-training",
@@ -2504,7 +2504,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2535,7 +2535,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -2550,20 +2550,20 @@
       "native_name_quality": "chain",
       "netuid": 83,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 5231190,
       "slug": "sn-83",
       "source_repo": "https://github.com/toptensor/CliqueAI",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ᚦ",
       "tempo": 360,
       "website_url": "https://cliqueai.toptensor.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "chip-design",
@@ -2597,7 +2597,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2627,7 +2627,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -2642,20 +2642,20 @@
       "native_name_quality": "placeholder",
       "netuid": 86,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 6914378,
       "slug": "sn-86",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ᚳ",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2688,7 +2688,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated",
         "data-artifact",
@@ -2722,7 +2722,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2752,7 +2752,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -2767,20 +2767,20 @@
       "native_name_quality": "chain",
       "netuid": 90,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 7063126,
       "slug": "sn-90",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": " ",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2810,7 +2810,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "stale-source-cleanup"
@@ -2839,7 +2839,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -2867,7 +2867,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -2895,7 +2895,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -2910,20 +2910,20 @@
       "native_name_quality": "chain",
       "netuid": 95,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 5403674,
       "slug": "sn-95",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "ᚅ",
       "tempo": 360,
       "website_url": "https://actual.inc/"
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -2959,7 +2959,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -2974,20 +2974,20 @@
       "native_name_quality": "chain",
       "netuid": 97,
       "participant_count": 256,
-      "probed_surface_count": 10,
+      "probed_surface_count": 11,
       "registered_at_block": 7735450,
       "slug": "sn-97",
       "source_repo": "https://github.com/unarbos/albedo",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "ა",
       "tempo": 360,
       "website_url": "https://us-east-1.hippius.com/albedo/index.html"
     },
     {
       "block": 8357554,
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-curated",
         "finance",
@@ -3019,7 +3019,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -3034,20 +3034,20 @@
       "native_name_quality": "chain",
       "netuid": 99,
       "participant_count": 256,
-      "probed_surface_count": 10,
+      "probed_surface_count": 11,
       "registered_at_block": 7415113,
       "slug": "sn-99",
       "source_repo": "https://github.com/RendixNetwork/leoma",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "გ",
       "tempo": 360,
       "website_url": "https://leoma.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -3062,20 +3062,20 @@
       "native_name_quality": "chain",
       "netuid": 100,
       "participant_count": 256,
-      "probed_surface_count": 9,
+      "probed_surface_count": 10,
       "registered_at_block": 6693448,
       "slug": "sn-100",
       "source_repo": "https://github.com/PlatformNetwork/platform",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "დ",
       "tempo": 360,
       "website_url": "https://platform.network/"
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -3090,20 +3090,20 @@
       "native_name_quality": "chain",
       "netuid": 101,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 5481350,
       "slug": "sn-101",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ე",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3134,7 +3134,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3165,7 +3165,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -3180,20 +3180,20 @@
       "native_name_quality": "chain",
       "netuid": 104,
       "participant_count": 64,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 5528520,
       "slug": "sn-104",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "Բ",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -3208,20 +3208,20 @@
       "native_name_quality": "chain",
       "netuid": 105,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 6841399,
       "slug": "sn-105",
       "source_repo": "https://github.com/orgs/Beam-Network/repositories",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "Գ",
       "tempo": 360,
       "website_url": "https://b1m.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 12,
+      "candidate_count": 13,
       "categories": [
         "baseline-curated"
       ],
@@ -3236,20 +3236,20 @@
       "native_name_quality": "chain",
       "netuid": 106,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 5558480,
       "slug": "sn-106",
       "source_repo": "https://github.com/v0idai/SN106",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "Դ",
       "tempo": 360,
       "website_url": "https://voidai.com/"
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -3264,20 +3264,20 @@
       "native_name_quality": "chain",
       "netuid": 107,
       "participant_count": 64,
-      "probed_surface_count": 10,
+      "probed_surface_count": 11,
       "registered_at_block": 7457580,
       "slug": "sn-107",
       "source_repo": "https://github.com/minos-protocol/minos_subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 10,
+      "surface_count": 11,
       "symbol": "ミ",
       "tempo": 360,
       "website_url": "https://theminos.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -3292,20 +3292,20 @@
       "native_name_quality": "chain",
       "netuid": 108,
       "participant_count": 150,
-      "probed_surface_count": 6,
+      "probed_surface_count": 7,
       "registered_at_block": 7105263,
       "slug": "sn-108",
       "source_repo": "https://github.com/talkheadai/talkhead-subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "Զ",
       "tempo": 360,
       "website_url": "https://www.talkhead.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3335,7 +3335,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3367,7 +3367,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "data",
@@ -3400,7 +3400,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -3415,20 +3415,20 @@
       "native_name_quality": "chain",
       "netuid": 112,
       "participant_count": 256,
-      "probed_surface_count": 6,
+      "probed_surface_count": 7,
       "registered_at_block": 5633022,
       "slug": "sn-112",
       "source_repo": "https://github.com/subnet112/minotaur_subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "Ђ",
       "tempo": 360,
       "website_url": "https://minotaursubnet.com/"
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3461,7 +3461,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-curated"
       ],
@@ -3489,7 +3489,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3519,7 +3519,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -3534,20 +3534,20 @@
       "native_name_quality": "chain",
       "netuid": 116,
       "participant_count": 73,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 8294730,
       "slug": "sn-116",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "ъ",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated",
         "identity-dispute",
@@ -3578,7 +3578,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated"
       ],
@@ -3593,20 +3593,20 @@
       "native_name_quality": "chain",
       "netuid": 118,
       "participant_count": 256,
-      "probed_surface_count": 9,
+      "probed_surface_count": 10,
       "registered_at_block": 5724794,
       "slug": "sn-118",
       "source_repo": "https://github.com/orgs/ditto-assistant/repositories",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "ⲁ",
       "tempo": 360,
       "website_url": "https://heyditto.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -3621,20 +3621,20 @@
       "native_name_quality": "chain",
       "netuid": 119,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 5740660,
       "slug": "sn-119",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "Ⲃ",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -3662,7 +3662,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3693,7 +3693,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3726,7 +3726,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated",
         "identity-reviewed",
@@ -3756,7 +3756,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -3784,7 +3784,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-curated"
       ],
@@ -3799,20 +3799,20 @@
       "native_name_quality": "chain",
       "netuid": 125,
       "participant_count": 256,
-      "probed_surface_count": 4,
+      "probed_surface_count": 5,
       "registered_at_block": 5834408,
       "slug": "sn-125",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 4,
+      "surface_count": 5,
       "symbol": "𑀂",
       "tempo": 360,
       "website_url": null
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -3840,7 +3840,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -3855,20 +3855,20 @@
       "native_name_quality": "chain",
       "netuid": 127,
       "participant_count": 256,
-      "probed_surface_count": 6,
+      "probed_surface_count": 7,
       "registered_at_block": 5848837,
       "slug": "sn-127",
       "source_repo": "https://github.com/astridintelligence/sn-127",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "𑀅",
       "tempo": 360,
       "website_url": "https://www.astrid.global/"
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -3883,13 +3883,13 @@
       "native_name_quality": "chain",
       "netuid": 128,
       "participant_count": 256,
-      "probed_surface_count": 9,
+      "probed_surface_count": 10,
       "registered_at_block": 5856038,
       "slug": "sn-128",
       "source_repo": "https://github.com/byteleapai/byteleap-Miner",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 9,
+      "surface_count": 10,
       "symbol": "න",
       "tempo": 360,
       "website_url": "https://byteleap.ai/"

--- a/public/metagraph/surfaces.json
+++ b/public/metagraph/surfaces.json
@@ -978,6 +978,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-5-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Hone Taostats metagraph",
+      "netuid": 5,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/5/metagraph"
+      ],
+      "subnet_name": "Hone",
+      "subnet_slug": "sn-5",
+      "url": "https://taostats.io/subnets/5/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-5-tensorplex-docs",
       "kind": "docs",
       "name": "Hone Tensorplex subnet docs",
@@ -1668,6 +1700,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-8-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Vanta Taostats metagraph",
+      "netuid": 8,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/8/metagraph"
+      ],
+      "subnet_name": "Vanta",
+      "subnet_slug": "sn-8",
+      "url": "https://taostats.io/subnets/8/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-8-tensorplex-docs",
       "kind": "docs",
       "name": "Vanta Tensorplex subnet docs",
@@ -1696,38 +1760,6 @@
       "subnet_name": "Vanta",
       "subnet_slug": "sn-8",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/8"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-8-website-link-www-vantanetwork-io-dashboard-1",
-      "kind": "dashboard",
-      "name": "Vanta dashboard",
-      "netuid": 8,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://www.vantanetwork.io/"
-      ],
-      "subnet_name": "Vanta",
-      "subnet_slug": "sn-8",
-      "url": "https://www.vantanetwork.io/dashboard"
     },
     {
       "auth_required": false,
@@ -1961,6 +1993,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-10-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Swap Taostats metagraph",
+      "netuid": 10,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/10/metagraph"
+      ],
+      "subnet_name": "Swap",
+      "subnet_slug": "sn-10",
+      "url": "https://taostats.io/subnets/10/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-10-tensorplex-docs",
       "kind": "docs",
       "name": "Swap Tensorplex subnet docs",
@@ -2153,6 +2217,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-11-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "TrajectoryRL Taostats metagraph",
+      "netuid": 11,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/11/metagraph"
+      ],
+      "subnet_name": "TrajectoryRL",
+      "subnet_slug": "sn-11",
+      "url": "https://taostats.io/subnets/11/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-11-tensorplex-docs",
       "kind": "docs",
       "name": "TrajectoryRL Tensorplex subnet docs",
@@ -2213,38 +2309,6 @@
       "subnet_name": "TrajectoryRL",
       "subnet_slug": "sn-11",
       "url": "https://trajrl.com/docs"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-11-website-link-trajrl-com-dashboard-3",
-      "kind": "dashboard",
-      "name": "TrajectoryRL dashboard",
-      "netuid": 11,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://trajrl.com/"
-      ],
-      "subnet_name": "TrajectoryRL",
-      "subnet_slug": "sn-11",
-      "url": "https://trajrl.com/leaderboard"
     },
     {
       "auth_required": false,
@@ -2540,6 +2604,7 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
+        "https://cacheon.ai/",
         "https://github.com/latent-to/cacheon/blob/main/README.md"
       ],
       "subnet_name": "Cacheon",
@@ -3027,6 +3092,38 @@
       "subnet_name": "BitAds",
       "subnet_slug": "sn-16",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-16-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "BitAds Taostats metagraph",
+      "netuid": 16,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/16/metagraph"
+      ],
+      "subnet_name": "BitAds",
+      "subnet_slug": "sn-16",
+      "url": "https://taostats.io/subnets/16/metagraph"
     },
     {
       "auth_required": false,
@@ -3542,6 +3639,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-18-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Zeus Taostats metagraph",
+      "netuid": 18,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/18/metagraph"
+      ],
+      "subnet_name": "Zeus",
+      "subnet_slug": "sn-18",
+      "url": "https://taostats.io/subnets/18/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-18-tensorplex-docs",
       "kind": "docs",
       "name": "Zeus Tensorplex subnet docs",
@@ -3570,38 +3699,6 @@
       "subnet_name": "Zeus",
       "subnet_slug": "sn-18",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/18"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-18-website-link-www-zeussubnet-com-dashboard-5",
-      "kind": "dashboard",
-      "name": "Zeus dashboard",
-      "netuid": 18,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://www.zeussubnet.com/"
-      ],
-      "subnet_name": "Zeus",
-      "subnet_slug": "sn-18",
-      "url": "https://www.zeussubnet.com/dashboard"
     },
     {
       "auth_required": false,
@@ -4423,6 +4520,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-26-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Perturb Taostats metagraph",
+      "netuid": 26,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/26/metagraph"
+      ],
+      "subnet_name": "Perturb",
+      "subnet_slug": "sn-26",
+      "url": "https://taostats.io/subnets/26/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-26-tensorplex-docs",
       "kind": "docs",
       "name": "Perturb Tensorplex subnet docs",
@@ -4583,6 +4712,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-27-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Nodexo Taostats metagraph",
+      "netuid": 27,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/27/metagraph"
+      ],
+      "subnet_name": "Nodexo",
+      "subnet_slug": "sn-27",
+      "url": "https://taostats.io/subnets/27/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-27-tensorplex-docs",
       "kind": "docs",
       "name": "Nodexo Tensorplex subnet docs",
@@ -4707,6 +4868,38 @@
       "subnet_name": "gm",
       "subnet_slug": "sn-28",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-28-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "gm Taostats metagraph",
+      "netuid": 28,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/28/metagraph"
+      ],
+      "subnet_name": "gm",
+      "subnet_slug": "sn-28",
+      "url": "https://taostats.io/subnets/28/metagraph"
     },
     {
       "auth_required": false,
@@ -5023,6 +5216,38 @@
       "subnet_name": "Recall",
       "subnet_slug": "sn-31",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-31-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Recall Taostats metagraph",
+      "netuid": 31,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/31/metagraph"
+      ],
+      "subnet_name": "Recall",
+      "subnet_slug": "sn-31",
+      "url": "https://taostats.io/subnets/31/metagraph"
     },
     {
       "auth_required": false,
@@ -5475,6 +5700,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-35-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "OxMarkets Taostats metagraph",
+      "netuid": 35,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/35/metagraph"
+      ],
+      "subnet_name": "OxMarkets",
+      "subnet_slug": "sn-35",
+      "url": "https://taostats.io/subnets/35/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-35-tensorplex-docs",
       "kind": "docs",
       "name": "OxMarkets Tensorplex subnet docs",
@@ -5697,6 +5954,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-36-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Eirel Taostats metagraph",
+      "netuid": 36,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/36/metagraph"
+      ],
+      "subnet_name": "Eirel",
+      "subnet_slug": "sn-36",
+      "url": "https://taostats.io/subnets/36/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-36-tensorplex-docs",
       "kind": "docs",
       "name": "Eirel Tensorplex subnet docs",
@@ -5757,38 +6046,6 @@
       "subnet_name": "Eirel",
       "subnet_slug": "sn-36",
       "url": "https://eirel.ai/docs"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-36-website-link-eirel-ai-dashboard-3",
-      "kind": "dashboard",
-      "name": "Eirel dashboard",
-      "netuid": 36,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://eirel.ai/"
-      ],
-      "subnet_name": "Eirel",
-      "subnet_slug": "sn-36",
-      "url": "https://leaderboard.eirel.ai/"
     },
     {
       "auth_required": false,
@@ -5948,6 +6205,38 @@
       "subnet_name": "Aurelius",
       "subnet_slug": "sn-37",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-37-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Aurelius Taostats metagraph",
+      "netuid": 37,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/37/metagraph"
+      ],
+      "subnet_name": "Aurelius",
+      "subnet_slug": "sn-37",
+      "url": "https://taostats.io/subnets/37/metagraph"
     },
     {
       "auth_required": false,
@@ -6140,6 +6429,38 @@
       "subnet_name": "colosseum",
       "subnet_slug": "sn-38",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-38-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "colosseum Taostats metagraph",
+      "netuid": 38,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/38/metagraph"
+      ],
+      "subnet_name": "colosseum",
+      "subnet_slug": "sn-38",
+      "url": "https://taostats.io/subnets/38/metagraph"
     },
     {
       "auth_required": false,
@@ -6385,6 +6706,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-40-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Chunking Taostats metagraph",
+      "netuid": 40,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/40/metagraph"
+      ],
+      "subnet_name": "Chunking",
+      "subnet_slug": "sn-40",
+      "url": "https://taostats.io/subnets/40/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-40-tensorplex-docs",
       "kind": "docs",
       "name": "Chunking Tensorplex subnet docs",
@@ -6573,6 +6926,38 @@
       "subnet_name": "Almanac",
       "subnet_slug": "sn-41",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-41-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Almanac Taostats metagraph",
+      "netuid": 41,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/41/metagraph"
+      ],
+      "subnet_name": "Almanac",
+      "subnet_slug": "sn-41",
+      "url": "https://taostats.io/subnets/41/metagraph"
     },
     {
       "auth_required": false,
@@ -6926,6 +7311,38 @@
       "subnet_name": "Score",
       "subnet_slug": "sn-44",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_44/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-44-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Score Taostats metagraph",
+      "netuid": 44,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/44/metagraph"
+      ],
+      "subnet_name": "Score",
+      "subnet_slug": "sn-44",
+      "url": "https://taostats.io/subnets/44/metagraph"
     },
     {
       "auth_required": false,
@@ -7852,6 +8269,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-50-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Synth Taostats metagraph",
+      "netuid": 50,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/50/metagraph"
+      ],
+      "subnet_name": "Synth",
+      "subnet_slug": "sn-50",
+      "url": "https://taostats.io/subnets/50/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-50-tensorplex-docs",
       "kind": "docs",
       "name": "Synth Tensorplex subnet docs",
@@ -8137,6 +8586,38 @@
       "subnet_name": "lium.io",
       "subnet_slug": "sn-51",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-51-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "lium.io Taostats metagraph",
+      "netuid": 51,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/51/metagraph"
+      ],
+      "subnet_name": "lium.io",
+      "subnet_slug": "sn-51",
+      "url": "https://taostats.io/subnets/51/metagraph"
     },
     {
       "auth_required": false,
@@ -8445,6 +8926,38 @@
       "subnet_name": "EfficientFrontier",
       "subnet_slug": "sn-53",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-53-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "EfficientFrontier Taostats metagraph",
+      "netuid": 53,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/53/metagraph"
+      ],
+      "subnet_name": "EfficientFrontier",
+      "subnet_slug": "sn-53",
+      "url": "https://taostats.io/subnets/53/metagraph"
     },
     {
       "auth_required": false,
@@ -8865,6 +9378,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-55-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "NIOME Taostats metagraph",
+      "netuid": 55,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/55/metagraph"
+      ],
+      "subnet_name": "NIOME",
+      "subnet_slug": "sn-55",
+      "url": "https://taostats.io/subnets/55/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-55-tensorplex-docs",
       "kind": "docs",
       "name": "NIOME Tensorplex subnet docs",
@@ -9052,6 +9597,38 @@
       "subnet_name": "Gradients",
       "subnet_slug": "sn-56",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-56-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Gradients Taostats metagraph",
+      "netuid": 56,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/56/metagraph"
+      ],
+      "subnet_name": "Gradients",
+      "subnet_slug": "sn-56",
+      "url": "https://taostats.io/subnets/56/metagraph"
     },
     {
       "auth_required": false,
@@ -9693,6 +10270,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-59-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Babelbit Taostats metagraph",
+      "netuid": 59,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/59/metagraph"
+      ],
+      "subnet_name": "Babelbit",
+      "subnet_slug": "sn-59",
+      "url": "https://taostats.io/subnets/59/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-59-tensorplex-docs",
       "kind": "docs",
       "name": "Babelbit Tensorplex subnet docs",
@@ -9721,38 +10330,6 @@
       "subnet_name": "Babelbit",
       "subnet_slug": "sn-59",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/59"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-59-website-link-babelbit-ai-dashboard-1",
-      "kind": "dashboard",
-      "name": "Babelbit dashboard",
-      "netuid": 59,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://babelbit.ai/"
-      ],
-      "subnet_name": "Babelbit",
-      "subnet_slug": "sn-59",
-      "url": "https://babelbit.ai/main/dashboard"
     },
     {
       "auth_required": false,
@@ -9944,6 +10521,38 @@
       "subnet_name": "Bitsec.ai",
       "subnet_slug": "sn-60",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-60-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Bitsec.ai Taostats metagraph",
+      "netuid": 60,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/60/metagraph"
+      ],
+      "subnet_name": "Bitsec.ai",
+      "subnet_slug": "sn-60",
+      "url": "https://taostats.io/subnets/60/metagraph"
     },
     {
       "auth_required": false,
@@ -10651,6 +11260,38 @@
       "subnet_name": "TAO Private Network",
       "subnet_slug": "sn-65",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-65-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "TAO Private Network Taostats metagraph",
+      "netuid": 65,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/65/metagraph"
+      ],
+      "subnet_name": "TAO Private Network",
+      "subnet_slug": "sn-65",
+      "url": "https://taostats.io/subnets/65/metagraph"
     },
     {
       "auth_required": false,
@@ -11378,6 +12019,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-68-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "NOVA Taostats metagraph",
+      "netuid": 68,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/68/metagraph"
+      ],
+      "subnet_name": "NOVA",
+      "subnet_slug": "sn-68",
+      "url": "https://taostats.io/subnets/68/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-68-tensorplex-docs",
       "kind": "docs",
       "name": "NOVA Tensorplex subnet docs",
@@ -11406,38 +12079,6 @@
       "subnet_name": "NOVA",
       "subnet_slug": "sn-68",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/68"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-68-website-link-www-metanova-labs-ai-dashboard-5",
-      "kind": "dashboard",
-      "name": "NOVA dashboard",
-      "netuid": 68,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://www.metanova-labs.ai/"
-      ],
-      "subnet_name": "NOVA",
-      "subnet_slug": "sn-68",
-      "url": "https://www.metanova-labs.ai/dashboard"
     },
     {
       "auth_required": false,
@@ -11598,6 +12239,38 @@
       "subnet_name": "ain",
       "subnet_slug": "sn-69",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-69-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ain Taostats metagraph",
+      "netuid": 69,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/69/metagraph"
+      ],
+      "subnet_name": "ain",
+      "subnet_slug": "sn-69",
+      "url": "https://taostats.io/subnets/69/metagraph"
     },
     {
       "auth_required": false,
@@ -11789,6 +12462,38 @@
       "subnet_name": "NexisGen",
       "subnet_slug": "sn-70",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-70-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "NexisGen Taostats metagraph",
+      "netuid": 70,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/70/metagraph"
+      ],
+      "subnet_name": "NexisGen",
+      "subnet_slug": "sn-70",
+      "url": "https://taostats.io/subnets/70/metagraph"
     },
     {
       "auth_required": false,
@@ -12045,6 +12750,38 @@
       "subnet_name": "Leadpoet",
       "subnet_slug": "sn-71",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-71-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Leadpoet Taostats metagraph",
+      "netuid": 71,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/71/metagraph"
+      ],
+      "subnet_name": "Leadpoet",
+      "subnet_slug": "sn-71",
+      "url": "https://taostats.io/subnets/71/metagraph"
     },
     {
       "auth_required": false,
@@ -12380,6 +13117,38 @@
       "subnet_name": "Parked",
       "subnet_slug": "sn-73",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-73-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Parked Taostats metagraph",
+      "netuid": 73,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/73/metagraph"
+      ],
+      "subnet_name": "Parked",
+      "subnet_slug": "sn-73",
+      "url": "https://taostats.io/subnets/73/metagraph"
     },
     {
       "auth_required": false,
@@ -12847,6 +13616,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-77-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Liquidity Taostats metagraph",
+      "netuid": 77,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/77/metagraph"
+      ],
+      "subnet_name": "Liquidity",
+      "subnet_slug": "sn-77",
+      "url": "https://taostats.io/subnets/77/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-77-tensorplex-docs",
       "kind": "docs",
       "name": "Liquidity Tensorplex subnet docs",
@@ -13099,6 +13900,38 @@
       "subnet_name": "Vocence",
       "subnet_slug": "sn-78",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-78-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Vocence Taostats metagraph",
+      "netuid": 78,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/78/metagraph"
+      ],
+      "subnet_name": "Vocence",
+      "subnet_slug": "sn-78",
+      "url": "https://taostats.io/subnets/78/metagraph"
     },
     {
       "auth_required": false,
@@ -13491,6 +14324,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-80-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "dogelayer Taostats metagraph",
+      "netuid": 80,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/80/metagraph"
+      ],
+      "subnet_name": "dogelayer",
+      "subnet_slug": "sn-80",
+      "url": "https://taostats.io/subnets/80/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-80-tensorplex-docs",
       "kind": "docs",
       "name": "dogelayer Tensorplex subnet docs",
@@ -13584,70 +14449,6 @@
       "subnet_name": "dogelayer",
       "subnet_slug": "sn-80",
       "url": "https://dogelayer.ai/swagger"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-80-website-link-dogelayer-ai-dashboard-1",
-      "kind": "dashboard",
-      "name": "dogelayer dashboard",
-      "netuid": 80,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://dogelayer.ai/"
-      ],
-      "subnet_name": "dogelayer",
-      "subnet_slug": "sn-80",
-      "url": "https://dogelayer.ai/en/dashboard"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-80-website-link-dogelayer-ai-docs-2",
-      "kind": "docs",
-      "name": "dogelayer docs",
-      "netuid": 80,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://dogelayer.ai/"
-      ],
-      "subnet_name": "dogelayer",
-      "subnet_slug": "sn-80",
-      "url": "https://dogelayer.ai/en/docs"
     },
     {
       "auth_required": false,
@@ -13924,6 +14725,38 @@
       "subnet_name": "CliqueAI",
       "subnet_slug": "sn-83",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-83-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "CliqueAI Taostats metagraph",
+      "netuid": 83,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/83/metagraph"
+      ],
+      "subnet_name": "CliqueAI",
+      "subnet_slug": "sn-83",
+      "url": "https://taostats.io/subnets/83/metagraph"
     },
     {
       "auth_required": false,
@@ -14236,6 +15069,38 @@
       "subnet_name": "Subnet 86",
       "subnet_slug": "sn-86",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-86-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Subnet 86 Taostats metagraph",
+      "netuid": 86,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/86/metagraph"
+      ],
+      "subnet_name": "Subnet 86",
+      "subnet_slug": "sn-86",
+      "url": "https://taostats.io/subnets/86/metagraph"
     },
     {
       "auth_required": false,
@@ -14673,6 +15538,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-90-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ogham Taostats metagraph",
+      "netuid": 90,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/90/metagraph"
+      ],
+      "subnet_name": "ogham",
+      "subnet_slug": "sn-90",
+      "url": "https://taostats.io/subnets/90/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-90-tensorplex-docs",
       "kind": "docs",
       "name": "ogham Tensorplex subnet docs",
@@ -14957,6 +15854,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-93-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Bitcast Taostats metagraph",
+      "netuid": 93,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/93/metagraph"
+      ],
+      "subnet_name": "Bitcast",
+      "subnet_slug": "sn-93",
+      "url": "https://taostats.io/subnets/93/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-93-tensorplex-docs",
       "kind": "docs",
       "name": "Bitcast Tensorplex subnet docs",
@@ -15050,38 +15979,6 @@
       "subnet_name": "Bitcast",
       "subnet_slug": "sn-93",
       "url": "https://stats.bitcast.network/swagger"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-93-website-link-stats-bitcast-network-dashboard-1",
-      "kind": "dashboard",
-      "name": "Bitcast dashboard",
-      "netuid": 93,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://stats.bitcast.network/"
-      ],
-      "subnet_name": "Bitcast",
-      "subnet_slug": "sn-93",
-      "url": "https://stats.bitcast.network/bitcast"
     },
     {
       "auth_required": false,
@@ -15245,6 +16142,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-94-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Bitsota Taostats metagraph",
+      "netuid": 94,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/94/metagraph"
+      ],
+      "subnet_name": "Bitsota",
+      "subnet_slug": "sn-94",
+      "url": "https://taostats.io/subnets/94/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-94-tensorplex-docs",
       "kind": "docs",
       "name": "Bitsota Tensorplex subnet docs",
@@ -15305,38 +16234,6 @@
       "subnet_name": "Bitsota",
       "subnet_slug": "sn-94",
       "url": "https://bitsota.ai/docs"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-94-website-link-bitsota-ai-dashboard-3",
-      "kind": "dashboard",
-      "name": "Bitsota dashboard",
-      "netuid": 94,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://bitsota.ai/"
-      ],
-      "subnet_name": "Bitsota",
-      "subnet_slug": "sn-94",
-      "url": "https://bitsota.ai/leaderboard"
     },
     {
       "auth_required": false,
@@ -15465,6 +16362,38 @@
       "subnet_name": "Actual",
       "subnet_slug": "sn-95",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-95-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Actual Taostats metagraph",
+      "netuid": 95,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/95/metagraph"
+      ],
+      "subnet_name": "Actual",
+      "subnet_slug": "sn-95",
+      "url": "https://taostats.io/subnets/95/metagraph"
     },
     {
       "auth_required": false,
@@ -15970,6 +16899,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-97-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Albedo Taostats metagraph",
+      "netuid": 97,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/97/metagraph"
+      ],
+      "subnet_name": "Albedo",
+      "subnet_slug": "sn-97",
+      "url": "https://taostats.io/subnets/97/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-97-tensorplex-docs",
       "kind": "docs",
       "name": "Albedo Tensorplex subnet docs",
@@ -16336,6 +17297,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-99-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Leoma Taostats metagraph",
+      "netuid": 99,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/99/metagraph"
+      ],
+      "subnet_name": "Leoma",
+      "subnet_slug": "sn-99",
+      "url": "https://taostats.io/subnets/99/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-99-tensorplex-docs",
       "kind": "docs",
       "name": "Leoma Tensorplex subnet docs",
@@ -16623,6 +17616,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-100-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Plaτform Taostats metagraph",
+      "netuid": 100,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/100/metagraph"
+      ],
+      "subnet_name": "Plaτform",
+      "subnet_slug": "sn-100",
+      "url": "https://taostats.io/subnets/100/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-100-tensorplex-docs",
       "kind": "docs",
       "name": "Plaτform Tensorplex subnet docs",
@@ -16842,6 +17867,38 @@
       "subnet_name": "eni",
       "subnet_slug": "sn-101",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-101-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "eni Taostats metagraph",
+      "netuid": 101,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/101/metagraph"
+      ],
+      "subnet_name": "eni",
+      "subnet_slug": "sn-101",
+      "url": "https://taostats.io/subnets/101/metagraph"
     },
     {
       "auth_required": false,
@@ -17066,6 +18123,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-104-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "for sale (burn to uid1) Taostats metagraph",
+      "netuid": 104,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/104/metagraph"
+      ],
+      "subnet_name": "for sale (burn to uid1)",
+      "subnet_slug": "sn-104",
+      "url": "https://taostats.io/subnets/104/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-104-tensorplex-docs",
       "kind": "docs",
       "name": "for sale (burn to uid1) Tensorplex subnet docs",
@@ -17254,6 +18343,38 @@
       "subnet_name": "Beam",
       "subnet_slug": "sn-105",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-105-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Beam Taostats metagraph",
+      "netuid": 105,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/105/metagraph"
+      ],
+      "subnet_name": "Beam",
+      "subnet_slug": "sn-105",
+      "url": "https://taostats.io/subnets/105/metagraph"
     },
     {
       "auth_required": false,
@@ -17514,6 +18635,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-106-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "VoidAI Taostats metagraph",
+      "netuid": 106,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/106/metagraph"
+      ],
+      "subnet_name": "VoidAI",
+      "subnet_slug": "sn-106",
+      "url": "https://taostats.io/subnets/106/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-106-tensorplex-docs",
       "kind": "docs",
       "name": "VoidAI Tensorplex subnet docs",
@@ -17765,6 +18918,38 @@
       "subnet_name": "Minos",
       "subnet_slug": "sn-107",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-107-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Minos Taostats metagraph",
+      "netuid": 107,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/107/metagraph"
+      ],
+      "subnet_name": "Minos",
+      "subnet_slug": "sn-107",
+      "url": "https://taostats.io/subnets/107/metagraph"
     },
     {
       "auth_required": false,
@@ -18052,6 +19237,38 @@
       "subnet_name": "TalkHead",
       "subnet_slug": "sn-108",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-108-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "TalkHead Taostats metagraph",
+      "netuid": 108,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/108/metagraph"
+      ],
+      "subnet_name": "TalkHead",
+      "subnet_slug": "sn-108",
+      "url": "https://taostats.io/subnets/108/metagraph"
     },
     {
       "auth_required": false,
@@ -18475,6 +19692,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-112-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "minotaur Taostats metagraph",
+      "netuid": 112,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/112/metagraph"
+      ],
+      "subnet_name": "minotaur",
+      "subnet_slug": "sn-112",
+      "url": "https://taostats.io/subnets/112/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-112-tensorplex-docs",
       "kind": "docs",
       "name": "minotaur Tensorplex subnet docs",
@@ -18735,6 +19984,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-114-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "SOMA Taostats metagraph",
+      "netuid": 114,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/114/metagraph"
+      ],
+      "subnet_name": "SOMA",
+      "subnet_slug": "sn-114",
+      "url": "https://taostats.io/subnets/114/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-114-tensorplex-docs",
       "kind": "docs",
       "name": "SOMA Tensorplex subnet docs",
@@ -18794,38 +20075,6 @@
       "subnet_name": "SOMA",
       "subnet_slug": "sn-114",
       "url": "https://github.com/Level114/level114-subnet"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-114-website-link-thesoma-ai-dashboard-6",
-      "kind": "dashboard",
-      "name": "SOMA dashboard",
-      "netuid": 114,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://thesoma.ai/"
-      ],
-      "subnet_name": "SOMA",
-      "subnet_slug": "sn-114",
-      "url": "https://thesoma.ai/dashboard"
     },
     {
       "auth_required": false,
@@ -18978,6 +20227,38 @@
       "subnet_name": "hard_sign",
       "subnet_slug": "sn-116",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-116-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "hard_sign Taostats metagraph",
+      "netuid": 116,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/116/metagraph"
+      ],
+      "subnet_name": "hard_sign",
+      "subnet_slug": "sn-116",
+      "url": "https://taostats.io/subnets/116/metagraph"
     },
     {
       "auth_required": false,
@@ -19222,6 +20503,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-118-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Ditto Taostats metagraph",
+      "netuid": 118,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/118/metagraph"
+      ],
+      "subnet_name": "Ditto",
+      "subnet_slug": "sn-118",
+      "url": "https://taostats.io/subnets/118/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-118-tensorplex-docs",
       "kind": "docs",
       "name": "Ditto Tensorplex subnet docs",
@@ -19441,6 +20754,38 @@
       "subnet_name": "Satori",
       "subnet_slug": "sn-119",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-119-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Satori Taostats metagraph",
+      "netuid": 119,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/119/metagraph"
+      ],
+      "subnet_name": "Satori",
+      "subnet_slug": "sn-119",
+      "url": "https://taostats.io/subnets/119/metagraph"
     },
     {
       "auth_required": false,
@@ -20226,6 +21571,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-125-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "8 Ball Taostats metagraph",
+      "netuid": 125,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/125/metagraph"
+      ],
+      "subnet_name": "8 Ball",
+      "subnet_slug": "sn-125",
+      "url": "https://taostats.io/subnets/125/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-125-tensorplex-docs",
       "kind": "docs",
       "name": "8 Ball Tensorplex subnet docs",
@@ -20417,6 +21794,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-126-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Poker44 Taostats metagraph",
+      "netuid": 126,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/126/metagraph"
+      ],
+      "subnet_name": "Poker44",
+      "subnet_slug": "sn-126",
+      "url": "https://taostats.io/subnets/126/metagraph"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-126-tensorplex-docs",
       "kind": "docs",
       "name": "Poker44 Tensorplex subnet docs",
@@ -20445,38 +21854,6 @@
       "subnet_name": "Poker44",
       "subnet_slug": "sn-126",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/126"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-126-website-link-poker44-net-dashboard-1",
-      "kind": "dashboard",
-      "name": "Poker44 dashboard",
-      "netuid": 126,
-      "notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://poker44.net/"
-      ],
-      "subnet_name": "Poker44",
-      "subnet_slug": "sn-126",
-      "url": "https://poker44.net/dashboard"
     },
     {
       "auth_required": false,
@@ -20636,6 +22013,38 @@
       "subnet_name": "Astrid",
       "subnet_slug": "sn-127",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-127-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Astrid Taostats metagraph",
+      "netuid": 127,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/127/metagraph"
+      ],
+      "subnet_name": "Astrid",
+      "subnet_slug": "sn-127",
+      "url": "https://taostats.io/subnets/127/metagraph"
     },
     {
       "auth_required": false,
@@ -20828,6 +22237,38 @@
       "subnet_name": "ByteLeap",
       "subnet_slug": "sn-128",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-128-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ByteLeap Taostats metagraph",
+      "netuid": 128,
+      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taostats",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://taostats.io/subnets/128/metagraph"
+      ],
+      "subnet_name": "ByteLeap",
+      "subnet_slug": "sn-128",
+      "url": "https://taostats.io/subnets/128/metagraph"
     },
     {
       "auth_required": false,

--- a/registry/candidates/generated/public-sources.json
+++ b/registry/candidates/generated/public-sources.json
@@ -45,6 +45,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-0-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "root Taostats metagraph",
+      "netuid": 0,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/0/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/0/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/0/metagraph"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-0-tensorplex-docs",
       "kind": "docs",
       "name": "root Tensorplex subnet docs",
@@ -107,6 +128,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-1-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Apex Taostats metagraph",
+      "netuid": 1,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/1/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/1/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/1/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-1-github-readme-macrocosm-os-apex-docs-1",
       "kind": "docs",
@@ -121,6 +163,7 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/macrocosm-os/apex/blob/main/README.md",
       "source_urls": [
+        "https://apex.macrocosmos.ai/",
         "https://github.com/macrocosm-os/apex/blob/main/README.md"
       ],
       "state": "schema-valid",
@@ -549,6 +592,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-2-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "DSperse Taostats metagraph",
+      "netuid": 2,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/2/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/2/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/2/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-2-github-readme-inference-labs-inc-subnet-2-docs-1",
       "kind": "docs",
@@ -823,6 +887,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-3-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "deprecated Taostats metagraph",
+      "netuid": 3,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/3/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/3/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/3/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-3-taopedia-article",
       "kind": "docs",
@@ -925,6 +1010,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/4"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-4-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Targon Taostats metagraph",
+      "netuid": 4,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/4/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/4/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/4/metagraph"
     },
     {
       "auth_required": false,
@@ -1412,6 +1518,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-5-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Hone Taostats metagraph",
+      "netuid": 5,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/5/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/5/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/5/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-5-taopedia-article",
       "kind": "docs",
@@ -1746,6 +1873,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/6"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-6-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Numinous Taostats metagraph",
+      "netuid": 6,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/6/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/6/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/6/metagraph"
     },
     {
       "auth_required": false,
@@ -2086,6 +2234,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-7-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Allways Taostats metagraph",
+      "netuid": 7,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/7/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/7/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/7/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-7-taopedia-article",
       "kind": "docs",
@@ -2336,6 +2505,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/8"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-8-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Vanta Taostats metagraph",
+      "netuid": 8,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/8/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/8/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/8/metagraph"
     },
     {
       "auth_required": false,
@@ -2673,6 +2863,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/9"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-9-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "iota Taostats metagraph",
+      "netuid": 9,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/9/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/9/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/9/metagraph"
     },
     {
       "auth_required": false,
@@ -3118,6 +3329,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-10-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Swap Taostats metagraph",
+      "netuid": 10,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/10/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/10/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/10/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-10-taopedia-article",
       "kind": "docs",
@@ -3368,6 +3600,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/11"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-11-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "TrajectoryRL Taostats metagraph",
+      "netuid": 11,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/11/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/11/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/11/metagraph"
     },
     {
       "auth_required": false,
@@ -3708,6 +3961,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-12-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Compute Horde Taostats metagraph",
+      "netuid": 12,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/12/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/12/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/12/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-12-taopedia-article",
       "kind": "docs",
@@ -3853,6 +4127,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/13"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-13-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Data Universe Taostats metagraph",
+      "netuid": 13,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/13/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/13/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/13/metagraph"
     },
     {
       "auth_required": false,
@@ -4298,6 +4593,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-14-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Cacheon Taostats metagraph",
+      "netuid": 14,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/14/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/14/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/14/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-14-website-link-cacheon-ai-dashboard-1",
       "kind": "dashboard",
@@ -4333,6 +4649,7 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/latent-to/cacheon/blob/main/README.md",
       "source_urls": [
+        "https://cacheon.ai/",
         "https://github.com/latent-to/cacheon/blob/main/README.md"
       ],
       "state": "schema-valid",
@@ -4673,6 +4990,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/15"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-15-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ORO Taostats metagraph",
+      "netuid": 15,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/15/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/15/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/15/metagraph"
     },
     {
       "auth_required": false,
@@ -5076,6 +5414,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-16-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "BitAds Taostats metagraph",
+      "netuid": 16,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/16/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/16/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/16/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-16-taopedia-article",
       "kind": "docs",
@@ -5346,6 +5705,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/17"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-17-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "404—GEN Taostats metagraph",
+      "netuid": 17,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/17/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/17/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/17/metagraph"
     },
     {
       "auth_required": false,
@@ -5703,6 +6083,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/18"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-18-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Zeus Taostats metagraph",
+      "netuid": 18,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/18/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/18/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/18/metagraph"
     },
     {
       "auth_required": false,
@@ -6064,6 +6465,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-19-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "blockmachine Taostats metagraph",
+      "netuid": 19,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/19/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/19/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/19/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-19-github-readme-taostat-blockmachine-docs-1",
       "kind": "docs",
@@ -6078,6 +6500,7 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/taostat/blockmachine/blob/main/README.md",
       "source_urls": [
+        "https://blockmachine.io/",
         "https://github.com/taostat/blockmachine/blob/main/README.md"
       ],
       "state": "schema-valid",
@@ -6527,6 +6950,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-20-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "GroundLayer Taostats metagraph",
+      "netuid": 20,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/20/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/20/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/20/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-20-taopedia-article",
       "kind": "docs",
@@ -6818,6 +7262,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/21"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-21-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "AdTAO Taostats metagraph",
+      "netuid": 21,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/21/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/21/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/21/metagraph"
     },
     {
       "auth_required": false,
@@ -7283,6 +7748,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-22-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Desearch Taostats metagraph",
+      "netuid": 22,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/22/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/22/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/22/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-22-taopedia-article",
       "kind": "docs",
@@ -7529,7 +8015,8 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md",
       "source_urls": [
-        "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md"
+        "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md",
+        "https://trishool.ai/"
       ],
       "state": "schema-valid",
       "url": "https://trishool.ai/dashboard"
@@ -7554,6 +8041,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/23"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-23-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Trishool Taostats metagraph",
+      "netuid": 23,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/23/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/23/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/23/metagraph"
     },
     {
       "auth_required": false,
@@ -7781,7 +8289,8 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md",
       "source_urls": [
-        "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md"
+        "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md",
+        "https://github.com/TrishoolAI/trishool-subnet/blob/main/README.md"
       ],
       "state": "schema-valid",
       "url": "https://api.trishool.ai/"
@@ -7890,6 +8399,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/24"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-24-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Quasar Taostats metagraph",
+      "netuid": 24,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/24/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/24/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/24/metagraph"
     },
     {
       "auth_required": false,
@@ -8248,6 +8778,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/25"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-25-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Mainframe Taostats metagraph",
+      "netuid": 25,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/25/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/25/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/25/metagraph"
     },
     {
       "auth_required": false,
@@ -8693,6 +9244,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-26-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Perturb Taostats metagraph",
+      "netuid": 26,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/26/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/26/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/26/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-26-taopedia-article",
       "kind": "docs",
@@ -9029,6 +9601,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-27-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Nodexo Taostats metagraph",
+      "netuid": 27,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/27/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/27/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/27/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-27-taopedia-article",
       "kind": "docs",
@@ -9282,6 +9875,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-28-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "gm Taostats metagraph",
+      "netuid": 28,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/28/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/28/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/28/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-28-taopedia-article",
       "kind": "docs",
@@ -9363,6 +9977,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/29"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-29-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Coldint Taostats metagraph",
+      "netuid": 29,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/29/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/29/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/29/metagraph"
     },
     {
       "auth_required": false,
@@ -9490,6 +10125,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/30"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-30-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Endure Network Taostats metagraph",
+      "netuid": 30,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/30/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/30/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/30/metagraph"
     },
     {
       "auth_required": false,
@@ -9766,6 +10422,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-31-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Recall Taostats metagraph",
+      "netuid": 31,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/31/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/31/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/31/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-31-taopedia-article",
       "kind": "docs",
@@ -9847,6 +10524,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/32"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-32-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ItsAI Taostats metagraph",
+      "netuid": 32,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/32/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/32/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/32/metagraph"
     },
     {
       "auth_required": false,
@@ -10313,6 +11011,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-33-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ReadyAI Taostats metagraph",
+      "netuid": 33,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/33/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/33/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/33/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-data-artifact-1",
       "kind": "data-artifact",
@@ -10461,6 +11180,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-34-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "BitMind Taostats metagraph",
+      "netuid": 34,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/34/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/34/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/34/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-34-taopedia-article",
       "kind": "docs",
@@ -10564,6 +11304,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/35"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-35-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "OxMarkets Taostats metagraph",
+      "netuid": 35,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/35/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/35/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/35/metagraph"
     },
     {
       "auth_required": false,
@@ -10837,6 +11598,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/36"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-36-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Eirel Taostats metagraph",
+      "netuid": 36,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/36/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/36/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/36/metagraph"
     },
     {
       "auth_required": false,
@@ -11173,6 +11955,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/37"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-37-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Aurelius Taostats metagraph",
+      "netuid": 37,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/37/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/37/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/37/metagraph"
     },
     {
       "auth_required": false,
@@ -11533,6 +12336,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-38-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "colosseum Taostats metagraph",
+      "netuid": 38,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/38/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/38/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/38/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-38-taopedia-article",
       "kind": "docs",
@@ -11786,6 +12610,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-39-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "deprecated Taostats metagraph",
+      "netuid": 39,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/39/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/39/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/39/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-39-taopedia-article",
       "kind": "docs",
@@ -11912,6 +12757,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-40-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Chunking Taostats metagraph",
+      "netuid": 40,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/40/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/40/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/40/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-40-taopedia-article",
       "kind": "docs",
@@ -12015,6 +12881,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/41"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-41-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Almanac Taostats metagraph",
+      "netuid": 41,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/41/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/41/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/41/metagraph"
     },
     {
       "auth_required": false,
@@ -12292,10 +13179,31 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-42-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Gopher Taostats metagraph",
+      "netuid": 42,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/42/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/42/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/42/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-42-taopedia-article",
       "kind": "docs",
-      "name": "Subnet 42 Taopedia article",
+      "name": "Gopher Taopedia article",
       "netuid": 42,
       "provider": "taopedia-articles",
       "public_safe": true,
@@ -12373,6 +13281,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/43"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-43-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Graphite Taostats metagraph",
+      "netuid": 43,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/43/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/43/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/43/metagraph"
     },
     {
       "auth_required": false,
@@ -12479,6 +13408,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/44"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-44-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Score Taostats metagraph",
+      "netuid": 44,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/44/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/44/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/44/metagraph"
     },
     {
       "auth_required": false,
@@ -12773,6 +13723,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/45"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-45-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Talisman AI Taostats metagraph",
+      "netuid": 45,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/45/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/45/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/45/metagraph"
     },
     {
       "auth_required": false,
@@ -13280,6 +14251,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-46-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Zipcode Taostats metagraph",
+      "netuid": 46,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/46/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/46/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/46/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-46-website-link-zipcode-ai-dashboard-1",
       "kind": "dashboard",
@@ -13700,6 +14692,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-47-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "EvolAI Taostats metagraph",
+      "netuid": 47,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/47/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/47/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/47/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-47-github-readme-openevolai-evolai-data-artifact-1",
       "kind": "data-artifact",
@@ -13844,6 +14857,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/48"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-48-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Quantum Compute Taostats metagraph",
+      "netuid": 48,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/48/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/48/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/48/metagraph"
     },
     {
       "auth_required": false,
@@ -14309,6 +15343,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-49-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Nepher Robotics Taostats metagraph",
+      "netuid": 49,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/49/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/49/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/49/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-49-github-readme-nepher-ai-nepher-subnet-docs-1",
       "kind": "docs",
@@ -14603,6 +15658,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-50-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Synth Taostats metagraph",
+      "netuid": 50,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/50/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/50/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/50/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-50-taopedia-article",
       "kind": "docs",
@@ -14874,6 +15950,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/51"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-51-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "lium.io Taostats metagraph",
+      "netuid": 51,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/51/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/51/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/51/metagraph"
     },
     {
       "auth_required": false,
@@ -15361,6 +16458,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-52-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Dojo Taostats metagraph",
+      "netuid": 52,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/52/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/52/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/52/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-52-github-readme-tensorplex-labs-dojo-docs-1",
       "kind": "docs",
@@ -15551,6 +16669,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-53-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "EfficientFrontier Taostats metagraph",
+      "netuid": 53,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/53/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/53/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/53/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-53-taopedia-article",
       "kind": "docs",
@@ -15675,6 +16814,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/54"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-54-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Yanez MIID Taostats metagraph",
+      "netuid": 54,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/54/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/54/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/54/metagraph"
     },
     {
       "auth_required": false,
@@ -15970,6 +17130,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/55"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-55-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "NIOME Taostats metagraph",
+      "netuid": 55,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/55/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/55/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/55/metagraph"
     },
     {
       "auth_required": false,
@@ -16307,6 +17488,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/56"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-56-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Gradients Taostats metagraph",
+      "netuid": 56,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/56/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/56/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/56/metagraph"
     },
     {
       "auth_required": false,
@@ -16793,6 +17995,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-57-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "gaia Taostats metagraph",
+      "netuid": 57,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/57/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/57/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/57/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-57-taopedia-article",
       "kind": "docs",
@@ -16895,6 +18118,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/58"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-58-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Pending Taostats metagraph",
+      "netuid": 58,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/58/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/58/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/58/metagraph"
     },
     {
       "auth_required": false,
@@ -17042,6 +18286,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/59"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-59-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Babelbit Taostats metagraph",
+      "netuid": 59,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/59/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/59/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/59/metagraph"
     },
     {
       "auth_required": false,
@@ -17403,6 +18668,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-60-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Bitsec.ai Taostats metagraph",
+      "netuid": 60,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/60/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/60/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/60/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-60-github-readme-bitsec-ai-sandbox-docs-1",
       "kind": "docs",
@@ -17690,7 +18976,8 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md",
       "source_urls": [
-        "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md"
+        "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md",
+        "https://www.theredteam.io/"
       ],
       "state": "schema-valid",
       "url": "https://dashboard.theredteam.io/"
@@ -17718,6 +19005,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-61-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "RedTeam Taostats metagraph",
+      "netuid": 61,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/61/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/61/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/61/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-61-github-readme-redteamsubnet-redteam-docs-2",
       "kind": "docs",
@@ -17732,7 +19040,8 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md",
       "source_urls": [
-        "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md"
+        "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md",
+        "https://www.theredteam.io/"
       ],
       "state": "schema-valid",
       "url": "https://docs.theredteam.io/"
@@ -17992,6 +19301,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-62-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Ridges Taostats metagraph",
+      "netuid": 62,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/62/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/62/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/62/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-62-taopedia-article",
       "kind": "docs",
@@ -18242,6 +19572,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/63"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-63-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Enigma Taostats metagraph",
+      "netuid": 63,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/63/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/63/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/63/metagraph"
     },
     {
       "auth_required": false,
@@ -18707,6 +20058,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-64-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Chutes Taostats metagraph",
+      "netuid": 64,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/64/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/64/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/64/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-64-website-link-chutes-ai-data-artifact-5",
       "kind": "data-artifact",
@@ -18952,7 +20324,8 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/chutesai/chutes/blob/main/README.md",
       "source_urls": [
-        "https://github.com/chutesai/chutes/blob/main/README.md"
+        "https://github.com/chutesai/chutes/blob/main/README.md",
+        "https://github.com/rayonlabs/chutes/blob/main/README.md"
       ],
       "state": "schema-valid",
       "url": "https://api.chutes.ai/pricing"
@@ -18973,7 +20346,8 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/chutesai/chutes/blob/main/README.md",
       "source_urls": [
-        "https://github.com/chutesai/chutes/blob/main/README.md"
+        "https://github.com/chutesai/chutes/blob/main/README.md",
+        "https://github.com/rayonlabs/chutes/blob/main/README.md"
       ],
       "state": "schema-valid",
       "url": "https://api.chutes.dev/"
@@ -19271,6 +20645,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/65"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-65-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "TAO Private Network Taostats metagraph",
+      "netuid": 65,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/65/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/65/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/65/metagraph"
     },
     {
       "auth_required": false,
@@ -19653,6 +21048,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-66-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ninja Taostats metagraph",
+      "netuid": 66,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/66/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/66/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/66/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-66-website-link-ninja-arbos-life-dashboard-1",
       "kind": "dashboard",
@@ -19990,6 +21406,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-67-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Harnyx Taostats metagraph",
+      "netuid": 67,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/67/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/67/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/67/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-67-website-link-harnyx-ai-dashboard-1",
       "kind": "dashboard",
@@ -20281,6 +21718,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/68"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-68-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "NOVA Taostats metagraph",
+      "netuid": 68,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/68/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/68/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/68/metagraph"
     },
     {
       "auth_required": false,
@@ -20642,6 +22100,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-69-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ain Taostats metagraph",
+      "netuid": 69,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/69/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/69/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/69/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-69-taopedia-article",
       "kind": "docs",
@@ -20723,6 +22202,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/70"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-70-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "NexisGen Taostats metagraph",
+      "netuid": 70,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/70/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/70/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/70/metagraph"
     },
     {
       "auth_required": false,
@@ -21083,6 +22583,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-71-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Leadpoet Taostats metagraph",
+      "netuid": 71,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/71/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/71/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/71/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-71-taopedia-article",
       "kind": "docs",
@@ -21333,6 +22854,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/72"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-72-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "StreetVision by NATIX Taostats metagraph",
+      "netuid": 72,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/72/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/72/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/72/metagraph"
     },
     {
       "auth_required": false,
@@ -21820,6 +23362,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-73-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Parked Taostats metagraph",
+      "netuid": 73,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/73/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/73/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/73/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-73-taopedia-article",
       "kind": "docs",
@@ -21922,6 +23485,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/74"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-74-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Gittensor Taostats metagraph",
+      "netuid": 74,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/74/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/74/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/74/metagraph"
     },
     {
       "auth_required": false,
@@ -22216,6 +23800,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/75"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-75-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Hippius Taostats metagraph",
+      "netuid": 75,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/75/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/75/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/75/metagraph"
     },
     {
       "auth_required": false,
@@ -22724,6 +24329,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-76-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Byzantium Taostats metagraph",
+      "netuid": 76,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/76/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/76/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/76/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-76-taopedia-article",
       "kind": "docs",
@@ -22973,6 +24599,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/77"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-77-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Liquidity Taostats metagraph",
+      "netuid": 77,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/77/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/77/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/77/metagraph"
     },
     {
       "auth_required": false,
@@ -23226,6 +24873,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/78"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-78-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Vocence Taostats metagraph",
+      "netuid": 78,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/78/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/78/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/78/metagraph"
     },
     {
       "auth_required": false,
@@ -23520,6 +25188,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/79"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-79-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "MVTRX Taostats metagraph",
+      "netuid": 79,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/79/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/79/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/79/metagraph"
     },
     {
       "auth_required": false,
@@ -24006,24 +25695,24 @@
     },
     {
       "auth_required": false,
-      "confidence": "low",
-      "id": "sn-80-website-link-dogelayer-ai-dashboard-1",
+      "confidence": "medium",
+      "id": "sn-80-taostats-metagraph",
       "kind": "dashboard",
-      "name": "dogelayer dashboard",
+      "name": "dogelayer Taostats metagraph",
       "netuid": 80,
-      "provider": "taomarketcap",
+      "provider": "taostats",
       "public_safe": true,
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Discovered from a public project website link. Requires verification before promotion.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
       "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://dogelayer.ai/",
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/80/metagraph",
       "source_urls": [
-        "https://dogelayer.ai/"
+        "https://taostats.io/subnets/80/metagraph"
       ],
       "state": "schema-valid",
-      "url": "https://dogelayer.ai/en/dashboard"
+      "url": "https://taostats.io/subnets/80/metagraph"
     },
     {
       "auth_required": false,
@@ -24087,27 +25776,6 @@
       ],
       "state": "schema-valid",
       "url": "https://dogelayer.ai/docs"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-80-website-link-dogelayer-ai-docs-2",
-      "kind": "docs",
-      "name": "dogelayer docs",
-      "netuid": 80,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Discovered from a public project website link. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://dogelayer.ai/",
-      "source_urls": [
-        "https://dogelayer.ai/"
-      ],
-      "state": "schema-valid",
-      "url": "https://dogelayer.ai/en/docs"
     },
     {
       "auth_required": false,
@@ -24300,6 +25968,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-81-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "deprecated Taostats metagraph",
+      "netuid": 81,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/81/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/81/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/81/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-81-taopedia-article",
       "kind": "docs",
@@ -24423,6 +26112,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/82"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-82-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Compelle Taostats metagraph",
+      "netuid": 82,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/82/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/82/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/82/metagraph"
     },
     {
       "auth_required": false,
@@ -24909,6 +26619,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-83-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "CliqueAI Taostats metagraph",
+      "netuid": 83,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/83/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/83/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/83/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-83-taopedia-article",
       "kind": "docs",
@@ -25162,6 +26893,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-84-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ansuz Taostats metagraph",
+      "netuid": 84,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/84/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/84/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/84/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-84-taopedia-article",
       "kind": "docs",
@@ -25285,6 +27037,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/85"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-85-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Vidaio Taostats metagraph",
+      "netuid": 85,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/85/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/85/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/85/metagraph"
     },
     {
       "auth_required": false,
@@ -25688,6 +27461,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-86-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Subnet 86 Taostats metagraph",
+      "netuid": 86,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/86/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/86/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/86/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-86-taopedia-article",
       "kind": "docs",
@@ -25772,6 +27566,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-87-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Luminar Network Taostats metagraph",
+      "netuid": 87,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/87/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/87/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/87/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-87-taopedia-article",
       "kind": "docs",
@@ -25849,7 +27664,8 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/mobiusfund/investing/blob/main/README.md",
       "source_urls": [
-        "https://github.com/mobiusfund/investing/blob/main/README.md"
+        "https://github.com/mobiusfund/investing/blob/main/README.md",
+        "https://investing88.ai/"
       ],
       "state": "schema-valid",
       "url": "https://db.investing88.ai/"
@@ -25874,6 +27690,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/88"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-88-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Investing Taostats metagraph",
+      "netuid": 88,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/88/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/88/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/88/metagraph"
     },
     {
       "auth_required": false,
@@ -26214,6 +28051,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-89-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "InfiniteHash Taostats metagraph",
+      "netuid": 89,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/89/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/89/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/89/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-89-taopedia-article",
       "kind": "docs",
@@ -26467,6 +28325,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-90-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ogham Taostats metagraph",
+      "netuid": 90,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/90/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/90/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/90/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-90-taopedia-article",
       "kind": "docs",
@@ -26548,6 +28427,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/91"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-91-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Bitstarter #1 Taostats metagraph",
+      "netuid": 91,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/91/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/91/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/91/metagraph"
     },
     {
       "auth_required": false,
@@ -26887,6 +28787,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-92-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "luis Taostats metagraph",
+      "netuid": 92,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/92/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/92/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/92/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-92-taopedia-article",
       "kind": "docs",
@@ -27010,6 +28931,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/93"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-93-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Bitcast Taostats metagraph",
+      "netuid": 93,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/93/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/93/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/93/metagraph"
     },
     {
       "auth_required": false,
@@ -27371,6 +29313,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-94-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Bitsota Taostats metagraph",
+      "netuid": 94,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/94/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/94/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/94/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-94-website-link-bitsota-ai-dashboard-3",
       "kind": "dashboard",
@@ -27686,6 +29649,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-95-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Actual Taostats metagraph",
+      "netuid": 95,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/95/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/95/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/95/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-95-taopedia-article",
       "kind": "docs",
@@ -27980,6 +29964,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-96-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Verathos Taostats metagraph",
+      "netuid": 96,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/96/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/96/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/96/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-96-github-readme-verathos-ai-verathos-docs-1",
       "kind": "docs",
@@ -27994,7 +29999,8 @@
       "source_type": "github-readme-link",
       "source_url": "https://github.com/verathos-ai/verathos/blob/main/README.md",
       "source_urls": [
-        "https://github.com/verathos-ai/verathos/blob/main/README.md"
+        "https://github.com/verathos-ai/verathos/blob/main/README.md",
+        "https://verathos.ai/"
       ],
       "state": "schema-valid",
       "url": "https://verathos.ai/docs"
@@ -28271,6 +30277,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/97"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-97-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Albedo Taostats metagraph",
+      "netuid": 97,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/97/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/97/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/97/metagraph"
     },
     {
       "auth_required": false,
@@ -28607,6 +30634,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/98"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-98-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ForeverMoney Taostats metagraph",
+      "netuid": 98,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/98/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/98/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/98/metagraph"
     },
     {
       "auth_required": false,
@@ -29030,6 +31078,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-99-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Leoma Taostats metagraph",
+      "netuid": 99,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/99/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/99/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/99/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-99-github-readme-rendixnetwork-leoma-docs-2",
       "kind": "docs",
@@ -29342,6 +31411,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/100"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-100-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Plaτform Taostats metagraph",
+      "netuid": 100,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/100/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/100/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/100/metagraph"
     },
     {
       "auth_required": false,
@@ -29723,6 +31813,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-101-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "eni Taostats metagraph",
+      "netuid": 101,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/101/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/101/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/101/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-101-taopedia-article",
       "kind": "docs",
@@ -29804,6 +31915,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/102"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-102-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ConnitoAI Taostats metagraph",
+      "netuid": 102,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/102/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/102/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/102/metagraph"
     },
     {
       "auth_required": false,
@@ -30161,6 +32293,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/103"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-103-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Djinn Taostats metagraph",
+      "netuid": 103,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/103/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/103/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/103/metagraph"
     },
     {
       "auth_required": false,
@@ -30605,6 +32758,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-104-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "for sale (burn to uid1) Taostats metagraph",
+      "netuid": 104,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/104/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/104/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/104/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-104-taopedia-article",
       "kind": "docs",
@@ -30686,6 +32860,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/105"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-105-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Beam Taostats metagraph",
+      "netuid": 105,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/105/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/105/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/105/metagraph"
     },
     {
       "auth_required": false,
@@ -30941,6 +33136,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-106-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "VoidAI Taostats metagraph",
+      "netuid": 106,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/106/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/106/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/106/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-106-taopedia-article",
       "kind": "docs",
@@ -31190,6 +33406,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/107"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-107-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Minos Taostats metagraph",
+      "netuid": 107,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/107/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/107/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/107/metagraph"
     },
     {
       "auth_required": false,
@@ -31592,6 +33829,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-108-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "TalkHead Taostats metagraph",
+      "netuid": 108,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/108/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/108/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/108/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-108-website-link-www-talkhead-ai-dashboard-3",
       "kind": "dashboard",
@@ -31971,6 +34229,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-109-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Academia Taostats metagraph",
+      "netuid": 109,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/109/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/109/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/109/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-109-taopedia-article",
       "kind": "docs",
@@ -32073,6 +34352,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/110"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-110-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Green Compute Taostats metagraph",
+      "netuid": 110,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/110/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/110/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/110/metagraph"
     },
     {
       "auth_required": false,
@@ -32538,6 +34838,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-111-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "oneoneone Taostats metagraph",
+      "netuid": 111,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/111/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/111/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/111/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-111-taopedia-article",
       "kind": "docs",
@@ -32641,6 +34962,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/112"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-112-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "minotaur Taostats metagraph",
+      "netuid": 112,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/112/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/112/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/112/metagraph"
     },
     {
       "auth_required": false,
@@ -32915,6 +35257,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/113"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-113-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "TensorUSD Taostats metagraph",
+      "netuid": 113,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/113/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/113/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/113/metagraph"
     },
     {
       "auth_required": false,
@@ -33293,6 +35656,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/114"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-114-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "SOMA Taostats metagraph",
+      "netuid": 114,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/114/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/114/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/114/metagraph"
     },
     {
       "auth_required": false,
@@ -33716,6 +36100,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-115-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "HashiChain Taostats metagraph",
+      "netuid": 115,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/115/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/115/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/115/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-115-taopedia-article",
       "kind": "docs",
@@ -33818,6 +36223,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/116"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-116-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "hard_sign Taostats metagraph",
+      "netuid": 116,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/116/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/116/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/116/metagraph"
     },
     {
       "auth_required": false,
@@ -33926,10 +36352,31 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-117-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "BrainPlay Taostats metagraph",
+      "netuid": 117,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/117/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/117/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/117/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-117-taopedia-article",
       "kind": "docs",
-      "name": "Subnet 117 Taopedia article",
+      "name": "BrainPlay Taopedia article",
       "netuid": 117,
       "provider": "taopedia-articles",
       "public_safe": true,
@@ -34070,6 +36517,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/118"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-118-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Ditto Taostats metagraph",
+      "netuid": 118,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/118/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/118/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/118/metagraph"
     },
     {
       "auth_required": false,
@@ -34535,6 +37003,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-119-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Satori Taostats metagraph",
+      "netuid": 119,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/119/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/119/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/119/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-119-taopedia-article",
       "kind": "docs",
@@ -34658,6 +37147,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/120"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-120-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Affine Taostats metagraph",
+      "netuid": 120,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/120/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/120/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/120/metagraph"
     },
     {
       "auth_required": false,
@@ -34911,6 +37421,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/121"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-121-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "sundae_bar Taostats metagraph",
+      "netuid": 121,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/121/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/121/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/121/metagraph"
     },
     {
       "auth_required": false,
@@ -35376,6 +37907,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-122-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "gamma_small Taostats metagraph",
+      "netuid": 122,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/122/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/122/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/122/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-122-taopedia-article",
       "kind": "docs",
@@ -35478,6 +38030,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/123"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-123-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "MANTIS Taostats metagraph",
+      "netuid": 123,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/123/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/123/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/123/metagraph"
     },
     {
       "auth_required": false,
@@ -35605,6 +38178,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/124"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-124-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Swarm Taostats metagraph",
+      "netuid": 124,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/124/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/124/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/124/metagraph"
     },
     {
       "auth_required": false,
@@ -35861,6 +38455,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-125-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "8 Ball Taostats metagraph",
+      "netuid": 125,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/125/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/125/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/125/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-125-taopedia-article",
       "kind": "docs",
@@ -35942,6 +38557,27 @@
       ],
       "state": "schema-valid",
       "url": "https://taomarketcap.com/subnets/126"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-126-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Poker44 Taostats metagraph",
+      "netuid": 126,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/126/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/126/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/126/metagraph"
     },
     {
       "auth_required": false,
@@ -36281,6 +38917,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-127-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "Astrid Taostats metagraph",
+      "netuid": 127,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/127/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/127/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/127/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-127-taopedia-article",
       "kind": "docs",
@@ -36596,6 +39253,27 @@
     },
     {
       "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-128-taostats-metagraph",
+      "kind": "dashboard",
+      "name": "ByteLeap Taostats metagraph",
+      "netuid": 128,
+      "provider": "taostats",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "taostats-metagraph-dashboard",
+      "source_url": "https://taostats.io/subnets/128/metagraph",
+      "source_urls": [
+        "https://taostats.io/subnets/128/metagraph"
+      ],
+      "state": "schema-valid",
+      "url": "https://taostats.io/subnets/128/metagraph"
+    },
+    {
+      "auth_required": false,
       "confidence": "low",
       "id": "sn-128-taopedia-article",
       "kind": "docs",
@@ -36831,7 +39509,7 @@
   "generated_by": "metagraphed-discover-candidates",
   "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
   "notes": "Generated candidate surfaces from public sources. These are not verified registry surfaces until maintainer review promotes them into registry/subnets.",
-  "observed_at": "2026-06-08T11:59:34.000Z",
+  "observed_at": "2026-06-08T12:31:57.000Z",
   "schema_version": 1,
   "sources": [
     {
@@ -36841,6 +39519,10 @@
     {
       "id": "backprop-finance",
       "url": "https://backprop.finance/dtao/subnets/"
+    },
+    {
+      "id": "taostats",
+      "url": "https://taostats.io/subnets/"
     },
     {
       "id": "tensorplex-subnet-docs",

--- a/registry/generated/subnet-overlays-summary.json
+++ b/registry/generated/subnet-overlays-summary.json
@@ -12,10 +12,10 @@
       "surface_count": 10
     },
     {
-      "checksum": "b3b011140c928bdbdd2c41caec33bb4d0002d49d910fb6dc37caacd8f98265ab",
+      "checksum": "22a5a79613fc3456bb6239a616bb2af778cab916fa2c9051d05fe3ab8c1fb720",
       "netuid": 5,
       "slug": "sn-5",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
       "checksum": "5392b9f4623eaf5843ee51a46d6211b448772602498f668180702214523c6732",
@@ -24,34 +24,34 @@
       "surface_count": 7
     },
     {
-      "checksum": "f905e602da626e658c41f668fda992b4abe7892f3cd180229b552a16eea9b94d",
+      "checksum": "7e39430bb3dfbabce10b4a174c391e4b2decb0457c37c06ec8f6286d6a73a1ff",
       "netuid": 8,
       "slug": "sn-8",
       "surface_count": 7
     },
     {
-      "checksum": "a26e3105c211f61b400cc509b05a7cd775a710088baa9c35c87c1fb1e20a1929",
+      "checksum": "5d0156642ac0bad8aa30fccbcf7357c9a6fa42e218e33b5d5bc39305940847cd",
       "netuid": 10,
       "slug": "sn-10",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "checksum": "99066b1f91407095f6f69cdb470cd69e412f04182e65ce91a43ad09fea192c8b",
+      "checksum": "5349a17577e4f9547460c7b531fdf8c3b64947f607c3d38e060b07c196a22de2",
       "netuid": 11,
       "slug": "sn-11",
       "surface_count": 8
     },
     {
-      "checksum": "b1a7be14b793d00956e8584906d899a7db25d3f26486b1c5673c4410d75ab65b",
+      "checksum": "5d387c525667b0d8d6fe8abc31bd0769216c9e4394b0b18b14a56779b48c46c6",
       "netuid": 14,
       "slug": "sn-14",
       "surface_count": 10
     },
     {
-      "checksum": "7559b8dde31b557c1461f756a95309861bc16e241987f3f199a8b4f2574431fb",
+      "checksum": "11cc744e02ef2bd6a0548638c7784791485aa9fc205f0d3577b1ff654a685698",
       "netuid": 16,
       "slug": "sn-16",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
       "checksum": "f18fc65ce8a98552e75407532f470fc5c424c8fec536a2f044a36e8617c9999d",
@@ -60,76 +60,76 @@
       "surface_count": 8
     },
     {
-      "checksum": "95ae80de82d1f7104a3c8611c1798123fd5a635400ac6b2de72a35a3e88832e2",
+      "checksum": "77b31801051291fe2266ca2a0bb14f9f5abaac0a7c95a62bd21f3e0df27b3578",
       "netuid": 18,
       "slug": "sn-18",
       "surface_count": 8
     },
     {
-      "checksum": "bef58ed7f6abbc504d984e64b4953c9201dde987e46f693a99f1a9d7c8552a2f",
+      "checksum": "e57d47410d94f0cc0e17ddd14eb4dd67e9dbc16f8a0e3d0a51c4fa85e84de83c",
       "netuid": 26,
       "slug": "sn-26",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "checksum": "5714617dfc4ee0dccc07cdcd4a1fbd4074b24e11b6ebfc4ed901a45451ab0004",
+      "checksum": "47959eb46fceafe15b26a117472416a1c59e37915eefd9f6d22929e7cca3f539",
       "netuid": 27,
       "slug": "sn-27",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "d57ed6847ebf3757805e000d12170ca2771e7a258d91802e72ee892afba978de",
+      "checksum": "9be99ac34b5de7ea6543a3fced3cebeb6d2f788fc386d2547f861845a5eb4a01",
       "netuid": 28,
       "slug": "sn-28",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "f2c3cec514e5dfacbc2da56504fd543ebeb552d22b0b15444d816ad0647f20e3",
+      "checksum": "f347b0e6b94d43c570d781e652439b1343e34aef7f66df30653c5f10e2a51883",
       "netuid": 31,
       "slug": "sn-31",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "93339f199abb7a46e29af01ef0ca5d8a542fcaa56c631228af6c049914cde27e",
+      "checksum": "9928b72cbd52e02498fff1ab337a0a92f0d525002b969d1ed82065979d3dc8de",
       "netuid": 35,
       "slug": "sn-35",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "checksum": "3ad02132e502509cd9e96d5ac238fc2556e07b89d1accde2bcfbfe2032e85a9f",
+      "checksum": "a6d397b712c9d4aa19c6c92ab5c867aa7064f11fe77de59f88698846cc8e90ac",
       "netuid": 36,
       "slug": "sn-36",
       "surface_count": 8
     },
     {
-      "checksum": "e3504881171be0577b12433b05c68c08083f7371fd265f94c0f914fdfac92378",
+      "checksum": "add784ded2cb8300a0d07321c5734a052936916156f5cbae32f82cac383aab42",
       "netuid": 37,
       "slug": "sn-37",
-      "surface_count": 7
-    },
-    {
-      "checksum": "0e488e5e50a77a5f401f2b4e4b851588aa7e779ee116becce2502622e60b4638",
-      "netuid": 38,
-      "slug": "sn-38",
-      "surface_count": 7
-    },
-    {
-      "checksum": "46ac7f97a442be1568a5c44d566a56a621dbb91a35c335a4c1643d6c6c680118",
-      "netuid": 40,
-      "slug": "sn-40",
-      "surface_count": 4
-    },
-    {
-      "checksum": "33d39918702a6b771520577e18bb935591a32c9088cd0f6a082700bbcfda84d8",
-      "netuid": 41,
-      "slug": "sn-41",
       "surface_count": 8
     },
     {
-      "checksum": "b24426f4318ae76ff1ada484f9d11309cb527e97a08eb9bba91bceec1959fccb",
+      "checksum": "e50feb88867b321308d7a04b7797eb63eb57a63d483be90d5c486ef163c7a753",
+      "netuid": 38,
+      "slug": "sn-38",
+      "surface_count": 8
+    },
+    {
+      "checksum": "da7e1ede26a46779bf942d6030066dc65ba2bc2b34cfac44f621f9e1fbaf3675",
+      "netuid": 40,
+      "slug": "sn-40",
+      "surface_count": 5
+    },
+    {
+      "checksum": "3fe09c914b5b1bf09255c0d2c344478eb89293c76a6167819ab9722a65b4e5c4",
+      "netuid": 41,
+      "slug": "sn-41",
+      "surface_count": 9
+    },
+    {
+      "checksum": "d0f5a50edee38dbc025e054ca8979390eb387694a1fef868b52433f8989396f9",
       "netuid": 44,
       "slug": "sn-44",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
       "checksum": "9d0255bd91735f15b93db81ae0281824299432860dabe8c92cc9a00f3c6e50df",
@@ -138,22 +138,22 @@
       "surface_count": 11
     },
     {
-      "checksum": "04a5dcf366f3dcab75bff09b022baa21649c850a638ffdfbda26942c5365cb7c",
+      "checksum": "715d088a5998408f4592063ca7335f41396ef3fc10b56f2519fe783f76ca963a",
       "netuid": 50,
       "slug": "sn-50",
-      "surface_count": 8
-    },
-    {
-      "checksum": "3a841a5f1e7d35edd0aab3330e11943e8e7d724a5adf780dbcbc096758197c91",
-      "netuid": 51,
-      "slug": "sn-51",
       "surface_count": 9
     },
     {
-      "checksum": "c1dd7dea0f37b45f25143e205f97accce692c969e5952d6c742961d241838575",
+      "checksum": "85ebdcb8e71e624adcc8aba1e10a27aad347f2136c909d38bfbf219cc5014815",
+      "netuid": 51,
+      "slug": "sn-51",
+      "surface_count": 10
+    },
+    {
+      "checksum": "ee3fa477b5ba232a6826caaf90441032bba7113cf4242725197aa0e176b2b8a8",
       "netuid": 53,
       "slug": "sn-53",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
       "checksum": "bb5458d9bfe23eff83cbdbbcb72139c3f9599aa1c396b3452c433ec239180afa",
@@ -162,34 +162,34 @@
       "surface_count": 7
     },
     {
-      "checksum": "0419c8084dd8971dc9b3f5122aba1b1d26a502a4e385a58a7ab5ccf0318f529f",
+      "checksum": "c7955303f6bd7cada3ba62e53babcdece52d95c00439279ef25efe40a09b316d",
       "netuid": 55,
       "slug": "sn-55",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "checksum": "01847aa380cd9496dbbf2b4b3a61926da811bff5c6d4eef730ca2a25b423a7aa",
+      "checksum": "5bbb19648575cc4bd6ee21267f990f1193debdd25c7355415499e18c4d11b773",
       "netuid": 56,
       "slug": "sn-56",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "checksum": "419a7516dc7898d3cb91d75ace94535c72d376f0c31e0d073ce8075478114139",
+      "checksum": "d628ee40f1b0e2c6e9c2957ae33b6ae434184c375d583851139b2197531f1dce",
       "netuid": 59,
       "slug": "sn-59",
       "surface_count": 8
     },
     {
-      "checksum": "06c6a40155684a739bcbea80f5093294318fa14dcb5985cffe5b0e9f89278aa4",
+      "checksum": "87405fbbedfaa87818503141be83ff9b702a09e78d600e37c856b1e38d184be6",
       "netuid": 60,
       "slug": "sn-60",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "checksum": "cb35409b28d241cc2c0cb8b231db37d0ae78f93e86b69bed1281ef83900a8064",
+      "checksum": "a2d1c714921e549b0a91da9fa6b193d56ce4cb0e35a1fbb0366b9cbd771275cf",
       "netuid": 65,
       "slug": "sn-65",
-      "surface_count": 9
+      "surface_count": 10
     },
     {
       "checksum": "33f60f7f671671e01168e9751827d5130c474f8a8c0189fc4b6c7dcd970e82b2",
@@ -198,172 +198,172 @@
       "surface_count": 7
     },
     {
-      "checksum": "e3d538373fd2dc4e7f9bffac706cb7fbdf7e9b9e106c76e77180313f454e01f9",
+      "checksum": "82168017963125f99b3fa1b913f8638f4a3b77fb9730adda10c2a820b2c5d7cf",
       "netuid": 68,
       "slug": "sn-68",
       "surface_count": 9
     },
     {
-      "checksum": "f29c750f0ad8f92984b54d4c060ba946b3fe376196da97cb735d52c27eddc1a0",
+      "checksum": "ef1b1962e248ec13e53b9cf4d5cbabc285e537b94fbebaf353035af64038348d",
       "netuid": 69,
       "slug": "sn-69",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "8884f559274ec4dcf2c57164a4418156975ac3f8559bf2a1a19e2a3187738344",
+      "checksum": "a044e08e98def59f14b407837e3c92e46db4f8b78029995f90134e38bab1bd32",
       "netuid": 70,
       "slug": "sn-70",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "checksum": "9c87e5409675ea58d3eb71e2c7cc7a6f8fb41efde496d77b8a386a0f3135e129",
+      "checksum": "d89762d8da21bffe24675cec707299358b4278227bbe19e1318543e61388f093",
       "netuid": 71,
       "slug": "sn-71",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "checksum": "81f90671e0ccea42caf981b9673b51efeab1ccfbb68d4f8b6c431e783499b688",
+      "checksum": "644c97fe76b9cedf12932fd42602f546a2f78eb5765e22e5297c8b288ba453b7",
       "netuid": 73,
       "slug": "sn-73",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "9b772d8aa76ca3cbd5656cc01a4791b5fd445dafdb6c1dea86f5d141d3087c59",
+      "checksum": "1a663ced9dd65b0a369298677989515cb39239ef51270272049e2febafaa8b85",
       "netuid": 77,
       "slug": "sn-77",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "checksum": "712ae1b0a54fea1cbbd183302728eb220ee651d3e25ef2cca74c671195cf7ff5",
+      "checksum": "50c33629958df381a6dfc645191de04d1a9d53ea4d887b774b279d9c8ad8d4c4",
       "netuid": 78,
       "slug": "sn-78",
-      "surface_count": 10
+      "surface_count": 11
     },
     {
-      "checksum": "d4ce5d6b6ba97272f40a6af64b7760789467b61b7acb286bc2f2049446fb870f",
+      "checksum": "0a765a8283e4aef87587f1dfbdb33c92328acfb6208122312a334359d8d30b73",
       "netuid": 80,
       "slug": "sn-80",
-      "surface_count": 10
+      "surface_count": 9
     },
     {
-      "checksum": "dbd80c9b79fdbe8e62d84691b0a275690b1f0f7bcbec4a8e1a3bd809f4f325c5",
+      "checksum": "598a4adfcfc6f522647b8bf8b44daf02a55e9e034b4ec406e3ff17b0115ddbc0",
       "netuid": 83,
       "slug": "sn-83",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "checksum": "27cb1a42c86e14a29b20515523af712a4244e00e8b4e559e21de7683476b384c",
+      "checksum": "0e0e2d46cdc851a20f88ea425bccca4e86718c920b629c9f7daf3a0be70c586d",
       "netuid": 86,
       "slug": "sn-86",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "1bb8e07a99c8ec47907f6dc2f9f9acb9beb96c32bf4153441f57d8662b124b05",
+      "checksum": "54765fdfef1e47e40c0bcce8a4964631bdd3b9a0c4f74673ac18645ae0297e8e",
       "netuid": 90,
       "slug": "sn-90",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "cdb5f3d738da5468991a9752dd647ebef898530248258421cb68be09e8431fea",
+      "checksum": "6d3a14f3aca9018ddb4a438980ba4412c36e84032694d032bf8833c1fe1d1296",
       "netuid": 93,
       "slug": "sn-93",
       "surface_count": 9
     },
     {
-      "checksum": "ec31af13e2ed9a090d35d36ad7c08d9e2d2f0e04c3db0f1580e08d5bb1e469ce",
+      "checksum": "54bf6a6b0fe4c43c0e41426e609fcf23d038a5fd299d1e66a7bb34bd5d9e8ed2",
       "netuid": 94,
       "slug": "sn-94",
       "surface_count": 8
     },
     {
-      "checksum": "a20dbf3ece641977854ed9b76ceead4c63aa04f4d5a362fdafdec3d320ad8ad0",
+      "checksum": "b2a366ff3a81a4e75a00044f0b99766977c3b8988a2dbd8d16f8285ba536ddce",
       "netuid": 95,
       "slug": "sn-95",
-      "surface_count": 7
-    },
-    {
-      "checksum": "f2c876bbd751991d3d8528fb99c4a204b39ac1a359c4ceeb7ae823a331c66730",
-      "netuid": 97,
-      "slug": "sn-97",
-      "surface_count": 10
-    },
-    {
-      "checksum": "c67f4affe791d7c68b0a06bb9c997e9ff12a450ef01ca8f21e3a87c1a7d42fd7",
-      "netuid": 99,
-      "slug": "sn-99",
-      "surface_count": 10
-    },
-    {
-      "checksum": "c73b83c3c4cd580da1ec3d97dba12859ae97b08038d831f8c47424451ede4b8f",
-      "netuid": 100,
-      "slug": "sn-100",
-      "surface_count": 9
-    },
-    {
-      "checksum": "1cc7336f0e79841a13a4abb25c9ce173f7fb993d0272a0541a635f25ce3e38b4",
-      "netuid": 101,
-      "slug": "sn-101",
-      "surface_count": 4
-    },
-    {
-      "checksum": "1bc9fbdee58d9f0fe7d05fb108ff2ae05ef1256c75a0bd8be473120b2f90bd54",
-      "netuid": 104,
-      "slug": "sn-104",
-      "surface_count": 4
-    },
-    {
-      "checksum": "f94452ca13b0935d539be8c84a1f28dad0eae03c06f53400eaaf81536ab988d2",
-      "netuid": 105,
-      "slug": "sn-105",
       "surface_count": 8
     },
     {
-      "checksum": "4dd2e02dc5893d41dc212e18c90bb1e7def8e53439c04ae690bd9aeb4864596b",
-      "netuid": 106,
-      "slug": "sn-106",
-      "surface_count": 7
+      "checksum": "6a05d5447ddcaf511cdfd5ae9174e1bbc5c0d51702df25d0d9bc4eae28a8d966",
+      "netuid": 97,
+      "slug": "sn-97",
+      "surface_count": 11
     },
     {
-      "checksum": "8d099348038706a01eaf1fceada99c332427781e8db967638fafd95e89d7c5e7",
-      "netuid": 107,
-      "slug": "sn-107",
+      "checksum": "1cb542a5e91031ab31191dc1965faaca63a86d057507c3f25f35978e035f44bc",
+      "netuid": 99,
+      "slug": "sn-99",
+      "surface_count": 11
+    },
+    {
+      "checksum": "7628196216a215b43bbb069d7b3f6dac55f35bf5a76f6bb8321c571c869a6002",
+      "netuid": 100,
+      "slug": "sn-100",
       "surface_count": 10
     },
     {
-      "checksum": "783761c1f1d2eda6ca52d0e6be0896d0400ed1f64691a85345ab2f33096908db",
+      "checksum": "edd14e7f79a08e79832880548d8e3161b9b587c1733516d0fdb787310b62b87f",
+      "netuid": 101,
+      "slug": "sn-101",
+      "surface_count": 5
+    },
+    {
+      "checksum": "7435523b13ae8883d70c9b1d5fbf0ff34c48c901c8f4d00ec885f46429ffa694",
+      "netuid": 104,
+      "slug": "sn-104",
+      "surface_count": 5
+    },
+    {
+      "checksum": "76527276269bff57b4ad909f210c17d93fd6f9cef3ecf62e666b5c0e4586fdd5",
+      "netuid": 105,
+      "slug": "sn-105",
+      "surface_count": 9
+    },
+    {
+      "checksum": "91256002e8f6c08f59518742e3ff50e5f083ac4506dc4ce20c285310a4e2ee53",
+      "netuid": 106,
+      "slug": "sn-106",
+      "surface_count": 8
+    },
+    {
+      "checksum": "d89659d03bf7cb892945d9a6d96997e58aff79f2055f1122a4904283845803c1",
+      "netuid": 107,
+      "slug": "sn-107",
+      "surface_count": 11
+    },
+    {
+      "checksum": "6aca082998173349b074993808705fbf754a76cd718284b11bdc056c5b802576",
       "netuid": 108,
       "slug": "sn-108",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "checksum": "2ae1e9dfe2824d398e04f3e1bed2d82497e29a34fb6bd322f4575df770936a15",
+      "checksum": "5895ca77e1877951e01f095e226de153587f4a9efe2f787c504d14714e068e8a",
       "netuid": 112,
       "slug": "sn-112",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "checksum": "0fbcbafa623a6371c1c62f064f1ca15109f52337837a3009430fd56c7e0ce54c",
+      "checksum": "3472ab2a612a27a6f215a9adb95db766548a83c6e0771a8f5b72665719eb233d",
       "netuid": 114,
       "slug": "sn-114",
       "surface_count": 9
     },
     {
-      "checksum": "cf6667bb395e55c20e31591bfe139584d170e0216a4b9178219c08c9c0dc47f5",
+      "checksum": "e350fd4d19a1b841cfe7d66c465bd8c6a44ed1c0e44558b3fedee8008f658bcf",
       "netuid": 116,
       "slug": "sn-116",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "c7a67e2c11f36a4ebe9ab6800f39399eebe57b496a95cd1f33a400c87cda1554",
+      "checksum": "8dfef40578ca8317e1b4867461107752d20d29f1c0c35e664d87fff0996e2388",
       "netuid": 118,
       "slug": "sn-118",
-      "surface_count": 9
+      "surface_count": 10
     },
     {
-      "checksum": "ef96968b5bef66a089dfa72ea7dcb84d90aec7d1a6c77833f4d507284b6f7e0f",
+      "checksum": "7959fd972124dc1ea74f6c099bcbfb7fb1212f10ad5c6a1d9d2d8ec724a93ae0",
       "netuid": 119,
       "slug": "sn-119",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
       "checksum": "edd1dc03c883b74c56ae36ef1526e022d58759e823e5504537a207da04ef35bb",
@@ -378,32 +378,32 @@
       "surface_count": 9
     },
     {
-      "checksum": "c8f1f1aa99eda3af60e70b5b41723fb3a407af8693bf12affc217b9b93914cd1",
+      "checksum": "ebfd69cefb54590ba20fa91a9c57844ac7d7825449ac9224493cd6e9a3ca44d0",
       "netuid": 125,
       "slug": "sn-125",
-      "surface_count": 4
+      "surface_count": 5
     },
     {
-      "checksum": "70c0bb95dfdd0c6a1b01be79eebf31b8fbfe7abf9d6f7441a7fe84eb7a3f3a52",
+      "checksum": "de16899216742721123ea59d5ee37a12951739783097f38dc5134be88bf48b48",
       "netuid": 126,
       "slug": "sn-126",
       "surface_count": 7
     },
     {
-      "checksum": "9943f6cf87f698107063cb4076879ecc083f4083d6b906ab478b411b005cd443",
+      "checksum": "4e55ee7b17f66f7f681dafc7ff5927acebce34c11435df299a5b7278d0446e95",
       "netuid": 127,
       "slug": "sn-127",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
-      "checksum": "c878e0b8953ad49e670a54b8ffdbfd505a6f6688d9e2237be406567afde24de8",
+      "checksum": "c51f055cda177d13de1b9d920f730d7b53e84df9c53e3902d6165ebadceabbbb",
       "netuid": 128,
       "slug": "sn-128",
-      "surface_count": 9
+      "surface_count": 10
     }
   ],
-  "promoted_surface_count": 477,
+  "promoted_surface_count": 522,
   "schema_version": 1,
   "total_overlay_count": 129,
-  "verification_result_count": 1753
+  "verification_result_count": 1880
 }

--- a/registry/verification/promotions.json
+++ b/registry/verification/promotions.json
@@ -1,5 +1,5 @@
 {
-  "candidate_count": 1753,
+  "candidate_count": 1880,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "notes": "Compact promotion snapshot for deterministic Git review. Full latency, timestamp, and probe-detail rows are staged for R2 during refresh/publish runs.",
   "results": [
@@ -34,6 +34,27 @@
       "netuid": 0,
       "private_redirect_blocked": false,
       "provider": "taomarketcap",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-0-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 0,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -183,6 +204,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-1-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 1,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -626,6 +668,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-2-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 2,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-2-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -836,6 +899,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-3-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 3,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-3-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -969,6 +1053,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-4-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 4,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -1454,6 +1559,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-5-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 5,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-5-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -1780,6 +1906,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-6-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 6,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -2139,6 +2286,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-7-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 7,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-7-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -2381,6 +2549,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-8-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 8,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -2734,6 +2923,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-9-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 9,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -3156,6 +3366,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-10-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 10,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-10-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -3398,6 +3629,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-11-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 11,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -3736,6 +3988,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-12-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 12,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-12-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -3914,6 +4187,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-13-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 13,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -4357,6 +4651,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-14-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 14,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-14-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -4727,6 +5042,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-15-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 15,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-15-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -5080,6 +5416,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-16-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 16,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-16-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -5343,6 +5700,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-17-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 17,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -5692,6 +6070,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-18-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 18,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -6066,6 +6465,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-19-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 19,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -6512,6 +6932,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-20-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 20,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-20-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -6796,6 +7237,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-21-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 21,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -7260,6 +7722,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-22-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 22,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-22-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -7544,6 +8027,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-23-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 23,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -7872,6 +8376,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-24-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 24,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -8246,6 +8771,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-25-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 25,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -8647,6 +9193,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-26-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 26,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-26-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -8980,6 +9547,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-27-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 27,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-27-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -9184,6 +9772,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-28-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 28,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-28-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -9279,6 +9888,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-29-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 29,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -9401,6 +10031,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-30-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 30,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -9659,6 +10310,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-31-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 31,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-31-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -9775,6 +10447,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-32-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 32,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -10260,6 +10953,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-33-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 33,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-33-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -10355,6 +11069,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-34-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 34,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -10477,6 +11212,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-35-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 35,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -10742,6 +11498,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-36-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 36,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -11074,6 +11851,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-37-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 37,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -11433,6 +12231,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-38-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 38,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-38-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -11663,6 +12482,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-39-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 39,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-39-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -11778,6 +12618,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-40-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 40,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -11900,6 +12761,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-41-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 41,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -12137,6 +13019,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-42-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 42,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-42-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -12232,6 +13135,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-43-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 43,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -12354,6 +13278,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-44-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 44,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -12640,6 +13585,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-45-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 45,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -13143,6 +14109,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-46-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 46,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-46-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -13382,7 +14369,7 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": "https://accounts.google.com/v3/signin/identifier?opparams=%253F&dsh=S-786323433%3A1780919993033721&client_id=327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com&code_challenge=82T5qm2yWE5F6hgu1Su0em5wKORYESWuANAvIfpXvOo&code_challenge_method=S256&nonce=hCMxCf-uWl6AxUzHiVdjpd_epkD_0T1umaaD6GQSlXk&o2v=2&prompt=select_account&redirect_uri=https%3A%2F%2Fzipcode.ai%2Fapi%2Fportal-auth%2Fgoogle%2Fcallback&response_type=code&scope=openid+email+profile&service=lso&state=vq08BjmaDI-162x2baKook9-Uas4s0Zwcxc9p20GydU&flowName=GeneralOAuthLite&continue=https%3A%2F%2Faccounts.google.com%2Fsignin%2Foauth%2Flegacy%2Fconsent%3Fauthuser%3Dunknown%26part%3DAJi8hAMQoyika56f8rIvLwV-KDsZiqPkZWopEYyVPCtIMh6G_0P13kkJTRxXMz6gVFvSZNdEPgHguyQXwHpv9pP_qXvQ62l_2gsKkDo1XWVDTtWD6jlY29akzUYLzmMipAo79uEJEFL4EEIylnSqK0I5z7NpPwgqQjofsjLMJSekDdLaPyyYT343Wb_eGuKGEIUdi2-CIhY9R9X6UvZsrLyy98-jt_6yz0HDcAhICgIXn_YDI6SegCm3rZ3YFOmu9y9BrHcJORrMKKitEmTwtVv1hQqOE2ECXW8em8478Nzx1-8N1VsOTwIzRHCmOOs2h-axZXv-5qy_yX7s16tCFFVT_fZrdn50w0bQDiUvExGw9EFvHJQ1H6Ow3mXCm3tPxiqpZMPknV8ITBxLfHuZUrwwefVKWGk4CCGtbWnm2cveROHOk7xWW6DbBEwm4j3WLoL-8ah8hv0i_LWL3aafTUxQh8YoA_6POQ%26flowName%3DGeneralOAuthFlow%26as%3DS-786323433%253A1780919993033721%26client_id%3D327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com%23&app_domain=https%3A%2F%2Fzipcode.ai&rart=ANgoxcfoiOgLImFsWCNAKwHwP4_TsMmXyYEQXSA0foiFxcynqRD3KONa_NyrbgSwGcylCj6cY8-7wXJZsTfHSb76T8_BhrJ5wWCZ0Wt9umtwTPa0uAVReFI",
+      "redirect_target": "https://accounts.google.com/v3/signin/identifier?opparams=%253F&dsh=S-1925616973%3A1780921947442192&client_id=327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com&code_challenge=bLTC06w6UOJhO4Regu-XM-ltxNaXzpJPL5m-kenCYkU&code_challenge_method=S256&nonce=mdHuyKMp9FP3yapP__S3Mlmmx5Qtbpkv3G5C8B2Bzy0&o2v=2&prompt=select_account&redirect_uri=https%3A%2F%2Fzipcode.ai%2Fapi%2Fportal-auth%2Fgoogle%2Fcallback&response_type=code&scope=openid+email+profile&service=lso&state=R74w55IoHhBLS7gF-2woonhdPtylnamv4WqrJ8r9b08&flowName=GeneralOAuthLite&continue=https%3A%2F%2Faccounts.google.com%2Fsignin%2Foauth%2Flegacy%2Fconsent%3Fauthuser%3Dunknown%26part%3DAJi8hAN60d6GUsdGH1lr32fXTO2W9hasAvrUiKihRrPhNdbtv5IAsghmhxvr9TVjNOp1qfN86tgsFERXQmRmhBnlI-bTaokLoG-NVk19zrREusksP3Z6IULn_XMSg1H7gT8iO6awC8Prq1BkWovDTZZyGFbt5AGFnsuXp3keAITkiId06CURvogK0NF3Ro5cQHoZdXgp--a17ug3qvvePj7mX5paA6le7yrEF0Ff1QZrwX67nxKMQrbN7L1LABSB2W18gD5_q0XrIr_HHClZjPdVLONbarA9NbVFBMduKa9q2KkZYQolGzi6KfDoJXmOWjkPkZWqnRI_Dgq4pPaU-XHuLNYk5uugrhmOQzYC2k6A_3xoa1T13PCa39DV19Pdm0w1XD_m6G3Fuao4Y_l617CpxNzFslaKGhrB2tnMmjZjIR67dw11X8yVgWFQ-uTAfF54bGQNrkLnbU6xtH0P8D0nnvR8TYBzfA%26flowName%3DGeneralOAuthFlow%26as%3DS-1925616973%253A1780921947442192%26client_id%3D327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com%23&app_domain=https%3A%2F%2Fzipcode.ai&rart=ANgoxce2jc38B-dJcNMqw9MU_SFgnGQNxd1RBK4sfCUrRI4BwmdFFhxjgrbuABCfyuvp-5FDfLJ_W4aAGShoWWALiZGjkg41eBLaK1hCEyxN9A1qpwVPUXQ",
       "status": "ok"
     },
     {
@@ -13529,6 +14516,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-47-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 47,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-47-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -13662,6 +14670,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-48-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 48,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -14166,6 +15195,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-49-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 49,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-49-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -14423,6 +15473,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-50-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 50,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -14692,6 +15763,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-51-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 51,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -15156,6 +16248,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-52-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 52,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-52-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -15314,6 +16427,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-53-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 53,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-53-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -15451,6 +16585,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-54-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 54,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -15741,6 +16896,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-55-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 55,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -16073,6 +17249,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-56-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 56,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -16516,6 +17713,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-57-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 57,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-57-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -16653,6 +17871,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-58-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 58,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -16813,6 +18052,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-59-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 59,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -17172,6 +18432,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-60-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 60,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-60-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -17479,6 +18760,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-61-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 61,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-61-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -17727,6 +19029,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-62-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 62,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-62-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -17969,6 +19292,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-63-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 63,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -18494,6 +19838,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-64-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 64,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-64-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -18986,6 +20351,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-65-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 65,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-65-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -19360,6 +20746,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-66-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 66,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-66-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -19675,6 +21082,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-67-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 67,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-67-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -19976,6 +21404,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-68-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 68,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -20297,6 +21746,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-69-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 69,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-69-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -20413,6 +21883,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-70-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 70,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -20772,6 +22263,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-71-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 71,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-71-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -21035,6 +22547,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-72-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 72,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -21461,6 +22994,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-73-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 73,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-73-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -21639,6 +23193,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-74-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 74,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -21904,6 +23479,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-75-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 75,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -22385,6 +23981,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-76-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 76,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-76-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -22654,6 +24271,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-77-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 77,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-77-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -22896,6 +24534,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-78-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 78,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -23186,6 +24845,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-79-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 79,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -23667,6 +25347,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-80-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 80,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-80-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -23814,48 +25515,6 @@
       "status": "ok"
     },
     {
-      "candidate_id": "sn-80-website-link-dogelayer-ai-dashboard-1",
-      "classification": "live",
-      "confidence_score": 76,
-      "content_type": "text/html; charset=utf-8",
-      "error": null,
-      "kind": "dashboard",
-      "netuid": 80,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "redirect_target": null,
-      "status": "ok"
-    },
-    {
-      "candidate_id": "sn-80-website-link-dogelayer-ai-docs-2",
-      "classification": "live",
-      "confidence_score": 76,
-      "content_type": "text/html; charset=utf-8",
-      "error": null,
-      "kind": "docs",
-      "netuid": 80,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "redirect_target": null,
-      "status": "ok"
-    },
-    {
       "candidate_id": "sn-81-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -23933,6 +25592,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-81-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 81,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -24072,6 +25752,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-82-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 82,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -24553,6 +26254,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-83-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 83,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-83-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -24763,6 +26485,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-84-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 84,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-84-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -24913,6 +26656,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-85-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 85,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -25276,6 +27040,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-86-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 86,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-86-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -25354,6 +27139,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-87-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 87,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -25518,6 +27324,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-88-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 88,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -25835,6 +27662,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-89-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 89,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-89-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -26045,6 +27893,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-90-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 90,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-90-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -26144,6 +28013,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-91-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 91,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -26465,6 +28355,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-92-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 92,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-92-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -26621,6 +28532,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-93-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 93,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -26980,6 +28912,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-94-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 94,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-94-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -27288,6 +29241,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-95-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 95,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -27626,6 +29600,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-96-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 96,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-96-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -27912,6 +29907,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-97-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 97,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-97-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -28192,6 +30208,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-98-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 98,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -28655,6 +30692,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-99-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 99,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-99-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -28914,6 +30972,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-100-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 100,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -29252,6 +31331,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-101-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 101,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-101-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -29389,6 +31489,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-102-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 102,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -29721,6 +31842,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-103-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 103,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -30126,6 +32268,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-104-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 104,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-104-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -30245,6 +32408,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-105-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 105,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -30493,6 +32677,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-106-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 106,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -30782,6 +32987,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-107-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 107,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -31131,6 +33357,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-108-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 108,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -31490,6 +33737,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-109-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 109,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-109-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -31589,6 +33857,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-110-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 110,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -32049,6 +34338,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-111-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 111,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-111-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -32165,6 +34475,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-112-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 112,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -32455,6 +34786,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-113-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 113,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -32808,6 +35160,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-114-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 114,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -33205,6 +35578,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-115-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 115,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-115-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -33283,6 +35677,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-116-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 116,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -33404,6 +35819,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-117-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 117,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -33567,6 +36003,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-118-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 118,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -34009,6 +36466,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-119-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 119,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-119-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -34146,6 +36624,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-120-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 120,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -34394,6 +36893,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-121-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 121,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -34820,6 +37340,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-122-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 122,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-122-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -34932,6 +37473,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-123-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 123,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -35075,6 +37637,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-124-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 124,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -35291,6 +37874,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-125-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 125,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-125-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -35407,6 +38011,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-126-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 126,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -35745,6 +38370,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-127-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 127,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-127-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -36056,6 +38702,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-128-taostats-metagraph",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 128,
+      "private_redirect_blocked": false,
+      "provider": "taostats",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-128-tensorplex-docs",
       "classification": "live",
       "confidence_score": 73,
@@ -36226,7 +38893,7 @@
       "auth-required": 9,
       "content-mismatch": 46,
       "dead": 396,
-      "live": 1102,
+      "live": 1229,
       "rate-limited": 7,
       "redirected": 159,
       "transient": 4,
@@ -36234,9 +38901,9 @@
       "unsupported": 28
     },
     "by_kind": {
-      "dashboard": 306,
+      "dashboard": 434,
       "data-artifact": 14,
-      "docs": 417,
+      "docs": 416,
       "openapi": 280,
       "source-repo": 156,
       "subnet-api": 215,
@@ -36246,11 +38913,12 @@
       "allways": 1,
       "backprop-finance": 129,
       "gittensor": 1,
-      "taomarketcap": 1298,
+      "taomarketcap": 1296,
       "taopedia-articles": 128,
+      "taostats": 129,
       "tensorplex-subnet-docs": 196
     },
-    "promotable_count": 1261
+    "promotable_count": 1388
   },
   "verification_finished_at": null,
   "verification_started_at": null

--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -1,7 +1,7 @@
 export const ARTIFACT_SIZE_BUDGETS = [
   budget("candidates.json", 4_000_000, 8_000_000),
   budget("review-queue.json", 4_000_000, 8_000_000),
-  budget("verification/latest.json", 2_000_000, 5_000_000),
+  budget("verification/latest.json", 3_000_000, 5_000_000),
   budget("surfaces.json", 1_500_000, 4_000_000),
   budget("endpoints.json", 1_750_000, 4_000_000),
   budget("providers/*/endpoints.json", 1_000_000, 3_000_000),

--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -43,6 +43,7 @@ await discoverFromTensorplexSubnetDocs();
 await discoverFromTaopediaArticles();
 await discoverUniversalTaoMarketCapDashboards();
 await discoverUniversalBackpropFinanceDashboards();
+await discoverUniversalTaostatsMetagraphDashboards();
 if (restoredProviders.size === 0) {
   await discoverFromGithubReadmes();
   await discoverFromProjectWebsites();
@@ -98,6 +99,10 @@ if (!dryRun) {
         {
           id: "backprop-finance",
           url: "https://backprop.finance/dtao/subnets/",
+        },
+        {
+          id: "taostats",
+          url: "https://taostats.io/subnets/",
         },
         {
           id: "tensorplex-subnet-docs",
@@ -387,6 +392,27 @@ async function discoverUniversalBackpropFinanceDashboards() {
       provider: "backprop-finance",
       review_notes:
         "Universal Backprop Finance dTAO subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+    });
+  }
+}
+
+async function discoverUniversalTaostatsMetagraphDashboards() {
+  for (const subnet of nativeSnapshot.subnets) {
+    const displayName = displayNameForNetuid(subnet.netuid);
+    const url = `https://taostats.io/subnets/${subnet.netuid}/metagraph`;
+    addCandidate({
+      id: `sn-${subnet.netuid}-taostats-metagraph`,
+      netuid: subnet.netuid,
+      name: `${displayName} Taostats metagraph`,
+      kind: "dashboard",
+      url,
+      source_url: url,
+      source_type: "taostats-metagraph-dashboard",
+      source_tier: "third-party-index",
+      confidence: "medium",
+      provider: "taostats",
+      review_notes:
+        "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
     });
   }
 }

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -169,6 +169,13 @@ describe("public contract registry", () => {
     );
   });
 
+  test("requires canonical component schemas before building OpenAPI", () => {
+    assert.throws(
+      () => buildOpenApiArtifact("1970-01-01T00:00:00.000Z", null),
+      /requires canonical component schemas/,
+    );
+  });
+
   test("keeps public API route payloads on typed artifact schemas", async () => {
     const generatedAt = "1970-01-01T00:00:00.000Z";
     const openapi = buildOpenApiArtifact(

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -41,6 +41,7 @@ import {
   redactCredentialedUrls,
   registrySurfaceKey,
   repoRoot,
+  isReviewableReadmeLink,
   selectReviewableReadmeLinks,
   sha256Hex,
   slugify,
@@ -356,6 +357,25 @@ describe("script utility contracts", () => {
         "https://api.exampleproject.ai/openapi.json",
         "https://grafana.public.example/d/subnet?var-subnet=42",
       ],
+    );
+  });
+
+  test("README link review rejects malformed and generic references", () => {
+    assert.equal(isReviewableReadmeLink(null), false);
+    assert.equal(
+      isReviewableReadmeLink({
+        classification: { kind: "docs", label: "docs" },
+        url: "not a url",
+      }),
+      false,
+    );
+    assert.equal(
+      isReviewableReadmeLink({
+        classification: { kind: "docs", label: "docs" },
+        label: "Bittensor docs",
+        url: "https://docs.learnbittensor.org/subnets/understanding-subnets",
+      }),
+      false,
     );
   });
 


### PR DESCRIPTION
## Summary
- add Taostats per-subnet metagraph pages as third-party dashboard enrichment
- refresh compact registry/candidate/surface artifacts after verification
- keep artifact budget validation warning-free after expanded all-subnet verification detail

## What changed
- discovery now emits one Taostats metagraph dashboard candidate per active Finney netuid
- all 129 Taostats candidates verified live in the local refresh
- 58 Taostats surfaces were promoted into generated overlays while preserving hand-curated overlays
- coverage tests were added for OpenAPI schema guarding and README link filtering

## Why
- Taostats exposes stable public metagraph pages that fit Metagraphed's operational interface registry model
- this improves all-subnet operational surface coverage without treating third-party analytics as identity authority

## Validation
- `GITHUB_TOKEN=... npm run check`
- `npm run test:coverage`
- `npm run curation:brief -- --limit 8`
- `git diff --check`

## Notes
- Third-party Taostats dashboards are enrichment only, not chain or subnet identity authority.
- R2-only detail artifacts remain untracked; this PR updates compact Git-reviewed indexes and source bundles.