### PR TITLE
fix(registry): preserve freshness with compact verification

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -89,6 +89,9 @@ const previousArtifactDigests = await collectArtifactDigests({
 const previousSubnetsArtifact = await readOptionalJson(
   path.join(outputRoot, "subnets.json"),
 );
+const previousFreshnessArtifact = await readOptionalJson(
+  path.join(outputRoot, "freshness.json"),
+);
 const previousCoverageArtifact = await readOptionalJson(
   path.join(outputRoot, "coverage.json"),
 );
@@ -555,6 +558,7 @@ await writeJson(
     generatedAt,
     healthArtifacts,
     nativeSnapshot,
+    previousFreshness: previousFreshnessArtifact,
     schemaDrift: schemaDriftPlaceholder,
     verification,
   }),
@@ -2276,6 +2280,7 @@ function buildFreshnessArtifact({
   generatedAt: timestamp,
   healthArtifacts: health,
   nativeSnapshot: native,
+  previousFreshness,
   schemaDrift,
   verification: verificationArtifact,
 }) {
@@ -2302,6 +2307,10 @@ function buildFreshnessArtifact({
   const verificationAsOf =
     verificationArtifact.verification_finished_at ||
     nonPlaceholderTimestamp(verificationArtifact.generated_at) ||
+    previousFreshness?.sources?.find(
+      (source) => source.id === "candidate-verification",
+    )?.as_of ||
+    previousFreshness?.summary?.verification_as_of ||
     null;
   const healthProbeAsOf =
     health.latest.source === "live-smoke-probe"

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1070,9 +1070,12 @@ async function validateGeneratedArtifacts(
     freshnessArtifact.summary?.native_data_as_of === nativeSnapshot.captured_at,
     "freshness: native_data_as_of mismatch",
   );
+  const candidateVerificationFreshness = freshnessArtifact.sources.find(
+    (source) => source.id === "candidate-verification",
+  );
   assert(
     freshnessArtifact.summary?.verification_as_of ===
-      verificationArtifact.verification_finished_at,
+      candidateVerificationFreshness?.as_of,
     "freshness: verification_as_of mismatch",
   );
   assert(

--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -168,38 +168,43 @@ async function verifyGithubRepo(base, repo) {
   const apiUrl = `https://api.github.com/repos/${repo.owner}/${repo.repo}`;
   const api = await fetchJson(apiUrl, githubHeaders());
   if (api.ok) {
-    const metadata = api.body;
-    const classification = metadata.archived ? "unsupported" : "live";
-    return {
-      ...base,
-      archived: Boolean(metadata.archived),
-      classification,
-      confidence_score: metadata.archived ? 20 : 80,
-      default_branch: metadata.default_branch || null,
-      description: metadata.description || null,
-      github_api_url: apiUrl,
-      homepage: normalizeNullableUrl(metadata.homepage),
-      html_url: metadata.html_url || base.url,
-      last_push_at: metadata.pushed_at || null,
-      quality_signals: {
-        archived: Boolean(metadata.archived),
-        has_default_branch: Boolean(metadata.default_branch),
-        has_recent_push_metadata: Boolean(metadata.pushed_at),
-        public_safe: true,
-        source_tier: base.source_tier || null,
-      },
-      status: metadata.archived ? "failed" : "ok",
-      topics: Array.isArray(metadata.topics)
-        ? metadata.topics.slice().sort()
-        : [],
-    };
+    return githubMetadataResult(base, apiUrl, api.body, {
+      classification: "live",
+    });
   }
 
-  const fallback = await probeUrl(
+  let fallback = await probeUrl(
     base.url,
     "HEAD",
     "text/html,application/xhtml+xml",
   );
+  if (!fallback.ok || [400, 403, 404, 405].includes(fallback.status_code)) {
+    const getFallback = await probeUrl(
+      base.url,
+      "GET",
+      "text/html,application/xhtml+xml",
+    );
+    if (getFallback.ok || !fallback.ok) {
+      fallback = getFallback;
+    }
+  }
+
+  const redirectedRepo = parseGithubRepo(fallback.redirect_target);
+  if (redirectedRepo) {
+    const redirectApiUrl = `https://api.github.com/repos/${redirectedRepo.owner}/${redirectedRepo.repo}`;
+    const redirectApi = await fetchJson(redirectApiUrl, githubHeaders());
+    if (redirectApi.ok) {
+      return githubMetadataResult(base, redirectApiUrl, redirectApi.body, {
+        api_error: api.error || null,
+        api_status: api.status_code || null,
+        classification: "redirected",
+        latency_ms: fallback.latency_ms,
+        method_tested: fallback.method_tested,
+        redirect_target: fallback.redirect_target,
+      });
+    }
+  }
+
   const classification = classifyHttpProbe(fallback);
   return {
     ...base,
@@ -222,6 +227,42 @@ async function verifyGithubRepo(base, repo) {
     status: fallback.ok ? "ok" : "failed",
     status_code: fallback.status_code || null,
   };
+}
+
+function githubMetadataResult(base, apiUrl, metadata, options = {}) {
+  const archived = Boolean(metadata.archived);
+  const classification = archived
+    ? "unsupported"
+    : options.classification || "live";
+  return stripNullish({
+    ...base,
+    archived,
+    classification,
+    confidence_score: archived ? 20 : 80,
+    default_branch: metadata.default_branch || null,
+    description: metadata.description || null,
+    error: options.api_error || null,
+    github_api_status: options.api_status || null,
+    github_api_url: apiUrl,
+    homepage: normalizeNullableUrl(metadata.homepage),
+    html_url: metadata.html_url || base.url,
+    last_push_at: metadata.pushed_at || null,
+    latency_ms: options.latency_ms,
+    method_tested: options.method_tested,
+    quality_signals: stripNullish({
+      archived,
+      has_default_branch: Boolean(metadata.default_branch),
+      has_recent_push_metadata: Boolean(metadata.pushed_at),
+      public_safe: true,
+      redirected: options.redirect_target ? true : undefined,
+      source_tier: base.source_tier || null,
+    }),
+    redirect_target: redactCredentialedUrl(options.redirect_target),
+    status: archived ? "failed" : "ok",
+    topics: Array.isArray(metadata.topics)
+      ? metadata.topics.slice().sort()
+      : [],
+  });
 }
 
 async function verifyHttpSurface(base, candidate) {


### PR DESCRIPTION
## Summary
- preserve candidate verification freshness when rebuilding from compact Git artifacts
- make validation compare freshness summary against the freshness source row instead of stripped compact verification timestamps
- harden source-repo verification for GitHub URL redirects and renamed repository targets

## What changed
- build freshness now falls back to the previous reviewed candidate-verification timestamp when detailed verification is not present locally
- validation no longer requires compact promotion artifacts to carry volatile `verification_finished_at` fields
- GitHub source-repo verification now retries with a GET fallback and resolves redirected repo targets through the GitHub API when possible

## Why
- clean local staging should not rewrite `public/metagraph/freshness.json` to a missing verification state just because detailed verification rows are R2-backed
- renamed GitHub repositories should not be treated as dead when a public-safe redirect can be resolved to canonical metadata

## Validation
- `GITHUB_TOKEN=... npm run check`
- `git diff --check`

## Notes
- This is code-only; it does not publish or refresh registry data artifacts.
- Current SN27 source-repo evidence still returns 404 through GitHub API and curl, so it remains unpromoted until current official evidence is available.