### PR TITLE
feat(registry): enrich low completeness subnets

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -2,12 +2,12 @@
   "adapter_count": 2,
   "artifact_budget_summary": {
     "fail_count": 0,
-    "ok_count": 1207,
+    "ok_count": 1215,
     "warn_count": 0
   },
   "artifact_budgets": [],
   "artifact_count": 22,
-  "artifact_size_bytes": 4443331,
+  "artifact_size_bytes": 4465122,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -17,8 +17,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "1e4ed1e51518580136834e40bd66b38b2e43181966d7d72be98174b34bd51b14",
-      "size_bytes": 3288,
+      "sha256": "234d381425319b0a0d5238449f8d6011295a7ed0d762d50af60e1e83194bdaa9",
+      "size_bytes": 1349,
       "storage_tier": "dual"
     },
     {
@@ -29,32 +29,32 @@
     },
     {
       "path": "coverage.json",
-      "sha256": "e186b2ed3dab46d5ba9b3b56007bfed9d15b98b96e32f566abfd9aa38300b7be",
+      "sha256": "411565b9077ad8d8db4390041ffcbca39f982b684cefe21c1e17681aef075bbb",
       "size_bytes": 984,
       "storage_tier": "dual"
     },
     {
       "path": "curation.json",
-      "sha256": "3994712d15a4053e51812b479dc545402171bfad4d9b5dc66789d20a97128503",
-      "size_bytes": 156768,
+      "sha256": "4af721577e89cfa64db395f38e70794ce218118bae2bd1b504e31e24f9f58cbc",
+      "size_bytes": 159521,
       "storage_tier": "dual"
     },
     {
       "path": "evidence-ledger.json",
-      "sha256": "58404d11f70c04b2057898a11ec8e05ca4e616c5529929431edbf2b88fa1101c",
-      "size_bytes": 843085,
+      "sha256": "59ff31ac9b70a35b2605d6f8ba6a016332b6230045444271ff5712f10c6806e2",
+      "size_bytes": 847225,
       "storage_tier": "dual"
     },
     {
       "path": "freshness.json",
-      "sha256": "d7d7b0d9ef836fd1a0c74449d73ee498877ca925ff72dc7fbc60db6ae6f955a7",
+      "sha256": "4c5db4208a1e88b0233ea3bfb3f5e29f42dafe51ec390fa5b3aa2c75d3690f91",
       "size_bytes": 4324,
       "storage_tier": "dual"
     },
     {
       "path": "gaps.json",
-      "sha256": "bb6854d6d302a958595e362fc8b58fb13769a025952d3f222b4f0584f239413d",
-      "size_bytes": 90569,
+      "sha256": "05d8a498e14a54e9c214df7f2f059be2c1a148ae6a2e87b95164cf5ddb83254f",
+      "size_bytes": 91868,
       "storage_tier": "dual"
     },
     {
@@ -65,38 +65,38 @@
     },
     {
       "path": "profiles.json",
-      "sha256": "d3accc91a589d8d2ecb9924104932adeb0ba293c1c090c3b5f108b01a05962fa",
-      "size_bytes": 367985,
+      "sha256": "032d46df2fd4e9ef52c4af95f18dd1a9476e776a5722a2babba72bf34d3f255f",
+      "size_bytes": 368150,
       "storage_tier": "dual"
     },
     {
       "path": "providers.json",
-      "sha256": "25998ba09b13d1b8caed346094fc0801ff1f4e8479523c111b6f5e188de209f5",
-      "size_bytes": 27898,
+      "sha256": "28a083649fe55ae64a30193958ce6eca59b8e7795e1143120c1dfa7485280178",
+      "size_bytes": 29625,
       "storage_tier": "dual"
     },
     {
       "path": "review/adapter-candidates.json",
-      "sha256": "fb61b55cc58775e03ba37561d60158b6e23e66b97e5aa7c362c7343d52e669ec",
-      "size_bytes": 26538,
+      "sha256": "a65e777f253648867ffe0702ed337ddbbab0cc0738531fff5c6980e4cf787e61",
+      "size_bytes": 26542,
       "storage_tier": "dual"
     },
     {
       "path": "review/curation.json",
-      "sha256": "0552407f2080a8746b9a4010d9abeebedb7f1e9ee29549f4db5a543ba5d32c42",
-      "size_bytes": 94143,
+      "sha256": "034370e6f3fa328465b0273c0b0e7e192ac6de3622a09033b0f5a3e5cedf7110",
+      "size_bytes": 94028,
       "storage_tier": "dual"
     },
     {
       "path": "review/enrichment-queue.json",
-      "sha256": "02484f79d23177d20047c19917ec1a428e9e1d4c86fa987cdce2d6206814b209",
-      "size_bytes": 346351,
+      "sha256": "09f4301b4a5a5ce31cf845453bb1cce45f27916474d73732687fd5c2809fd069",
+      "size_bytes": 346281,
       "storage_tier": "dual"
     },
     {
       "path": "review/gap-priorities.json",
-      "sha256": "9f737864dcfa531553db7ba7ae2f02da54e32f4742cb97abc0566b23d6875286",
-      "size_bytes": 65756,
+      "sha256": "6458bd06bedd3165689ff873eac819bf98ff3c8fb9605324821a60bf3020ae50",
+      "size_bytes": 65637,
       "storage_tier": "dual"
     },
     {
@@ -107,8 +107,8 @@
     },
     {
       "path": "review/profile-completeness.json",
-      "sha256": "e0edf11e38d69d7473a6767de1befd78a7122215430b4504968e300133e1f9d2",
-      "size_bytes": 129636,
+      "sha256": "286414a702ca6c5813092ccfffe15275ac82b8166dcb6c7ca936e1f42d183f45",
+      "size_bytes": 129571,
       "storage_tier": "git"
     },
     {
@@ -125,35 +125,35 @@
     },
     {
       "path": "search.json",
-      "sha256": "2cdb689a7d6667deb3a36c2f437a7fa635f21819d87eef9150a06622bca45bd0",
-      "size_bytes": 602840,
+      "sha256": "ca6042fd8386a52ca87a138b3c81246a6241b49bd58f0936f7f2776a03fec0c8",
+      "size_bytes": 605604,
       "storage_tier": "dual"
     },
     {
       "path": "subnets.json",
-      "sha256": "20a7f2d2e1568dc3bcb8b50283286c82a8a21f097b4a229d27a9b4a8974f9d95",
-      "size_bytes": 125544,
+      "sha256": "2857b9294fe09774b94481b35b0728cb5f17bc659cd8245950f31abef2421e38",
+      "size_bytes": 126106,
       "storage_tier": "dual"
     },
     {
       "path": "surfaces.json",
-      "sha256": "a4a4be54f7f61c408b6a31583a6b603390c8e3bc8d696f58e1b89e32da7c4787",
-      "size_bytes": 1128957,
+      "sha256": "ac8e86b20151d7ec32f44f1d02253052c13f303d2a0ec2074170a262376d7fc2",
+      "size_bytes": 1139642,
       "storage_tier": "dual"
     }
   ],
-  "candidate_count": 1891,
+  "candidate_count": 2018,
   "contract_version": "2026-06-06.1",
   "coverage": {
     "application_subnet_count": 128,
-    "candidate_count": 1891,
+    "candidate_count": 2018,
     "candidate_subnet_count": 129,
     "chain_subnet_count": 129,
     "curated_overlay_count": 129,
     "curation_level_counts": {
       "adapter-backed": 2,
-      "machine-verified": 66,
-      "maintainer-reviewed": 61
+      "machine-verified": 62,
+      "maintainer-reviewed": 65
     },
     "generated_at": "1970-01-01T00:00:00.000Z",
     "manifested_count": 0,
@@ -163,7 +163,7 @@
     "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
     "network": "finney",
     "probed_count": 129,
-    "probed_surface_count": 1110,
+    "probed_surface_count": 1115,
     "root_subnet_count": 1,
     "schema_version": 1,
     "source": {
@@ -177,14 +177,14 @@
       },
       "overlays": "registry/subnets"
     },
-    "surface_count": 1114
+    "surface_count": 1122
   },
-  "endpoint_count": 1114,
-  "full_artifact_count": 1207,
-  "full_artifact_size_bytes": 46159593,
+  "endpoint_count": 1122,
+  "full_artifact_count": 1215,
+  "full_artifact_size_bytes": 47821880,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
-  "provider_count": 68,
+  "provider_count": 72,
   "public_contract": {
     "url": "/metagraph/contracts.json",
     "version": "2026-06-06.1"
@@ -193,13 +193,13 @@
   "storage_tier_counts": {
     "dual": 21,
     "git": 1,
-    "r2": 1185
+    "r2": 1193
   },
   "storage_tier_size_bytes": {
-    "dual": 4313695,
-    "git": 129636,
-    "r2": 41716262
+    "dual": 4335551,
+    "git": 129571,
+    "r2": 43356758
   },
   "subnet_count": 129,
-  "surface_count": 1114
+  "surface_count": 1122
 }

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -3,64 +3,8 @@
     "added": [],
     "modified": [
       {
-        "hash": "e186b2ed3dab46d5ba9b3b56007bfed9d15b98b96e32f566abfd9aa38300b7be",
-        "path": "coverage.json"
-      },
-      {
-        "hash": "3994712d15a4053e51812b479dc545402171bfad4d9b5dc66789d20a97128503",
-        "path": "curation.json"
-      },
-      {
-        "hash": "58404d11f70c04b2057898a11ec8e05ca4e616c5529929431edbf2b88fa1101c",
-        "path": "evidence-ledger.json"
-      },
-      {
-        "hash": "d7d7b0d9ef836fd1a0c74449d73ee498877ca925ff72dc7fbc60db6ae6f955a7",
+        "hash": "4c5db4208a1e88b0233ea3bfb3f5e29f42dafe51ec390fa5b3aa2c75d3690f91",
         "path": "freshness.json"
-      },
-      {
-        "hash": "bb6854d6d302a958595e362fc8b58fb13769a025952d3f222b4f0584f239413d",
-        "path": "gaps.json"
-      },
-      {
-        "hash": "d3accc91a589d8d2ecb9924104932adeb0ba293c1c090c3b5f108b01a05962fa",
-        "path": "profiles.json"
-      },
-      {
-        "hash": "fb61b55cc58775e03ba37561d60158b6e23e66b97e5aa7c362c7343d52e669ec",
-        "path": "review/adapter-candidates.json"
-      },
-      {
-        "hash": "0552407f2080a8746b9a4010d9abeebedb7f1e9ee29549f4db5a543ba5d32c42",
-        "path": "review/curation.json"
-      },
-      {
-        "hash": "02484f79d23177d20047c19917ec1a428e9e1d4c86fa987cdce2d6206814b209",
-        "path": "review/enrichment-queue.json"
-      },
-      {
-        "hash": "9f737864dcfa531553db7ba7ae2f02da54e32f4742cb97abc0566b23d6875286",
-        "path": "review/gap-priorities.json"
-      },
-      {
-        "hash": "e0edf11e38d69d7473a6767de1befd78a7122215430b4504968e300133e1f9d2",
-        "path": "review/profile-completeness.json"
-      },
-      {
-        "hash": "a79bde821884f19d45900944b1746aa962d86d5985c6d7cd013ad420d6019166",
-        "path": "schema-drift.json"
-      },
-      {
-        "hash": "2cdb689a7d6667deb3a36c2f437a7fa635f21819d87eef9150a06622bca45bd0",
-        "path": "search.json"
-      },
-      {
-        "hash": "20a7f2d2e1568dc3bcb8b50283286c82a8a21f097b4a229d27a9b4a8974f9d95",
-        "path": "subnets.json"
-      },
-      {
-        "hash": "a4a4be54f7f61c408b6a31583a6b603390c8e3bc8d696f58e1b89e32da7c4787",
-        "path": "surfaces.json"
       }
     ],
     "removed": []
@@ -80,12 +24,12 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 15,
+    "artifact_modified_count": 1,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {
-        "after": 1891,
-        "before": 1891,
+        "after": 2018,
+        "before": 2018,
         "delta": 0
       },
       "curated_overlay_count": {
@@ -100,9 +44,9 @@
       },
       "provider_count": null,
       "surface_count": {
-        "after": 1114,
-        "before": 1116,
-        "delta": -2
+        "after": 1122,
+        "before": 1122,
+        "delta": 0
       }
     },
     "netuid_added_count": 0,

--- a/public/metagraph/coverage.json
+++ b/public/metagraph/coverage.json
@@ -1,13 +1,13 @@
 {
   "application_subnet_count": 128,
-  "candidate_count": 1891,
+  "candidate_count": 2018,
   "candidate_subnet_count": 129,
   "chain_subnet_count": 129,
   "curated_overlay_count": 129,
   "curation_level_counts": {
     "adapter-backed": 2,
-    "machine-verified": 66,
-    "maintainer-reviewed": 61
+    "machine-verified": 62,
+    "maintainer-reviewed": 65
   },
   "generated_at": "1970-01-01T00:00:00.000Z",
   "manifested_count": 0,
@@ -17,7 +17,7 @@
   "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
   "network": "finney",
   "probed_count": 129,
-  "probed_surface_count": 1110,
+  "probed_surface_count": 1115,
   "root_subnet_count": 1,
   "schema_version": 1,
   "source": {
@@ -31,5 +31,5 @@
     },
     "overlays": "registry/subnets"
   },
-  "surface_count": 1114
+  "surface_count": 1122
 }

--- a/public/metagraph/curation.json
+++ b/public/metagraph/curation.json
@@ -1,7 +1,7 @@
 {
   "curation": [
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -41,7 +41,7 @@
       "surface_count": 14
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -85,7 +85,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -125,7 +125,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -169,7 +169,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -213,7 +213,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -255,7 +255,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -267,7 +267,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -297,7 +297,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -335,7 +335,7 @@
       "surface_count": 23
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -421,7 +421,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -433,7 +433,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -460,10 +460,10 @@
       "name": "Swap",
       "netuid": 10,
       "slug": "sn-10",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -505,7 +505,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -549,7 +549,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -591,7 +591,7 @@
       "surface_count": 13
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -603,7 +603,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 7,
+        "source_count": 8,
         "verified_at": null
       },
       "gap_count": 4,
@@ -633,7 +633,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -675,7 +675,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -715,7 +715,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -727,7 +727,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -757,7 +757,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -799,7 +799,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -841,7 +841,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -887,7 +887,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -931,7 +931,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -969,7 +969,7 @@
       "surface_count": 16
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -981,7 +981,7 @@
         "level": "maintainer-reviewed",
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:50:00.000Z",
-        "source_count": 7,
+        "source_count": 8,
         "verified_at": "2026-06-08T09:50:00.000Z"
       },
       "gap_count": 3,
@@ -1011,7 +1011,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1051,7 +1051,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1066,7 +1066,7 @@
         "level": "maintainer-reviewed",
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:50:00.000Z",
-        "source_count": 7,
+        "source_count": 8,
         "verified_at": "2026-06-08T09:50:00.000Z"
       },
       "gap_count": 4,
@@ -1099,7 +1099,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1145,32 +1145,33 @@
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Official website/docs/console are browser-facing but currently reject simple machine probes with connection resets, so these surfaces are listed without recurring probe monitoring.",
+          "Previously discovered GitHub source repository candidates currently return 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
-        "level": "machine-verified",
-        "review_state": "machine-generated",
-        "reviewed_at": null,
-        "source_count": 5,
-        "verified_at": null
+        "level": "maintainer-reviewed",
+        "review_state": "maintainer-reviewed",
+        "reviewed_at": "2026-06-08T14:15:00.000Z",
+        "source_count": 7,
+        "verified_at": "2026-06-08T14:15:00.000Z"
       },
-      "gap_count": 6,
+      "gap_count": 5,
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Official website/docs/console are browser-facing but currently reject simple machine probes with connection resets, so these surfaces are listed without recurring probe monitoring.",
+          "Previously discovered GitHub source repository candidates currently return 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
         "missing_kinds": [
           "source-repo",
-          "website",
           "openapi",
           "subnet-api",
           "sse",
@@ -1178,16 +1179,17 @@
         ],
         "supported_kinds": [
           "dashboard",
-          "docs"
+          "docs",
+          "website"
         ]
       },
       "name": "Nodexo",
       "netuid": 27,
-      "slug": "sn-27",
-      "surface_count": 5
+      "slug": "nodexo",
+      "surface_count": 8
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1233,7 +1235,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1273,7 +1275,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1317,7 +1319,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1376,7 +1378,7 @@
         "level": "maintainer-reviewed",
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T10:10:00.000Z",
-        "source_count": 7,
+        "source_count": 6,
         "verified_at": "2026-06-08T10:10:00.000Z"
       },
       "gap_count": 4,
@@ -1404,10 +1406,10 @@
       "name": "ItsAI",
       "netuid": 32,
       "slug": "sn-32",
-      "surface_count": 8
+      "surface_count": 7
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1447,7 +1449,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1489,7 +1491,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1501,7 +1503,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -1528,10 +1530,10 @@
       "name": "OxMarkets",
       "netuid": 35,
       "slug": "sn-35",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1573,7 +1575,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1615,11 +1617,10 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
-          "No verified source repository yet.",
           "No verified subnet API surface yet.",
           "No verified SSE/event stream yet.",
           "No verified data artifact yet."
@@ -1630,16 +1631,14 @@
         "source_count": 6,
         "verified_at": null
       },
-      "gap_count": 4,
+      "gap_count": 3,
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
           "No verified subnet API surface yet.",
           "No verified SSE/event stream yet.",
           "No verified data artifact yet."
         ],
         "missing_kinds": [
-          "source-repo",
           "subnet-api",
           "sse",
           "data-artifact"
@@ -1648,16 +1647,17 @@
           "dashboard",
           "docs",
           "openapi",
+          "source-repo",
           "website"
         ]
       },
       "name": "colosseum",
       "netuid": 38,
       "slug": "sn-38",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1703,7 +1703,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1749,7 +1749,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1789,7 +1789,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1835,7 +1835,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1879,7 +1879,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1921,7 +1921,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1965,7 +1965,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -1976,7 +1976,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 6,
+        "source_count": 7,
         "verified_at": null
       },
       "gap_count": 3,
@@ -2005,7 +2005,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2049,7 +2049,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2093,7 +2093,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2131,7 +2131,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2171,7 +2171,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2211,7 +2211,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 10,
+      "candidate_count": 11,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2253,36 +2253,39 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "SignalPlus website is live and is tracked as the team/project website.",
+          "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
-        "level": "machine-verified",
-        "review_state": "machine-generated",
-        "reviewed_at": null,
-        "source_count": 5,
-        "verified_at": null
+        "level": "maintainer-reviewed",
+        "review_state": "maintainer-reviewed",
+        "reviewed_at": "2026-06-08T14:15:00.000Z",
+        "source_count": 7,
+        "verified_at": "2026-06-08T14:15:00.000Z"
       },
-      "gap_count": 6,
+      "gap_count": 5,
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "SignalPlus website is live and is tracked as the team/project website.",
+          "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
         "missing_kinds": [
           "source-repo",
-          "website",
           "openapi",
           "subnet-api",
           "sse",
@@ -2290,16 +2293,17 @@
         ],
         "supported_kinds": [
           "dashboard",
-          "docs"
+          "docs",
+          "website"
         ]
       },
       "name": "EfficientFrontier",
       "netuid": 53,
-      "slug": "sn-53",
-      "surface_count": 5
+      "slug": "efficientfrontier",
+      "surface_count": 7
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2311,7 +2315,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -2341,7 +2345,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2383,7 +2387,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2421,7 +2425,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2465,7 +2469,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2503,7 +2507,7 @@
       "surface_count": 13
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2543,7 +2547,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2583,7 +2587,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2639,7 +2643,7 @@
         "level": "maintainer-reviewed",
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:25:00.000Z",
-        "source_count": 7,
+        "source_count": 6,
         "verified_at": "2026-06-08T09:25:00.000Z"
       },
       "gap_count": 4,
@@ -2668,10 +2672,10 @@
       "name": "Ridges",
       "netuid": 62,
       "slug": "sn-62",
-      "surface_count": 7
+      "surface_count": 6
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2715,7 +2719,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 28,
+      "candidate_count": 29,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2753,7 +2757,7 @@
       "surface_count": 17
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2793,7 +2797,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2833,7 +2837,7 @@
       "surface_count": 13
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2845,7 +2849,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -2875,7 +2879,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2915,7 +2919,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -2961,7 +2965,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3001,7 +3005,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3041,7 +3045,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3081,32 +3085,38 @@
       "surface_count": 12
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Native chain name currently reports as Parked; multiple public directories identify SN73 as MetaHash.",
+          "Official-looking docs domain docs.metahash73.com currently does not resolve from simple probes.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified official website yet.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
-        "level": "machine-verified",
-        "review_state": "machine-generated",
-        "reviewed_at": null,
+        "level": "maintainer-reviewed",
+        "review_state": "maintainer-reviewed",
+        "reviewed_at": "2026-06-08T14:15:00.000Z",
         "source_count": 5,
-        "verified_at": null
+        "verified_at": "2026-06-08T14:15:00.000Z"
       },
       "gap_count": 6,
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Native chain name currently reports as Parked; multiple public directories identify SN73 as MetaHash.",
+          "Official-looking docs domain docs.metahash73.com currently does not resolve from simple probes.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified official website yet.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
         "missing_kinds": [
           "source-repo",
@@ -3121,13 +3131,13 @@
           "docs"
         ]
       },
-      "name": "Parked",
+      "name": "MetaHash",
       "netuid": 73,
-      "slug": "sn-73",
+      "slug": "metahash",
       "surface_count": 5
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3170,7 +3180,7 @@
       "surface_count": 17
     },
     {
-      "candidate_count": 25,
+      "candidate_count": 26,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3212,7 +3222,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3258,7 +3268,7 @@
       "surface_count": 6
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3298,7 +3308,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3338,7 +3348,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 25,
+      "candidate_count": 26,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3380,7 +3390,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3420,7 +3430,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3468,7 +3478,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 25,
+      "candidate_count": 26,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3512,7 +3522,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3552,7 +3562,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3594,7 +3604,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3638,7 +3648,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3684,7 +3694,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3728,7 +3738,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3768,7 +3778,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3814,7 +3824,7 @@
       "surface_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3862,7 +3872,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3908,7 +3918,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3958,7 +3968,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -3998,7 +4008,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4040,7 +4050,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4082,7 +4092,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4120,7 +4130,7 @@
       "surface_count": 13
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4160,7 +4170,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4204,7 +4214,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4244,7 +4254,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4286,7 +4296,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4332,7 +4342,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4420,7 +4430,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4466,7 +4476,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4506,7 +4516,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4548,7 +4558,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4588,7 +4598,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4630,7 +4640,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4676,7 +4686,7 @@
       "surface_count": 6
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4716,7 +4726,7 @@
       "surface_count": 11
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4760,7 +4770,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 16,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4772,7 +4782,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -4799,10 +4809,10 @@
       "name": "minotaur",
       "netuid": 112,
       "slug": "sn-112",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4844,7 +4854,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4884,7 +4894,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -4930,36 +4940,39 @@
       "surface_count": 6
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Native chain name currently reports as hard_sign; public directories identify SN116 as TaoLend.",
+          "Official website currently returns 500/server-error responses to simple probes and should appear degraded until it recovers.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
-        "level": "machine-verified",
-        "review_state": "machine-generated",
-        "reviewed_at": null,
-        "source_count": 5,
-        "verified_at": null
+        "level": "maintainer-reviewed",
+        "review_state": "maintainer-reviewed",
+        "reviewed_at": "2026-06-08T14:15:00.000Z",
+        "source_count": 6,
+        "verified_at": "2026-06-08T14:15:00.000Z"
       },
-      "gap_count": 6,
+      "gap_count": 5,
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Native chain name currently reports as hard_sign; public directories identify SN116 as TaoLend.",
+          "Official website currently returns 500/server-error responses to simple probes and should appear degraded until it recovers.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
         "missing_kinds": [
           "source-repo",
-          "website",
           "openapi",
           "subnet-api",
           "sse",
@@ -4967,16 +4980,17 @@
         ],
         "supported_kinds": [
           "dashboard",
-          "docs"
+          "docs",
+          "website"
         ]
       },
-      "name": "hard_sign",
+      "name": "TaoLend",
       "netuid": 116,
-      "slug": "sn-116",
-      "surface_count": 5
+      "slug": "taolend",
+      "surface_count": 6
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5024,7 +5038,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5066,7 +5080,7 @@
       "surface_count": 10
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5112,7 +5126,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5124,7 +5138,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 5,
+        "source_count": 6,
         "verified_at": null
       },
       "gap_count": 4,
@@ -5154,7 +5168,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5198,7 +5212,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5240,7 +5254,7 @@
       "surface_count": 8
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5286,7 +5300,7 @@
       "surface_count": 6
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5297,7 +5311,7 @@
         "level": "machine-verified",
         "review_state": "machine-generated",
         "reviewed_at": null,
-        "source_count": 6,
+        "source_count": 7,
         "verified_at": null
       },
       "gap_count": 3,
@@ -5326,7 +5340,7 @@
       "surface_count": 9
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5372,7 +5386,7 @@
       "surface_count": 5
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5414,7 +5428,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [
@@ -5456,7 +5470,7 @@
       "surface_count": 7
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "coverage_level": "probed",
       "curation": {
         "gap_notes": [

--- a/public/metagraph/evidence-ledger.json
+++ b/public/metagraph/evidence-ledger.json
@@ -23,6 +23,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "root SubnetRadar dashboard is a candidate dashboard surface for SN0.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/0",
+      "subject": "candidate:sn-0-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "root TaoMarketCap dashboard is a candidate dashboard surface for SN0.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -75,6 +86,17 @@
       "source_url": "https://github.com/macrocosm-os/apex/blob/main/README.md",
       "subject": "candidate:sn-1-github-readme-macrocosm-os-apex-docs-1",
       "support_summary": "Discovered from a project-affiliated public GitHub README link after README noise filters. Requires verification before promotion.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Apex SubnetRadar dashboard is a candidate dashboard surface for SN1.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/1",
+      "subject": "candidate:sn-1-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -287,6 +309,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Swap SubnetRadar dashboard is a candidate dashboard surface for SN10.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/10",
+      "subject": "candidate:sn-10-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Swap TaoMarketCap dashboard is a candidate dashboard surface for SN10.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -419,6 +452,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Swap docs subdomain is a candidate docs surface for SN10.",
+      "confidence": "low",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "provider-claimed",
+      "source_type": "project-website-docs-subdomain",
+      "source_url": "https://www.taofi.com/pool",
+      "subject": "candidate:sn-10-website-subdomain-docs-docs-taofi-com",
+      "support_summary": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "TrajectoryRL Backprop Finance dashboard is a candidate dashboard surface for SN11.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -427,6 +471,17 @@
       "source_url": "https://backprop.finance/dtao/subnets/11-trajectoryrl",
       "subject": "candidate:sn-11-backprop-dashboard",
       "support_summary": "Universal Backprop Finance dTAO subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "TrajectoryRL SubnetRadar dashboard is a candidate dashboard surface for SN11.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/11",
+      "subject": "candidate:sn-11-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -628,6 +683,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Compute Horde SubnetRadar dashboard is a candidate dashboard surface for SN12.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/12",
+      "subject": "candidate:sn-12-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Compute Horde TaoMarketCap dashboard is a candidate dashboard surface for SN12.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -724,6 +790,17 @@
       "source_url": "https://github.com/macrocosm-os/data-universe/blob/main/README.md",
       "subject": "candidate:sn-13-github-readme-macrocosm-os-data-universe-subnet-api-2",
       "support_summary": "Discovered from a project-affiliated public GitHub README link after README noise filters. Requires verification before promotion.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Data Universe SubnetRadar dashboard is a candidate dashboard surface for SN13.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/13",
+      "subject": "candidate:sn-13-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -969,6 +1046,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Cacheon SubnetRadar dashboard is a candidate dashboard surface for SN14.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/14",
+      "subject": "candidate:sn-14-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Cacheon TaoMarketCap dashboard is a candidate dashboard surface for SN14.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -1112,171 +1200,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Cacheon docs is a candidate docs surface for SN14.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://cacheon.ai/",
-      "subject": "candidate:sn-14-website-link-cacheon-ai-docs-3",
-      "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Cacheon docs is a candidate docs surface for SN14.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-link",
-      "source_url": "https://cacheon.ai/",
-      "subject": "candidate:sn-14-website-link-cacheon-ai-docs-4",
-      "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO Backprop Finance dashboard is a candidate dashboard surface for SN15.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "backprop-dashboard",
-      "source_url": "https://backprop.finance/dtao/subnets/15-oro",
-      "subject": "candidate:sn-15-backprop-dashboard",
-      "support_summary": "Universal Backprop Finance dTAO subnet dashboard candidate. Third-party enrichment, not protocol authority.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO dashboard is a candidate dashboard surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "community-docs",
-      "source_type": "github-readme-link",
-      "source_url": "https://github.com/ORO-AI/oro/blob/main/README.md",
-      "subject": "candidate:sn-15-github-readme-oro-ai-oro-dashboard-1",
-      "support_summary": "Discovered from a project-affiliated public GitHub README link after README noise filters. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO docs is a candidate docs surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "community-docs",
-      "source_type": "github-readme-link",
-      "source_url": "https://github.com/ORO-AI/oro/blob/main/README.md",
-      "subject": "candidate:sn-15-github-readme-oro-ai-oro-docs-2",
-      "support_summary": "Discovered from a project-affiliated public GitHub README link after README noise filters. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO API surface is a candidate subnet-api surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "community-docs",
-      "source_type": "github-readme-link",
-      "source_url": "https://github.com/ORO-AI/oro/blob/main/README.md",
-      "subject": "candidate:sn-15-github-readme-oro-ai-oro-subnet-api-3",
-      "support_summary": "Discovered from a project-affiliated public GitHub README link after README noise filters. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO TaoMarketCap dashboard is a candidate dashboard surface for SN15.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "taomarketcap-dashboard",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/15",
-      "subject": "candidate:sn-15-taomarketcap-dashboard",
-      "support_summary": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO source repository is a candidate source-repo surface for SN15.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "taomarketcap-subnet-identity-v3",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/15",
-      "subject": "candidate:sn-15-taomarketcap-source-repo",
-      "support_summary": "Discovered from TaoMarketCap subnet identity metadata. Not probed or verified by Metagraphed.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO website is a candidate website surface for SN15.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "taomarketcap-subnet-identity-v3",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/15",
-      "subject": "candidate:sn-15-taomarketcap-website",
-      "support_summary": "Discovered from TaoMarketCap subnet identity metadata. Not probed or verified by Metagraphed.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO Taopedia article is a candidate docs surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "community-docs",
-      "source_type": "taopedia-article",
-      "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_15/index.mdx",
-      "subject": "candidate:sn-15-taopedia-article",
-      "support_summary": "Discovered from the public Taopedia article repository. Not verified as an operational interface.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO Taostats metagraph is a candidate dashboard surface for SN15.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "third-party-index",
-      "source_type": "taostats-metagraph-dashboard",
-      "source_url": "https://taostats.io/subnets/15/metagraph",
-      "subject": "candidate:sn-15-taostats-metagraph",
-      "support_summary": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO Tensorplex subnet docs is a candidate docs surface for SN15.",
-      "confidence": "medium",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "community-docs",
-      "source_type": "tensorplex-subnet-docs",
-      "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/15/subnet.json",
-      "subject": "candidate:sn-15-tensorplex-docs",
-      "support_summary": "Discovered from Tensorplex subnet-docs. Useful as documentation enrichment, not verified operational authority.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO API is a candidate subnet-api surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-common-path",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-common-api",
-      "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO docs is a candidate docs surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-common-path",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-common-docs",
-      "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ORO health endpoint is a candidate subnet-api surface for SN15.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-common-path",
-      "source_url": "https://oroagents.com/",
-      "subject": "candidate:sn-15-website-common-health",
-      "support_summary": "Common read-only path discovered from a public project website root. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "DSperse Backprop Finance dashboard is a candidate dashboard surface for SN2.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -1318,6 +1241,17 @@
       "source_url": "https://github.com/inference-labs-inc/subnet-2/blob/main/README.md",
       "subject": "candidate:sn-2-github-readme-inference-labs-inc-subnet-2-docs-1",
       "support_summary": "Discovered from a project-affiliated public GitHub README link after README noise filters. Requires verification before promotion.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "DSperse SubnetRadar dashboard is a candidate dashboard surface for SN2.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/2",
+      "subject": "candidate:sn-2-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -1464,6 +1398,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "deprecated SubnetRadar dashboard is a candidate dashboard surface for SN3.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/3",
+      "subject": "candidate:sn-3-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "deprecated TaoMarketCap dashboard is a candidate dashboard surface for SN3.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -1527,6 +1472,17 @@
       "source_url": "https://backprop.finance/dtao/subnets/4-targon",
       "subject": "candidate:sn-4-backprop-dashboard",
       "support_summary": "Universal Backprop Finance dTAO subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Targon SubnetRadar dashboard is a candidate dashboard surface for SN4.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/4",
+      "subject": "candidate:sn-4-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -1690,6 +1646,17 @@
       "source_tier": "provider-claimed",
       "source_type": "project-website-link",
       "source_url": "https://targon.com/",
+      "subject": "candidate:sn-4-website-link-targon-com-docs-4",
+      "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Targon docs is a candidate docs surface for SN4.",
+      "confidence": "low",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "provider-claimed",
+      "source_type": "project-website-link",
+      "source_url": "https://targon.com/",
       "subject": "candidate:sn-4-website-link-targon-com-docs-9",
       "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
       "verified_at": "1970-01-01T00:00:00.000Z"
@@ -1772,17 +1739,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Targon docs subdomain is a candidate docs surface for SN4.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://targon.com/",
-      "subject": "candidate:sn-4-website-subdomain-docs-docs-targon-com",
-      "support_summary": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Hone Backprop Finance dashboard is a candidate dashboard surface for SN5.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -1791,6 +1747,17 @@
       "source_url": "https://backprop.finance/dtao/subnets/5-hone",
       "subject": "candidate:sn-5-backprop-dashboard",
       "support_summary": "Universal Backprop Finance dTAO subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Hone SubnetRadar dashboard is a candidate dashboard surface for SN5.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/5",
+      "subject": "candidate:sn-5-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -1992,6 +1959,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Numinous SubnetRadar dashboard is a candidate dashboard surface for SN6.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/6",
+      "subject": "candidate:sn-6-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Numinous TaoMarketCap dashboard is a candidate dashboard surface for SN6.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -2179,6 +2157,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Allways SubnetRadar dashboard is a candidate dashboard surface for SN7.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/7",
+      "subject": "candidate:sn-7-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Allways TaoMarketCap dashboard is a candidate dashboard surface for SN7.",
       "confidence": "medium",
       "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
@@ -2319,6 +2308,17 @@
       "source_url": "https://backprop.finance/dtao/subnets/8-vanta",
       "subject": "candidate:sn-8-backprop-dashboard",
       "support_summary": "Universal Backprop Finance dTAO subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Vanta SubnetRadar dashboard is a candidate dashboard surface for SN8.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/8",
+      "subject": "candidate:sn-8-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -2517,6 +2517,17 @@
       "source_url": "https://github.com/macrocosm-os/iota/blob/main/README.md",
       "subject": "candidate:sn-9-github-readme-macrocosm-os-iota-docs-2",
       "support_summary": "Discovered from a project-affiliated public GitHub README link after README noise filters. Requires verification before promotion.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "iota SubnetRadar dashboard is a candidate dashboard surface for SN9.",
+      "confidence": "medium",
+      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/9",
+      "subject": "candidate:sn-9-subnetradar-dashboard",
+      "support_summary": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -2737,17 +2748,6 @@
       "source_url": "https://iota.macrocosmos.ai/",
       "subject": "candidate:sn-9-website-link-iota-macrocosmos-ai-website-6",
       "support_summary": "Discovered from a public project website link. Requires verification before promotion.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "iota docs subdomain is a candidate docs surface for SN9.",
-      "confidence": "low",
-      "limits": "Candidate records are discovery leads and are not promoted registry truth until verification and maintainer review.",
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://iota.macrocosmos.ai/",
-      "subject": "candidate:sn-9-website-subdomain-docs-docs-iota-macrocosmos-ai",
-      "support_summary": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -4555,6 +4555,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "root SubnetRadar dashboard is a public dashboard surface for SN0.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/0",
+      "subject": "surface:sn-0-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for root.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "root TaoMarketCap dashboard is a public dashboard surface for SN0.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -4562,17 +4573,6 @@
       "source_type": "provider-claimed",
       "source_url": "https://api.taomarketcap.com/public/v1/subnets/0",
       "subject": "surface:sn-0-taomarketcap-dashboard",
-      "support_summary": "Listed in curated overlay for root.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "root Taostats metagraph is a public dashboard surface for SN0.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/0/metagraph",
-      "subject": "surface:sn-0-taostats-metagraph",
       "support_summary": "Listed in curated overlay for root.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -4632,6 +4632,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Apex SubnetRadar dashboard is a public dashboard surface for SN1.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/1",
+      "subject": "surface:sn-1-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-1.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Apex TaoMarketCap dashboard is a public dashboard surface for SN1.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -4650,17 +4661,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_1_apex/index.mdx",
       "subject": "surface:sn-1-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-1.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Apex Taostats metagraph is a public dashboard surface for SN1.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/1/metagraph",
-      "subject": "surface:sn-1-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-1.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -4694,6 +4694,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/10-swap",
       "subject": "surface:sn-10-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-10.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Swap SubnetRadar dashboard is a public dashboard surface for SN10.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/10",
+      "subject": "surface:sn-10-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-10.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -4742,17 +4753,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Swap Taostats metagraph is a public dashboard surface for SN10.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/10/metagraph",
-      "subject": "surface:sn-10-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-10.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Swap Tensorplex subnet docs is a public docs surface for SN10.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -4764,6 +4764,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Swap docs subdomain is a public docs surface for SN10.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://www.taofi.com/pool",
+      "subject": "surface:sn-10-website-subdomain-docs-docs-taofi-com",
+      "support_summary": "Listed in curated overlay for sn-10.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Plaτform Backprop Finance dashboard is a public dashboard surface for SN100.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -4771,6 +4782,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/100-pla-form",
       "subject": "surface:sn-100-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-100.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Plaτform SubnetRadar dashboard is a public dashboard surface for SN100.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/100",
+      "subject": "surface:sn-100-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-100.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -4815,17 +4837,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx",
       "subject": "surface:sn-100-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-100.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Plaτform Taostats metagraph is a public dashboard surface for SN100.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/100/metagraph",
-      "subject": "surface:sn-100-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-100.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -4885,6 +4896,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "eni SubnetRadar dashboard is a public dashboard surface for SN101.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/101",
+      "subject": "surface:sn-101-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-101.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "eni TaoMarketCap dashboard is a public dashboard surface for SN101.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -4903,17 +4925,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx",
       "subject": "surface:sn-101-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-101.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "eni Taostats metagraph is a public dashboard surface for SN101.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/101/metagraph",
-      "subject": "surface:sn-101-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-101.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -4962,6 +4973,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ConnitoAI SubnetRadar dashboard is a public dashboard surface for SN102.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/102",
+      "subject": "surface:sn-102-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-102.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ConnitoAI TaoMarketCap dashboard is a public dashboard surface for SN102.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -4980,17 +5002,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_102/index.mdx",
       "subject": "surface:sn-102-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-102.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ConnitoAI Taostats metagraph is a public dashboard surface for SN102.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/102/metagraph",
-      "subject": "surface:sn-102-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-102.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5061,6 +5072,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Djinn SubnetRadar dashboard is a public dashboard surface for SN103.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/103",
+      "subject": "surface:sn-103-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-103.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Djinn TaoMarketCap dashboard is a public dashboard surface for SN103.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5090,17 +5112,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_103/index.mdx",
       "subject": "surface:sn-103-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-103.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Djinn Taostats metagraph is a public dashboard surface for SN103.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/103/metagraph",
-      "subject": "surface:sn-103-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-103.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5138,6 +5149,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "for sale (burn to uid1) SubnetRadar dashboard is a public dashboard surface for SN104.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/104",
+      "subject": "surface:sn-104-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-104.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "for sale (burn to uid1) TaoMarketCap dashboard is a public dashboard surface for SN104.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5160,17 +5182,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "for sale (burn to uid1) Taostats metagraph is a public dashboard surface for SN104.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/104/metagraph",
-      "subject": "surface:sn-104-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-104.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "for sale (burn to uid1) Tensorplex subnet docs is a public docs surface for SN104.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5189,6 +5200,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/105-beam",
       "subject": "surface:sn-105-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-105.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Beam SubnetRadar dashboard is a public dashboard surface for SN105.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/105",
+      "subject": "surface:sn-105-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-105.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5237,17 +5259,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Beam Taostats metagraph is a public dashboard surface for SN105.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/105/metagraph",
-      "subject": "surface:sn-105-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-105.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Beam Tensorplex subnet docs is a public docs surface for SN105.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5288,6 +5299,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/106-voidai",
       "subject": "surface:sn-106-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-106.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "VoidAI SubnetRadar dashboard is a public dashboard surface for SN106.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/106",
+      "subject": "surface:sn-106-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-106.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5336,17 +5358,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "VoidAI Taostats metagraph is a public dashboard surface for SN106.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/106/metagraph",
-      "subject": "surface:sn-106-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-106.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "VoidAI Tensorplex subnet docs is a public docs surface for SN106.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5391,6 +5402,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Minos SubnetRadar dashboard is a public dashboard surface for SN107.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/107",
+      "subject": "surface:sn-107-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-107.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Minos TaoMarketCap dashboard is a public dashboard surface for SN107.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5431,17 +5453,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
       "subject": "surface:sn-107-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-107.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Minos Taostats metagraph is a public dashboard surface for SN107.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/107/metagraph",
-      "subject": "surface:sn-107-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-107.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5501,6 +5512,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "TalkHead SubnetRadar dashboard is a public dashboard surface for SN108.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/108",
+      "subject": "surface:sn-108-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-108.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "TalkHead TaoMarketCap dashboard is a public dashboard surface for SN108.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5545,17 +5567,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "TalkHead Taostats metagraph is a public dashboard surface for SN108.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/108/metagraph",
-      "subject": "surface:sn-108-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-108.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "TalkHead Tensorplex subnet docs is a public docs surface for SN108.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5589,6 +5600,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Academia SubnetRadar dashboard is a public dashboard surface for SN109.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/109",
+      "subject": "surface:sn-109-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-109.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Academia TaoMarketCap dashboard is a public dashboard surface for SN109.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5611,17 +5633,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Academia Taostats metagraph is a public dashboard surface for SN109.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/109/metagraph",
-      "subject": "surface:sn-109-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-109.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Academia Tensorplex subnet docs is a public docs surface for SN109.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5640,6 +5651,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/11-trajectoryrl",
       "subject": "surface:sn-11-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-11.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "TrajectoryRL SubnetRadar dashboard is a public dashboard surface for SN11.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/11",
+      "subject": "surface:sn-11-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-11.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5684,17 +5706,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
       "subject": "surface:sn-11-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-11.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "TrajectoryRL Taostats metagraph is a public dashboard surface for SN11.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/11/metagraph",
-      "subject": "surface:sn-11-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-11.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5765,6 +5776,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Green Compute SubnetRadar dashboard is a public dashboard surface for SN110.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/110",
+      "subject": "surface:sn-110-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-110.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Green Compute TaoMarketCap dashboard is a public dashboard surface for SN110.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5783,17 +5805,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx",
       "subject": "surface:sn-110-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-110.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Green Compute Taostats metagraph is a public dashboard surface for SN110.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/110/metagraph",
-      "subject": "surface:sn-110-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-110.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5875,6 +5886,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "oneoneone SubnetRadar dashboard is a public dashboard surface for SN111.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/111",
+      "subject": "surface:sn-111-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-111.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "oneoneone TaoMarketCap dashboard is a public dashboard surface for SN111.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5897,17 +5919,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "oneoneone Taostats metagraph is a public dashboard surface for SN111.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/111/metagraph",
-      "subject": "surface:sn-111-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-111.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "oneoneone Tensorplex subnet docs is a public docs surface for SN111.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5926,6 +5937,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/112-minotaur",
       "subject": "surface:sn-112-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-112.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "minotaur SubnetRadar dashboard is a public dashboard surface for SN112.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/112",
+      "subject": "surface:sn-112-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-112.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -5974,17 +5996,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "minotaur Taostats metagraph is a public dashboard surface for SN112.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/112/metagraph",
-      "subject": "surface:sn-112-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-112.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "minotaur Tensorplex subnet docs is a public docs surface for SN112.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -5996,6 +6007,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "minotaur docs subdomain is a public docs surface for SN112.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://minotaursubnet.com/",
+      "subject": "surface:sn-112-website-subdomain-docs-docs-minotaursubnet-com",
+      "support_summary": "Listed in curated overlay for sn-112.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "TensorUSD Backprop Finance dashboard is a public dashboard surface for SN113.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6003,6 +6025,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/113-tensorusd",
       "subject": "surface:sn-113-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-113.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "TensorUSD SubnetRadar dashboard is a public dashboard surface for SN113.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/113",
+      "subject": "surface:sn-113-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-113.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6025,17 +6058,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_113/index.mdx",
       "subject": "surface:sn-113-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-113.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "TensorUSD Taostats metagraph is a public dashboard surface for SN113.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/113/metagraph",
-      "subject": "surface:sn-113-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-113.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6106,6 +6128,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "SOMA SubnetRadar dashboard is a public dashboard surface for SN114.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/114",
+      "subject": "surface:sn-114-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-114.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "SOMA TaoMarketCap dashboard is a public dashboard surface for SN114.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6146,17 +6179,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_114/index.mdx",
       "subject": "surface:sn-114-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-114.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "SOMA Taostats metagraph is a public dashboard surface for SN114.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/114/metagraph",
-      "subject": "surface:sn-114-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-114.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6216,6 +6238,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "HashiChain SubnetRadar dashboard is a public dashboard surface for SN115.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/115",
+      "subject": "surface:sn-115-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-115.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "HashiChain TaoMarketCap dashboard is a public dashboard surface for SN115.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6238,17 +6271,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "HashiChain Taostats metagraph is a public dashboard surface for SN115.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/115/metagraph",
-      "subject": "surface:sn-115-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-115.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "HashiChain Tensorplex subnet docs is a public docs surface for SN115.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6267,7 +6289,29 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/116-hard-sign",
       "subject": "surface:sn-116-backprop-dashboard",
-      "support_summary": "Listed in curated overlay for sn-116.",
+      "support_summary": "Listed in curated overlay for taolend.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "hard_sign SubnetRadar dashboard is a public dashboard surface for SN116.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/116",
+      "subject": "surface:sn-116-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for taolend.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "TaoLend website is a public website surface for SN116.",
+      "confidence": "high",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "provider-claimed",
+      "source_type": "official",
+      "source_url": "https://taolend.io/",
+      "subject": "surface:sn-116-taolend-website",
+      "support_summary": "Listed in curated overlay for taolend.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -6278,7 +6322,7 @@
       "source_type": "registry-observed",
       "source_url": "https://api.taomarketcap.com/public/v1/subnets/116",
       "subject": "surface:sn-116-taomarketcap-dashboard",
-      "support_summary": "Listed in curated overlay for sn-116.",
+      "support_summary": "Listed in curated overlay for taolend.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -6289,18 +6333,7 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
       "subject": "surface:sn-116-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-116.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "hard_sign Taostats metagraph is a public dashboard surface for SN116.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/116/metagraph",
-      "subject": "surface:sn-116-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-116.",
+      "support_summary": "Listed in curated overlay for taolend.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -6311,7 +6344,7 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json",
       "subject": "surface:sn-116-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-116.",
+      "support_summary": "Listed in curated overlay for taolend.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -6344,6 +6377,17 @@
       "source_type": "provider-claimed",
       "source_url": "https://github.com/shiftlayer-llc/brainplay-subnet",
       "subject": "surface:sn-117-brainplay-source",
+      "support_summary": "Listed in curated overlay for sn-117.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "BrainPlay SubnetRadar dashboard is a public dashboard surface for SN117.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/117",
+      "subject": "surface:sn-117-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-117.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6381,17 +6425,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "BrainPlay Taostats metagraph is a public dashboard surface for SN117.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/117/metagraph",
-      "subject": "surface:sn-117-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-117.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "BrainPlay Tensorplex subnet docs is a public docs surface for SN117.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6410,6 +6443,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/118-ditto",
       "subject": "surface:sn-118-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-118.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Ditto SubnetRadar dashboard is a public dashboard surface for SN118.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/118",
+      "subject": "surface:sn-118-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-118.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6454,17 +6498,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_118/index.mdx",
       "subject": "surface:sn-118-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-118.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Ditto Taostats metagraph is a public dashboard surface for SN118.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/118/metagraph",
-      "subject": "surface:sn-118-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-118.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6524,6 +6557,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Satori SubnetRadar dashboard is a public dashboard surface for SN119.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/119",
+      "subject": "surface:sn-119-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-119.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Satori TaoMarketCap dashboard is a public dashboard surface for SN119.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6542,17 +6586,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx",
       "subject": "surface:sn-119-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-119.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Satori Taostats metagraph is a public dashboard surface for SN119.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/119/metagraph",
-      "subject": "surface:sn-119-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-119.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6601,6 +6634,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Compute Horde SubnetRadar dashboard is a public dashboard surface for SN12.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/12",
+      "subject": "surface:sn-12-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-12.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Compute Horde TaoMarketCap dashboard is a public dashboard surface for SN12.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6619,17 +6663,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_12/index.mdx",
       "subject": "surface:sn-12-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-12.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Compute Horde Taostats metagraph is a public dashboard surface for SN12.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/12/metagraph",
-      "subject": "surface:sn-12-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-12.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6667,13 +6700,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Affine TaoMarketCap dashboard is a public dashboard surface for SN120.",
+      "claim": "Affine SubnetRadar dashboard is a public dashboard surface for SN120.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/120",
-      "subject": "surface:sn-120-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/120",
+      "subject": "surface:sn-120-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-120.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6733,6 +6766,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "sundae_bar SubnetRadar dashboard is a public dashboard surface for SN121.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/121",
+      "subject": "surface:sn-121-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-121.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Sundae Bar source repository is a public source-repo surface for SN121.",
       "confidence": "high",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6773,17 +6817,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_121/index.mdx",
       "subject": "surface:sn-121-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-121.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "sundae_bar Taostats metagraph is a public dashboard surface for SN121.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/121/metagraph",
-      "subject": "surface:sn-121-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-121.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6843,6 +6876,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "gamma_small SubnetRadar dashboard is a public dashboard surface for SN122.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/122",
+      "subject": "surface:sn-122-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-122.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "gamma_small TaoMarketCap dashboard is a public dashboard surface for SN122.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6861,17 +6905,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_122/index.mdx",
       "subject": "surface:sn-122-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-122.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "gamma_small Taostats metagraph is a public dashboard surface for SN122.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/122/metagraph",
-      "subject": "surface:sn-122-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-122.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6909,6 +6942,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "MANTIS SubnetRadar dashboard is a public dashboard surface for SN123.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/123",
+      "subject": "surface:sn-123-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-123.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "MANTIS TaoMarketCap dashboard is a public dashboard surface for SN123.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -6927,17 +6971,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx",
       "subject": "surface:sn-123-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-123.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "MANTIS Taostats metagraph is a public dashboard surface for SN123.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/123/metagraph",
-      "subject": "surface:sn-123-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-123.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -6975,13 +7008,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Swarm TaoMarketCap dashboard is a public dashboard surface for SN124.",
+      "claim": "Swarm SubnetRadar dashboard is a public dashboard surface for SN124.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/124",
-      "subject": "surface:sn-124-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/124",
+      "subject": "surface:sn-124-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-124.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7063,6 +7096,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "8 Ball SubnetRadar dashboard is a public dashboard surface for SN125.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/125",
+      "subject": "surface:sn-125-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-125.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "8 Ball TaoMarketCap dashboard is a public dashboard surface for SN125.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7085,17 +7129,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "8 Ball Taostats metagraph is a public dashboard surface for SN125.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/125/metagraph",
-      "subject": "surface:sn-125-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-125.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "8 Ball Tensorplex subnet docs is a public docs surface for SN125.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7114,6 +7147,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/126-poker44",
       "subject": "surface:sn-126-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-126.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Poker44 SubnetRadar dashboard is a public dashboard surface for SN126.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/126",
+      "subject": "surface:sn-126-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-126.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7162,17 +7206,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Poker44 Taostats metagraph is a public dashboard surface for SN126.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/126/metagraph",
-      "subject": "surface:sn-126-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-126.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Poker44 Tensorplex subnet docs is a public docs surface for SN126.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7191,6 +7224,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/127-astrid",
       "subject": "surface:sn-127-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-127.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Astrid SubnetRadar dashboard is a public dashboard surface for SN127.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/127",
+      "subject": "surface:sn-127-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-127.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7239,17 +7283,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Astrid Taostats metagraph is a public dashboard surface for SN127.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/127/metagraph",
-      "subject": "surface:sn-127-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-127.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Astrid Tensorplex subnet docs is a public docs surface for SN127.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7268,6 +7301,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/128-byteleap",
       "subject": "surface:sn-128-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-128.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "ByteLeap SubnetRadar dashboard is a public dashboard surface for SN128.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/128",
+      "subject": "surface:sn-128-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-128.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7312,17 +7356,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
       "subject": "surface:sn-128-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-128.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ByteLeap Taostats metagraph is a public dashboard surface for SN128.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/128/metagraph",
-      "subject": "surface:sn-128-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-128.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7448,6 +7481,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Data Universe SubnetRadar dashboard is a public dashboard surface for SN13.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/13",
+      "subject": "surface:sn-13-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-13.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Data Universe TaoMarketCap dashboard is a public dashboard surface for SN13.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7477,17 +7521,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_13/index.mdx",
       "subject": "surface:sn-13-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-13.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Data Universe Taostats metagraph is a public dashboard surface for SN13.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/13/metagraph",
-      "subject": "surface:sn-13-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-13.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7547,13 +7580,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Cacheon TaoMarketCap dashboard is a public dashboard surface for SN14.",
+      "claim": "Cacheon SubnetRadar dashboard is a public dashboard surface for SN14.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/14",
-      "subject": "surface:sn-14-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/14",
+      "subject": "surface:sn-14-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-14.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7679,13 +7712,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "ORO TaoMarketCap dashboard is a public dashboard surface for SN15.",
+      "claim": "ORO SubnetRadar dashboard is a public dashboard surface for SN15.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/15",
-      "subject": "surface:sn-15-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/15",
+      "subject": "surface:sn-15-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-15.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7734,6 +7767,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "BitAds SubnetRadar dashboard is a public dashboard surface for SN16.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/16",
+      "subject": "surface:sn-16-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-16.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "BitAds TaoMarketCap dashboard is a public dashboard surface for SN16.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7774,17 +7818,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx",
       "subject": "surface:sn-16-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-16.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "BitAds Taostats metagraph is a public dashboard surface for SN16.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/16/metagraph",
-      "subject": "surface:sn-16-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-16.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7844,13 +7877,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "404—GEN TaoMarketCap dashboard is a public dashboard surface for SN17.",
+      "claim": "404—GEN SubnetRadar dashboard is a public dashboard surface for SN17.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/17",
-      "subject": "surface:sn-17-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/17",
+      "subject": "surface:sn-17-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-17.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -7921,6 +7954,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Zeus SubnetRadar dashboard is a public dashboard surface for SN18.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/18",
+      "subject": "surface:sn-18-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-18.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Zeus TaoMarketCap dashboard is a public dashboard surface for SN18.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -7961,17 +8005,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx",
       "subject": "surface:sn-18-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-18.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Zeus Taostats metagraph is a public dashboard surface for SN18.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/18/metagraph",
-      "subject": "surface:sn-18-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-18.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8042,6 +8075,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "blockmachine SubnetRadar dashboard is a public dashboard surface for SN19.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/19",
+      "subject": "surface:sn-19-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-19.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "blockmachine TaoMarketCap dashboard is a public dashboard surface for SN19.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -8060,17 +8104,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_19/index.mdx",
       "subject": "surface:sn-19-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-19.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "blockmachine Taostats metagraph is a public dashboard surface for SN19.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/19/metagraph",
-      "subject": "surface:sn-19-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-19.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8229,6 +8262,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "GroundLayer SubnetRadar dashboard is a public dashboard surface for SN20.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/20",
+      "subject": "surface:sn-20-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-20.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "GroundLayer TaoMarketCap dashboard is a public dashboard surface for SN20.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -8258,17 +8302,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_20/index.mdx",
       "subject": "surface:sn-20-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-20.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "GroundLayer Taostats metagraph is a public dashboard surface for SN20.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/20/metagraph",
-      "subject": "surface:sn-20-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-20.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8317,6 +8350,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "AdTAO SubnetRadar dashboard is a public dashboard surface for SN21.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/21",
+      "subject": "surface:sn-21-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-21.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "AdTAO TaoMarketCap dashboard is a public dashboard surface for SN21.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -8335,17 +8379,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_21/index.mdx",
       "subject": "surface:sn-21-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-21.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "AdTAO Taostats metagraph is a public dashboard surface for SN21.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/21/metagraph",
-      "subject": "surface:sn-21-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-21.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8438,6 +8471,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Desearch SubnetRadar dashboard is a public dashboard surface for SN22.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/22",
+      "subject": "surface:sn-22-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-22.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Desearch TaoMarketCap dashboard is a public dashboard surface for SN22.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -8478,17 +8522,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_22/index.mdx",
       "subject": "surface:sn-22-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-22.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Desearch Taostats metagraph is a public dashboard surface for SN22.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/22/metagraph",
-      "subject": "surface:sn-22-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-22.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8548,13 +8581,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Trishool TaoMarketCap dashboard is a public dashboard surface for SN23.",
+      "claim": "Trishool SubnetRadar dashboard is a public dashboard surface for SN23.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/23",
-      "subject": "surface:sn-23-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/23",
+      "subject": "surface:sn-23-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-23.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8642,18 +8675,18 @@
       "source_tier": "community-docs",
       "source_type": "registry-observed",
       "source_url": "https://trishool.ai/",
-      "subject": "surface:sn-23-website-link-trishool-ai-docs-2",
+      "subject": "surface:sn-23-website-link-trishool-ai-docs-1",
       "support_summary": "Listed in curated overlay for sn-23.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Trishool docs subdomain is a public docs surface for SN23.",
+      "claim": "Trishool docs is a public docs surface for SN23.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
       "source_url": "https://trishool.ai/",
-      "subject": "surface:sn-23-website-subdomain-docs-docs-trishool-ai",
+      "subject": "surface:sn-23-website-link-trishool-ai-docs-2",
       "support_summary": "Listed in curated overlay for sn-23.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8724,6 +8757,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Quasar SubnetRadar dashboard is a public dashboard surface for SN24.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/24",
+      "subject": "surface:sn-24-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-24.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Quasar TaoMarketCap dashboard is a public dashboard surface for SN24.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -8742,17 +8786,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_24/index.mdx",
       "subject": "surface:sn-24-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-24.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Quasar Taostats metagraph is a public dashboard surface for SN24.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/24/metagraph",
-      "subject": "surface:sn-24-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-24.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8812,13 +8845,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Mainframe TaoMarketCap dashboard is a public dashboard surface for SN25.",
+      "claim": "Mainframe SubnetRadar dashboard is a public dashboard surface for SN25.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/25",
-      "subject": "surface:sn-25-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/25",
+      "subject": "surface:sn-25-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-25.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8862,18 +8895,18 @@
       "source_tier": "community-docs",
       "source_type": "registry-observed",
       "source_url": "https://macrocosmos.ai/sn25",
-      "subject": "surface:sn-25-website-link-macrocosmos-ai-docs-6",
+      "subject": "surface:sn-25-website-link-macrocosmos-ai-docs-3",
       "support_summary": "Listed in curated overlay for sn-25.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Mainframe docs subdomain is a public docs surface for SN25.",
+      "claim": "Mainframe docs is a public docs surface for SN25.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
       "source_url": "https://macrocosmos.ai/sn25",
-      "subject": "surface:sn-25-website-subdomain-docs-docs-macrocosmos-ai",
+      "subject": "surface:sn-25-website-link-macrocosmos-ai-docs-6",
       "support_summary": "Listed in curated overlay for sn-25.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8885,6 +8918,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/26-perturb",
       "subject": "surface:sn-26-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-26.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Perturb SubnetRadar dashboard is a public dashboard surface for SN26.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/26",
+      "subject": "surface:sn-26-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-26.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -8933,17 +8977,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Perturb Taostats metagraph is a public dashboard surface for SN26.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/26/metagraph",
-      "subject": "surface:sn-26-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-26.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Perturb Tensorplex subnet docs is a public docs surface for SN26.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -8973,7 +9006,51 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/27-nodexo",
       "subject": "surface:sn-27-backprop-dashboard",
-      "support_summary": "Listed in curated overlay for sn-27.",
+      "support_summary": "Listed in curated overlay for nodexo.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Nodexo console is a public dashboard surface for SN27.",
+      "confidence": "high",
+      "limits": "Surface is public metadata but requires authentication for access.",
+      "source_tier": "provider-claimed",
+      "source_type": "official",
+      "source_url": "https://nodexo.ai/",
+      "subject": "surface:sn-27-nodexo-console",
+      "support_summary": "Listed in curated overlay for nodexo.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Nodexo docs is a public docs surface for SN27.",
+      "confidence": "high",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "provider-claimed",
+      "source_type": "official",
+      "source_url": "https://nodexo.ai/",
+      "subject": "surface:sn-27-nodexo-docs",
+      "support_summary": "Listed in curated overlay for nodexo.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Nodexo website is a public website surface for SN27.",
+      "confidence": "high",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "provider-claimed",
+      "source_type": "official",
+      "source_url": "https://nodexo.ai/",
+      "subject": "surface:sn-27-nodexo-website",
+      "support_summary": "Listed in curated overlay for nodexo.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Nodexo SubnetRadar dashboard is a public dashboard surface for SN27.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/27",
+      "subject": "surface:sn-27-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for nodexo.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -8984,7 +9061,7 @@
       "source_type": "registry-observed",
       "source_url": "https://api.taomarketcap.com/public/v1/subnets/27",
       "subject": "surface:sn-27-taomarketcap-dashboard",
-      "support_summary": "Listed in curated overlay for sn-27.",
+      "support_summary": "Listed in curated overlay for nodexo.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -8995,18 +9072,7 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
       "subject": "surface:sn-27-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-27.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Nodexo Taostats metagraph is a public dashboard surface for SN27.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/27/metagraph",
-      "subject": "surface:sn-27-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-27.",
+      "support_summary": "Listed in curated overlay for nodexo.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -9017,7 +9083,7 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json",
       "subject": "surface:sn-27-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-27.",
+      "support_summary": "Listed in curated overlay for nodexo.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -9028,6 +9094,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/28-gm",
       "subject": "surface:sn-28-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-28.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "gm SubnetRadar dashboard is a public dashboard surface for SN28.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/28",
+      "subject": "surface:sn-28-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-28.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9050,17 +9127,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx",
       "subject": "surface:sn-28-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-28.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "gm Taostats metagraph is a public dashboard surface for SN28.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/28/metagraph",
-      "subject": "surface:sn-28-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-28.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9153,6 +9219,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Coldint SubnetRadar dashboard is a public dashboard surface for SN29.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/29",
+      "subject": "surface:sn-29-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-29.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Coldint TaoMarketCap dashboard is a public dashboard surface for SN29.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9171,17 +9248,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_29/index.mdx",
       "subject": "surface:sn-29-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-29.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Coldint Taostats metagraph is a public dashboard surface for SN29.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/29/metagraph",
-      "subject": "surface:sn-29-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-29.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9208,6 +9274,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "deprecated SubnetRadar dashboard is a public dashboard surface for SN3.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/3",
+      "subject": "surface:sn-3-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-3.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "deprecated TaoMarketCap dashboard is a public dashboard surface for SN3.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9226,17 +9303,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_3/index.mdx",
       "subject": "surface:sn-3-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-3.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "deprecated Taostats metagraph is a public dashboard surface for SN3.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/3/metagraph",
-      "subject": "surface:sn-3-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-3.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9351,6 +9417,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Endure Network SubnetRadar dashboard is a public dashboard surface for SN30.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/30",
+      "subject": "surface:sn-30-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-30.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Endure Network TaoMarketCap dashboard is a public dashboard surface for SN30.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9369,17 +9446,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_30/index.mdx",
       "subject": "surface:sn-30-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-30.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Endure Network Taostats metagraph is a public dashboard surface for SN30.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/30/metagraph",
-      "subject": "surface:sn-30-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-30.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9406,6 +9472,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Recall SubnetRadar dashboard is a public dashboard surface for SN31.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/31",
+      "subject": "surface:sn-31-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-31.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Recall TaoMarketCap dashboard is a public dashboard surface for SN31.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9424,17 +9501,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx",
       "subject": "surface:sn-31-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-31.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Recall Taostats metagraph is a public dashboard surface for SN31.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/31/metagraph",
-      "subject": "surface:sn-31-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-31.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9483,6 +9549,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ItsAI SubnetRadar dashboard is a public dashboard surface for SN32.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/32",
+      "subject": "surface:sn-32-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-32.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ItsAI TaoMarketCap dashboard is a public dashboard surface for SN32.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9505,17 +9582,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "ItsAI Taostats metagraph is a public dashboard surface for SN32.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/32/metagraph",
-      "subject": "surface:sn-32-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-32.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "ItsAI Tensorplex subnet docs is a public docs surface for SN32.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9523,17 +9589,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/32/subnet.json",
       "subject": "surface:sn-32-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-32.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ItsAI docs subdomain is a public docs surface for SN32.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://its-ai.org/en",
-      "subject": "surface:sn-32-website-subdomain-docs-docs-its-ai-org",
       "support_summary": "Listed in curated overlay for sn-32.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9604,6 +9659,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ReadyAI SubnetRadar dashboard is a public dashboard surface for SN33.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/33",
+      "subject": "surface:sn-33-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-33.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ReadyAI TaoMarketCap dashboard is a public dashboard surface for SN33.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9622,17 +9688,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_33/index.mdx",
       "subject": "surface:sn-33-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-33.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ReadyAI Taostats metagraph is a public dashboard surface for SN33.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/33/metagraph",
-      "subject": "surface:sn-33-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-33.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9703,6 +9758,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "BitMind SubnetRadar dashboard is a public dashboard surface for SN34.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/34",
+      "subject": "surface:sn-34-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-34.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "BitMind TaoMarketCap dashboard is a public dashboard surface for SN34.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9725,17 +9791,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "BitMind Taostats metagraph is a public dashboard surface for SN34.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/34/metagraph",
-      "subject": "surface:sn-34-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-34.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "BitMind Tensorplex subnet docs is a public docs surface for SN34.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9754,6 +9809,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/35-oxmarkets",
       "subject": "surface:sn-35-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-35.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "OxMarkets SubnetRadar dashboard is a public dashboard surface for SN35.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/35",
+      "subject": "surface:sn-35-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-35.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9802,17 +9868,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "OxMarkets Taostats metagraph is a public dashboard surface for SN35.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/35/metagraph",
-      "subject": "surface:sn-35-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-35.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "OxMarkets Tensorplex subnet docs is a public docs surface for SN35.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9835,6 +9890,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "OxMarkets docs subdomain is a public docs surface for SN35.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://www.0xmarkets.io/",
+      "subject": "surface:sn-35-website-subdomain-docs-docs-0xmarkets-io",
+      "support_summary": "Listed in curated overlay for sn-35.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Eirel Backprop Finance dashboard is a public dashboard surface for SN36.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9842,6 +9908,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/36-eirel",
       "subject": "surface:sn-36-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-36.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Eirel SubnetRadar dashboard is a public dashboard surface for SN36.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/36",
+      "subject": "surface:sn-36-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-36.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9890,17 +9967,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Eirel Taostats metagraph is a public dashboard surface for SN36.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/36/metagraph",
-      "subject": "surface:sn-36-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-36.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Eirel Tensorplex subnet docs is a public docs surface for SN36.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -9930,6 +9996,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/37-aurelius",
       "subject": "surface:sn-37-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-37.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Aurelius SubnetRadar dashboard is a public dashboard surface for SN37.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/37",
+      "subject": "surface:sn-37-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-37.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -9978,17 +10055,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Aurelius Taostats metagraph is a public dashboard surface for SN37.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/37/metagraph",
-      "subject": "surface:sn-37-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-37.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Aurelius Tensorplex subnet docs is a public docs surface for SN37.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10022,6 +10088,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "colosseum SubnetRadar dashboard is a public dashboard surface for SN38.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/38",
+      "subject": "surface:sn-38-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-38.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "colosseum TaoMarketCap dashboard is a public dashboard surface for SN38.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10029,6 +10106,17 @@
       "source_type": "registry-observed",
       "source_url": "https://api.taomarketcap.com/public/v1/subnets/38",
       "subject": "surface:sn-38-taomarketcap-dashboard",
+      "support_summary": "Listed in curated overlay for sn-38.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "colosseum source repository is a public source-repo surface for SN38.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://api.taomarketcap.com/public/v1/subnets/38",
+      "subject": "surface:sn-38-taomarketcap-source-repo",
       "support_summary": "Listed in curated overlay for sn-38.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10051,17 +10139,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
       "subject": "surface:sn-38-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-38.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "colosseum Taostats metagraph is a public dashboard surface for SN38.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/38/metagraph",
-      "subject": "surface:sn-38-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-38.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10132,6 +10209,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "deprecated SubnetRadar dashboard is a public dashboard surface for SN39.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/39",
+      "subject": "surface:sn-39-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-39.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "deprecated TaoMarketCap dashboard is a public dashboard surface for SN39.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10150,17 +10238,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_39/index.mdx",
       "subject": "surface:sn-39-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-39.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "deprecated Taostats metagraph is a public dashboard surface for SN39.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/39/metagraph",
-      "subject": "surface:sn-39-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-39.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10198,6 +10275,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Targon SubnetRadar dashboard is a public dashboard surface for SN4.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/4",
+      "subject": "surface:sn-4-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-4.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Targon TaoMarketCap dashboard is a public dashboard surface for SN4.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10216,17 +10304,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_4/index.mdx",
       "subject": "surface:sn-4-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-4.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Targon Taostats metagraph is a public dashboard surface for SN4.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/4/metagraph",
-      "subject": "surface:sn-4-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-4.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10281,7 +10358,7 @@
       "source_tier": "community-docs",
       "source_type": "registry-observed",
       "source_url": "https://targon.com/",
-      "subject": "surface:sn-4-website-link-targon-com-docs-9",
+      "subject": "surface:sn-4-website-link-targon-com-docs-4",
       "support_summary": "Listed in curated overlay for sn-4.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10293,6 +10370,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/40-chunking",
       "subject": "surface:sn-40-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-40.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Chunking SubnetRadar dashboard is a public dashboard surface for SN40.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/40",
+      "subject": "surface:sn-40-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-40.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10319,17 +10407,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Chunking Taostats metagraph is a public dashboard surface for SN40.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/40/metagraph",
-      "subject": "surface:sn-40-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-40.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Chunking Tensorplex subnet docs is a public docs surface for SN40.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10348,6 +10425,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/41-almanac",
       "subject": "surface:sn-41-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-41.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Almanac SubnetRadar dashboard is a public dashboard surface for SN41.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/41",
+      "subject": "surface:sn-41-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-41.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10392,17 +10480,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx",
       "subject": "surface:sn-41-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-41.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Almanac Taostats metagraph is a public dashboard surface for SN41.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/41/metagraph",
-      "subject": "surface:sn-41-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-41.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10473,6 +10550,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Gopher SubnetRadar dashboard is a public dashboard surface for SN42.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/42",
+      "subject": "surface:sn-42-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-42.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Gopher TaoMarketCap dashboard is a public dashboard surface for SN42.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10491,17 +10579,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_42/index.mdx",
       "subject": "surface:sn-42-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-42.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Gopher Taostats metagraph is a public dashboard surface for SN42.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/42/metagraph",
-      "subject": "surface:sn-42-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-42.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10550,6 +10627,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Graphite SubnetRadar dashboard is a public dashboard surface for SN43.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/43",
+      "subject": "surface:sn-43-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-43.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Graphite TaoMarketCap dashboard is a public dashboard surface for SN43.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10572,17 +10660,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Graphite Taostats metagraph is a public dashboard surface for SN43.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/43/metagraph",
-      "subject": "surface:sn-43-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-43.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Graphite Tensorplex subnet docs is a public docs surface for SN43.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10601,6 +10678,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/44-score",
       "subject": "surface:sn-44-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-44.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Score SubnetRadar dashboard is a public dashboard surface for SN44.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/44",
+      "subject": "surface:sn-44-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-44.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10649,17 +10737,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Score Taostats metagraph is a public dashboard surface for SN44.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/44/metagraph",
-      "subject": "surface:sn-44-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-44.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Score Tensorplex subnet docs is a public docs surface for SN44.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10689,6 +10766,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/45-talisman-ai",
       "subject": "surface:sn-45-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-45.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Talisman AI SubnetRadar dashboard is a public dashboard surface for SN45.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/45",
+      "subject": "surface:sn-45-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-45.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10733,17 +10821,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_45/index.mdx",
       "subject": "surface:sn-45-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-45.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Talisman AI Taostats metagraph is a public dashboard surface for SN45.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/45/metagraph",
-      "subject": "surface:sn-45-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-45.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10803,13 +10880,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Zipcode TaoMarketCap dashboard is a public dashboard surface for SN46.",
+      "claim": "Zipcode SubnetRadar dashboard is a public dashboard surface for SN46.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/46",
-      "subject": "surface:sn-46-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/46",
+      "subject": "surface:sn-46-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-46.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -10935,6 +11012,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "EvolAI SubnetRadar dashboard is a public dashboard surface for SN47.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/47",
+      "subject": "surface:sn-47-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-47.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "EvolAI TaoMarketCap dashboard is a public dashboard surface for SN47.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -10964,17 +11052,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_47/index.mdx",
       "subject": "surface:sn-47-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-47.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "EvolAI Taostats metagraph is a public dashboard surface for SN47.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/47/metagraph",
-      "subject": "surface:sn-47-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-47.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11034,6 +11111,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Quantum Compute SubnetRadar dashboard is a public dashboard surface for SN48.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/48",
+      "subject": "surface:sn-48-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-48.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Quantum Compute TaoMarketCap dashboard is a public dashboard surface for SN48.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11052,17 +11140,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_48/index.mdx",
       "subject": "surface:sn-48-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-48.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Quantum Compute Taostats metagraph is a public dashboard surface for SN48.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/48/metagraph",
-      "subject": "surface:sn-48-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-48.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11155,6 +11232,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Nepher Robotics SubnetRadar dashboard is a public dashboard surface for SN49.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/49",
+      "subject": "surface:sn-49-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-49.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Nepher Robotics TaoMarketCap dashboard is a public dashboard surface for SN49.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11177,17 +11265,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Nepher Robotics Taostats metagraph is a public dashboard surface for SN49.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/49/metagraph",
-      "subject": "surface:sn-49-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-49.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Nepher Robotics Tensorplex subnet docs is a public docs surface for SN49.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11206,6 +11283,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/5-hone",
       "subject": "surface:sn-5-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-5.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Hone SubnetRadar dashboard is a public dashboard surface for SN5.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/5",
+      "subject": "surface:sn-5-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-5.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11254,17 +11342,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Hone Taostats metagraph is a public dashboard surface for SN5.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/5/metagraph",
-      "subject": "surface:sn-5-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-5.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Hone Tensorplex subnet docs is a public docs surface for SN5.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11283,6 +11360,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/50-synth",
       "subject": "surface:sn-50-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-50.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Synth SubnetRadar dashboard is a public dashboard surface for SN50.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/50",
+      "subject": "surface:sn-50-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-50.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11327,17 +11415,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx",
       "subject": "surface:sn-50-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-50.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Synth Taostats metagraph is a public dashboard surface for SN50.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/50/metagraph",
-      "subject": "surface:sn-50-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-50.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11397,6 +11474,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "lium.io SubnetRadar dashboard is a public dashboard surface for SN51.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/51",
+      "subject": "surface:sn-51-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-51.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "lium.io TaoMarketCap dashboard is a public dashboard surface for SN51.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11437,17 +11525,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
       "subject": "surface:sn-51-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-51.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "lium.io Taostats metagraph is a public dashboard surface for SN51.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/51/metagraph",
-      "subject": "surface:sn-51-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-51.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11540,6 +11617,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Dojo SubnetRadar dashboard is a public dashboard surface for SN52.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/52",
+      "subject": "surface:sn-52-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-52.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Dojo TaoMarketCap dashboard is a public dashboard surface for SN52.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11558,17 +11646,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_52/index.mdx",
       "subject": "surface:sn-52-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-52.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Dojo Taostats metagraph is a public dashboard surface for SN52.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/52/metagraph",
-      "subject": "surface:sn-52-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-52.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11602,7 +11679,40 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/53-efficientfrontier",
       "subject": "surface:sn-53-backprop-dashboard",
-      "support_summary": "Listed in curated overlay for sn-53.",
+      "support_summary": "Listed in curated overlay for efficientfrontier.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "EfficientFrontier mining app is a public dashboard surface for SN53.",
+      "confidence": "high",
+      "limits": "Surface is public metadata but requires authentication for access.",
+      "source_tier": "provider-claimed",
+      "source_type": "official",
+      "source_url": "https://t.signalplus.com/mining",
+      "subject": "surface:sn-53-signalplus-mining",
+      "support_summary": "Listed in curated overlay for efficientfrontier.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "SignalPlus website is a public website surface for SN53.",
+      "confidence": "high",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "provider-claimed",
+      "source_type": "official",
+      "source_url": "https://www.signalplus.com/",
+      "subject": "surface:sn-53-signalplus-website",
+      "support_summary": "Listed in curated overlay for efficientfrontier.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "EfficientFrontier SubnetRadar dashboard is a public dashboard surface for SN53.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/53",
+      "subject": "surface:sn-53-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for efficientfrontier.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -11613,7 +11723,7 @@
       "source_type": "registry-observed",
       "source_url": "https://api.taomarketcap.com/public/v1/subnets/53",
       "subject": "surface:sn-53-taomarketcap-dashboard",
-      "support_summary": "Listed in curated overlay for sn-53.",
+      "support_summary": "Listed in curated overlay for efficientfrontier.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -11624,18 +11734,7 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
       "subject": "surface:sn-53-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-53.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "EfficientFrontier Taostats metagraph is a public dashboard surface for SN53.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/53/metagraph",
-      "subject": "surface:sn-53-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-53.",
+      "support_summary": "Listed in curated overlay for efficientfrontier.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -11646,7 +11745,7 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
       "subject": "surface:sn-53-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-53.",
+      "support_summary": "Listed in curated overlay for efficientfrontier.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -11672,13 +11771,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Yanez MIID TaoMarketCap dashboard is a public dashboard surface for SN54.",
+      "claim": "Yanez MIID SubnetRadar dashboard is a public dashboard surface for SN54.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/54",
-      "subject": "surface:sn-54-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/54",
+      "subject": "surface:sn-54-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-54.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11738,6 +11837,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "NIOME SubnetRadar dashboard is a public dashboard surface for SN55.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/55",
+      "subject": "surface:sn-55-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-55.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "NIOME TaoMarketCap dashboard is a public dashboard surface for SN55.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11782,17 +11892,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "NIOME Taostats metagraph is a public dashboard surface for SN55.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/55/metagraph",
-      "subject": "surface:sn-55-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-55.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "NIOME Tensorplex subnet docs is a public docs surface for SN55.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11811,6 +11910,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/56-gradients",
       "subject": "surface:sn-56-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-56.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Gradients SubnetRadar dashboard is a public dashboard surface for SN56.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/56",
+      "subject": "surface:sn-56-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-56.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11855,17 +11965,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
       "subject": "surface:sn-56-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-56.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Gradients Taostats metagraph is a public dashboard surface for SN56.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/56/metagraph",
-      "subject": "surface:sn-56-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-56.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -11958,6 +12057,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "gaia SubnetRadar dashboard is a public dashboard surface for SN57.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/57",
+      "subject": "surface:sn-57-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-57.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "gaia TaoMarketCap dashboard is a public dashboard surface for SN57.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -11976,17 +12086,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_57/index.mdx",
       "subject": "surface:sn-57-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-57.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "gaia Taostats metagraph is a public dashboard surface for SN57.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/57/metagraph",
-      "subject": "surface:sn-57-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-57.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12101,6 +12200,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Pending SubnetRadar dashboard is a public dashboard surface for SN58.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/58",
+      "subject": "surface:sn-58-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-58.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Handshake58 TaoMarketCap dashboard is a public dashboard surface for SN58.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12119,17 +12229,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_58/index.mdx",
       "subject": "surface:sn-58-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-58.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Pending Taostats metagraph is a public dashboard surface for SN58.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/58/metagraph",
-      "subject": "surface:sn-58-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-58.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12163,6 +12262,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/babelbit/babelbit_subnet/blob/main/README.md",
       "subject": "surface:sn-59-github-readme-babelbit-babelbit-subnet-subnet-api-1",
+      "support_summary": "Listed in curated overlay for sn-59.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Babelbit SubnetRadar dashboard is a public dashboard surface for SN59.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/59",
+      "subject": "surface:sn-59-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-59.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12211,17 +12321,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Babelbit Taostats metagraph is a public dashboard surface for SN59.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/59/metagraph",
-      "subject": "surface:sn-59-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-59.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Babelbit Tensorplex subnet docs is a public docs surface for SN59.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12255,13 +12354,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Numinous TaoMarketCap dashboard is a public dashboard surface for SN6.",
+      "claim": "Numinous SubnetRadar dashboard is a public dashboard surface for SN6.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/6",
-      "subject": "surface:sn-6-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/6",
+      "subject": "surface:sn-6-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-6.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12332,6 +12431,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Bitsec.ai SubnetRadar dashboard is a public dashboard surface for SN60.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/60",
+      "subject": "surface:sn-60-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-60.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Bitsec.ai TaoMarketCap dashboard is a public dashboard surface for SN60.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12372,17 +12482,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx",
       "subject": "surface:sn-60-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-60.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Bitsec.ai Taostats metagraph is a public dashboard surface for SN60.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/60/metagraph",
-      "subject": "surface:sn-60-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-60.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12486,13 +12585,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "RedTeam TaoMarketCap dashboard is a public dashboard surface for SN61.",
+      "claim": "RedTeam SubnetRadar dashboard is a public dashboard surface for SN61.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/61",
-      "subject": "surface:sn-61-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/61",
+      "subject": "surface:sn-61-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-61.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12541,6 +12640,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Ridges SubnetRadar dashboard is a public dashboard surface for SN62.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/62",
+      "subject": "surface:sn-62-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-62.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Ridges TaoMarketCap dashboard is a public dashboard surface for SN62.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12563,17 +12673,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Ridges Taostats metagraph is a public dashboard surface for SN62.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/62/metagraph",
-      "subject": "surface:sn-62-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-62.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Ridges Tensorplex subnet docs is a public docs surface for SN62.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12581,17 +12680,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/62/subnet.json",
       "subject": "surface:sn-62-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-62.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Ridges docs subdomain is a public docs surface for SN62.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://www.ridges.ai/",
-      "subject": "surface:sn-62-website-subdomain-docs-docs-ridges-ai",
       "support_summary": "Listed in curated overlay for sn-62.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12629,6 +12717,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Enigma SubnetRadar dashboard is a public dashboard surface for SN63.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/63",
+      "subject": "surface:sn-63-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-63.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Enigma TaoMarketCap dashboard is a public dashboard surface for SN63.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12647,17 +12746,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_63/index.mdx",
       "subject": "surface:sn-63-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-63.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Enigma Taostats metagraph is a public dashboard surface for SN63.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/63/metagraph",
-      "subject": "surface:sn-63-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-63.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12772,6 +12860,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Chutes SubnetRadar dashboard is a public dashboard surface for SN64.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/64",
+      "subject": "surface:sn-64-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-64.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Chutes TaoMarketCap dashboard is a public dashboard surface for SN64.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12790,17 +12889,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_64/index.mdx",
       "subject": "surface:sn-64-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-64.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Chutes Taostats metagraph is a public dashboard surface for SN64.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/64/metagraph",
-      "subject": "surface:sn-64-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-64.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -12871,6 +12959,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "TAO Private Network SubnetRadar dashboard is a public dashboard surface for SN65.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/65",
+      "subject": "surface:sn-65-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-65.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "TAO Private Network TaoMarketCap dashboard is a public dashboard surface for SN65.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -12911,17 +13010,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx",
       "subject": "surface:sn-65-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-65.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "TAO Private Network Taostats metagraph is a public dashboard surface for SN65.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/65/metagraph",
-      "subject": "surface:sn-65-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-65.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13047,6 +13135,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ninja SubnetRadar dashboard is a public dashboard surface for SN66.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/66",
+      "subject": "surface:sn-66-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-66.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ninja TaoMarketCap dashboard is a public dashboard surface for SN66.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -13065,17 +13164,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_66/index.mdx",
       "subject": "surface:sn-66-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-66.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ninja Taostats metagraph is a public dashboard surface for SN66.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/66/metagraph",
-      "subject": "surface:sn-66-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-66.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13135,13 +13223,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Harnyx TaoMarketCap dashboard is a public dashboard surface for SN67.",
+      "claim": "Harnyx SubnetRadar dashboard is a public dashboard surface for SN67.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/67",
-      "subject": "surface:sn-67-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/67",
+      "subject": "surface:sn-67-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-67.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13201,6 +13289,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "NOVA SubnetRadar dashboard is a public dashboard surface for SN68.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/68",
+      "subject": "surface:sn-68-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-68.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "NOVA TaoMarketCap dashboard is a public dashboard surface for SN68.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -13241,17 +13340,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx",
       "subject": "surface:sn-68-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-68.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "NOVA Taostats metagraph is a public dashboard surface for SN68.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/68/metagraph",
-      "subject": "surface:sn-68-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-68.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13300,6 +13388,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ain SubnetRadar dashboard is a public dashboard surface for SN69.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/69",
+      "subject": "surface:sn-69-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-69.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ain TaoMarketCap dashboard is a public dashboard surface for SN69.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -13318,17 +13417,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx",
       "subject": "surface:sn-69-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-69.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ain Taostats metagraph is a public dashboard surface for SN69.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/69/metagraph",
-      "subject": "surface:sn-69-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-69.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13355,6 +13443,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Allways SubnetRadar dashboard is a public dashboard surface for SN7.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/7",
+      "subject": "surface:sn-7-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for allways.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Allways TaoMarketCap dashboard is a public dashboard surface for SN7.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -13373,17 +13472,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_7/index.mdx",
       "subject": "surface:sn-7-taopedia-article",
-      "support_summary": "Listed in curated overlay for allways.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Allways Taostats metagraph is a public dashboard surface for SN7.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/7/metagraph",
-      "subject": "surface:sn-7-taostats-metagraph",
       "support_summary": "Listed in curated overlay for allways.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13432,6 +13520,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "NexisGen SubnetRadar dashboard is a public dashboard surface for SN70.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/70",
+      "subject": "surface:sn-70-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-70.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "NexisGen TaoMarketCap dashboard is a public dashboard surface for SN70.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -13472,17 +13571,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx",
       "subject": "surface:sn-70-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-70.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "NexisGen Taostats metagraph is a public dashboard surface for SN70.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/70/metagraph",
-      "subject": "surface:sn-70-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-70.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13531,6 +13619,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Leadpoet SubnetRadar dashboard is a public dashboard surface for SN71.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/71",
+      "subject": "surface:sn-71-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-71.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Leadpoet TaoMarketCap dashboard is a public dashboard surface for SN71.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -13571,17 +13670,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx",
       "subject": "surface:sn-71-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-71.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Leadpoet Taostats metagraph is a public dashboard surface for SN71.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/71/metagraph",
-      "subject": "surface:sn-71-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-71.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13696,6 +13784,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "StreetVision by NATIX SubnetRadar dashboard is a public dashboard surface for SN72.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/72",
+      "subject": "surface:sn-72-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-72.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "StreetVision by NATIX TaoMarketCap dashboard is a public dashboard surface for SN72.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -13729,17 +13828,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "StreetVision by NATIX Taostats metagraph is a public dashboard surface for SN72.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/72/metagraph",
-      "subject": "surface:sn-72-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-72.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "StreetVision by NATIX Tensorplex subnet docs is a public docs surface for SN72.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -13758,7 +13846,18 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/73-parked",
       "subject": "surface:sn-73-backprop-dashboard",
-      "support_summary": "Listed in curated overlay for sn-73.",
+      "support_summary": "Listed in curated overlay for metahash.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Parked SubnetRadar dashboard is a public dashboard surface for SN73.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/73",
+      "subject": "surface:sn-73-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for metahash.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -13769,7 +13868,7 @@
       "source_type": "registry-observed",
       "source_url": "https://api.taomarketcap.com/public/v1/subnets/73",
       "subject": "surface:sn-73-taomarketcap-dashboard",
-      "support_summary": "Listed in curated overlay for sn-73.",
+      "support_summary": "Listed in curated overlay for metahash.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -13780,18 +13879,7 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx",
       "subject": "surface:sn-73-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-73.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Parked Taostats metagraph is a public dashboard surface for SN73.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/73/metagraph",
-      "subject": "surface:sn-73-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-73.",
+      "support_summary": "Listed in curated overlay for metahash.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -13802,7 +13890,7 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json",
       "subject": "surface:sn-73-tensorplex-docs",
-      "support_summary": "Listed in curated overlay for sn-73.",
+      "support_summary": "Listed in curated overlay for metahash.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
@@ -13824,6 +13912,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/entrius/gittensor/blob/main/README.md",
       "subject": "surface:sn-74-github-readme-entrius-gittensor-docs-1",
+      "support_summary": "Listed in curated overlay for gittensor.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Gittensor SubnetRadar dashboard is a public dashboard surface for SN74.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/74",
+      "subject": "surface:sn-74-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for gittensor.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13857,17 +13956,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_74/index.mdx",
       "subject": "surface:sn-74-taopedia-article",
-      "support_summary": "Listed in curated overlay for gittensor.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Gittensor Taostats metagraph is a public dashboard surface for SN74.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/74/metagraph",
-      "subject": "surface:sn-74-taostats-metagraph",
       "support_summary": "Listed in curated overlay for gittensor.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -13971,6 +14059,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Hippius SubnetRadar dashboard is a public dashboard surface for SN75.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/75",
+      "subject": "surface:sn-75-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-75.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Hippius TaoMarketCap dashboard is a public dashboard surface for SN75.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14000,17 +14099,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_75/index.mdx",
       "subject": "surface:sn-75-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-75.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Hippius Taostats metagraph is a public dashboard surface for SN75.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/75/metagraph",
-      "subject": "surface:sn-75-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-75.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14048,6 +14136,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Byzantium SubnetRadar dashboard is a public dashboard surface for SN76.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/76",
+      "subject": "surface:sn-76-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-76.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Byzantium TaoMarketCap dashboard is a public dashboard surface for SN76.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14070,17 +14169,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Byzantium Taostats metagraph is a public dashboard surface for SN76.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/76/metagraph",
-      "subject": "surface:sn-76-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-76.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Byzantium Tensorplex subnet docs is a public docs surface for SN76.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14099,6 +14187,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/77-liquidity",
       "subject": "surface:sn-77-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-77.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Liquidity SubnetRadar dashboard is a public dashboard surface for SN77.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/77",
+      "subject": "surface:sn-77-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-77.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14147,17 +14246,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Liquidity Taostats metagraph is a public dashboard surface for SN77.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/77/metagraph",
-      "subject": "surface:sn-77-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-77.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Liquidity Tensorplex subnet docs is a public docs surface for SN77.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14202,6 +14290,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Vocence SubnetRadar dashboard is a public dashboard surface for SN78.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/78",
+      "subject": "surface:sn-78-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-78.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Vocence TaoMarketCap dashboard is a public dashboard surface for SN78.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14242,17 +14341,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
       "subject": "surface:sn-78-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-78.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Vocence Taostats metagraph is a public dashboard surface for SN78.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/78/metagraph",
-      "subject": "surface:sn-78-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-78.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14367,6 +14455,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "MVTRX SubnetRadar dashboard is a public dashboard surface for SN79.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/79",
+      "subject": "surface:sn-79-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-79.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "MVTRX TaoMarketCap dashboard is a public dashboard surface for SN79.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14389,17 +14488,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "MVTRX Taostats metagraph is a public dashboard surface for SN79.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/79/metagraph",
-      "subject": "surface:sn-79-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-79.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "MVTRX Tensorplex subnet docs is a public docs surface for SN79.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14418,6 +14506,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/8-vanta",
       "subject": "surface:sn-8-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-8.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Vanta SubnetRadar dashboard is a public dashboard surface for SN8.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/8",
+      "subject": "surface:sn-8-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-8.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14466,17 +14565,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Vanta Taostats metagraph is a public dashboard surface for SN8.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/8/metagraph",
-      "subject": "surface:sn-8-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-8.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Vanta Tensorplex subnet docs is a public docs surface for SN8.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14495,6 +14583,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/80-dogelayer",
       "subject": "surface:sn-80-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-80.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "dogelayer SubnetRadar dashboard is a public dashboard surface for SN80.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/80",
+      "subject": "surface:sn-80-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-80.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14539,17 +14638,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx",
       "subject": "surface:sn-80-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-80.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "dogelayer Taostats metagraph is a public dashboard surface for SN80.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/80/metagraph",
-      "subject": "surface:sn-80-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-80.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14642,6 +14730,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "deprecated SubnetRadar dashboard is a public dashboard surface for SN81.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/81",
+      "subject": "surface:sn-81-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-81.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "deprecated TaoMarketCap dashboard is a public dashboard surface for SN81.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14660,17 +14759,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_81/index.mdx",
       "subject": "surface:sn-81-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-81.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "deprecated Taostats metagraph is a public dashboard surface for SN81.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/81/metagraph",
-      "subject": "surface:sn-81-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-81.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14730,6 +14818,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Compelle SubnetRadar dashboard is a public dashboard surface for SN82.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/82",
+      "subject": "surface:sn-82-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-82.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Compelle TaoMarketCap dashboard is a public dashboard surface for SN82.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14748,17 +14847,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_82/index.mdx",
       "subject": "surface:sn-82-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-82.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Compelle Taostats metagraph is a public dashboard surface for SN82.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/82/metagraph",
-      "subject": "surface:sn-82-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-82.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14792,6 +14880,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/83-cliqueai",
       "subject": "surface:sn-83-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-83.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "CliqueAI SubnetRadar dashboard is a public dashboard surface for SN83.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/83",
+      "subject": "surface:sn-83-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-83.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14836,17 +14935,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx",
       "subject": "surface:sn-83-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-83.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "CliqueAI Taostats metagraph is a public dashboard surface for SN83.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/83/metagraph",
-      "subject": "surface:sn-83-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-83.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14928,6 +15016,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ansuz SubnetRadar dashboard is a public dashboard surface for SN84.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/84",
+      "subject": "surface:sn-84-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-84.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ansuz TaoMarketCap dashboard is a public dashboard surface for SN84.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -14946,17 +15045,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_84/index.mdx",
       "subject": "surface:sn-84-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-84.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ansuz Taostats metagraph is a public dashboard surface for SN84.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/84/metagraph",
-      "subject": "surface:sn-84-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-84.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -14994,6 +15082,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Vidaio SubnetRadar dashboard is a public dashboard surface for SN85.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/85",
+      "subject": "surface:sn-85-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-85.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Vidaio TaoMarketCap dashboard is a public dashboard surface for SN85.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15012,17 +15111,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_85/index.mdx",
       "subject": "surface:sn-85-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-85.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Vidaio Taostats metagraph is a public dashboard surface for SN85.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/85/metagraph",
-      "subject": "surface:sn-85-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-85.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15071,6 +15159,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Subnet 86 SubnetRadar dashboard is a public dashboard surface for SN86.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/86",
+      "subject": "surface:sn-86-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-86.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Subnet 86 TaoMarketCap dashboard is a public dashboard surface for SN86.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15089,17 +15188,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx",
       "subject": "surface:sn-86-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-86.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Subnet 86 Taostats metagraph is a public dashboard surface for SN86.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/86/metagraph",
-      "subject": "surface:sn-86-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-86.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15159,6 +15247,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Luminar Network SubnetRadar dashboard is a public dashboard surface for SN87.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/87",
+      "subject": "surface:sn-87-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-87.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Luminar Network TaoMarketCap dashboard is a public dashboard surface for SN87.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15177,17 +15276,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
       "subject": "surface:sn-87-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-87.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Luminar Network Taostats metagraph is a public dashboard surface for SN87.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/87/metagraph",
-      "subject": "surface:sn-87-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-87.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15258,13 +15346,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Investing TaoMarketCap dashboard is a public dashboard surface for SN88.",
+      "claim": "Investing SubnetRadar dashboard is a public dashboard surface for SN88.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/88",
-      "subject": "surface:sn-88-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/88",
+      "subject": "surface:sn-88-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-88.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15313,6 +15401,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "InfiniteHash SubnetRadar dashboard is a public dashboard surface for SN89.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/89",
+      "subject": "surface:sn-89-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-89.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "InfiniteHash TaoMarketCap dashboard is a public dashboard surface for SN89.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15331,17 +15430,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_89/index.mdx",
       "subject": "surface:sn-89-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-89.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "InfiniteHash Taostats metagraph is a public dashboard surface for SN89.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/89/metagraph",
-      "subject": "surface:sn-89-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-89.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15401,13 +15489,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "iota TaoMarketCap dashboard is a public dashboard surface for SN9.",
+      "claim": "iota SubnetRadar dashboard is a public dashboard surface for SN9.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
-      "source_url": "https://api.taomarketcap.com/public/v1/subnets/9",
-      "subject": "surface:sn-9-taomarketcap-dashboard",
+      "source_url": "https://subnetradar.com/subnet/9",
+      "subject": "surface:sn-9-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-9.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15489,6 +15577,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ogham SubnetRadar dashboard is a public dashboard surface for SN90.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/90",
+      "subject": "surface:sn-90-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-90.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ogham TaoMarketCap dashboard is a public dashboard surface for SN90.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15507,17 +15606,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx",
       "subject": "surface:sn-90-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-90.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ogham Taostats metagraph is a public dashboard surface for SN90.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/90/metagraph",
-      "subject": "surface:sn-90-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-90.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15566,6 +15654,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Bitstarter #1 SubnetRadar dashboard is a public dashboard surface for SN91.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/91",
+      "subject": "surface:sn-91-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-91.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Bitstarter #1 TaoMarketCap dashboard is a public dashboard surface for SN91.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15584,17 +15683,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_91/index.mdx",
       "subject": "surface:sn-91-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-91.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Bitstarter #1 Taostats metagraph is a public dashboard surface for SN91.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/91/metagraph",
-      "subject": "surface:sn-91-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-91.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15621,6 +15709,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "luis SubnetRadar dashboard is a public dashboard surface for SN92.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/92",
+      "subject": "surface:sn-92-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-92.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "SN92 TaoMarketCap dashboard is a public dashboard surface for SN92.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15643,17 +15742,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "luis Taostats metagraph is a public dashboard surface for SN92.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/92/metagraph",
-      "subject": "surface:sn-92-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-92.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "SN92 Tensorplex metadata is a public docs surface for SN92.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15672,6 +15760,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/93-bitcast",
       "subject": "surface:sn-93-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-93.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Bitcast SubnetRadar dashboard is a public dashboard surface for SN93.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/93",
+      "subject": "surface:sn-93-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-93.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15720,17 +15819,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Bitcast Taostats metagraph is a public dashboard surface for SN93.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/93/metagraph",
-      "subject": "surface:sn-93-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-93.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Bitcast Tensorplex subnet docs is a public docs surface for SN93.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15771,6 +15859,17 @@
       "source_type": "registry-observed",
       "source_url": "https://backprop.finance/dtao/subnets/94-bitsota",
       "subject": "surface:sn-94-backprop-dashboard",
+      "support_summary": "Listed in curated overlay for sn-94.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Bitsota SubnetRadar dashboard is a public dashboard surface for SN94.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/94",
+      "subject": "surface:sn-94-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-94.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15819,17 +15918,6 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "Bitsota Taostats metagraph is a public dashboard surface for SN94.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/94/metagraph",
-      "subject": "surface:sn-94-taostats-metagraph",
-      "support_summary": "Listed in curated overlay for sn-94.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
       "claim": "Bitsota Tensorplex subnet docs is a public docs surface for SN94.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15863,6 +15951,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Actual SubnetRadar dashboard is a public dashboard surface for SN95.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/95",
+      "subject": "surface:sn-95-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-95.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Actual TaoMarketCap dashboard is a public dashboard surface for SN95.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15892,17 +15991,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
       "subject": "surface:sn-95-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-95.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Actual Taostats metagraph is a public dashboard surface for SN95.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/95/metagraph",
-      "subject": "surface:sn-95-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-95.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -15951,6 +16039,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Verathos SubnetRadar dashboard is a public dashboard surface for SN96.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/96",
+      "subject": "surface:sn-96-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-96.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Verathos TaoMarketCap dashboard is a public dashboard surface for SN96.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -15969,17 +16068,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_96/index.mdx",
       "subject": "surface:sn-96-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-96.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Verathos Taostats metagraph is a public dashboard surface for SN96.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/96/metagraph",
-      "subject": "surface:sn-96-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-96.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -16105,6 +16193,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "Albedo SubnetRadar dashboard is a public dashboard surface for SN97.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/97",
+      "subject": "surface:sn-97-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-97.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "Albedo TaoMarketCap dashboard is a public dashboard surface for SN97.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -16145,17 +16244,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_97/index.mdx",
       "subject": "surface:sn-97-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-97.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Albedo Taostats metagraph is a public dashboard surface for SN97.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/97/metagraph",
-      "subject": "surface:sn-97-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-97.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -16237,6 +16325,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "ForeverMoney SubnetRadar dashboard is a public dashboard surface for SN98.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/98",
+      "subject": "surface:sn-98-subnetradar-dashboard",
+      "support_summary": "Listed in curated overlay for sn-98.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "ForeverMoney TaoMarketCap dashboard is a public dashboard surface for SN98.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -16255,17 +16354,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_98/index.mdx",
       "subject": "surface:sn-98-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-98.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "ForeverMoney Taostats metagraph is a public dashboard surface for SN98.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/98/metagraph",
-      "subject": "surface:sn-98-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-98.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -16292,13 +16380,13 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
-      "claim": "ForeverMoney docs subdomain is a public docs surface for SN98.",
+      "claim": "ForeverMoney docs is a public docs surface for SN98.",
       "confidence": "medium",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
       "source_tier": "community-docs",
       "source_type": "registry-observed",
       "source_url": "https://forevermoney.ai/",
-      "subject": "surface:sn-98-website-subdomain-docs-docs-forevermoney-ai",
+      "subject": "surface:sn-98-website-link-forevermoney-ai-docs-2",
       "support_summary": "Listed in curated overlay for sn-98.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -16321,6 +16409,17 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/RendixNetwork/leoma/blob/main/README.md",
       "subject": "surface:sn-99-github-readme-rendixnetwork-leoma-docs-2",
+      "support_summary": "Listed in curated overlay for sn-99.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
+      "claim": "Leoma SubnetRadar dashboard is a public dashboard surface for SN99.",
+      "confidence": "medium",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "community-docs",
+      "source_type": "registry-observed",
+      "source_url": "https://subnetradar.com/subnet/99",
+      "subject": "surface:sn-99-subnetradar-dashboard",
       "support_summary": "Listed in curated overlay for sn-99.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -16365,17 +16464,6 @@
       "source_type": "registry-observed",
       "source_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_99/index.mdx",
       "subject": "surface:sn-99-taopedia-article",
-      "support_summary": "Listed in curated overlay for sn-99.",
-      "verified_at": "1970-01-01T00:00:00.000Z"
-    },
-    {
-      "claim": "Leoma Taostats metagraph is a public dashboard surface for SN99.",
-      "confidence": "medium",
-      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
-      "source_tier": "community-docs",
-      "source_type": "registry-observed",
-      "source_url": "https://taostats.io/subnets/99/metagraph",
-      "subject": "surface:sn-99-taostats-metagraph",
       "support_summary": "Listed in curated overlay for sn-99.",
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
@@ -16430,8 +16518,8 @@
   "schema_version": 1,
   "summary": {
     "candidate_claim_count": 250,
-    "claim_count": 1493,
+    "claim_count": 1501,
     "subnet_claim_count": 129,
-    "surface_claim_count": 1114
+    "surface_claim_count": 1122
   }
 }

--- a/public/metagraph/freshness.json
+++ b/public/metagraph/freshness.json
@@ -43,7 +43,7 @@
       "timestamp_field": null
     },
     {
-      "as_of": "2026-06-08T13:11:57.000Z",
+      "as_of": "2026-06-08T14:11:05.342Z",
       "id": "candidate-discovery",
       "lane": "candidate-discovery",
       "notes": "",
@@ -52,11 +52,11 @@
       "stale_after_hours": 24,
       "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-08T13:11:57.000Z",
+      "timestamp": "2026-06-08T14:11:05.342Z",
       "timestamp_field": "candidate_discovery_as_of"
     },
     {
-      "as_of": "2026-06-08T13:16:03.655Z",
+      "as_of": "2026-06-08T14:12:26.654Z",
       "id": "candidate-verification",
       "lane": "candidate-verification",
       "notes": "",
@@ -65,7 +65,7 @@
       "stale_after_hours": 24,
       "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-08T13:16:03.655Z",
+      "timestamp": "2026-06-08T14:12:26.654Z",
       "timestamp_field": "verification_as_of"
     },
     {
@@ -95,7 +95,7 @@
       "timestamp_field": "schema_snapshot_as_of"
     },
     {
-      "as_of": "2026-06-08T13:42:08.702Z",
+      "as_of": "2026-06-08T14:15:40.511Z",
       "id": "surface-health",
       "lane": "health-probe",
       "notes": "Observed health is probe-derived.",
@@ -104,7 +104,7 @@
       "stale_after_hours": 6,
       "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-08T13:42:08.702Z",
+      "timestamp": "2026-06-08T14:15:40.511Z",
       "timestamp_field": "health_probe_as_of"
     }
   ],
@@ -112,9 +112,9 @@
     "adapter_count": 2,
     "adapter_snapshot_as_of": "2026-06-07T21:52:49.513Z",
     "blocking_source_count": 5,
-    "candidate_discovery_as_of": "2026-06-08T13:11:57.000Z",
-    "health_probe_as_of": "2026-06-08T13:42:08.702Z",
-    "health_surface_count": 1110,
+    "candidate_discovery_as_of": "2026-06-08T14:11:05.342Z",
+    "health_probe_as_of": "2026-06-08T14:15:40.511Z",
+    "health_surface_count": 1115,
     "missing_blocking_source_count": 0,
     "native_data_as_of": "2026-06-07T21:51:54Z",
     "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
@@ -124,7 +124,7 @@
     "stale_window_warnings": [
       "schema-drift has no observed timestamp; review before relying on this lane."
     ],
-    "verification_as_of": "2026-06-08T13:16:03.655Z",
+    "verification_as_of": "2026-06-08T14:12:26.654Z",
     "verification_generated_at": "1970-01-01T00:00:00.000Z",
     "warning_source_count": 3
   }

--- a/public/metagraph/gaps.json
+++ b/public/metagraph/gaps.json
@@ -735,19 +735,19 @@
     },
     {
       "coverage_level": "probed",
-      "curation_level": "machine-verified",
+      "curation_level": "maintainer-reviewed",
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Official website/docs/console are browser-facing but currently reject simple machine probes with connection resets, so these surfaces are listed without recurring probe monitoring.",
+          "Previously discovered GitHub source repository candidates currently return 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
         "missing_kinds": [
           "source-repo",
-          "website",
           "openapi",
           "subnet-api",
           "sse",
@@ -755,12 +755,13 @@
         ],
         "supported_kinds": [
           "dashboard",
-          "docs"
+          "docs",
+          "website"
         ]
       },
       "name": "Nodexo",
       "netuid": 27,
-      "slug": "sn-27"
+      "slug": "nodexo"
     },
     {
       "coverage_level": "probed",
@@ -1041,13 +1042,11 @@
       "curation_level": "machine-verified",
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
           "No verified subnet API surface yet.",
           "No verified SSE/event stream yet.",
           "No verified data artifact yet."
         ],
         "missing_kinds": [
-          "source-repo",
           "subnet-api",
           "sse",
           "data-artifact"
@@ -1056,6 +1055,7 @@
           "dashboard",
           "docs",
           "openapi",
+          "source-repo",
           "website"
         ]
       },
@@ -1447,19 +1447,20 @@
     },
     {
       "coverage_level": "probed",
-      "curation_level": "machine-verified",
+      "curation_level": "maintainer-reviewed",
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "SignalPlus website is live and is tracked as the team/project website.",
+          "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
         "missing_kinds": [
           "source-repo",
-          "website",
           "openapi",
           "subnet-api",
           "sse",
@@ -1467,12 +1468,13 @@
         ],
         "supported_kinds": [
           "dashboard",
-          "docs"
+          "docs",
+          "website"
         ]
       },
       "name": "EfficientFrontier",
       "netuid": 53,
-      "slug": "sn-53"
+      "slug": "efficientfrontier"
     },
     {
       "coverage_level": "probed",
@@ -1981,15 +1983,18 @@
     },
     {
       "coverage_level": "probed",
-      "curation_level": "machine-verified",
+      "curation_level": "maintainer-reviewed",
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Native chain name currently reports as Parked; multiple public directories identify SN73 as MetaHash.",
+          "Official-looking docs domain docs.metahash73.com currently does not resolve from simple probes.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified official website yet.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
         "missing_kinds": [
           "source-repo",
@@ -2004,9 +2009,9 @@
           "docs"
         ]
       },
-      "name": "Parked",
+      "name": "MetaHash",
       "netuid": 73,
-      "slug": "sn-73"
+      "slug": "metahash"
     },
     {
       "coverage_level": "probed",
@@ -3164,19 +3169,20 @@
     },
     {
       "coverage_level": "probed",
-      "curation_level": "machine-verified",
+      "curation_level": "maintainer-reviewed",
       "gaps": {
         "gap_notes": [
-          "No verified source repository yet.",
-          "No verified project website yet.",
-          "No verified OpenAPI/Swagger surface yet.",
-          "No verified subnet API surface yet.",
+          "Native chain name currently reports as hard_sign; public directories identify SN116 as TaoLend.",
+          "Official website currently returns 500/server-error responses to simple probes and should appear degraded until it recovers.",
+          "Previously discovered GitHub source repository currently returns 404.",
+          "No verified live source repository yet.",
+          "No verified machine-readable OpenAPI/Swagger schema yet.",
+          "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
-          "No verified data artifact yet."
+          "No verified standalone static data artifact yet."
         ],
         "missing_kinds": [
           "source-repo",
-          "website",
           "openapi",
           "subnet-api",
           "sse",
@@ -3184,12 +3190,13 @@
         ],
         "supported_kinds": [
           "dashboard",
-          "docs"
+          "docs",
+          "website"
         ]
       },
-      "name": "hard_sign",
+      "name": "TaoLend",
       "netuid": 116,
-      "slug": "sn-116"
+      "slug": "taolend"
     },
     {
       "coverage_level": "probed",

--- a/public/metagraph/profiles.json
+++ b/public/metagraph/profiles.json
@@ -4,7 +4,7 @@
   "notes": "Public-safe subnet profiles derived from native chain data, curated overlays, verified surfaces, candidates, and explicit gaps.",
   "profiles": [
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-augmented",
         "chain-rpc",
@@ -74,8 +74,8 @@
           "https://github.com/opentensor/subtensor",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/0/subnet.json",
           "https://onfinality.io/en/networks/bittensor-finney",
+          "https://subnetradar.com/subnet/0",
           "https://taomarketcap.com/subnets/0",
-          "https://taostats.io/subnets/0/metagraph",
           "https://www.comparenodes.com/library/public-endpoints/bittensor/"
         ]
       },
@@ -96,7 +96,7 @@
       "team": null
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -168,8 +168,8 @@
           "https://github.com/macrocosm-os/apex",
           "https://github.com/macrocosm-os/apex/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/1/subnet.json",
-          "https://taomarketcap.com/subnets/1",
-          "https://taostats.io/subnets/1/metagraph"
+          "https://subnetradar.com/subnet/1",
+          "https://taomarketcap.com/subnets/1"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -187,7 +187,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -271,7 +271,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -340,7 +340,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_3/index.mdx",
           "https://github.com/one-covenant/templar",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/3/subnet.json",
-          "https://taostats.io/subnets/3/metagraph",
+          "https://subnetradar.com/subnet/3",
           "https://wandb.ai/tplr/templar",
           "https://www.tplr.ai/"
         ]
@@ -360,7 +360,7 @@
       "team": null
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -427,8 +427,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_4/index.mdx",
           "https://github.com/manifold-inc/targon",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/4/subnet.json",
+          "https://subnetradar.com/subnet/4",
           "https://taomarketcap.com/subnets/4",
-          "https://taostats.io/subnets/4/metagraph",
           "https://targon.com/"
         ]
       },
@@ -447,7 +447,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -510,7 +510,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx",
           "https://github.com/manifold-inc/hone",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/5/subnet.json",
-          "https://taostats.io/subnets/5/metagraph",
+          "https://subnetradar.com/subnet/5",
           "https://www.hone.training/"
         ]
       },
@@ -529,7 +529,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -583,7 +583,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -593,7 +593,8 @@
           "https://github.com/numinouslabs/numinous",
           "https://github.com/numinouslabs/numinous/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/6/subnet.json",
-          "https://numinouslabs.io/"
+          "https://numinouslabs.io/",
+          "https://subnetradar.com/subnet/6"
         ]
       },
       "review_state": "machine-generated",
@@ -611,7 +612,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-augmented",
         "bitcoin",
@@ -678,7 +679,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_7/index.mdx",
           "https://github.com/entrius/allways",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/7/subnet.json",
-          "https://taostats.io/subnets/7/metagraph"
+          "https://subnetradar.com/subnet/7"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -699,7 +700,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -762,7 +763,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx",
           "https://github.com/taoshidev/vanta-network",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/8/subnet.json",
-          "https://taostats.io/subnets/8/metagraph",
+          "https://subnetradar.com/subnet/8",
           "https://www.vantanetwork.io/"
         ]
       },
@@ -845,14 +846,14 @@
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:50:00.000Z",
         "source_urls": [
-          "https://api.taomarketcap.com/public/v1/subnets/9",
           "https://backprop.finance/dtao/subnets/9-iota",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_9/index.mdx",
           "https://github.com/macrocosm-os/iota",
           "https://github.com/macrocosm-os/iota/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/9/subnet.json",
           "https://iota.macrocosmos.ai/",
-          "https://iota.macrocosmos.ai/dashboard/mainnet"
+          "https://iota.macrocosmos.ai/dashboard/mainnet",
+          "https://subnetradar.com/subnet/9"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -870,7 +871,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -896,10 +897,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 8,
       "name": "Swap",
       "native_name": "Swap",
       "native_name_quality": "chain",
@@ -933,7 +934,7 @@
           "https://github.com/Swap-Subnet/swap-subnet",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/10/subnet.json",
-          "https://taostats.io/subnets/10/metagraph",
+          "https://subnetradar.com/subnet/10",
           "https://www.taofi.com/pool"
         ]
       },
@@ -947,12 +948,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "κ",
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -1015,7 +1016,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/11/subnet.json",
           "https://github.com/trajectoryRL/trajectoryRL",
-          "https://taostats.io/subnets/11/metagraph",
+          "https://subnetradar.com/subnet/11",
           "https://trajrl.com/"
         ]
       },
@@ -1034,7 +1035,7 @@
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1104,8 +1105,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_12/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/12/subnet.json",
           "https://learnbittensor.org/subnets/12",
-          "https://taomarketcap.com/subnets/12",
-          "https://taostats.io/subnets/12/metagraph"
+          "https://subnetradar.com/subnet/12",
+          "https://taomarketcap.com/subnets/12"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -1123,7 +1124,7 @@
       "team": null
     },
     {
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1198,7 +1199,7 @@
           "https://github.com/macrocosm-os/data-universe/blob/main/README.md",
           "https://github.com/macrocosm-os/scrapers",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/13/subnet.json",
-          "https://taostats.io/subnets/13/metagraph",
+          "https://subnetradar.com/subnet/13",
           "https://www.macrocosmos.ai/gravity"
         ]
       },
@@ -1217,7 +1218,7 @@
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -1271,7 +1272,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 9,
+        "interface_source_count": 10,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -1283,7 +1284,8 @@
           "https://github.com/latent-to/cacheon",
           "https://github.com/latent-to/cacheon/blob/main/README.md",
           "https://github.com/latent-to/taohash/blob/main/README.md",
-          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/14/subnet.json"
+          "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/14/subnet.json",
+          "https://subnetradar.com/subnet/14"
         ]
       },
       "review_state": "machine-generated",
@@ -1301,7 +1303,7 @@
       "team": null
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1364,14 +1366,14 @@
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:50:00.000Z",
         "source_urls": [
-          "https://api.taomarketcap.com/public/v1/subnets/15",
           "https://backprop.finance/dtao/subnets/15-oro",
           "https://docs.oroagents.com/docs/miners/quick-start",
           "https://github.com/ORO-AI/oro",
           "https://github.com/ORO-AI/oro/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_15/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/15/subnet.json",
-          "https://oroagents.com/"
+          "https://oroagents.com/",
+          "https://subnetradar.com/subnet/15"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -1389,7 +1391,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -1453,7 +1455,7 @@
           "https://github.com/FirstTensorLabs/BitAds",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
-          "https://taostats.io/subnets/16/metagraph"
+          "https://subnetradar.com/subnet/16"
         ]
       },
       "review_state": "machine-generated",
@@ -1472,7 +1474,7 @@
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -1526,7 +1528,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -1536,6 +1538,7 @@
           "https://github.com/404-Repo/three-gen-subnet/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_17/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/17/subnet.json",
+          "https://subnetradar.com/subnet/17",
           "https://www.404.xyz/"
         ]
       },
@@ -1554,7 +1557,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -1617,7 +1620,7 @@
           "https://github.com/Orpheus-AI/Zeus",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/18/subnet.json",
-          "https://taostats.io/subnets/18/metagraph",
+          "https://subnetradar.com/subnet/18",
           "https://www.zeussubnet.com/"
         ]
       },
@@ -1636,7 +1639,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1706,8 +1709,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_19/index.mdx",
           "https://github.com/taostat/blockmachine",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/19/subnet.json",
-          "https://taomarketcap.com/subnets/19",
-          "https://taostats.io/subnets/19/metagraph"
+          "https://subnetradar.com/subnet/19",
+          "https://taomarketcap.com/subnets/19"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -1725,7 +1728,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1793,8 +1796,8 @@
           "https://backprop.finance/dtao/subnets/20-groundlayer",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_20/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/20/subnet.json",
+          "https://subnetradar.com/subnet/20",
           "https://taomarketcap.com/subnets/20",
-          "https://taostats.io/subnets/20/metagraph",
           "https://www.groundlayer.xyz/"
         ]
       },
@@ -1812,7 +1815,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "advertising",
         "baseline-augmented",
@@ -1881,8 +1884,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_21/index.mdx",
           "https://github.com/ippcteam/SN21-adtao",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/21/subnet.json",
-          "https://taomarketcap.com/subnets/21",
-          "https://taostats.io/subnets/21/metagraph"
+          "https://subnetradar.com/subnet/21",
+          "https://taomarketcap.com/subnets/21"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -1900,7 +1903,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1974,7 +1977,7 @@
           "https://github.com/Desearch-ai/subnet-22",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_22/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/22/subnet.json",
-          "https://taostats.io/subnets/22/metagraph",
+          "https://subnetradar.com/subnet/22",
           "https://www.desearch.ai/",
           "https://www.desearch.ai/docs",
           "https://www.desearch.ai/openapi.json"
@@ -1997,7 +2000,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2056,7 +2059,7 @@
       "provenance": {
         "curation_level": "maintainer-reviewed",
         "identity_source": "curated-overlay",
-        "interface_source_count": 8,
+        "interface_source_count": 9,
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:50:00.000Z",
         "source_urls": [
@@ -2066,6 +2069,7 @@
           "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_23/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/23/subnet.json",
+          "https://subnetradar.com/subnet/23",
           "https://trishool.ai/",
           "https://trishool.ai/dashboard"
         ]
@@ -2086,7 +2090,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2158,8 +2162,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_24/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/24/subnet.json",
           "https://silxinc.com/",
-          "https://taomarketcap.com/subnets/24",
-          "https://taostats.io/subnets/24/metagraph"
+          "https://subnetradar.com/subnet/24",
+          "https://taomarketcap.com/subnets/24"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -2178,7 +2182,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2237,7 +2241,7 @@
       "provenance": {
         "curation_level": "maintainer-reviewed",
         "identity_source": "curated-overlay",
-        "interface_source_count": 8,
+        "interface_source_count": 9,
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:50:00.000Z",
         "source_urls": [
@@ -2248,6 +2252,7 @@
           "https://github.com/macrocosm-os/mainframe/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/25/subnet.json",
           "https://macrocosmos.ai/sn25",
+          "https://subnetradar.com/subnet/25",
           "https://taomarketcap.com/subnets/25"
         ]
       },
@@ -2266,7 +2271,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -2329,7 +2334,7 @@
           "https://github.com/0xsigurd/Perturb",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_26/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/26/subnet.json",
-          "https://taostats.io/subnets/26/metagraph",
+          "https://subnetradar.com/subnet/26",
           "https://www.perturbai.io/"
         ]
       },
@@ -2350,19 +2355,24 @@
     {
       "candidate_count": 14,
       "categories": [
-        "baseline-curated"
+        "baseline-augmented",
+        "baseline-curated",
+        "compute",
+        "gpu",
+        "identity-reviewed",
+        "official-docs",
+        "official-website"
       ],
       "completeness": {
-        "confidence": "medium",
+        "confidence": "high",
         "gap_reasons": [
           "missing-source-repo",
-          "missing-website",
           "missing-openapi",
           "missing-subnet-api",
           "missing-sse",
           "missing-data-artifact"
         ],
-        "missing_critical_count": 6,
+        "missing_critical_count": 5,
         "missing_operational": [
           "openapi",
           "subnet-api",
@@ -2370,18 +2380,17 @@
           "data-artifact"
         ],
         "missing_required": [
-          "source-repo",
-          "website"
+          "source-repo"
         ],
         "profile_level": "directory-only",
-        "score": 20
+        "score": 40
       },
-      "completeness_score": 20,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "endpoint_count": 5,
-      "interface_count": 2,
-      "missing_critical_count": 6,
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "endpoint_count": 8,
+      "interface_count": 3,
+      "missing_critical_count": 5,
       "monitored_endpoint_count": 5,
       "name": "Nodexo",
       "native_name": "Nodexo",
@@ -2390,48 +2399,52 @@
       "operational_interface_count": 0,
       "operational_interface_kinds": [],
       "primary_app_surface": {
-        "id": "sn-27-taopedia-article",
-        "kind": "docs",
-        "name": "Nodexo Taopedia article",
-        "provider": "taopedia-articles",
-        "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx"
+        "id": "sn-27-nodexo-website",
+        "kind": "website",
+        "name": "Nodexo website",
+        "provider": "nodexo",
+        "url": "https://nodexo.ai/"
       },
       "primary_links": {
-        "dashboard_url": "https://backprop.finance/dtao/subnets/27-nodexo",
-        "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
+        "dashboard_url": "https://console.nodexo.ai/",
+        "docs_url": "https://docs.nodexo.ai/",
         "source_repo": null,
-        "website_url": null
+        "website_url": "https://nodexo.ai/"
       },
       "profile_level": "directory-only",
       "project_name": "Nodexo",
       "provenance": {
-        "curation_level": "machine-verified",
+        "curation_level": "maintainer-reviewed",
         "identity_source": "curated-overlay",
-        "interface_source_count": 5,
-        "review_state": "machine-generated",
-        "reviewed_at": null,
+        "interface_source_count": 8,
+        "review_state": "maintainer-reviewed",
+        "reviewed_at": "2026-06-08T14:15:00.000Z",
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/27",
           "https://backprop.finance/dtao/subnets/27-nodexo",
+          "https://console.nodexo.ai/",
+          "https://docs.nodexo.ai/",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json",
-          "https://taostats.io/subnets/27/metagraph"
+          "https://nodexo.ai/",
+          "https://subnetradar.com/subnet/27"
         ]
       },
-      "review_state": "machine-generated",
-      "slug": "sn-27",
+      "review_state": "maintainer-reviewed",
+      "slug": "nodexo",
       "status": "active",
       "subnet_type": "application",
       "supported_interface_kinds": [
         "dashboard",
-        "docs"
+        "docs",
+        "website"
       ],
-      "surface_count": 5,
+      "surface_count": 8,
       "symbol": "ג",
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -2498,7 +2511,7 @@
           "https://backprop.finance/dtao/subnets/28-gm",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/28/subnet.json",
-          "https://taostats.io/subnets/28/metagraph"
+          "https://subnetradar.com/subnet/28"
         ]
       },
       "review_state": "machine-generated",
@@ -2514,7 +2527,7 @@
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2588,7 +2601,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_29/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/29/subnet.json",
           "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2",
-          "https://taostats.io/subnets/29/metagraph",
+          "https://subnetradar.com/subnet/29",
           "https://taostats.io/subnets/netuid-29"
         ]
       },
@@ -2608,7 +2621,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2681,8 +2694,8 @@
           "https://endure.network/",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_30/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json",
-          "https://taomarketcap.com/subnets/30",
-          "https://taostats.io/subnets/30/metagraph"
+          "https://subnetradar.com/subnet/30",
+          "https://taomarketcap.com/subnets/30"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -2699,7 +2712,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -2766,7 +2779,7 @@
           "https://backprop.finance/dtao/subnets/31-recall",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json",
-          "https://taostats.io/subnets/31/metagraph"
+          "https://subnetradar.com/subnet/31"
         ]
       },
       "review_state": "machine-generated",
@@ -2812,10 +2825,10 @@
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
-      "endpoint_count": 8,
+      "endpoint_count": 7,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 7,
       "name": "ItsAI",
       "native_name": "ItsAI",
       "native_name_quality": "chain",
@@ -2850,8 +2863,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_32/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/32/subnet.json",
           "https://its-ai.org/en",
-          "https://taomarketcap.com/subnets/32",
-          "https://taostats.io/subnets/32/metagraph"
+          "https://subnetradar.com/subnet/32",
+          "https://taomarketcap.com/subnets/32"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -2864,12 +2877,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 7,
       "symbol": "ח",
       "team": null
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2943,7 +2956,7 @@
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/33/subnet.json",
           "https://huggingface.co/datasets/ReadyAi/5000-podcast-conversations-with-metadata-and-embedding-dataset",
           "https://readyai.ai/",
-          "https://taostats.io/subnets/33/metagraph"
+          "https://subnetradar.com/subnet/33"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -2962,7 +2975,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3036,7 +3049,7 @@
           "https://github.com/BitMind-AI/bitmind-subnet",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_34/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/34/subnet.json",
-          "https://taostats.io/subnets/34/metagraph"
+          "https://subnetradar.com/subnet/34"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -3054,7 +3067,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -3080,10 +3093,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
+      "endpoint_count": 9,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 8,
+      "monitored_endpoint_count": 9,
       "name": "OxMarkets",
       "native_name": "OxMarkets",
       "native_name_quality": "chain",
@@ -3117,7 +3130,7 @@
           "https://github.com/General-Tao-Ventures/cartha-validator",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_35/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/35/subnet.json",
-          "https://taostats.io/subnets/35/metagraph",
+          "https://subnetradar.com/subnet/35",
           "https://www.0xmarkets.io/"
         ]
       },
@@ -3131,12 +3144,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ך",
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -3200,7 +3213,7 @@
           "https://github.com/RendixNetwork/eirel-ai",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/36/subnet.json",
-          "https://taostats.io/subnets/36/metagraph"
+          "https://subnetradar.com/subnet/36"
         ]
       },
       "review_state": "machine-generated",
@@ -3218,7 +3231,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -3282,7 +3295,7 @@
           "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json",
-          "https://taostats.io/subnets/37/metagraph"
+          "https://subnetradar.com/subnet/37"
         ]
       },
       "review_state": "machine-generated",
@@ -3300,37 +3313,34 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
       "completeness": {
         "confidence": "medium",
         "gap_reasons": [
-          "missing-source-repo",
           "missing-subnet-api",
           "missing-sse",
           "missing-data-artifact"
         ],
-        "missing_critical_count": 4,
+        "missing_critical_count": 3,
         "missing_operational": [
           "subnet-api",
           "sse",
           "data-artifact"
         ],
-        "missing_required": [
-          "source-repo"
-        ],
+        "missing_required": [],
         "profile_level": "operational",
-        "score": 50
+        "score": 65
       },
-      "completeness_score": 50,
+      "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 8,
-      "interface_count": 4,
-      "missing_critical_count": 4,
-      "monitored_endpoint_count": 8,
+      "endpoint_count": 9,
+      "interface_count": 5,
+      "missing_critical_count": 3,
+      "monitored_endpoint_count": 9,
       "name": "colosseum",
       "native_name": "colosseum",
       "native_name_quality": "chain",
@@ -3349,7 +3359,7 @@
       "primary_links": {
         "dashboard_url": "https://backprop.finance/dtao/subnets/38-colosseum",
         "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
-        "source_repo": null,
+        "source_repo": "https://github.com/TAO-Colosseum/tao-colosseum-subnet",
         "website_url": "https://www.taocolosseum.com/"
       },
       "profile_level": "operational",
@@ -3357,15 +3367,16 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 6,
+        "interface_source_count": 7,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/38",
           "https://backprop.finance/dtao/subnets/38-colosseum",
+          "https://github.com/TAO-Colosseum/tao-colosseum-subnet",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/38/subnet.json",
-          "https://taostats.io/subnets/38/metagraph",
+          "https://subnetradar.com/subnet/38",
           "https://www.taocolosseum.com/"
         ]
       },
@@ -3377,14 +3388,15 @@
         "dashboard",
         "docs",
         "openapi",
+        "source-repo",
         "website"
       ],
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ם",
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3452,8 +3464,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_39/index.mdx",
           "https://github.com/one-covenant/basilica",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/39/subnet.json",
+          "https://subnetradar.com/subnet/39",
           "https://taomarketcap.com/subnets/39",
-          "https://taostats.io/subnets/39/metagraph",
           "https://www.basilica.ai/"
         ]
       },
@@ -3472,7 +3484,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated"
       ],
@@ -3539,7 +3551,7 @@
           "https://backprop.finance/dtao/subnets/40-chunking",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_40/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json",
-          "https://taostats.io/subnets/40/metagraph"
+          "https://subnetradar.com/subnet/40"
         ]
       },
       "review_state": "machine-generated",
@@ -3555,7 +3567,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -3619,7 +3631,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx",
           "https://github.com/sportstensor/sn41",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json",
-          "https://taostats.io/subnets/41/metagraph"
+          "https://subnetradar.com/subnet/41"
         ]
       },
       "review_state": "machine-generated",
@@ -3638,7 +3650,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3713,8 +3725,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_42/index.mdx",
           "https://github.com/gopher-lab/subnet-42",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/42/subnet.json",
-          "https://taomarketcap.com/subnets/42",
-          "https://taostats.io/subnets/42/metagraph"
+          "https://subnetradar.com/subnet/42",
+          "https://taomarketcap.com/subnets/42"
         ]
       },
       "review_state": "needs-review",
@@ -3731,7 +3743,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3802,8 +3814,8 @@
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/43/subnet.json",
           "https://graphite-ai.net/",
           "https://learnbittensor.org/subnets/43",
-          "https://taomarketcap.com/subnets/43",
-          "https://taostats.io/subnets/43/metagraph"
+          "https://subnetradar.com/subnet/43",
+          "https://taomarketcap.com/subnets/43"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -3821,7 +3833,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -3884,7 +3896,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_44/index.mdx",
           "https://github.com/score-technologies/turbovision",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/44/subnet.json",
-          "https://taostats.io/subnets/44/metagraph",
+          "https://subnetradar.com/subnet/44",
           "https://www.wearescore.com/"
         ]
       },
@@ -3903,7 +3915,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3971,8 +3983,8 @@
           "https://github.com/Team-Rizzo/talisman-ai",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_45/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/45/subnet.json",
-          "https://taomarketcap.com/subnets/45",
-          "https://taostats.io/subnets/45/metagraph"
+          "https://subnetradar.com/subnet/45",
+          "https://taomarketcap.com/subnets/45"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -3990,7 +4002,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated"
       ],
@@ -4044,7 +4056,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -4054,6 +4066,7 @@
           "https://github.com/resi-labs-ai/RESI-models",
           "https://github.com/resi-labs-ai/RESI-models/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/46/subnet.json",
+          "https://subnetradar.com/subnet/46",
           "https://zipcode.ai/"
         ]
       },
@@ -4073,7 +4086,7 @@
       "team": null
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -4144,8 +4157,8 @@
           "https://github.com/openevolai/evolai",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/47/subnet.json",
           "https://huggingface.co/datasets/evolai/universal_qa",
-          "https://taomarketcap.com/subnets/47",
-          "https://taostats.io/subnets/47/metagraph"
+          "https://subnetradar.com/subnet/47",
+          "https://taomarketcap.com/subnets/47"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -4163,7 +4176,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -4232,8 +4245,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_48/index.mdx",
           "https://github.com/qbittensor-labs/quantum-compute",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/48/subnet.json",
+          "https://subnetradar.com/subnet/48",
           "https://taomarketcap.com/subnets/48",
-          "https://taostats.io/subnets/48/metagraph",
           "https://www.qbittensorlabs.com/"
         ]
       },
@@ -4252,7 +4265,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -4325,7 +4338,7 @@
           "https://github.com/nepher-ai/nepher-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/49/subnet.json",
           "https://nepher.ai",
-          "https://taostats.io/subnets/49/metagraph",
+          "https://subnetradar.com/subnet/49",
           "https://tournament-api.nepher.ai/docs",
           "https://tournament-api.nepher.ai/openapi.json",
           "https://tournament.nepher.ai"
@@ -4348,7 +4361,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -4411,8 +4424,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx",
           "https://github.com/mode-network/synth-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/50/subnet.json",
-          "https://synthdata.co/",
-          "https://taostats.io/subnets/50/metagraph"
+          "https://subnetradar.com/subnet/50",
+          "https://synthdata.co/"
         ]
       },
       "review_state": "machine-generated",
@@ -4431,7 +4444,7 @@
       "team": null
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-curated"
       ],
@@ -4497,7 +4510,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
           "https://lium.io/",
-          "https://taostats.io/subnets/51/metagraph"
+          "https://subnetradar.com/subnet/51"
         ]
       },
       "review_state": "machine-generated",
@@ -4516,7 +4529,7 @@
       "team": null
     },
     {
-      "candidate_count": 10,
+      "candidate_count": 11,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -4588,8 +4601,8 @@
           "https://github.com/tensorplex-labs/dojo-ui",
           "https://github.com/tensorplex-labs/dojo-worker-api",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/52/subnet.json",
+          "https://subnetradar.com/subnet/52",
           "https://taomarketcap.com/subnets/52",
-          "https://taostats.io/subnets/52/metagraph",
           "https://www.tensorplex.ai/"
         ]
       },
@@ -4608,21 +4621,26 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
-        "baseline-curated"
+        "baseline-augmented",
+        "baseline-curated",
+        "defi",
+        "financial-trading",
+        "identity-reviewed",
+        "official-website",
+        "trading-strategies"
       ],
       "completeness": {
-        "confidence": "medium",
+        "confidence": "high",
         "gap_reasons": [
           "missing-source-repo",
-          "missing-website",
           "missing-openapi",
           "missing-subnet-api",
           "missing-sse",
           "missing-data-artifact"
         ],
-        "missing_critical_count": 6,
+        "missing_critical_count": 5,
         "missing_operational": [
           "openapi",
           "subnet-api",
@@ -4630,19 +4648,18 @@
           "data-artifact"
         ],
         "missing_required": [
-          "source-repo",
-          "website"
+          "source-repo"
         ],
         "profile_level": "directory-only",
-        "score": 20
+        "score": 40
       },
-      "completeness_score": 20,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "endpoint_count": 5,
-      "interface_count": 2,
-      "missing_critical_count": 6,
-      "monitored_endpoint_count": 5,
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "endpoint_count": 7,
+      "interface_count": 3,
+      "missing_critical_count": 5,
+      "monitored_endpoint_count": 7,
       "name": "EfficientFrontier",
       "native_name": "EfficientFrontier",
       "native_name_quality": "chain",
@@ -4650,48 +4667,51 @@
       "operational_interface_count": 0,
       "operational_interface_kinds": [],
       "primary_app_surface": {
-        "id": "sn-53-taopedia-article",
-        "kind": "docs",
-        "name": "EfficientFrontier Taopedia article",
-        "provider": "taopedia-articles",
-        "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx"
+        "id": "sn-53-signalplus-website",
+        "kind": "website",
+        "name": "SignalPlus website",
+        "provider": "signalplus",
+        "url": "https://www.signalplus.com/"
       },
       "primary_links": {
-        "dashboard_url": "https://backprop.finance/dtao/subnets/53-efficientfrontier",
+        "dashboard_url": "https://t.signalplus.com/mining",
         "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
         "source_repo": null,
-        "website_url": null
+        "website_url": "https://www.signalplus.com/"
       },
       "profile_level": "directory-only",
       "project_name": "EfficientFrontier",
       "provenance": {
-        "curation_level": "machine-verified",
+        "curation_level": "maintainer-reviewed",
         "identity_source": "curated-overlay",
-        "interface_source_count": 5,
-        "review_state": "machine-generated",
-        "reviewed_at": null,
+        "interface_source_count": 7,
+        "review_state": "maintainer-reviewed",
+        "reviewed_at": "2026-06-08T14:15:00.000Z",
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/53",
           "https://backprop.finance/dtao/subnets/53-efficientfrontier",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
-          "https://taostats.io/subnets/53/metagraph"
+          "https://subnetradar.com/subnet/53",
+          "https://t.signalplus.com/mining",
+          "https://www.signalplus.com/"
         ]
       },
-      "review_state": "machine-generated",
-      "slug": "sn-53",
+      "review_state": "maintainer-reviewed",
+      "slug": "efficientfrontier",
       "status": "active",
       "subnet_type": "application",
       "supported_interface_kinds": [
         "dashboard",
-        "docs"
+        "docs",
+        "website"
       ],
-      "surface_count": 5,
+      "surface_count": 7,
       "symbol": "ب",
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -4745,7 +4765,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -4755,6 +4775,7 @@
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/54/subnet.json",
           "https://github.com/yanez-compliance/MIID-subnet",
           "https://github.com/yanez-compliance/MIID-subnet/blob/main/README.md",
+          "https://subnetradar.com/subnet/54",
           "https://www.yanez.ai/"
         ]
       },
@@ -4773,7 +4794,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -4837,7 +4858,7 @@
           "https://github.com/genomesio/subnet-niome",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/55/subnet.json",
           "https://niome.genomes.io/",
-          "https://taostats.io/subnets/55/metagraph"
+          "https://subnetradar.com/subnet/55"
         ]
       },
       "review_state": "machine-generated",
@@ -4855,7 +4876,7 @@
       "team": null
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-curated"
       ],
@@ -4917,7 +4938,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
           "https://github.com/gradients-ai/G.O.D",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/56/subnet.json",
-          "https://taostats.io/subnets/56/metagraph",
+          "https://subnetradar.com/subnet/56",
           "https://www.gradients.io/"
         ]
       },
@@ -4938,7 +4959,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -5009,8 +5030,8 @@
           "https://github.com/sparket-ai/sparket-ai",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/57/subnet.json",
           "https://sparket.ai/",
-          "https://taomarketcap.com/subnets/57",
-          "https://taostats.io/subnets/57/metagraph"
+          "https://subnetradar.com/subnet/57",
+          "https://taomarketcap.com/subnets/57"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -5028,7 +5049,7 @@
       "team": null
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "categories": [
         "ai-marketplace",
         "baseline-augmented",
@@ -5104,8 +5125,8 @@
           "https://handshake58.com/.well-known/ai-plugin.json",
           "https://handshake58.com/openapi.json",
           "https://handshake58.com/skill.md",
-          "https://taomarketcap.com/subnets/58",
-          "https://taostats.io/subnets/58/metagraph"
+          "https://subnetradar.com/subnet/58",
+          "https://taomarketcap.com/subnets/58"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -5125,7 +5146,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -5190,7 +5211,7 @@
           "https://github.com/babelbit/babelbit_subnet/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_59/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json",
-          "https://taostats.io/subnets/59/metagraph"
+          "https://subnetradar.com/subnet/59"
         ]
       },
       "review_state": "machine-generated",
@@ -5209,7 +5230,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -5275,7 +5296,7 @@
           "https://github.com/Bitsec-AI/sandbox/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/60/subnet.json",
-          "https://taostats.io/subnets/60/metagraph"
+          "https://subnetradar.com/subnet/60"
         ]
       },
       "review_state": "machine-generated",
@@ -5294,7 +5315,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -5359,7 +5380,6 @@
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:50:00.000Z",
         "source_urls": [
-          "https://api.taomarketcap.com/public/v1/subnets/61",
           "https://backprop.finance/dtao/subnets/61-redteam",
           "https://dashboard.theredteam.io/",
           "https://docs.theredteam.io/",
@@ -5367,6 +5387,7 @@
           "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_61/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/61/subnet.json",
+          "https://subnetradar.com/subnet/61",
           "https://www.theredteam.io/"
         ]
       },
@@ -5415,10 +5436,10 @@
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
-      "endpoint_count": 7,
+      "endpoint_count": 6,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 6,
       "name": "Ridges",
       "native_name": "Ridges",
       "native_name_quality": "chain",
@@ -5452,8 +5473,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_62/index.mdx",
           "https://github.com/ridgesai/ridges",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/62/subnet.json",
+          "https://subnetradar.com/subnet/62",
           "https://taomarketcap.com/subnets/62",
-          "https://taostats.io/subnets/62/metagraph",
           "https://www.ridges.ai/"
         ]
       },
@@ -5467,12 +5488,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 6,
       "symbol": "ز",
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -5540,8 +5561,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_63/index.mdx",
           "https://github.com/qbittensor-labs/enigma",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/63/subnet.json",
+          "https://subnetradar.com/subnet/63",
           "https://taomarketcap.com/subnets/63",
-          "https://taostats.io/subnets/63/metagraph",
           "https://www.qbittensorlabs.com/"
         ]
       },
@@ -5560,7 +5581,7 @@
       "team": null
     },
     {
-      "candidate_count": 28,
+      "candidate_count": 29,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -5636,7 +5657,7 @@
           "https://github.com/chutesai/chutes-miner",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_64/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/64/subnet.json",
-          "https://taostats.io/subnets/64/metagraph"
+          "https://subnetradar.com/subnet/64"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -5656,7 +5677,7 @@
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -5719,7 +5740,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx",
           "https://github.com/taofu-labs/tpn-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/65/subnet.json",
-          "https://taostats.io/subnets/65/metagraph",
+          "https://subnetradar.com/subnet/65",
           "https://tpn.taofu.xyz/"
         ]
       },
@@ -5739,7 +5760,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -5814,7 +5835,7 @@
           "https://ninja.arbos.life/",
           "https://ninja.arbos.life/health",
           "https://ninja.arbos.life/swagger",
-          "https://taostats.io/subnets/66/metagraph"
+          "https://subnetradar.com/subnet/66"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -5834,7 +5855,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -5888,7 +5909,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -5898,7 +5919,8 @@
           "https://github.com/harnyx/harnyx",
           "https://github.com/harnyx/harnyx/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/67/subnet.json",
-          "https://harnyx.ai/"
+          "https://harnyx.ai/",
+          "https://subnetradar.com/subnet/67"
         ]
       },
       "review_state": "machine-generated",
@@ -5916,7 +5938,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -5979,7 +6001,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx",
           "https://github.com/metanova-labs/nova",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/68/subnet.json",
-          "https://taostats.io/subnets/68/metagraph",
+          "https://subnetradar.com/subnet/68",
           "https://www.metanova-labs.ai/"
         ]
       },
@@ -5999,7 +6021,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -6066,7 +6088,7 @@
           "https://backprop.finance/dtao/subnets/69-ain",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/69/subnet.json",
-          "https://taostats.io/subnets/69/metagraph"
+          "https://subnetradar.com/subnet/69"
         ]
       },
       "review_state": "machine-generated",
@@ -6082,7 +6104,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -6146,7 +6168,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/70/subnet.json",
           "https://nexisgen.ai/",
-          "https://taostats.io/subnets/70/metagraph"
+          "https://subnetradar.com/subnet/70"
         ]
       },
       "review_state": "machine-generated",
@@ -6165,7 +6187,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -6229,7 +6251,7 @@
           "https://github.com/leadpoet/leadpoet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/71/subnet.json",
           "https://leadpoet.com/",
-          "https://taostats.io/subnets/71/metagraph"
+          "https://subnetradar.com/subnet/71"
         ]
       },
       "review_state": "machine-generated",
@@ -6248,7 +6270,7 @@
       "team": null
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -6321,7 +6343,7 @@
           "https://github.com/natixnetwork/streetvision-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/72/subnet.json",
           "https://huggingface.co/natix-network-org",
-          "https://taostats.io/subnets/72/metagraph",
+          "https://subnetradar.com/subnet/72",
           "https://www.natix.network/",
           "https://www.natix.network/vx360-depin-dashcam"
         ]
@@ -6342,12 +6364,17 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
-        "baseline-curated"
+        "baseline-augmented",
+        "baseline-curated",
+        "defi",
+        "identity-reviewed",
+        "otc",
+        "treasury"
       ],
       "completeness": {
-        "confidence": "medium",
+        "confidence": "high",
         "gap_reasons": [
           "missing-source-repo",
           "missing-website",
@@ -6368,16 +6395,16 @@
           "website"
         ],
         "profile_level": "directory-only",
-        "score": 20
+        "score": 25
       },
-      "completeness_score": 20,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
+      "completeness_score": 25,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
       "endpoint_count": 5,
       "interface_count": 2,
       "missing_critical_count": 6,
       "monitored_endpoint_count": 5,
-      "name": "Parked",
+      "name": "MetaHash",
       "native_name": "Parked",
       "native_name_quality": "chain",
       "netuid": 73,
@@ -6397,23 +6424,23 @@
         "website_url": null
       },
       "profile_level": "directory-only",
-      "project_name": "Parked",
+      "project_name": "MetaHash",
       "provenance": {
-        "curation_level": "machine-verified",
+        "curation_level": "maintainer-reviewed",
         "identity_source": "curated-overlay",
         "interface_source_count": 5,
-        "review_state": "machine-generated",
-        "reviewed_at": null,
+        "review_state": "maintainer-reviewed",
+        "reviewed_at": "2026-06-08T14:15:00.000Z",
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/73",
           "https://backprop.finance/dtao/subnets/73-parked",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json",
-          "https://taostats.io/subnets/73/metagraph"
+          "https://subnetradar.com/subnet/73"
         ]
       },
-      "review_state": "machine-generated",
-      "slug": "sn-73",
+      "review_state": "maintainer-reviewed",
+      "slug": "metahash",
       "status": "active",
       "subnet_type": "application",
       "supported_interface_kinds": [
@@ -6425,7 +6452,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-augmented",
         "developer-tools",
@@ -6496,7 +6523,7 @@
           "https://github.com/entrius/gittensor/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/74/subnet.json",
           "https://gittensor.io/",
-          "https://taostats.io/subnets/74/metagraph"
+          "https://subnetradar.com/subnet/74"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -6517,7 +6544,7 @@
       "team": null
     },
     {
-      "candidate_count": 25,
+      "candidate_count": 26,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -6591,8 +6618,8 @@
           "https://github.com/thenervelab/hippius-storage-miner",
           "https://github.com/thenervelab/hippius-validator",
           "https://hippius.com/",
-          "https://taomarketcap.com/subnets/75",
-          "https://taostats.io/subnets/75/metagraph"
+          "https://subnetradar.com/subnet/75",
+          "https://taomarketcap.com/subnets/75"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -6610,7 +6637,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -6678,8 +6705,8 @@
           "https://backprop.finance/dtao/subnets/76-byzantium",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_76/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/76/subnet.json",
+          "https://subnetradar.com/subnet/76",
           "https://taomarketcap.com/subnets/76",
-          "https://taostats.io/subnets/76/metagraph",
           "https://www.byzantiumai.net/"
         ]
       },
@@ -6697,7 +6724,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -6761,7 +6788,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/77/subnet.json",
           "https://sn77.xyz/",
-          "https://taostats.io/subnets/77/metagraph"
+          "https://subnetradar.com/subnet/77"
         ]
       },
       "review_state": "machine-generated",
@@ -6780,7 +6807,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -6843,7 +6870,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/78/subnet.json",
           "https://github.com/vocence-78/vocence",
-          "https://taostats.io/subnets/78/metagraph",
+          "https://subnetradar.com/subnet/78",
           "https://www.vocence.ai/"
         ]
       },
@@ -6863,7 +6890,7 @@
       "team": null
     },
     {
-      "candidate_count": 25,
+      "candidate_count": 26,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -6932,9 +6959,9 @@
           "https://github.com/taos-im/sn-79/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/79/subnet.json",
           "https://simulate.trading/taos-im-paper",
+          "https://subnetradar.com/subnet/79",
           "https://taomarketcap.com/subnets/79",
-          "https://taos.im/",
-          "https://taostats.io/subnets/79/metagraph"
+          "https://taos.im/"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -6953,7 +6980,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -7017,7 +7044,7 @@
           "https://github.com/dogelayer-ai/dogelayer",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/80/subnet.json",
-          "https://taostats.io/subnets/80/metagraph"
+          "https://subnetradar.com/subnet/80"
         ]
       },
       "review_state": "machine-generated",
@@ -7036,7 +7063,7 @@
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7108,7 +7135,7 @@
           "https://github.com/one-covenant/grail",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/81/subnet.json",
           "https://grail-grafana.tplr.ai/",
-          "https://taostats.io/subnets/81/metagraph"
+          "https://subnetradar.com/subnet/81"
         ]
       },
       "review_state": "needs-review",
@@ -7125,7 +7152,7 @@
       "team": null
     },
     {
-      "candidate_count": 25,
+      "candidate_count": 26,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7193,8 +7220,8 @@
           "https://github.com/compelle/compelle-validator",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_82/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/82/subnet.json",
-          "https://taomarketcap.com/subnets/82",
-          "https://taostats.io/subnets/82/metagraph"
+          "https://subnetradar.com/subnet/82",
+          "https://taomarketcap.com/subnets/82"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -7212,7 +7239,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -7276,7 +7303,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/83/subnet.json",
           "https://github.com/toptensor/CliqueAI",
-          "https://taostats.io/subnets/83/metagraph"
+          "https://subnetradar.com/subnet/83"
         ]
       },
       "review_state": "machine-generated",
@@ -7295,7 +7322,7 @@
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7367,8 +7394,8 @@
           "https://github.com/TatsuProject/ChipForge_SN84",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_84/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/84/subnet.json",
+          "https://subnetradar.com/subnet/84",
           "https://taomarketcap.com/subnets/84",
-          "https://taostats.io/subnets/84/metagraph",
           "https://www.chipforge.io/"
         ]
       },
@@ -7387,7 +7414,7 @@
       "team": null
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7453,8 +7480,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_85/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/85/subnet.json",
           "https://github.com/vidaio-subnet/vidaio-subnet",
+          "https://subnetradar.com/subnet/85",
           "https://taomarketcap.com/subnets/85",
-          "https://taostats.io/subnets/85/metagraph",
           "https://vidaio.io/"
         ]
       },
@@ -7473,7 +7500,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -7540,7 +7567,7 @@
           "https://backprop.finance/dtao/subnets/86-subnet-86",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/86/subnet.json",
-          "https://taostats.io/subnets/86/metagraph"
+          "https://subnetradar.com/subnet/86"
         ]
       },
       "review_state": "machine-generated",
@@ -7556,7 +7583,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7631,7 +7658,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/87/subnet.json",
           "https://luminar.network/",
-          "https://taostats.io/subnets/87/metagraph"
+          "https://subnetradar.com/subnet/87"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -7648,7 +7675,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7713,14 +7740,14 @@
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T09:50:00.000Z",
         "source_urls": [
-          "https://api.taomarketcap.com/public/v1/subnets/88",
           "https://backprop.finance/dtao/subnets/88-investing",
           "https://db.investing88.ai/",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_88/index.mdx",
           "https://github.com/mobiusfund/investing",
           "https://github.com/mobiusfund/investing/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/88/subnet.json",
-          "https://investing88.ai/"
+          "https://investing88.ai/",
+          "https://subnetradar.com/subnet/88"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -7739,7 +7766,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7808,8 +7835,8 @@
           "https://github.com/backend-developers-ltd/InfiniteHash",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_89/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/89/subnet.json",
-          "https://taomarketcap.com/subnets/89",
-          "https://taostats.io/subnets/89/metagraph"
+          "https://subnetradar.com/subnet/89",
+          "https://taomarketcap.com/subnets/89"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -7826,7 +7853,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7898,7 +7925,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json",
           "https://subnet90.com/",
-          "https://taostats.io/subnets/90/metagraph"
+          "https://subnetradar.com/subnet/90"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -7915,7 +7942,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -7985,8 +8012,8 @@
           "https://bitstarter.ai/",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_91/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/91/subnet.json",
-          "https://taomarketcap.com/subnets/91",
-          "https://taostats.io/subnets/91/metagraph"
+          "https://subnetradar.com/subnet/91",
+          "https://taomarketcap.com/subnets/91"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -8003,7 +8030,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -8072,8 +8099,8 @@
           "https://backprop.finance/dtao/subnets/92-luis",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_92/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/92/subnet.json",
-          "https://taomarketcap.com/subnets/92",
-          "https://taostats.io/subnets/92/metagraph"
+          "https://subnetradar.com/subnet/92",
+          "https://taomarketcap.com/subnets/92"
         ]
       },
       "review_state": "stale",
@@ -8089,7 +8116,7 @@
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -8153,7 +8180,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_93/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/93/subnet.json",
           "https://stats.bitcast.network/",
-          "https://taostats.io/subnets/93/metagraph"
+          "https://subnetradar.com/subnet/93"
         ]
       },
       "review_state": "machine-generated",
@@ -8172,7 +8199,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -8236,7 +8263,7 @@
           "https://github.com/AlveusLabs/SN94-BitSota",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json",
-          "https://taostats.io/subnets/94/metagraph"
+          "https://subnetradar.com/subnet/94"
         ]
       },
       "review_state": "machine-generated",
@@ -8254,7 +8281,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -8320,7 +8347,7 @@
           "https://backprop.finance/dtao/subnets/95-actual",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json",
-          "https://taostats.io/subnets/95/metagraph"
+          "https://subnetradar.com/subnet/95"
         ]
       },
       "review_state": "machine-generated",
@@ -8338,7 +8365,7 @@
       "team": null
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -8410,7 +8437,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_96/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/96/subnet.json",
           "https://github.com/verathos-ai/verathos",
-          "https://taostats.io/subnets/96/metagraph",
+          "https://subnetradar.com/subnet/96",
           "https://verathos.ai/",
           "https://verathos.ai/chat",
           "https://verathos.ai/docs",
@@ -8434,7 +8461,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -8499,7 +8526,7 @@
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/97/subnet.json",
           "https://github.com/unarbos/albedo",
           "https://github.com/unitone-labs/FlameWire/blob/main/README.md",
-          "https://taostats.io/subnets/97/metagraph",
+          "https://subnetradar.com/subnet/97",
           "https://us-east-1.hippius.com/albedo/index.html"
         ]
       },
@@ -8519,7 +8546,7 @@
       "team": null
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -8588,8 +8615,8 @@
           "https://github.com/SN98-ForeverMoney/forever-money",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_98/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/98/subnet.json",
-          "https://taomarketcap.com/subnets/98",
-          "https://taostats.io/subnets/98/metagraph"
+          "https://subnetradar.com/subnet/98",
+          "https://taomarketcap.com/subnets/98"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -8607,7 +8634,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -8673,7 +8700,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_99/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/99/subnet.json",
           "https://leoma.ai/",
-          "https://taostats.io/subnets/99/metagraph"
+          "https://subnetradar.com/subnet/99"
         ]
       },
       "review_state": "machine-generated",
@@ -8692,7 +8719,7 @@
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -8756,7 +8783,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/100/subnet.json",
           "https://platform.network/",
-          "https://taostats.io/subnets/100/metagraph"
+          "https://subnetradar.com/subnet/100"
         ]
       },
       "review_state": "machine-generated",
@@ -8774,7 +8801,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -8841,7 +8868,7 @@
           "https://backprop.finance/dtao/subnets/101-eni",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/101/subnet.json",
-          "https://taostats.io/subnets/101/metagraph"
+          "https://subnetradar.com/subnet/101"
         ]
       },
       "review_state": "machine-generated",
@@ -8857,7 +8884,7 @@
       "team": null
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -8925,8 +8952,8 @@
           "https://github.com/Connito-AI/Connito",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_102/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/102/subnet.json",
-          "https://taomarketcap.com/subnets/102",
-          "https://taostats.io/subnets/102/metagraph"
+          "https://subnetradar.com/subnet/102",
+          "https://taomarketcap.com/subnets/102"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -9012,8 +9039,8 @@
           "https://github.com/Djinn-Inc/djinn",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_103/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/103/subnet.json",
+          "https://subnetradar.com/subnet/103",
           "https://taomarketcap.com/subnets/103",
-          "https://taostats.io/subnets/103/metagraph",
           "https://www.djinn.gg/"
         ]
       },
@@ -9032,7 +9059,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -9099,7 +9126,7 @@
           "https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_104/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/104/subnet.json",
-          "https://taostats.io/subnets/104/metagraph"
+          "https://subnetradar.com/subnet/104"
         ]
       },
       "review_state": "machine-generated",
@@ -9115,7 +9142,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -9179,7 +9206,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx",
           "https://github.com/orgs/Beam-Network/repositories",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json",
-          "https://taostats.io/subnets/105/metagraph"
+          "https://subnetradar.com/subnet/105"
         ]
       },
       "review_state": "machine-generated",
@@ -9198,7 +9225,7 @@
       "team": null
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -9261,7 +9288,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/106/subnet.json",
           "https://github.com/v0idai/SN106",
-          "https://taostats.io/subnets/106/metagraph",
+          "https://subnetradar.com/subnet/106",
           "https://voidai.com/"
         ]
       },
@@ -9280,7 +9307,7 @@
       "team": null
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-curated"
       ],
@@ -9344,7 +9371,7 @@
           "https://github.com/minos-protocol/minos_subnet",
           "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/107/subnet.json",
-          "https://taostats.io/subnets/107/metagraph",
+          "https://subnetradar.com/subnet/107",
           "https://theminos.ai/"
         ]
       },
@@ -9364,7 +9391,7 @@
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -9427,7 +9454,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx",
           "https://github.com/talkheadai/talkhead-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/108/subnet.json",
-          "https://taostats.io/subnets/108/metagraph",
+          "https://subnetradar.com/subnet/108",
           "https://www.talkhead.ai/"
         ]
       },
@@ -9446,7 +9473,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -9515,8 +9542,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_109/index.mdx",
           "https://github.com/fx-integral/academia",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/109/subnet.json",
-          "https://taomarketcap.com/subnets/109",
-          "https://taostats.io/subnets/109/metagraph"
+          "https://subnetradar.com/subnet/109",
+          "https://taomarketcap.com/subnets/109"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -9533,7 +9560,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -9600,8 +9627,8 @@
           "https://github.com/Rich-Kids-of-TAO/rkt-subnet",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/110/subnet.json",
+          "https://subnetradar.com/subnet/110",
           "https://taomarketcap.com/subnets/110",
-          "https://taostats.io/subnets/110/metagraph",
           "https://www.green-compute.com/"
         ]
       },
@@ -9622,7 +9649,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -9693,8 +9720,8 @@
           "https://github.com/oneoneone-io/subnet-111",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/111/subnet.json",
           "https://oneoneone.io/",
-          "https://taomarketcap.com/subnets/111",
-          "https://taostats.io/subnets/111/metagraph"
+          "https://subnetradar.com/subnet/111",
+          "https://taomarketcap.com/subnets/111"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -9712,7 +9739,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -9738,10 +9765,10 @@
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
-      "endpoint_count": 7,
+      "endpoint_count": 8,
       "interface_count": 4,
       "missing_critical_count": 4,
-      "monitored_endpoint_count": 7,
+      "monitored_endpoint_count": 8,
       "name": "minotaur",
       "native_name": "minotaur",
       "native_name_quality": "chain",
@@ -9776,7 +9803,7 @@
           "https://github.com/subnet112/minotaur_subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/112/subnet.json",
           "https://minotaursubnet.com/",
-          "https://taostats.io/subnets/112/metagraph"
+          "https://subnetradar.com/subnet/112"
         ]
       },
       "review_state": "machine-generated",
@@ -9789,12 +9816,12 @@
         "source-repo",
         "website"
       ],
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "Ђ",
       "team": null
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -9865,8 +9892,8 @@
           "https://github.com/TensorUSD/subnet/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_113/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/113/subnet.json",
+          "https://subnetradar.com/subnet/113",
           "https://taomarketcap.com/subnets/113",
-          "https://taostats.io/subnets/113/metagraph",
           "https://tensorusd.com/"
         ]
       },
@@ -9885,7 +9912,7 @@
       "team": null
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-curated"
       ],
@@ -9948,7 +9975,7 @@
           "https://github.com/DendriteHQ/SOMA",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_114/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/114/subnet.json",
-          "https://taostats.io/subnets/114/metagraph",
+          "https://subnetradar.com/subnet/114",
           "https://thesoma.ai/"
         ]
       },
@@ -9968,7 +9995,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -10037,8 +10064,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_115/index.mdx",
           "https://github.com/hashi115/hashichain",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/115/subnet.json",
-          "https://taomarketcap.com/subnets/115",
-          "https://taostats.io/subnets/115/metagraph"
+          "https://subnetradar.com/subnet/115",
+          "https://taomarketcap.com/subnets/115"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -10055,21 +10082,25 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
-        "baseline-curated"
+        "baseline-augmented",
+        "baseline-curated",
+        "defi",
+        "identity-reviewed",
+        "lending",
+        "official-website"
       ],
       "completeness": {
-        "confidence": "medium",
+        "confidence": "high",
         "gap_reasons": [
           "missing-source-repo",
-          "missing-website",
           "missing-openapi",
           "missing-subnet-api",
           "missing-sse",
           "missing-data-artifact"
         ],
-        "missing_critical_count": 6,
+        "missing_critical_count": 5,
         "missing_operational": [
           "openapi",
           "subnet-api",
@@ -10077,68 +10108,69 @@
           "data-artifact"
         ],
         "missing_required": [
-          "source-repo",
-          "website"
+          "source-repo"
         ],
         "profile_level": "directory-only",
-        "score": 20
+        "score": 40
       },
-      "completeness_score": 20,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "endpoint_count": 5,
-      "interface_count": 2,
-      "missing_critical_count": 6,
-      "monitored_endpoint_count": 5,
-      "name": "hard_sign",
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "endpoint_count": 6,
+      "interface_count": 3,
+      "missing_critical_count": 5,
+      "monitored_endpoint_count": 6,
+      "name": "TaoLend",
       "native_name": "hard_sign",
       "native_name_quality": "chain",
       "netuid": 116,
       "operational_interface_count": 0,
       "operational_interface_kinds": [],
       "primary_app_surface": {
-        "id": "sn-116-taopedia-article",
-        "kind": "docs",
-        "name": "hard_sign Taopedia article",
-        "provider": "taopedia-articles",
-        "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx"
+        "id": "sn-116-taolend-website",
+        "kind": "website",
+        "name": "TaoLend website",
+        "provider": "taolend",
+        "url": "https://taolend.io/"
       },
       "primary_links": {
         "dashboard_url": "https://backprop.finance/dtao/subnets/116-hard-sign",
         "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
         "source_repo": null,
-        "website_url": null
+        "website_url": "https://taolend.io/"
       },
       "profile_level": "directory-only",
-      "project_name": "hard_sign",
+      "project_name": "TaoLend",
       "provenance": {
-        "curation_level": "machine-verified",
+        "curation_level": "maintainer-reviewed",
         "identity_source": "curated-overlay",
-        "interface_source_count": 5,
-        "review_state": "machine-generated",
-        "reviewed_at": null,
+        "interface_source_count": 6,
+        "review_state": "maintainer-reviewed",
+        "reviewed_at": "2026-06-08T14:15:00.000Z",
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/116",
           "https://backprop.finance/dtao/subnets/116-hard-sign",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json",
-          "https://taostats.io/subnets/116/metagraph"
+          "https://subnetradar.com/subnet/116",
+          "https://taolend.io/"
         ]
       },
-      "review_state": "machine-generated",
-      "slug": "sn-116",
+      "review_state": "maintainer-reviewed",
+      "slug": "taolend",
       "status": "active",
       "subnet_type": "application",
       "supported_interface_kinds": [
         "dashboard",
-        "docs"
+        "docs",
+        "website"
       ],
-      "surface_count": 5,
+      "surface_count": 6,
       "symbol": "ъ",
       "team": null
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -10206,8 +10238,8 @@
           "https://github.com/shiftlayer-llc/brainplay-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/117/subnet.json",
           "https://play.shiftlayer.ai/",
-          "https://taomarketcap.com/subnets/117",
-          "https://taostats.io/subnets/117/metagraph"
+          "https://subnetradar.com/subnet/117",
+          "https://taomarketcap.com/subnets/117"
         ]
       },
       "review_state": "needs-review",
@@ -10225,7 +10257,7 @@
       "team": null
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-curated"
       ],
@@ -10289,7 +10321,7 @@
           "https://github.com/orgs/ditto-assistant/repositories",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/118/subnet.json",
           "https://heyditto.ai/",
-          "https://taostats.io/subnets/118/metagraph"
+          "https://subnetradar.com/subnet/118"
         ]
       },
       "review_state": "machine-generated",
@@ -10307,7 +10339,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated"
       ],
@@ -10374,7 +10406,7 @@
           "https://backprop.finance/dtao/subnets/119-satori",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/119/subnet.json",
-          "https://taostats.io/subnets/119/metagraph"
+          "https://subnetradar.com/subnet/119"
         ]
       },
       "review_state": "machine-generated",
@@ -10390,7 +10422,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -10444,7 +10476,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -10454,6 +10486,7 @@
           "https://github.com/AffineFoundation/affine/blob/main/README.md",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_120/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/120/subnet.json",
+          "https://subnetradar.com/subnet/120",
           "https://www.affine.io/"
         ]
       },
@@ -10472,7 +10505,7 @@
       "team": null
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -10539,8 +10572,8 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_121/index.mdx",
           "https://github.com/sundae-bar/bittensor-subnet",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/121/subnet.json",
+          "https://subnetradar.com/subnet/121",
           "https://taomarketcap.com/subnets/121",
-          "https://taostats.io/subnets/121/metagraph",
           "https://www.sundaebar.ai/"
         ]
       },
@@ -10559,7 +10592,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -10630,8 +10663,8 @@
           "https://github.com/bitrecs/bitrecs-subnet",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_122/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/122/subnet.json",
+          "https://subnetradar.com/subnet/122",
           "https://taomarketcap.com/subnets/122",
-          "https://taostats.io/subnets/122/metagraph",
           "https://www.bitrecs.ai/"
         ]
       },
@@ -10650,7 +10683,7 @@
       "team": null
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -10719,8 +10752,8 @@
           "https://github.com/Barbariandev/MANTIS",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/123/subnet.json",
-          "https://taomarketcap.com/subnets/123",
-          "https://taostats.io/subnets/123/metagraph"
+          "https://subnetradar.com/subnet/123",
+          "https://taomarketcap.com/subnets/123"
         ]
       },
       "review_state": "maintainer-reviewed",
@@ -10737,7 +10770,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -10791,7 +10824,7 @@
       "provenance": {
         "curation_level": "machine-verified",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "machine-generated",
         "reviewed_at": null,
         "source_urls": [
@@ -10801,6 +10834,7 @@
           "https://github.com/swarm-subnet/swarm",
           "https://github.com/swarm-subnet/swarm/blob/main/README.md",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/124/subnet.json",
+          "https://subnetradar.com/subnet/124",
           "https://www.swarm124.com/"
         ]
       },
@@ -10820,7 +10854,7 @@
       "team": null
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -10887,7 +10921,7 @@
           "https://backprop.finance/dtao/subnets/125-8-ball",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_125/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/125/subnet.json",
-          "https://taostats.io/subnets/125/metagraph"
+          "https://subnetradar.com/subnet/125"
         ]
       },
       "review_state": "machine-generated",
@@ -10903,7 +10937,7 @@
       "team": null
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -10967,7 +11001,7 @@
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_126/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/126/subnet.json",
           "https://poker44.net/",
-          "https://taostats.io/subnets/126/metagraph"
+          "https://subnetradar.com/subnet/126"
         ]
       },
       "review_state": "machine-generated",
@@ -10985,7 +11019,7 @@
       "team": null
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -11048,7 +11082,7 @@
           "https://github.com/astridintelligence/sn-127",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/127/subnet.json",
-          "https://taostats.io/subnets/127/metagraph",
+          "https://subnetradar.com/subnet/127",
           "https://www.astrid.global/"
         ]
       },
@@ -11067,7 +11101,7 @@
       "team": null
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -11131,7 +11165,7 @@
           "https://github.com/byteleapai/byteleap-Miner",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json",
-          "https://taostats.io/subnets/128/metagraph"
+          "https://subnetradar.com/subnet/128"
         ]
       },
       "review_state": "machine-generated",
@@ -11152,11 +11186,11 @@
   ],
   "schema_version": 1,
   "summary": {
-    "average_completeness_score": 53,
+    "average_completeness_score": 54,
     "by_confidence": {
-      "high": 58,
+      "high": 62,
       "low": 5,
-      "medium": 66
+      "medium": 62
     },
     "by_profile_level": {
       "adapter-backed": 2,

--- a/public/metagraph/providers.json
+++ b/public/metagraph/providers.json
@@ -419,6 +419,16 @@
     },
     {
       "authority": "provider-claimed",
+      "docs_url": "https://docs.nodexo.ai/",
+      "id": "nodexo",
+      "kind": "subnet-team",
+      "name": "Nodexo",
+      "notes": "Provider entry for Nodexo Compute / SN27. Official browser-facing website, docs, and console surfaces are tracked, but simple Node/HEAD probes currently receive connection resets and are not treated as healthy monitored endpoints.",
+      "schema_version": 1,
+      "website_url": "https://nodexo.ai/"
+    },
+    {
+      "authority": "provider-claimed",
       "docs_url": "https://docs.nodies.app/rpc-services/public-endpoints",
       "id": "nodies",
       "kind": "infrastructure-provider",
@@ -531,6 +541,15 @@
       "website_url": "https://play.shiftlayer.ai/"
     },
     {
+      "authority": "provider-claimed",
+      "id": "signalplus",
+      "kind": "subnet-team",
+      "name": "SignalPlus",
+      "notes": "Provider entry for SignalPlus and SN53 EfficientFrontier. The SignalPlus company website is live; the subnet mining surface currently returns an auth/challenge-style response to simple probes.",
+      "schema_version": 1,
+      "website_url": "https://www.signalplus.com/"
+    },
+    {
       "authority": "official",
       "github_url": "https://github.com/SILX-LABS/QUASAR-SUBNET",
       "id": "silx-labs",
@@ -551,6 +570,16 @@
       "website_url": "https://sparket.ai/"
     },
     {
+      "authority": "provider-claimed",
+      "docs_url": "https://subnetradar.com/about",
+      "id": "subnetradar",
+      "kind": "data-provider",
+      "name": "SubnetRadar",
+      "notes": "Third-party Bittensor subnet analytics and risk/health dashboard. Tracked as dashboard enrichment only; Metagraphed's endpoint health remains probe-derived from our own monitors.",
+      "schema_version": 1,
+      "website_url": "https://subnetradar.com/"
+    },
+    {
       "authority": "official",
       "github_url": "https://github.com/sundae-bar/bittensor-subnet",
       "id": "sundae-bar",
@@ -569,6 +598,15 @@
       "notes": "Provider entry for Talisman AI SN45 website and source repository.",
       "schema_version": 1,
       "website_url": "https://ai.talisman.xyz/"
+    },
+    {
+      "authority": "provider-claimed",
+      "id": "taolend",
+      "kind": "subnet-team",
+      "name": "TaoLend",
+      "notes": "Provider entry for TaoLend / SN116. The official website is tracked with probe-derived degraded status when it returns server errors.",
+      "schema_version": 1,
+      "website_url": "https://taolend.io/"
     },
     {
       "authority": "provider-claimed",

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 4630408,
+  "artifact_size_bytes": 4652199,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "1e4ed1e51518580136834e40bd66b38b2e43181966d7d72be98174b34bd51b14",
-      "size_bytes": 3288,
+      "sha256": "234d381425319b0a0d5238449f8d6011295a7ed0d762d50af60e1e83194bdaa9",
+      "size_bytes": 1349,
       "storage_tier": "dual"
     },
     {
@@ -34,7 +34,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/coverage.json",
       "latest_key": "latest/coverage.json",
       "path": "/metagraph/coverage.json",
-      "sha256": "e186b2ed3dab46d5ba9b3b56007bfed9d15b98b96e32f566abfd9aa38300b7be",
+      "sha256": "411565b9077ad8d8db4390041ffcbca39f982b684cefe21c1e17681aef075bbb",
       "size_bytes": 984,
       "storage_tier": "dual"
     },
@@ -43,8 +43,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/curation.json",
       "latest_key": "latest/curation.json",
       "path": "/metagraph/curation.json",
-      "sha256": "3994712d15a4053e51812b479dc545402171bfad4d9b5dc66789d20a97128503",
-      "size_bytes": 156768,
+      "sha256": "4af721577e89cfa64db395f38e70794ce218118bae2bd1b504e31e24f9f58cbc",
+      "size_bytes": 159521,
       "storage_tier": "dual"
     },
     {
@@ -52,8 +52,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/evidence-ledger.json",
       "latest_key": "latest/evidence-ledger.json",
       "path": "/metagraph/evidence-ledger.json",
-      "sha256": "58404d11f70c04b2057898a11ec8e05ca4e616c5529929431edbf2b88fa1101c",
-      "size_bytes": 843085,
+      "sha256": "59ff31ac9b70a35b2605d6f8ba6a016332b6230045444271ff5712f10c6806e2",
+      "size_bytes": 847225,
       "storage_tier": "dual"
     },
     {
@@ -61,7 +61,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "d7d7b0d9ef836fd1a0c74449d73ee498877ca925ff72dc7fbc60db6ae6f955a7",
+      "sha256": "4c5db4208a1e88b0233ea3bfb3f5e29f42dafe51ec390fa5b3aa2c75d3690f91",
       "size_bytes": 4324,
       "storage_tier": "dual"
     },
@@ -70,8 +70,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/gaps.json",
       "latest_key": "latest/gaps.json",
       "path": "/metagraph/gaps.json",
-      "sha256": "bb6854d6d302a958595e362fc8b58fb13769a025952d3f222b4f0584f239413d",
-      "size_bytes": 90569,
+      "sha256": "05d8a498e14a54e9c214df7f2f059be2c1a148ae6a2e87b95164cf5ddb83254f",
+      "size_bytes": 91868,
       "storage_tier": "dual"
     },
     {
@@ -88,8 +88,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/profiles.json",
       "latest_key": "latest/profiles.json",
       "path": "/metagraph/profiles.json",
-      "sha256": "d3accc91a589d8d2ecb9924104932adeb0ba293c1c090c3b5f108b01a05962fa",
-      "size_bytes": 367985,
+      "sha256": "032d46df2fd4e9ef52c4af95f18dd1a9476e776a5722a2babba72bf34d3f255f",
+      "size_bytes": 368150,
       "storage_tier": "dual"
     },
     {
@@ -97,8 +97,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/providers.json",
       "latest_key": "latest/providers.json",
       "path": "/metagraph/providers.json",
-      "sha256": "25998ba09b13d1b8caed346094fc0801ff1f4e8479523c111b6f5e188de209f5",
-      "size_bytes": 27898,
+      "sha256": "28a083649fe55ae64a30193958ce6eca59b8e7795e1143120c1dfa7485280178",
+      "size_bytes": 29625,
       "storage_tier": "dual"
     },
     {
@@ -106,8 +106,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/adapter-candidates.json",
       "latest_key": "latest/review/adapter-candidates.json",
       "path": "/metagraph/review/adapter-candidates.json",
-      "sha256": "fb61b55cc58775e03ba37561d60158b6e23e66b97e5aa7c362c7343d52e669ec",
-      "size_bytes": 26538,
+      "sha256": "a65e777f253648867ffe0702ed337ddbbab0cc0738531fff5c6980e4cf787e61",
+      "size_bytes": 26542,
       "storage_tier": "dual"
     },
     {
@@ -115,8 +115,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/curation.json",
       "latest_key": "latest/review/curation.json",
       "path": "/metagraph/review/curation.json",
-      "sha256": "0552407f2080a8746b9a4010d9abeebedb7f1e9ee29549f4db5a543ba5d32c42",
-      "size_bytes": 94143,
+      "sha256": "034370e6f3fa328465b0273c0b0e7e192ac6de3622a09033b0f5a3e5cedf7110",
+      "size_bytes": 94028,
       "storage_tier": "dual"
     },
     {
@@ -124,8 +124,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
       "latest_key": "latest/review/enrichment-queue.json",
       "path": "/metagraph/review/enrichment-queue.json",
-      "sha256": "02484f79d23177d20047c19917ec1a428e9e1d4c86fa987cdce2d6206814b209",
-      "size_bytes": 346351,
+      "sha256": "09f4301b4a5a5ce31cf845453bb1cce45f27916474d73732687fd5c2809fd069",
+      "size_bytes": 346281,
       "storage_tier": "dual"
     },
     {
@@ -133,8 +133,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/gap-priorities.json",
       "latest_key": "latest/review/gap-priorities.json",
       "path": "/metagraph/review/gap-priorities.json",
-      "sha256": "9f737864dcfa531553db7ba7ae2f02da54e32f4742cb97abc0566b23d6875286",
-      "size_bytes": 65756,
+      "sha256": "6458bd06bedd3165689ff873eac819bf98ff3c8fb9605324821a60bf3020ae50",
+      "size_bytes": 65637,
       "storage_tier": "dual"
     },
     {
@@ -151,8 +151,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/profile-completeness.json",
       "latest_key": "latest/review/profile-completeness.json",
       "path": "/metagraph/review/profile-completeness.json",
-      "sha256": "e0edf11e38d69d7473a6767de1befd78a7122215430b4504968e300133e1f9d2",
-      "size_bytes": 129636,
+      "sha256": "286414a702ca6c5813092ccfffe15275ac82b8166dcb6c7ca936e1f42d183f45",
+      "size_bytes": 129571,
       "storage_tier": "git"
     },
     {
@@ -178,8 +178,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/search.json",
       "latest_key": "latest/search.json",
       "path": "/metagraph/search.json",
-      "sha256": "2cdb689a7d6667deb3a36c2f437a7fa635f21819d87eef9150a06622bca45bd0",
-      "size_bytes": 602840,
+      "sha256": "ca6042fd8386a52ca87a138b3c81246a6241b49bd58f0936f7f2776a03fec0c8",
+      "size_bytes": 605604,
       "storage_tier": "dual"
     },
     {
@@ -187,8 +187,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/subnets.json",
       "latest_key": "latest/subnets.json",
       "path": "/metagraph/subnets.json",
-      "sha256": "20a7f2d2e1568dc3bcb8b50283286c82a8a21f097b4a229d27a9b4a8974f9d95",
-      "size_bytes": 125544,
+      "sha256": "2857b9294fe09774b94481b35b0728cb5f17bc659cd8245950f31abef2421e38",
+      "size_bytes": 126106,
       "storage_tier": "dual"
     },
     {
@@ -196,8 +196,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/surfaces.json",
       "latest_key": "latest/surfaces.json",
       "path": "/metagraph/surfaces.json",
-      "sha256": "a4a4be54f7f61c408b6a31583a6b603390c8e3bc8d696f58e1b89e32da7c4787",
-      "size_bytes": 1128957,
+      "sha256": "ac8e86b20151d7ec32f44f1d02253052c13f303d2a0ec2074170a262376d7fc2",
+      "size_bytes": 1139642,
       "storage_tier": "dual"
     },
     {
@@ -213,8 +213,8 @@
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
-  "full_artifact_count": 1208,
-  "full_artifact_size_bytes": 46346670,
+  "full_artifact_count": 1216,
+  "full_artifact_size_bytes": 48008957,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -234,11 +234,11 @@
   "storage_tier_counts": {
     "dual": 22,
     "git": 1,
-    "r2": 1185
+    "r2": 1193
   },
   "storage_tier_size_bytes": {
-    "dual": 4500772,
-    "git": 129636,
-    "r2": 41716262
+    "dual": 4522628,
+    "git": 129571,
+    "r2": 43356758
   }
 }

--- a/public/metagraph/review/adapter-candidates.json
+++ b/public/metagraph/review/adapter-candidates.json
@@ -338,6 +338,18 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "colosseum",
+      "netuid": 38,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-38"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Almanac",
       "netuid": 41,
       "operational_kinds": [
@@ -492,18 +504,6 @@
       "slug": "sn-124"
     },
     {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "colosseum",
-      "netuid": 38,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-38"
-    },
-    {
       "candidate_api_count": 6,
       "curation_level": "machine-verified",
       "name": "Babelbit",
@@ -651,6 +651,16 @@
     },
     {
       "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "OxMarkets",
+      "netuid": 35,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 9,
+      "slug": "sn-35"
+    },
+    {
+      "candidate_api_count": 5,
       "curation_level": "maintainer-reviewed",
       "name": "Talisman AI",
       "netuid": 45,
@@ -702,6 +712,16 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "Swap",
+      "netuid": 10,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-10"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "TrajectoryRL",
       "netuid": 11,
       "operational_kinds": [],
@@ -740,24 +760,14 @@
       "slug": "sn-26"
     },
     {
-      "candidate_api_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "name": "ItsAI",
-      "netuid": 32,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 8,
-      "slug": "sn-32"
-    },
-    {
       "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "OxMarkets",
-      "netuid": 35,
+      "curation_level": "maintainer-reviewed",
+      "name": "Nodexo",
+      "netuid": 27,
       "operational_kinds": [],
       "operational_surface_count": 0,
       "priority_score": 8,
-      "slug": "sn-35"
+      "slug": "nodexo"
     },
     {
       "candidate_api_count": 5,
@@ -832,6 +842,16 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "minotaur",
+      "netuid": 112,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-112"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Hone",
       "netuid": 5,
       "operational_kinds": [],
@@ -858,16 +878,6 @@
       "operational_surface_count": 0,
       "priority_score": 7,
       "slug": "sn-8"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Swap",
-      "netuid": 10,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-10"
     },
     {
       "candidate_api_count": 1,
@@ -910,6 +920,16 @@
       "slug": "sn-30"
     },
     {
+      "candidate_api_count": 6,
+      "curation_level": "maintainer-reviewed",
+      "name": "ItsAI",
+      "netuid": 32,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 7,
+      "slug": "sn-32"
+    },
+    {
       "candidate_api_count": 5,
       "curation_level": "maintainer-reviewed",
       "name": "Quantum Compute",
@@ -938,16 +958,6 @@
       "operational_surface_count": 0,
       "priority_score": 7,
       "slug": "sn-55"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "maintainer-reviewed",
-      "name": "Ridges",
-      "netuid": 62,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-62"
     },
     {
       "candidate_api_count": 5,
@@ -1002,16 +1012,6 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "minotaur",
-      "netuid": 112,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-112"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
       "name": "Affine",
       "netuid": 120,
       "operational_kinds": [],
@@ -1052,6 +1052,16 @@
     {
       "candidate_api_count": 5,
       "curation_level": "maintainer-reviewed",
+      "name": "Ridges",
+      "netuid": 62,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 6,
+      "slug": "sn-62"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "maintainer-reviewed",
       "name": "Byzantium",
       "netuid": 76,
       "operational_kinds": [],
@@ -1068,16 +1078,6 @@
       "operational_surface_count": 0,
       "priority_score": 6,
       "slug": "sn-89"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Nodexo",
-      "netuid": 27,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 5,
-      "slug": "sn-27"
     }
   ],
   "contract_version": "2026-06-06.1",

--- a/public/metagraph/review/curation.json
+++ b/public/metagraph/review/curation.json
@@ -338,6 +338,18 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "colosseum",
+      "netuid": 38,
+      "operational_kinds": [
+        "openapi"
+      ],
+      "operational_surface_count": 1,
+      "priority_score": 29,
+      "slug": "sn-38"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Almanac",
       "netuid": 41,
       "operational_kinds": [
@@ -492,18 +504,6 @@
       "slug": "sn-124"
     },
     {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "colosseum",
-      "netuid": 38,
-      "operational_kinds": [
-        "openapi"
-      ],
-      "operational_surface_count": 1,
-      "priority_score": 28,
-      "slug": "sn-38"
-    },
-    {
       "candidate_api_count": 6,
       "curation_level": "machine-verified",
       "name": "Babelbit",
@@ -651,6 +651,16 @@
     },
     {
       "candidate_api_count": 5,
+      "curation_level": "machine-verified",
+      "name": "OxMarkets",
+      "netuid": 35,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 9,
+      "slug": "sn-35"
+    },
+    {
+      "candidate_api_count": 5,
       "curation_level": "maintainer-reviewed",
       "name": "Talisman AI",
       "netuid": 45,
@@ -702,6 +712,16 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "Swap",
+      "netuid": 10,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-10"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "TrajectoryRL",
       "netuid": 11,
       "operational_kinds": [],
@@ -740,24 +760,14 @@
       "slug": "sn-26"
     },
     {
-      "candidate_api_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "name": "ItsAI",
-      "netuid": 32,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 8,
-      "slug": "sn-32"
-    },
-    {
       "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "OxMarkets",
-      "netuid": 35,
+      "curation_level": "maintainer-reviewed",
+      "name": "Nodexo",
+      "netuid": 27,
       "operational_kinds": [],
       "operational_surface_count": 0,
       "priority_score": 8,
-      "slug": "sn-35"
+      "slug": "nodexo"
     },
     {
       "candidate_api_count": 5,
@@ -832,6 +842,16 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
+      "name": "minotaur",
+      "netuid": 112,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 8,
+      "slug": "sn-112"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "machine-verified",
       "name": "Hone",
       "netuid": 5,
       "operational_kinds": [],
@@ -858,16 +878,6 @@
       "operational_surface_count": 0,
       "priority_score": 7,
       "slug": "sn-8"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Swap",
-      "netuid": 10,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-10"
     },
     {
       "candidate_api_count": 1,
@@ -910,6 +920,16 @@
       "slug": "sn-30"
     },
     {
+      "candidate_api_count": 6,
+      "curation_level": "maintainer-reviewed",
+      "name": "ItsAI",
+      "netuid": 32,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 7,
+      "slug": "sn-32"
+    },
+    {
       "candidate_api_count": 5,
       "curation_level": "maintainer-reviewed",
       "name": "Quantum Compute",
@@ -938,16 +958,6 @@
       "operational_surface_count": 0,
       "priority_score": 7,
       "slug": "sn-55"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "maintainer-reviewed",
-      "name": "Ridges",
-      "netuid": 62,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-62"
     },
     {
       "candidate_api_count": 5,
@@ -1002,16 +1012,6 @@
     {
       "candidate_api_count": 5,
       "curation_level": "machine-verified",
-      "name": "minotaur",
-      "netuid": 112,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 7,
-      "slug": "sn-112"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
       "name": "Affine",
       "netuid": 120,
       "operational_kinds": [],
@@ -1052,6 +1052,16 @@
     {
       "candidate_api_count": 5,
       "curation_level": "maintainer-reviewed",
+      "name": "Ridges",
+      "netuid": 62,
+      "operational_kinds": [],
+      "operational_surface_count": 0,
+      "priority_score": 6,
+      "slug": "sn-62"
+    },
+    {
+      "candidate_api_count": 5,
+      "curation_level": "maintainer-reviewed",
       "name": "Byzantium",
       "netuid": 76,
       "operational_kinds": [],
@@ -1068,57 +1078,27 @@
       "operational_surface_count": 0,
       "priority_score": 6,
       "slug": "sn-89"
-    },
-    {
-      "candidate_api_count": 5,
-      "curation_level": "machine-verified",
-      "name": "Nodexo",
-      "netuid": 27,
-      "operational_kinds": [],
-      "operational_surface_count": 0,
-      "priority_score": 5,
-      "slug": "sn-27"
     }
   ],
   "contract_version": "2026-06-06.1",
   "gap_priorities": [
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "data-artifact"
       ],
       "name": "Allways",
       "netuid": 7,
-      "priority_score": 101,
+      "priority_score": 102,
       "review_state": "maintainer-reviewed",
       "slug": "allways",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 23,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 14,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "website",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Nodexo",
-      "netuid": 27,
-      "priority_score": 82,
-      "review_state": "machine-generated",
-      "slug": "sn-27",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1130,55 +1110,15 @@
       ],
       "name": "Chunking",
       "netuid": 40,
-      "priority_score": 74,
+      "priority_score": 75,
       "review_state": "machine-generated",
       "slug": "sn-40",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "website",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "EfficientFrontier",
-      "netuid": 53,
-      "priority_score": 74,
-      "review_state": "machine-generated",
-      "slug": "sn-53",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "website",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Parked",
-      "netuid": 73,
-      "priority_score": 74,
-      "review_state": "machine-generated",
-      "slug": "sn-73",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1190,35 +1130,15 @@
       ],
       "name": "luis",
       "netuid": 92,
-      "priority_score": 74,
+      "priority_score": 75,
       "review_state": "stale",
       "slug": "sn-92",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "website",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "hard_sign",
-      "netuid": 116,
-      "priority_score": 74,
-      "review_state": "machine-generated",
-      "slug": "sn-116",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1230,15 +1150,15 @@
       ],
       "name": "Satori",
       "netuid": 119,
-      "priority_score": 74,
+      "priority_score": 75,
       "review_state": "machine-generated",
       "slug": "sn-119",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1247,15 +1167,15 @@
       ],
       "name": "SOMA",
       "netuid": 114,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-114",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1267,15 +1187,15 @@
       ],
       "name": "gm",
       "netuid": 28,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-28",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1287,15 +1207,15 @@
       ],
       "name": "Recall",
       "netuid": 31,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-31",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1307,15 +1227,15 @@
       ],
       "name": "ain",
       "netuid": 69,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-69",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1327,15 +1247,15 @@
       ],
       "name": "Subnet 86",
       "netuid": 86,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-86",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1347,15 +1267,15 @@
       ],
       "name": "eni",
       "netuid": 101,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-101",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1367,15 +1287,15 @@
       ],
       "name": "for sale (burn to uid1)",
       "netuid": 104,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-104",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1387,15 +1307,15 @@
       ],
       "name": "8 Ball",
       "netuid": 125,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-125",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1403,15 +1323,15 @@
       ],
       "name": "Gradients",
       "netuid": 56,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-56",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 22
+      "verified_candidate_count": 23
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1420,15 +1340,15 @@
       ],
       "name": "NOVA",
       "netuid": 68,
-      "priority_score": 70,
+      "priority_score": 71,
       "review_state": "machine-generated",
       "slug": "sn-68",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1437,15 +1357,15 @@
       ],
       "name": "NexisGen",
       "netuid": 70,
-      "priority_score": 70,
+      "priority_score": 71,
       "review_state": "machine-generated",
       "slug": "sn-70",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1455,15 +1375,15 @@
       ],
       "name": "Ditto",
       "netuid": 118,
-      "priority_score": 68,
+      "priority_score": 69,
       "review_state": "machine-generated",
       "slug": "sn-118",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -1473,33 +1393,15 @@
       ],
       "name": "Actual",
       "netuid": 95,
-      "priority_score": 67,
+      "priority_score": 68,
       "review_state": "machine-generated",
       "slug": "sn-95",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "colosseum",
-      "netuid": 38,
-      "priority_score": 65,
-      "review_state": "machine-generated",
-      "slug": "sn-38",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1508,15 +1410,15 @@
       ],
       "name": "lium.io",
       "netuid": 51,
-      "priority_score": 64,
+      "priority_score": 65,
       "review_state": "machine-generated",
       "slug": "sn-51",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 19
+      "verified_candidate_count": 20
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1525,15 +1427,15 @@
       ],
       "name": "Zipcode",
       "netuid": 46,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-46",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1543,15 +1445,15 @@
       ],
       "name": "Cacheon",
       "netuid": 14,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-14",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1561,15 +1463,15 @@
       ],
       "name": "404—GEN",
       "netuid": 17,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-17",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1579,15 +1481,15 @@
       ],
       "name": "Plaτform",
       "netuid": 100,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-100",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1597,15 +1499,15 @@
       ],
       "name": "TalkHead",
       "netuid": 108,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-108",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -1616,15 +1518,15 @@
       ],
       "name": "Grail",
       "netuid": 81,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "needs-review",
       "slug": "sn-81",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1634,15 +1536,15 @@
       ],
       "name": "Numinous",
       "netuid": 6,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-6",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1652,9 +1554,27 @@
       ],
       "name": "Zeus",
       "netuid": 18,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-18",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 14
+    },
+    {
+      "candidate_count": 19,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Aurelius",
+      "netuid": 37,
+      "priority_score": 63,
+      "review_state": "machine-generated",
+      "slug": "sn-37",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
       "verified_candidate_count": 13
@@ -1668,35 +1588,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Aurelius",
-      "netuid": 37,
-      "priority_score": 62,
-      "review_state": "machine-generated",
-      "slug": "sn-37",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 12
-    },
-    {
-      "candidate_count": 17,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Hone",
       "netuid": 5,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-5",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1706,15 +1608,15 @@
       ],
       "name": "TrajectoryRL",
       "netuid": 11,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-11",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1724,15 +1626,15 @@
       ],
       "name": "Perturb",
       "netuid": 26,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-26",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1742,15 +1644,15 @@
       ],
       "name": "Eirel",
       "netuid": 36,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-36",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1760,15 +1662,15 @@
       ],
       "name": "NIOME",
       "netuid": 55,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-55",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1778,15 +1680,15 @@
       ],
       "name": "Poker44",
       "netuid": 126,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-126",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -1797,15 +1699,15 @@
       ],
       "name": "Gopher",
       "netuid": 42,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "needs-review",
       "slug": "sn-42",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1814,15 +1716,15 @@
       ],
       "name": "Minos",
       "netuid": 107,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-107",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1832,15 +1734,15 @@
       ],
       "name": "Vanta",
       "netuid": 8,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-8",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1850,15 +1752,15 @@
       ],
       "name": "Yanez MIID",
       "netuid": 54,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-54",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1868,15 +1770,15 @@
       ],
       "name": "Harnyx",
       "netuid": 67,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-67",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1886,15 +1788,15 @@
       ],
       "name": "Bitsota",
       "netuid": 94,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-94",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1904,15 +1806,15 @@
       ],
       "name": "Astrid",
       "netuid": 127,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-127",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1921,15 +1823,15 @@
       ],
       "name": "TAO Private Network",
       "netuid": 65,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-65",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1938,50 +1840,15 @@
       ],
       "name": "Bitcast",
       "netuid": 93,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-93",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 15,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Score",
-      "netuid": 44,
-      "priority_score": 59,
-      "review_state": "machine-generated",
-      "slug": "sn-44",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 9
-    },
-    {
-      "candidate_count": 18,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Babelbit",
-      "netuid": 59,
-      "priority_score": 58,
-      "review_state": "machine-generated",
-      "slug": "sn-59",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 14,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -1991,15 +1858,33 @@
       ],
       "name": "OxMarkets",
       "netuid": 35,
-      "priority_score": 58,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-35",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 8
+      "surface_count": 9,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 16,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Score",
+      "netuid": 44,
+      "priority_score": 60,
+      "review_state": "machine-generated",
+      "slug": "sn-44",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -2009,12 +1894,82 @@
       ],
       "name": "minotaur",
       "netuid": 112,
-      "priority_score": 58,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-112",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "candidate_count": 19,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Babelbit",
+      "netuid": 59,
+      "priority_score": 59,
+      "review_state": "machine-generated",
+      "slug": "sn-59",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 11
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Swap",
+      "netuid": 10,
+      "priority_score": 59,
+      "review_state": "machine-generated",
+      "slug": "sn-10",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 9
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Affine",
+      "netuid": 120,
+      "priority_score": 59,
+      "review_state": "machine-generated",
+      "slug": "sn-120",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
+    },
+    {
+      "candidate_count": 18,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Albedo",
+      "netuid": 97,
+      "priority_score": 58,
+      "review_state": "machine-generated",
+      "slug": "sn-97",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 11,
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 14,
@@ -2025,14 +1980,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Affine",
-      "netuid": 120,
+      "name": "VoidAI",
+      "netuid": 106,
       "priority_score": 58,
       "review_state": "machine-generated",
-      "slug": "sn-120",
+      "slug": "sn-106",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 8
+      "surface_count": 8,
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 17,
@@ -2042,70 +1997,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Albedo",
-      "netuid": 97,
-      "priority_score": 57,
-      "review_state": "machine-generated",
-      "slug": "sn-97",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 11,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Swap",
-      "netuid": 10,
-      "priority_score": 57,
-      "review_state": "machine-generated",
-      "slug": "sn-10",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "VoidAI",
-      "netuid": 106,
-      "priority_score": 57,
-      "review_state": "machine-generated",
-      "slug": "sn-106",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 8
-    },
-    {
-      "candidate_count": 16,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "DSperse",
       "netuid": 2,
-      "priority_score": 56,
+      "priority_score": 57,
       "review_state": "machine-generated",
       "slug": "sn-2",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2114,15 +2016,15 @@
       ],
       "name": "Leoma",
       "netuid": 99,
-      "priority_score": 56,
+      "priority_score": 57,
       "review_state": "machine-generated",
       "slug": "sn-99",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2131,15 +2033,15 @@
       ],
       "name": "Bitsec.ai",
       "netuid": 60,
-      "priority_score": 55,
+      "priority_score": 56,
       "review_state": "machine-generated",
       "slug": "sn-60",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2148,11 +2050,28 @@
       ],
       "name": "Vocence",
       "netuid": 78,
-      "priority_score": 55,
+      "priority_score": 56,
       "review_state": "machine-generated",
       "slug": "sn-78",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "candidate_count": 16,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "dogelayer",
+      "netuid": 80,
+      "priority_score": 56,
+      "review_state": "machine-generated",
+      "slug": "sn-80",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 10,
       "verified_candidate_count": 13
     },
     {
@@ -2163,34 +2082,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "dogelayer",
-      "netuid": 80,
-      "priority_score": 55,
-      "review_state": "machine-generated",
-      "slug": "sn-80",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 12
-    },
-    {
-      "candidate_count": 14,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Almanac",
       "netuid": 41,
-      "priority_score": 54,
+      "priority_score": 55,
       "review_state": "machine-generated",
       "slug": "sn-41",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2199,15 +2101,15 @@
       ],
       "name": "Synth",
       "netuid": 50,
-      "priority_score": 54,
+      "priority_score": 55,
       "review_state": "machine-generated",
       "slug": "sn-50",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2216,9 +2118,43 @@
       ],
       "name": "Swarm",
       "netuid": 124,
-      "priority_score": 54,
+      "priority_score": 55,
       "review_state": "machine-generated",
       "slug": "sn-124",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 9,
+      "verified_candidate_count": 13
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ByteLeap",
+      "netuid": 128,
+      "priority_score": 55,
+      "review_state": "machine-generated",
+      "slug": "sn-128",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 10,
+      "verified_candidate_count": 13
+    },
+    {
+      "candidate_count": 14,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "BitAds",
+      "netuid": 16,
+      "priority_score": 54,
+      "review_state": "machine-generated",
+      "slug": "sn-16",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
       "verified_candidate_count": 12
@@ -2231,34 +2167,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ByteLeap",
-      "netuid": 128,
+      "name": "colosseum",
+      "netuid": 38,
       "priority_score": 54,
       "review_state": "machine-generated",
-      "slug": "sn-128",
+      "slug": "sn-38",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
+      "surface_count": 9,
       "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "BitAds",
-      "netuid": 16,
-      "priority_score": 53,
-      "review_state": "machine-generated",
-      "slug": "sn-16",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2267,15 +2186,15 @@
       ],
       "name": "Leadpoet",
       "netuid": 71,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-71",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2284,15 +2203,15 @@
       ],
       "name": "Liquidity",
       "netuid": 77,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-77",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2301,15 +2220,15 @@
       ],
       "name": "CliqueAI",
       "netuid": 83,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-83",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -2318,15 +2237,15 @@
       ],
       "name": "Beam",
       "netuid": 105,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-105",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2336,12 +2255,30 @@
       ],
       "name": "Basilica",
       "netuid": 39,
-      "priority_score": 51,
+      "priority_score": 52,
       "review_state": "needs-review",
       "slug": "sn-39",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
+    },
+    {
+      "candidate_count": 8,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "BrainPlay",
+      "netuid": 117,
+      "priority_score": 52,
+      "review_state": "needs-review",
+      "slug": "sn-117",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 8
     },
     {
       "candidate_count": 7,
@@ -2352,35 +2289,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "BrainPlay",
-      "netuid": 117,
-      "priority_score": 51,
-      "review_state": "needs-review",
-      "slug": "sn-117",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Templar",
       "netuid": 3,
-      "priority_score": 50,
+      "priority_score": 51,
       "review_state": "needs-review",
       "slug": "sn-3",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2388,15 +2307,15 @@
       ],
       "name": "Green Compute",
       "netuid": 110,
-      "priority_score": 42,
+      "priority_score": 43,
       "review_state": "maintainer-reviewed",
       "slug": "sn-110",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2405,15 +2324,15 @@
       ],
       "name": "Quasar",
       "netuid": 24,
-      "priority_score": 40,
+      "priority_score": 41,
       "review_state": "maintainer-reviewed",
       "slug": "sn-24",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 28,
+      "candidate_count": 29,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2421,12 +2340,29 @@
       ],
       "name": "Chutes",
       "netuid": 64,
-      "priority_score": 39,
+      "priority_score": 40,
       "review_state": "maintainer-reviewed",
       "slug": "sn-64",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 17,
-      "verified_candidate_count": 21
+      "verified_candidate_count": 22
+    },
+    {
+      "candidate_count": 26,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "MVTRX",
+      "netuid": 79,
+      "priority_score": 33,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-79",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 19
     },
     {
       "candidate_count": 25,
@@ -2436,34 +2372,37 @@
         "subnet-api",
         "sse"
       ],
-      "name": "MVTRX",
-      "netuid": 79,
-      "priority_score": 32,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-79",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 18
-    },
-    {
-      "candidate_count": 24,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
       "name": "StreetVision by NATIX",
       "netuid": 72,
-      "priority_score": 31,
+      "priority_score": 32,
       "review_state": "maintainer-reviewed",
       "slug": "sn-72",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 12,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "source-repo",
+        "website",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "MetaHash",
+      "netuid": 73,
+      "priority_score": 30,
+      "review_state": "maintainer-reviewed",
+      "slug": "metahash",
+      "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
+      "surface_count": 5,
+      "verified_candidate_count": 6
+    },
+    {
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -2474,15 +2413,15 @@
       ],
       "name": "Bitstarter #1",
       "netuid": 91,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-91",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "subnet-api",
@@ -2490,15 +2429,15 @@
       ],
       "name": "Gittensor",
       "netuid": 74,
-      "priority_score": 27,
+      "priority_score": 28,
       "review_state": "maintainer-reviewed",
       "slug": "gittensor",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 17,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -2508,12 +2447,48 @@
       ],
       "name": "EvolAI",
       "netuid": 47,
-      "priority_score": 27,
+      "priority_score": 28,
       "review_state": "maintainer-reviewed",
       "slug": "sn-47",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
+    },
+    {
+      "candidate_count": 16,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "source-repo",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "GroundLayer",
+      "netuid": 20,
+      "priority_score": 27,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-20",
+      "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "candidate_count": 19,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "Investing",
+      "netuid": 88,
+      "priority_score": 26,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-88",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 8,
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 15,
@@ -2525,31 +2500,50 @@
         "sse",
         "data-artifact"
       ],
-      "name": "GroundLayer",
-      "netuid": 20,
+      "name": "Endure Network",
+      "netuid": 30,
       "priority_score": 26,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-20",
+      "slug": "sn-30",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 7,
       "verified_candidate_count": 8
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 26,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
         "subnet-api",
-        "sse"
+        "sse",
+        "data-artifact"
       ],
-      "name": "Investing",
-      "netuid": 88,
+      "name": "Hippius",
+      "netuid": 75,
       "priority_score": 25,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-88",
+      "slug": "sn-75",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 11,
+      "verified_candidate_count": 20
+    },
+    {
+      "candidate_count": 26,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Compelle",
+      "netuid": 82,
+      "priority_score": 25,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-82",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 19
     },
     {
       "candidate_count": 14,
@@ -2561,53 +2555,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Endure Network",
-      "netuid": 30,
+      "name": "Nodexo",
+      "netuid": 27,
       "priority_score": 25,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-30",
+      "slug": "nodexo",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
-      "surface_count": 7,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 25,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Hippius",
-      "netuid": 75,
-      "priority_score": 24,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-75",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 11,
-      "verified_candidate_count": 19
-    },
-    {
-      "candidate_count": 25,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Compelle",
-      "netuid": 82,
-      "priority_score": 24,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-82",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -2618,15 +2576,15 @@
       ],
       "name": "Byzantium",
       "netuid": 76,
-      "priority_score": 24,
+      "priority_score": 25,
       "review_state": "maintainer-reviewed",
       "slug": "sn-76",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 6,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -2637,15 +2595,15 @@
       ],
       "name": "InfiniteHash",
       "netuid": 89,
-      "priority_score": 24,
+      "priority_score": 25,
       "review_state": "maintainer-reviewed",
       "slug": "sn-89",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2655,12 +2613,29 @@
       ],
       "name": "Targon",
       "netuid": 4,
-      "priority_score": 23,
+      "priority_score": 24,
       "review_state": "maintainer-reviewed",
       "slug": "sn-4",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
+    },
+    {
+      "candidate_count": 9,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "ReadyAI",
+      "netuid": 33,
+      "priority_score": 24,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-33",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 10,
+      "verified_candidate_count": 8
     },
     {
       "candidate_count": 24,
@@ -2676,6 +2651,60 @@
       "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-9",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 17
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "blockmachine",
+      "netuid": 19,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-19",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 19
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "AdTAO",
+      "netuid": 21,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-21",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 7,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Mainframe",
+      "netuid": 25,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-25",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
       "verified_candidate_count": 16
@@ -2695,82 +2724,11 @@
       "review_state": "maintainer-reviewed",
       "slug": "sn-32",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 8,
-      "verified_candidate_count": 18
-    },
-    {
-      "candidate_count": 8,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "name": "ReadyAI",
-      "netuid": 33,
-      "priority_score": 23,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-33",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 10,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "blockmachine",
-      "netuid": 19,
-      "priority_score": 22,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-19",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 18
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "AdTAO",
-      "netuid": 21,
-      "priority_score": 22,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-21",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Mainframe",
-      "netuid": 25,
-      "priority_score": 22,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-25",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2780,15 +2738,15 @@
       ],
       "name": "Talisman AI",
       "netuid": 45,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-45",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2798,12 +2756,48 @@
       ],
       "name": "Quantum Compute",
       "netuid": 48,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-48",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Enigma",
+      "netuid": 63,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-63",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 7,
+      "verified_candidate_count": 17
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "sundae_bar",
+      "netuid": 121,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-121",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 7,
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 23,
@@ -2814,14 +2808,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Enigma",
-      "netuid": 63,
+      "name": "Data Universe",
+      "netuid": 13,
       "priority_score": 22,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-63",
+      "slug": "sn-13",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 7,
-      "verified_candidate_count": 16
+      "surface_count": 13,
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 23,
@@ -2839,25 +2833,7 @@
       "slug": "sn-103",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 17
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "sundae_bar",
-      "netuid": 121,
-      "priority_score": 22,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-121",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 7,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 22,
@@ -2868,35 +2844,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Data Universe",
-      "netuid": 13,
-      "priority_score": 21,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-13",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 13,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 21,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "ORO",
       "netuid": 15,
-      "priority_score": 20,
+      "priority_score": 21,
       "review_state": "maintainer-reviewed",
       "slug": "sn-15",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2906,12 +2864,46 @@
       ],
       "name": "Vidaio",
       "netuid": 85,
-      "priority_score": 20,
+      "priority_score": 21,
       "review_state": "maintainer-reviewed",
       "slug": "sn-85",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
+    },
+    {
+      "candidate_count": 22,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ForeverMoney",
+      "netuid": 98,
+      "priority_score": 21,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-98",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 14,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Desearch",
+      "netuid": 22,
+      "priority_score": 21,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-22",
+      "suggested_next_action": "evaluate for subnet-specific adapter",
+      "surface_count": 16,
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 21,
@@ -2922,30 +2914,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ForeverMoney",
-      "netuid": 98,
+      "name": "Apex",
+      "netuid": 1,
       "priority_score": 20,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-98",
+      "slug": "sn-1",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Desearch",
-      "netuid": 22,
-      "priority_score": 20,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-22",
-      "suggested_next_action": "evaluate for subnet-specific adapter",
-      "surface_count": 16,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 14
     },
     {
       "candidate_count": 20,
@@ -2956,11 +2932,11 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Apex",
-      "netuid": 1,
+      "name": "TensorUSD",
+      "netuid": 113,
       "priority_score": 19,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-1",
+      "slug": "sn-113",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
       "verified_candidate_count": 13
@@ -2974,35 +2950,36 @@
         "sse",
         "data-artifact"
       ],
-      "name": "TensorUSD",
-      "netuid": 113,
+      "name": "ConnitoAI",
+      "netuid": 102,
       "priority_score": 18,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-113",
+      "slug": "sn-102",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
+        "source-repo",
         "openapi",
         "subnet-api",
         "sse",
         "data-artifact"
       ],
-      "name": "ConnitoAI",
-      "netuid": 102,
-      "priority_score": 17,
+      "name": "EfficientFrontier",
+      "netuid": 53,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-102",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 12
+      "slug": "efficientfrontier",
+      "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
+      "surface_count": 7,
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -3013,15 +2990,15 @@
       ],
       "name": "Academia",
       "netuid": 109,
-      "priority_score": 17,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
       "slug": "sn-109",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -3032,15 +3009,34 @@
       ],
       "name": "HashiChain",
       "netuid": 115,
-      "priority_score": 17,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
       "slug": "sn-115",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
+      "verified_candidate_count": 7
+    },
+    {
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "source-repo",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "TaoLend",
+      "netuid": 116,
+      "priority_score": 18,
+      "review_state": "maintainer-reviewed",
+      "slug": "taolend",
+      "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
+      "surface_count": 6,
       "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -3051,15 +3047,15 @@
       ],
       "name": "MANTIS",
       "netuid": 123,
-      "priority_score": 17,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -3070,15 +3066,15 @@
       ],
       "name": "Luminar Network",
       "netuid": 87,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-87",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 8,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -3089,15 +3085,15 @@
       ],
       "name": "DegenBrain",
       "netuid": 90,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-90",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 7,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -3105,15 +3101,15 @@
       ],
       "name": "Handshake58",
       "netuid": 58,
-      "priority_score": 15,
+      "priority_score": 16,
       "review_state": "maintainer-reviewed",
       "slug": "sn-58",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 13,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3123,15 +3119,15 @@
       ],
       "name": "RedTeam",
       "netuid": 61,
-      "priority_score": 14,
+      "priority_score": 15,
       "review_state": "maintainer-reviewed",
       "slug": "sn-61",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -3139,15 +3135,15 @@
       ],
       "name": "Verathos",
       "netuid": 96,
-      "priority_score": 14,
+      "priority_score": 15,
       "review_state": "maintainer-reviewed",
       "slug": "sn-96",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 13,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3156,15 +3152,15 @@
       ],
       "name": "Coldint",
       "netuid": 29,
-      "priority_score": 14,
+      "priority_score": 15,
       "review_state": "maintainer-reviewed",
       "slug": "sn-29",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3173,12 +3169,12 @@
       ],
       "name": "Trishool",
       "netuid": 23,
-      "priority_score": 13,
+      "priority_score": 14,
       "review_state": "maintainer-reviewed",
       "slug": "sn-23",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 14,
@@ -3195,11 +3191,11 @@
       "review_state": "maintainer-reviewed",
       "slug": "sn-62",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 7,
+      "surface_count": 6,
       "verified_candidate_count": 7
     },
     {
-      "candidate_count": 10,
+      "candidate_count": 11,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3209,12 +3205,28 @@
       ],
       "name": "Dojo",
       "netuid": 52,
-      "priority_score": 9,
+      "priority_score": 10,
       "review_state": "maintainer-reviewed",
       "slug": "sn-52",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 10,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
+    },
+    {
+      "candidate_count": 17,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ninja",
+      "netuid": 66,
+      "priority_score": 8,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-66",
+      "suggested_next_action": "evaluate for subnet-specific adapter",
+      "surface_count": 13,
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 16,
@@ -3223,33 +3235,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ninja",
-      "netuid": 66,
-      "priority_score": 7,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-66",
-      "suggested_next_action": "evaluate for subnet-specific adapter",
-      "surface_count": 13,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 15,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "sse",
-        "data-artifact"
-      ],
       "name": "Nepher Robotics",
       "netuid": 49,
-      "priority_score": 6,
+      "priority_score": 7,
       "review_state": "maintainer-reviewed",
       "slug": "sn-49",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3259,9 +3255,63 @@
       ],
       "name": "Compute Horde",
       "netuid": 12,
-      "priority_score": 6,
+      "priority_score": 7,
       "review_state": "maintainer-reviewed",
       "slug": "sn-12",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 7,
+      "verified_candidate_count": 8
+    },
+    {
+      "candidate_count": 8,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ansuz",
+      "netuid": 84,
+      "priority_score": 7,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-84",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 8
+    },
+    {
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "BitMind",
+      "netuid": 34,
+      "priority_score": 6,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-34",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 7
+    },
+    {
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Graphite",
+      "netuid": 43,
+      "priority_score": 6,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-43",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
       "verified_candidate_count": 7
@@ -3275,71 +3325,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ansuz",
-      "netuid": 84,
-      "priority_score": 6,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-84",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "BitMind",
-      "netuid": 34,
-      "priority_score": 5,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-34",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 6
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Graphite",
-      "netuid": 43,
-      "priority_score": 5,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-43",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 7,
-      "verified_candidate_count": 6
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Sparket",
       "netuid": 57,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-57",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3349,15 +3345,15 @@
       ],
       "name": "oneoneone",
       "netuid": 111,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-111",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3367,15 +3363,15 @@
       ],
       "name": "Bitrecs",
       "netuid": 122,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-122",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -3385,12 +3381,12 @@
       ],
       "name": "root",
       "netuid": 0,
-      "priority_score": 3,
+      "priority_score": 4,
       "review_state": "maintainer-reviewed",
       "slug": "root",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 14,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     }
   ],
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -3442,13 +3438,13 @@
     "gap_kind_counts": {
       "data-artifact": 115,
       "openapi": 101,
-      "source-repo": 22,
+      "source-repo": 21,
       "sse": 128,
       "subnet-api": 117,
-      "website": 21
+      "website": 18
     },
     "maintainer_decision_count": 3,
-    "needs_maintainer_review_count": 71,
+    "needs_maintainer_review_count": 67,
     "subnet_count": 129
   }
 }

--- a/public/metagraph/review/enrichment-queue.json
+++ b/public/metagraph/review/enrichment-queue.json
@@ -5,7 +5,7 @@
   "queue": [
     {
       "adapter_score": 303,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -31,7 +31,7 @@
       "name": "Allways",
       "netuid": 7,
       "operational_interface_count": 3,
-      "priority_score": 223,
+      "priority_score": 225,
       "profile_level": "adapter-backed",
       "reason_codes": [
         "adapter-candidate"
@@ -41,9 +41,9 @@
       "sample_candidate_ids": [
         "community-sn-7-subnet-api-api-all-ways-io",
         "sn-7-backprop-dashboard",
+        "sn-7-subnetradar-dashboard",
         "sn-7-taomarketcap-dashboard",
-        "sn-7-taomarketcap-source-repo",
-        "sn-7-taomarketcap-website"
+        "sn-7-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -61,95 +61,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 23,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 5,
-      "candidate_count": 14,
-      "candidate_evidence_summary": {
-        "candidate_count": 7,
-        "kinds_with_candidates": [
-          "openapi",
-          "source-repo",
-          "subnet-api",
-          "website"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 7,
-        "stale_kinds": [
-          "openapi",
-          "source-repo",
-          "subnet-api",
-          "website"
-        ],
-        "stale_or_failed_count": 7,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 20,
-      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "website",
-        "source-repo"
-      ],
-      "endpoint_count": 5,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "source-repo",
-        "sse",
-        "subnet-api",
-        "website"
-      ],
-      "name": "Nodexo",
-      "netuid": 27,
-      "operational_interface_count": 0,
-      "priority_score": 167,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-source-repo",
-        "missing-website",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-27-backprop-dashboard",
-        "sn-27-taomarketcap-dashboard",
-        "sn-27-taomarketcap-source-repo",
-        "sn-27-taomarketcap-website",
-        "sn-27-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-27-taomarketcap-website",
-        "sn-27-taomarketcap-source-repo"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-27-taomarketcap-website",
-        "sn-27-taomarketcap-source-repo"
-      ],
-      "slug": "sn-27",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/27",
-        "https://backprop.finance/dtao/subnets/27-nodexo",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json",
-        "https://taostats.io/subnets/27/metagraph"
-      ],
-      "stale_candidate_count": 7,
-      "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -187,7 +103,7 @@
       "name": "Chunking",
       "netuid": 40,
       "operational_interface_count": 0,
-      "priority_score": 153,
+      "priority_score": 154,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -199,10 +115,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-40-backprop-dashboard",
+        "sn-40-subnetradar-dashboard",
         "sn-40-taomarketcap-dashboard",
         "sn-40-taomarketcap-source-repo",
-        "sn-40-taopedia-article",
-        "sn-40-taostats-metagraph"
+        "sn-40-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -217,167 +133,15 @@
         "https://backprop.finance/dtao/subnets/40-chunking",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_40/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json",
-        "https://taostats.io/subnets/40/metagraph"
+        "https://subnetradar.com/subnet/40"
       ],
       "stale_candidate_count": 1,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
-      "candidate_evidence_summary": {
-        "candidate_count": 1,
-        "kinds_with_candidates": [
-          "source-repo"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 1,
-        "stale_kinds": [
-          "source-repo"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 20,
-      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "website",
-        "source-repo"
-      ],
-      "endpoint_count": 5,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "source-repo",
-        "sse",
-        "subnet-api",
-        "website"
-      ],
-      "name": "EfficientFrontier",
-      "netuid": 53,
-      "operational_interface_count": 0,
-      "priority_score": 153,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-source-repo",
-        "missing-website",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-53-backprop-dashboard",
-        "sn-53-taomarketcap-dashboard",
-        "sn-53-taomarketcap-source-repo",
-        "sn-53-taopedia-article",
-        "sn-53-taostats-metagraph"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-53-taomarketcap-source-repo"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-53-taomarketcap-source-repo"
-      ],
-      "slug": "sn-53",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/53",
-        "https://backprop.finance/dtao/subnets/53-efficientfrontier",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
-        "https://taostats.io/subnets/53/metagraph"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 6,
-      "candidate_evidence_summary": {
-        "candidate_count": 1,
-        "kinds_with_candidates": [
-          "source-repo"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 1,
-        "stale_kinds": [
-          "source-repo"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 20,
-      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "website",
-        "source-repo"
-      ],
-      "endpoint_count": 5,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "source-repo",
-        "sse",
-        "subnet-api",
-        "website"
-      ],
-      "name": "Parked",
-      "netuid": 73,
-      "operational_interface_count": 0,
-      "priority_score": 153,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-source-repo",
-        "missing-website",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-73-backprop-dashboard",
-        "sn-73-taomarketcap-dashboard",
-        "sn-73-taopedia-article",
-        "sn-73-taostats-metagraph",
-        "sn-73-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-73-tensorplex-source-repo-1"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-73-tensorplex-source-repo-1"
-      ],
-      "slug": "sn-73",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/73",
-        "https://backprop.finance/dtao/subnets/73-parked",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json",
-        "https://taostats.io/subnets/73/metagraph"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -415,7 +179,7 @@
       "name": "luis",
       "netuid": 92,
       "operational_interface_count": 0,
-      "priority_score": 153,
+      "priority_score": 154,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -427,10 +191,10 @@
       "review_state": "stale",
       "sample_candidate_ids": [
         "sn-92-backprop-dashboard",
+        "sn-92-subnetradar-dashboard",
         "sn-92-taomarketcap-dashboard",
         "sn-92-taopedia-article",
-        "sn-92-taostats-metagraph",
-        "sn-92-tensorplex-docs"
+        "sn-92-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -445,92 +209,16 @@
         "https://backprop.finance/dtao/subnets/92-luis",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_92/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/92/subnet.json",
-        "https://taomarketcap.com/subnets/92",
-        "https://taostats.io/subnets/92/metagraph"
+        "https://subnetradar.com/subnet/92",
+        "https://taomarketcap.com/subnets/92"
       ],
       "stale_candidate_count": 1,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
-      "candidate_evidence_summary": {
-        "candidate_count": 1,
-        "kinds_with_candidates": [
-          "source-repo"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 1,
-        "stale_kinds": [
-          "source-repo"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 20,
-      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "website",
-        "source-repo"
-      ],
-      "endpoint_count": 5,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "source-repo",
-        "sse",
-        "subnet-api",
-        "website"
-      ],
-      "name": "hard_sign",
-      "netuid": 116,
-      "operational_interface_count": 0,
-      "priority_score": 153,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-source-repo",
-        "missing-website",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-116-backprop-dashboard",
-        "sn-116-taomarketcap-dashboard",
-        "sn-116-taopedia-article",
-        "sn-116-taostats-metagraph",
-        "sn-116-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-116-tensorplex-source-repo-1"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-116-tensorplex-source-repo-1"
-      ],
-      "slug": "sn-116",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/116",
-        "https://backprop.finance/dtao/subnets/116-hard-sign",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json",
-        "https://taostats.io/subnets/116/metagraph"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -568,7 +256,7 @@
       "name": "Satori",
       "netuid": 119,
       "operational_interface_count": 0,
-      "priority_score": 153,
+      "priority_score": 154,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -580,10 +268,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-119-backprop-dashboard",
+        "sn-119-subnetradar-dashboard",
         "sn-119-taomarketcap-dashboard",
         "sn-119-taomarketcap-source-repo",
-        "sn-119-taopedia-article",
-        "sn-119-taostats-metagraph"
+        "sn-119-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -598,15 +286,15 @@
         "https://backprop.finance/dtao/subnets/119-satori",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/119/subnet.json",
-        "https://taostats.io/subnets/119/metagraph"
+        "https://subnetradar.com/subnet/119"
       ],
       "stale_candidate_count": 1,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -640,7 +328,7 @@
       "name": "gm",
       "netuid": 28,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -652,10 +340,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-28-backprop-dashboard",
+        "sn-28-subnetradar-dashboard",
         "sn-28-taomarketcap-dashboard",
         "sn-28-taopedia-article",
-        "sn-28-taostats-metagraph",
-        "sn-28-tensorplex-docs"
+        "sn-28-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -666,15 +354,15 @@
         "https://backprop.finance/dtao/subnets/28-gm",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/28/subnet.json",
-        "https://taostats.io/subnets/28/metagraph"
+        "https://subnetradar.com/subnet/28"
       ],
       "stale_candidate_count": 0,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -708,7 +396,7 @@
       "name": "Recall",
       "netuid": 31,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -720,10 +408,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-31-backprop-dashboard",
+        "sn-31-subnetradar-dashboard",
         "sn-31-taomarketcap-dashboard",
         "sn-31-taopedia-article",
-        "sn-31-taostats-metagraph",
-        "sn-31-tensorplex-docs"
+        "sn-31-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -734,15 +422,15 @@
         "https://backprop.finance/dtao/subnets/31-recall",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/31/subnet.json",
-        "https://taostats.io/subnets/31/metagraph"
+        "https://subnetradar.com/subnet/31"
       ],
       "stale_candidate_count": 0,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -776,7 +464,7 @@
       "name": "ain",
       "netuid": 69,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -788,10 +476,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-69-backprop-dashboard",
+        "sn-69-subnetradar-dashboard",
         "sn-69-taomarketcap-dashboard",
         "sn-69-taopedia-article",
-        "sn-69-taostats-metagraph",
-        "sn-69-tensorplex-docs"
+        "sn-69-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -802,15 +490,15 @@
         "https://backprop.finance/dtao/subnets/69-ain",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/69/subnet.json",
-        "https://taostats.io/subnets/69/metagraph"
+        "https://subnetradar.com/subnet/69"
       ],
       "stale_candidate_count": 0,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -844,7 +532,7 @@
       "name": "Subnet 86",
       "netuid": 86,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -856,10 +544,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-86-backprop-dashboard",
+        "sn-86-subnetradar-dashboard",
         "sn-86-taomarketcap-dashboard",
         "sn-86-taopedia-article",
-        "sn-86-taostats-metagraph",
-        "sn-86-tensorplex-docs"
+        "sn-86-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -870,15 +558,15 @@
         "https://backprop.finance/dtao/subnets/86-subnet-86",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/86/subnet.json",
-        "https://taostats.io/subnets/86/metagraph"
+        "https://subnetradar.com/subnet/86"
       ],
       "stale_candidate_count": 0,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -912,7 +600,7 @@
       "name": "eni",
       "netuid": 101,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -924,10 +612,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-101-backprop-dashboard",
+        "sn-101-subnetradar-dashboard",
         "sn-101-taomarketcap-dashboard",
         "sn-101-taopedia-article",
-        "sn-101-taostats-metagraph",
-        "sn-101-tensorplex-docs"
+        "sn-101-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -938,15 +626,15 @@
         "https://backprop.finance/dtao/subnets/101-eni",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/101/subnet.json",
-        "https://taostats.io/subnets/101/metagraph"
+        "https://subnetradar.com/subnet/101"
       ],
       "stale_candidate_count": 0,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -980,7 +668,7 @@
       "name": "for sale (burn to uid1)",
       "netuid": 104,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -992,10 +680,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-104-backprop-dashboard",
+        "sn-104-subnetradar-dashboard",
         "sn-104-taomarketcap-dashboard",
         "sn-104-taopedia-article",
-        "sn-104-taostats-metagraph",
-        "sn-104-tensorplex-docs"
+        "sn-104-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -1006,15 +694,15 @@
         "https://backprop.finance/dtao/subnets/104-for-sale-burn-to-uid1",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_104/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/104/subnet.json",
-        "https://taostats.io/subnets/104/metagraph"
+        "https://subnetradar.com/subnet/104"
       ],
       "stale_candidate_count": 0,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -1048,7 +736,7 @@
       "name": "8 Ball",
       "netuid": 125,
       "operational_interface_count": 0,
-      "priority_score": 151,
+      "priority_score": 153,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -1060,10 +748,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-125-backprop-dashboard",
+        "sn-125-subnetradar-dashboard",
         "sn-125-taomarketcap-dashboard",
         "sn-125-taopedia-article",
-        "sn-125-taostats-metagraph",
-        "sn-125-tensorplex-docs"
+        "sn-125-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -1074,15 +762,91 @@
         "https://backprop.finance/dtao/subnets/125-8-ball",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_125/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/125/subnet.json",
-        "https://taostats.io/subnets/125/metagraph"
+        "https://subnetradar.com/subnet/125"
       ],
       "stale_candidate_count": 0,
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "source-repo",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Actual",
+      "netuid": 95,
+      "operational_interface_count": 1,
+      "priority_score": 134,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-source-repo",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-95-backprop-dashboard",
+        "sn-95-subnetradar-dashboard",
+        "sn-95-taomarketcap-dashboard",
+        "sn-95-taomarketcap-source-repo",
+        "sn-95-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-95-taomarketcap-source-repo"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-95-taomarketcap-source-repo"
+      ],
+      "slug": "sn-95",
+      "source_urls": [
+        "https://actual.inc/",
+        "https://api.taomarketcap.com/public/v1/subnets/95",
+        "https://backprop.finance/dtao/subnets/95-actual",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json",
+        "https://subnetradar.com/subnet/95"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 8,
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 10,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -1121,7 +885,7 @@
       "name": "Ditto",
       "netuid": 118,
       "operational_interface_count": 0,
-      "priority_score": 133,
+      "priority_score": 134,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -1134,9 +898,9 @@
       "sample_candidate_ids": [
         "sn-118-backprop-dashboard",
         "sn-118-github-readme-mobiusfund-etf-dashboard-1",
+        "sn-118-subnetradar-dashboard",
         "sn-118-taomarketcap-dashboard",
-        "sn-118-taomarketcap-source-repo",
-        "sn-118-taomarketcap-website"
+        "sn-118-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -1161,167 +925,15 @@
         "https://github.com/orgs/ditto-assistant/repositories",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/118/subnet.json",
         "https://heyditto.ai/",
-        "https://taostats.io/subnets/118/metagraph"
+        "https://subnetradar.com/subnet/118"
       ],
       "stale_candidate_count": 5,
       "surface_count": 10,
-      "verified_candidate_count": 18
-    },
-    {
-      "adapter_score": 28,
-      "candidate_count": 15,
-      "candidate_evidence_summary": {
-        "candidate_count": 3,
-        "kinds_with_candidates": [
-          "source-repo",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 3,
-        "stale_kinds": [
-          "source-repo"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "source-repo"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "source-repo",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Actual",
-      "netuid": 95,
-      "operational_interface_count": 1,
-      "priority_score": 132,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "missing-source-repo",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-95-backprop-dashboard",
-        "sn-95-taomarketcap-dashboard",
-        "sn-95-taomarketcap-source-repo",
-        "sn-95-taomarketcap-website",
-        "sn-95-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-95-taomarketcap-source-repo"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-95-taomarketcap-source-repo"
-      ],
-      "slug": "sn-95",
-      "source_urls": [
-        "https://actual.inc/",
-        "https://api.taomarketcap.com/public/v1/subnets/95",
-        "https://backprop.finance/dtao/subnets/95-actual",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/95/subnet.json",
-        "https://taostats.io/subnets/95/metagraph"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 8,
-      "verified_candidate_count": 12
-    },
-    {
-      "adapter_score": 28,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 3,
-        "kinds_with_candidates": [
-          "source-repo",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 3,
-        "stale_kinds": [
-          "source-repo"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "source-repo"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "source-repo",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "colosseum",
-      "netuid": 38,
-      "operational_interface_count": 1,
-      "priority_score": 129,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "missing-source-repo",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-38-backprop-dashboard",
-        "sn-38-taomarketcap-dashboard",
-        "sn-38-taomarketcap-source-repo",
-        "sn-38-taomarketcap-website",
-        "sn-38-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-38-taomarketcap-source-repo"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-38-taomarketcap-source-repo"
-      ],
-      "slug": "sn-38",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/38",
-        "https://backprop.finance/dtao/subnets/38-colosseum",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/38/subnet.json",
-        "https://taostats.io/subnets/38/metagraph",
-        "https://www.taocolosseum.com/"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 8,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 19
     },
     {
       "adapter_score": 29,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -1360,7 +972,7 @@
       "name": "SOMA",
       "netuid": 114,
       "operational_interface_count": 1,
-      "priority_score": 128,
+      "priority_score": 130,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -1372,10 +984,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-114-backprop-dashboard",
+        "sn-114-subnetradar-dashboard",
         "sn-114-taomarketcap-dashboard",
         "sn-114-taomarketcap-source-repo",
-        "sn-114-taomarketcap-website",
-        "sn-114-taopedia-article"
+        "sn-114-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [
         "sn-114-website-link-thesoma-ai-subnet-api-7",
@@ -1401,16 +1013,16 @@
         "https://github.com/DendriteHQ/SOMA",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_114/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/114/subnet.json",
-        "https://taostats.io/subnets/114/metagraph",
+        "https://subnetradar.com/subnet/114",
         "https://thesoma.ai/"
       ],
       "stale_candidate_count": 4,
       "surface_count": 9,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
       "adapter_score": 10,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -1451,7 +1063,7 @@
       "name": "Cacheon",
       "netuid": 14,
       "operational_interface_count": 0,
-      "priority_score": 125,
+      "priority_score": 127,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -1466,7 +1078,7 @@
         "sn-14-github-readme-latent-to-cacheon-docs-1",
         "sn-14-github-readme-latent-to-cacheon-subnet-api-2",
         "sn-14-github-readme-latent-to-taohash-dashboard-1",
-        "sn-14-taomarketcap-dashboard"
+        "sn-14-subnetradar-dashboard"
       ],
       "sample_live_candidate_ids": [
         "sn-14-github-readme-latent-to-cacheon-subnet-api-2"
@@ -1498,11 +1110,86 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "source-repo"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 25,
+      "contribution_hint": "Submit one official public website, source-repo candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "website",
+        "source-repo"
+      ],
+      "endpoint_count": 5,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "MetaHash",
+      "netuid": 73,
+      "operational_interface_count": 0,
+      "priority_score": 127,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo",
+        "missing-website"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-73-backprop-dashboard",
+        "sn-73-subnetradar-dashboard",
+        "sn-73-taomarketcap-dashboard",
+        "sn-73-taopedia-article",
+        "sn-73-taostats-metagraph"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-73-tensorplex-source-repo-1"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-73-tensorplex-source-repo-1"
+      ],
+      "slug": "metahash",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/73",
+        "https://backprop.finance/dtao/subnets/73-parked",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json",
+        "https://subnetradar.com/subnet/73"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 5,
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 10,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -1541,7 +1228,7 @@
       "name": "Plaτform",
       "netuid": 100,
       "operational_interface_count": 0,
-      "priority_score": 125,
+      "priority_score": 127,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -1553,10 +1240,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-100-backprop-dashboard",
+        "sn-100-subnetradar-dashboard",
         "sn-100-taomarketcap-dashboard",
         "sn-100-taomarketcap-source-repo",
-        "sn-100-taomarketcap-website",
-        "sn-100-taopedia-article"
+        "sn-100-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -1581,15 +1268,15 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/100/subnet.json",
         "https://platform.network/",
-        "https://taostats.io/subnets/100/metagraph"
+        "https://subnetradar.com/subnet/100"
       ],
       "stale_candidate_count": 5,
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 8,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -1628,7 +1315,7 @@
       "name": "404—GEN",
       "netuid": 17,
       "operational_interface_count": 0,
-      "priority_score": 124,
+      "priority_score": 126,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -1641,9 +1328,9 @@
       "sample_candidate_ids": [
         "sn-17-backprop-dashboard",
         "sn-17-github-readme-404-repo-three-gen-subnet-dashboard-1",
+        "sn-17-subnetradar-dashboard",
         "sn-17-taomarketcap-dashboard",
-        "sn-17-taomarketcap-source-repo",
-        "sn-17-taomarketcap-website"
+        "sn-17-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -1668,15 +1355,16 @@
         "https://github.com/404-Repo/three-gen-subnet/blob/main/README.md",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_17/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/17/subnet.json",
+        "https://subnetradar.com/subnet/17",
         "https://www.404.xyz/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 71,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -1713,7 +1401,7 @@
       "name": "Quasar",
       "netuid": 24,
       "operational_interface_count": 1,
-      "priority_score": 124,
+      "priority_score": 125,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -1725,9 +1413,9 @@
       "sample_candidate_ids": [
         "sn-24-backprop-dashboard",
         "sn-24-github-readme-silx-labs-quasar-subnet-data-artifact-1",
+        "sn-24-subnetradar-dashboard",
         "sn-24-taomarketcap-dashboard",
-        "sn-24-taomarketcap-source-repo",
-        "sn-24-taomarketcap-website"
+        "sn-24-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -1753,15 +1441,15 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_24/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/24/subnet.json",
         "https://silxinc.com/",
-        "https://taomarketcap.com/subnets/24"
+        "https://subnetradar.com/subnet/24"
       ],
       "stale_candidate_count": 5,
       "surface_count": 11,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 29,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -1798,7 +1486,7 @@
       "name": "NOVA",
       "netuid": 68,
       "operational_interface_count": 1,
-      "priority_score": 124,
+      "priority_score": 125,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -1810,10 +1498,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-68-backprop-dashboard",
+        "sn-68-subnetradar-dashboard",
         "sn-68-taomarketcap-dashboard",
         "sn-68-taomarketcap-source-repo",
-        "sn-68-taomarketcap-website",
-        "sn-68-taopedia-article"
+        "sn-68-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -1837,16 +1525,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx",
         "https://github.com/metanova-labs/nova",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/68/subnet.json",
-        "https://taostats.io/subnets/68/metagraph",
+        "https://subnetradar.com/subnet/68",
         "https://www.metanova-labs.ai/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 29,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -1883,7 +1571,7 @@
       "name": "NexisGen",
       "netuid": 70,
       "operational_interface_count": 1,
-      "priority_score": 124,
+      "priority_score": 125,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -1895,10 +1583,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-70-backprop-dashboard",
+        "sn-70-subnetradar-dashboard",
         "sn-70-taomarketcap-dashboard",
         "sn-70-taomarketcap-source-repo",
-        "sn-70-taomarketcap-website",
-        "sn-70-taopedia-article"
+        "sn-70-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -1923,15 +1611,169 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/70/subnet.json",
         "https://nexisgen.ai/",
-        "https://taostats.io/subnets/70/metagraph"
+        "https://subnetradar.com/subnet/70"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 8,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 9,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Grail",
+      "netuid": 81,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "needs-review",
+      "sample_candidate_ids": [
+        "sn-81-backprop-dashboard",
+        "sn-81-subnetradar-dashboard",
+        "sn-81-taomarketcap-dashboard",
+        "sn-81-taomarketcap-source-repo",
+        "sn-81-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-81",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/81",
+        "https://backprop.finance/dtao/subnets/81-deprecated",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_81/index.mdx",
+        "https://github.com/one-covenant/grail",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/81/subnet.json",
+        "https://grail-grafana.tplr.ai/",
+        "https://subnetradar.com/subnet/81"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 9,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 20,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TalkHead",
+      "netuid": 108,
+      "operational_interface_count": 0,
+      "priority_score": 125,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-108-backprop-dashboard",
+        "sn-108-subnetradar-dashboard",
+        "sn-108-taomarketcap-dashboard",
+        "sn-108-taomarketcap-source-repo",
+        "sn-108-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-108-website-common-openapi-json",
+        "sn-108-website-common-swagger",
+        "sn-108-website-common-swagger-json",
+        "sn-108-website-common-api",
+        "sn-108-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-108-website-common-openapi-json",
+        "sn-108-website-common-swagger",
+        "sn-108-website-common-swagger-json",
+        "sn-108-website-common-api",
+        "sn-108-website-common-health"
+      ],
+      "slug": "sn-108",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/108",
+        "https://backprop.finance/dtao/subnets/108-talkhead",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx",
+        "https://github.com/talkheadai/talkhead-subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/108/subnet.json",
+        "https://subnetradar.com/subnet/108",
+        "https://www.talkhead.ai/"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 8,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -1972,7 +1814,7 @@
       "name": "Zeus",
       "netuid": 18,
       "operational_interface_count": 0,
-      "priority_score": 123,
+      "priority_score": 124,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -1984,10 +1826,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-18-backprop-dashboard",
+        "sn-18-subnetradar-dashboard",
         "sn-18-taomarketcap-dashboard",
         "sn-18-taomarketcap-source-repo",
-        "sn-18-taomarketcap-website",
-        "sn-18-taopedia-article"
+        "sn-18-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [
         "sn-18-website-common-api"
@@ -2012,10 +1854,267 @@
         "https://github.com/Orpheus-AI/Zeus",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/18/subnet.json",
-        "https://taostats.io/subnets/18/metagraph",
+        "https://subnetradar.com/subnet/18",
         "https://www.zeussubnet.com/"
       ],
       "stale_candidate_count": 4,
+      "surface_count": 8,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Aurelius",
+      "netuid": 37,
+      "operational_interface_count": 0,
+      "priority_score": 124,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-37-backprop-dashboard",
+        "sn-37-subnetradar-dashboard",
+        "sn-37-taomarketcap-dashboard",
+        "sn-37-taomarketcap-source-repo",
+        "sn-37-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-37-website-common-openapi-json",
+        "sn-37-website-common-swagger",
+        "sn-37-website-common-swagger-json",
+        "sn-37-website-common-api",
+        "sn-37-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-37-website-common-openapi-json",
+        "sn-37-website-common-swagger",
+        "sn-37-website-common-swagger-json",
+        "sn-37-website-common-api",
+        "sn-37-website-common-health"
+      ],
+      "slug": "sn-37",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/37",
+        "https://aureliusaligned.ai/",
+        "https://backprop.finance/dtao/subnets/37-aurelius",
+        "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json",
+        "https://subnetradar.com/subnet/37"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 8,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 6,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "verify-existing-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Numinous",
+      "netuid": 6,
+      "operational_interface_count": 0,
+      "priority_score": 123,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-6-backprop-dashboard",
+        "sn-6-github-readme-numinouslabs-numinous-dashboard-1",
+        "sn-6-subnetradar-dashboard",
+        "sn-6-taomarketcap-dashboard",
+        "sn-6-taomarketcap-source-repo"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-6-website-link-numinouslabs-io-subnet-api-2"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-6-website-link-numinouslabs-io-subnet-api-2",
+        "sn-6-website-common-openapi-json",
+        "sn-6-website-common-swagger",
+        "sn-6-website-common-swagger-json",
+        "sn-6-website-common-api"
+      ],
+      "slug": "sn-6",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/6",
+        "https://backprop.finance/dtao/subnets/6-numinous",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_6/index.mdx",
+        "https://github.com/numinouslabs/numinous",
+        "https://github.com/numinouslabs/numinous/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/6/subnet.json",
+        "https://numinouslabs.io/",
+        "https://subnetradar.com/subnet/6"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 7,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TrajectoryRL",
+      "netuid": 11,
+      "operational_interface_count": 0,
+      "priority_score": 123,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-11-backprop-dashboard",
+        "sn-11-subnetradar-dashboard",
+        "sn-11-taomarketcap-dashboard",
+        "sn-11-taomarketcap-source-repo",
+        "sn-11-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-11-website-common-openapi-json",
+        "sn-11-website-common-swagger",
+        "sn-11-website-common-swagger-json",
+        "sn-11-website-common-api",
+        "sn-11-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-11-website-common-openapi-json",
+        "sn-11-website-common-swagger",
+        "sn-11-website-common-swagger-json",
+        "sn-11-website-common-api",
+        "sn-11-website-common-health"
+      ],
+      "slug": "sn-11",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/11",
+        "https://backprop.finance/dtao/subnets/11-trajectoryrl",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/11/subnet.json",
+        "https://github.com/trajectoryRL/trajectoryRL",
+        "https://subnetradar.com/subnet/11",
+        "https://trajrl.com/"
+      ],
+      "stale_candidate_count": 5,
       "surface_count": 8,
       "verified_candidate_count": 13
     },
@@ -2057,564 +2156,10 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Aurelius",
-      "netuid": 37,
-      "operational_interface_count": 0,
-      "priority_score": 123,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-37-backprop-dashboard",
-        "sn-37-taomarketcap-dashboard",
-        "sn-37-taomarketcap-source-repo",
-        "sn-37-taomarketcap-website",
-        "sn-37-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-37-website-common-openapi-json",
-        "sn-37-website-common-swagger",
-        "sn-37-website-common-swagger-json",
-        "sn-37-website-common-api",
-        "sn-37-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-37-website-common-openapi-json",
-        "sn-37-website-common-swagger",
-        "sn-37-website-common-swagger-json",
-        "sn-37-website-common-api",
-        "sn-37-website-common-health"
-      ],
-      "slug": "sn-37",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/37",
-        "https://aureliusaligned.ai/",
-        "https://backprop.finance/dtao/subnets/37-aurelius",
-        "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/37/subnet.json",
-        "https://taostats.io/subnets/37/metagraph"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 12
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 7,
-      "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "website"
-      ],
-      "endpoint_count": 9,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api",
-        "website"
-      ],
-      "name": "Grail",
-      "netuid": 81,
-      "operational_interface_count": 0,
-      "priority_score": 123,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-website",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "needs-review",
-      "sample_candidate_ids": [
-        "sn-81-backprop-dashboard",
-        "sn-81-taomarketcap-dashboard",
-        "sn-81-taomarketcap-source-repo",
-        "sn-81-taopedia-article",
-        "sn-81-taostats-metagraph"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-81",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/81",
-        "https://backprop.finance/dtao/subnets/81-deprecated",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_81/index.mdx",
-        "https://github.com/one-covenant/grail",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/81/subnet.json",
-        "https://grail-grafana.tplr.ai/",
-        "https://taostats.io/subnets/81/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 6
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 19,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "TalkHead",
-      "netuid": 108,
-      "operational_interface_count": 0,
-      "priority_score": 123,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-108-backprop-dashboard",
-        "sn-108-taomarketcap-dashboard",
-        "sn-108-taomarketcap-source-repo",
-        "sn-108-taomarketcap-website",
-        "sn-108-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-108-website-common-openapi-json",
-        "sn-108-website-common-swagger",
-        "sn-108-website-common-swagger-json",
-        "sn-108-website-common-api",
-        "sn-108-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-108-website-common-openapi-json",
-        "sn-108-website-common-swagger",
-        "sn-108-website-common-swagger-json",
-        "sn-108-website-common-api",
-        "sn-108-website-common-health"
-      ],
-      "slug": "sn-108",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/108",
-        "https://backprop.finance/dtao/subnets/108-talkhead",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx",
-        "https://github.com/talkheadai/talkhead-subnet",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/108/subnet.json",
-        "https://taostats.io/subnets/108/metagraph",
-        "https://www.talkhead.ai/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 9
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 18,
-      "candidate_evidence_summary": {
-        "candidate_count": 6,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 6,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "verify-existing-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Numinous",
-      "netuid": 6,
-      "operational_interface_count": 0,
-      "priority_score": 122,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-6-backprop-dashboard",
-        "sn-6-github-readme-numinouslabs-numinous-dashboard-1",
-        "sn-6-taomarketcap-dashboard",
-        "sn-6-taomarketcap-source-repo",
-        "sn-6-taomarketcap-website"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-6-website-link-numinouslabs-io-subnet-api-2"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-6-website-link-numinouslabs-io-subnet-api-2",
-        "sn-6-website-common-openapi-json",
-        "sn-6-website-common-swagger",
-        "sn-6-website-common-swagger-json",
-        "sn-6-website-common-api"
-      ],
-      "slug": "sn-6",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/6",
-        "https://backprop.finance/dtao/subnets/6-numinous",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_6/index.mdx",
-        "https://github.com/numinouslabs/numinous",
-        "https://github.com/numinouslabs/numinous/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/6/subnet.json",
-        "https://numinouslabs.io/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 7,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 51,
-      "candidate_count": 24,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 73,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 11,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Gradients",
-      "netuid": 56,
-      "operational_interface_count": 2,
-      "priority_score": 122,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-56-backprop-dashboard",
-        "sn-56-taomarketcap-dashboard",
-        "sn-56-taomarketcap-source-repo",
-        "sn-56-taomarketcap-website",
-        "sn-56-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-56-website-common-api",
-        "sn-56-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-56-website-common-api",
-        "sn-56-website-common-health"
-      ],
-      "slug": "sn-56",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/56",
-        "https://backprop.finance/dtao/subnets/56-gradients",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
-        "https://github.com/gradients-ai/G.O.D",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/56/subnet.json",
-        "https://taostats.io/subnets/56/metagraph",
-        "https://www.gradients.io/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 11,
-      "verified_candidate_count": 22
-    },
-    {
-      "adapter_score": 91,
-      "candidate_count": 23,
-      "candidate_evidence_summary": {
-        "candidate_count": 3,
-        "kinds_with_candidates": [
-          "openapi"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "stale_kinds": [
-          "openapi"
-        ],
-        "stale_or_failed_count": 3,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 78,
-      "contribution_hint": "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [],
-      "endpoint_count": 11,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "adapter-candidate",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "openapi",
-        "sse"
-      ],
-      "name": "Green Compute",
-      "netuid": 110,
-      "operational_interface_count": 2,
-      "priority_score": 121,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate"
-      ],
-      "recommended_action": "evaluate adapter support for data-artifact, subnet-api",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-110-backprop-dashboard",
-        "sn-110-taomarketcap-dashboard",
-        "sn-110-taomarketcap-website",
-        "sn-110-taopedia-article",
-        "sn-110-taostats-metagraph"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-110-website-common-openapi-json",
-        "sn-110-website-common-swagger",
-        "sn-110-website-common-swagger-json"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-110-website-common-openapi-json",
-        "sn-110-website-common-swagger",
-        "sn-110-website-common-swagger-json"
-      ],
-      "slug": "sn-110",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/110",
-        "https://backprop.finance/dtao/subnets/110-green-compute",
-        "https://github.com/Rich-Kids-of-TAO/rkt-subnet",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/110/subnet.json",
-        "https://taomarketcap.com/subnets/110",
-        "https://taostats.io/subnets/110/metagraph",
-        "https://www.green-compute.com/"
-      ],
-      "stale_candidate_count": 3,
-      "surface_count": 11,
-      "verified_candidate_count": 17
-    },
-    {
-      "adapter_score": 8,
-      "candidate_count": 17,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "TrajectoryRL",
-      "netuid": 11,
-      "operational_interface_count": 0,
-      "priority_score": 121,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-11-backprop-dashboard",
-        "sn-11-taomarketcap-dashboard",
-        "sn-11-taomarketcap-source-repo",
-        "sn-11-taomarketcap-website",
-        "sn-11-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
-      "slug": "sn-11",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/11",
-        "https://backprop.finance/dtao/subnets/11-trajectoryrl",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/11/subnet.json",
-        "https://github.com/trajectoryRL/trajectoryRL",
-        "https://taostats.io/subnets/11/metagraph",
-        "https://trajrl.com/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 12
-    },
-    {
-      "adapter_score": 8,
-      "candidate_count": 17,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
       "name": "Perturb",
       "netuid": 26,
       "operational_interface_count": 0,
-      "priority_score": 121,
+      "priority_score": 123,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -2626,10 +2171,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-26-backprop-dashboard",
+        "sn-26-subnetradar-dashboard",
         "sn-26-taomarketcap-dashboard",
         "sn-26-taomarketcap-source-repo",
-        "sn-26-taomarketcap-website",
-        "sn-26-taopedia-article"
+        "sn-26-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -2653,16 +2198,16 @@
         "https://github.com/0xsigurd/Perturb",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_26/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/26/subnet.json",
-        "https://taostats.io/subnets/26/metagraph",
+        "https://subnetradar.com/subnet/26",
         "https://www.perturbai.io/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 8,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -2701,7 +2246,7 @@
       "name": "Eirel",
       "netuid": 36,
       "operational_interface_count": 0,
-      "priority_score": 121,
+      "priority_score": 123,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -2713,10 +2258,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-36-backprop-dashboard",
+        "sn-36-subnetradar-dashboard",
         "sn-36-taomarketcap-dashboard",
         "sn-36-taomarketcap-source-repo",
-        "sn-36-taomarketcap-website",
-        "sn-36-taopedia-article"
+        "sn-36-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -2741,14 +2286,85 @@
         "https://github.com/RendixNetwork/eirel-ai",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/36/subnet.json",
-        "https://taostats.io/subnets/36/metagraph"
+        "https://subnetradar.com/subnet/36"
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "adapter_score": 30,
+      "adapter_score": 51,
+      "candidate_count": 25,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 73,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Gradients",
+      "netuid": 56,
+      "operational_interface_count": 2,
+      "priority_score": 123,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-56-backprop-dashboard",
+        "sn-56-subnetradar-dashboard",
+        "sn-56-taomarketcap-dashboard",
+        "sn-56-taomarketcap-source-repo",
+        "sn-56-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-56-website-common-api",
+        "sn-56-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-56-website-common-api",
+        "sn-56-website-common-health"
+      ],
+      "slug": "sn-56",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/56",
+        "https://backprop.finance/dtao/subnets/56-gradients",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx",
+        "https://github.com/gradients-ai/G.O.D",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/56/subnet.json",
+        "https://subnetradar.com/subnet/56",
+        "https://www.gradients.io/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 11,
+      "verified_candidate_count": 23
+    },
+    {
+      "adapter_score": 91,
       "candidate_count": 24,
       "candidate_evidence_summary": {
         "candidate_count": 3,
@@ -2765,66 +2381,64 @@
         "unverified_count": 0,
         "unverified_kinds": []
       },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
+      "completeness_score": 78,
+      "contribution_hint": "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
+      "curation_level": "maintainer-reviewed",
       "direct_submission_kinds": [],
-      "endpoint_count": 10,
+      "endpoint_count": 11,
       "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
+      "lane": "adapter-candidate",
       "manual_review_required": true,
       "missing_kinds": [
-        "data-artifact",
         "openapi",
         "sse"
       ],
-      "name": "lium.io",
-      "netuid": 51,
-      "operational_interface_count": 1,
-      "priority_score": 121,
+      "name": "Green Compute",
+      "netuid": 110,
+      "operational_interface_count": 2,
+      "priority_score": 122,
       "profile_level": "operational",
       "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
+        "adapter-candidate"
       ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
+      "recommended_action": "evaluate adapter support for data-artifact, subnet-api",
+      "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-51-backprop-dashboard",
-        "sn-51-github-readme-datura-ai-lium-io-docs-1",
-        "sn-51-taomarketcap-dashboard",
-        "sn-51-taomarketcap-source-repo",
-        "sn-51-taomarketcap-website"
+        "sn-110-backprop-dashboard",
+        "sn-110-subnetradar-dashboard",
+        "sn-110-taomarketcap-dashboard",
+        "sn-110-taomarketcap-website",
+        "sn-110-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
-        "sn-51-website-common-openapi-json",
-        "sn-51-website-common-swagger",
-        "sn-51-website-common-swagger-json"
+        "sn-110-website-common-openapi-json",
+        "sn-110-website-common-swagger",
+        "sn-110-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
-        "sn-51-website-common-openapi-json",
-        "sn-51-website-common-swagger",
-        "sn-51-website-common-swagger-json"
+        "sn-110-website-common-openapi-json",
+        "sn-110-website-common-swagger",
+        "sn-110-website-common-swagger-json"
       ],
-      "slug": "sn-51",
+      "slug": "sn-110",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/51",
-        "https://backprop.finance/dtao/subnets/51-lium-io",
-        "https://docs.lium.io/bittensor-subnet/overview",
-        "https://github.com/Datura-ai/lium-io",
-        "https://github.com/Datura-ai/lium-io/blob/main/README.md",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
-        "https://lium.io/"
+        "https://api.taomarketcap.com/public/v1/subnets/110",
+        "https://backprop.finance/dtao/subnets/110-green-compute",
+        "https://github.com/Rich-Kids-of-TAO/rkt-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/110/subnet.json",
+        "https://subnetradar.com/subnet/110",
+        "https://taomarketcap.com/subnets/110",
+        "https://www.green-compute.com/"
       ],
       "stale_candidate_count": 3,
-      "surface_count": 10,
-      "verified_candidate_count": 19
+      "surface_count": 11,
+      "verified_candidate_count": 18
     },
     {
       "adapter_score": 7,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -2863,7 +2477,7 @@
       "name": "Hone",
       "netuid": 5,
       "operational_interface_count": 0,
-      "priority_score": 120,
+      "priority_score": 122,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -2875,10 +2489,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-5-backprop-dashboard",
+        "sn-5-subnetradar-dashboard",
         "sn-5-taomarketcap-dashboard",
         "sn-5-taomarketcap-source-repo",
-        "sn-5-taomarketcap-website",
-        "sn-5-taopedia-article"
+        "sn-5-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -2902,16 +2516,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx",
         "https://github.com/manifold-inc/hone",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/5/subnet.json",
-        "https://taostats.io/subnets/5/metagraph",
+        "https://subnetradar.com/subnet/5",
         "https://www.hone.training/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 0,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -2943,7 +2557,7 @@
       "name": "Gopher",
       "netuid": 42,
       "operational_interface_count": 0,
-      "priority_score": 120,
+      "priority_score": 122,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -2954,10 +2568,10 @@
       "review_state": "needs-review",
       "sample_candidate_ids": [
         "sn-42-backprop-dashboard",
+        "sn-42-subnetradar-dashboard",
         "sn-42-taomarketcap-dashboard",
         "sn-42-taopedia-article",
-        "sn-42-taostats-metagraph",
-        "sn-42-tensorplex-docs"
+        "sn-42-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -2971,15 +2585,15 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_42/index.mdx",
         "https://github.com/gopher-lab/subnet-42",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/42/subnet.json",
-        "https://taomarketcap.com/subnets/42"
+        "https://subnetradar.com/subnet/42"
       ],
       "stale_candidate_count": 0,
       "surface_count": 7,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
       "adapter_score": 7,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -3018,7 +2632,7 @@
       "name": "NIOME",
       "netuid": 55,
       "operational_interface_count": 0,
-      "priority_score": 120,
+      "priority_score": 122,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3030,10 +2644,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-55-backprop-dashboard",
+        "sn-55-subnetradar-dashboard",
         "sn-55-taomarketcap-dashboard",
         "sn-55-taomarketcap-source-repo",
-        "sn-55-taomarketcap-website",
-        "sn-55-taopedia-article"
+        "sn-55-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -3058,102 +2672,15 @@
         "https://github.com/genomesio/subnet-niome",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/55/subnet.json",
         "https://niome.genomes.io/",
-        "https://taostats.io/subnets/55/metagraph"
+        "https://subnetradar.com/subnet/55"
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 9
-    },
-    {
-      "adapter_score": 8,
-      "candidate_count": 16,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Bitsota",
-      "netuid": 94,
-      "operational_interface_count": 0,
-      "priority_score": 120,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-94-backprop-dashboard",
-        "sn-94-taomarketcap-dashboard",
-        "sn-94-taomarketcap-source-repo",
-        "sn-94-taomarketcap-website",
-        "sn-94-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-94-website-common-openapi-json",
-        "sn-94-website-common-swagger",
-        "sn-94-website-common-swagger-json",
-        "sn-94-website-common-api",
-        "sn-94-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-94-website-common-openapi-json",
-        "sn-94-website-common-swagger",
-        "sn-94-website-common-swagger-json",
-        "sn-94-website-common-api",
-        "sn-94-website-common-health"
-      ],
-      "slug": "sn-94",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/94",
-        "https://backprop.finance/dtao/subnets/94-bitsota",
-        "https://bitsota.ai/",
-        "https://github.com/AlveusLabs/SN94-BitSota",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json",
-        "https://taostats.io/subnets/94/metagraph"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 7,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -3192,7 +2719,7 @@
       "name": "Poker44",
       "netuid": 126,
       "operational_interface_count": 0,
-      "priority_score": 120,
+      "priority_score": 122,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3204,10 +2731,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-126-backprop-dashboard",
+        "sn-126-subnetradar-dashboard",
         "sn-126-taomarketcap-dashboard",
         "sn-126-taomarketcap-source-repo",
-        "sn-126-taomarketcap-website",
-        "sn-126-taopedia-article"
+        "sn-126-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -3232,15 +2759,255 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_126/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/126/subnet.json",
         "https://poker44.net/",
-        "https://taostats.io/subnets/126/metagraph"
+        "https://subnetradar.com/subnet/126"
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 30,
+      "candidate_count": 25,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "lium.io",
+      "netuid": 51,
+      "operational_interface_count": 1,
+      "priority_score": 122,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-51-backprop-dashboard",
+        "sn-51-github-readme-datura-ai-lium-io-docs-1",
+        "sn-51-subnetradar-dashboard",
+        "sn-51-taomarketcap-dashboard",
+        "sn-51-taomarketcap-source-repo"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-51-website-common-openapi-json",
+        "sn-51-website-common-swagger",
+        "sn-51-website-common-swagger-json"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-51-website-common-openapi-json",
+        "sn-51-website-common-swagger",
+        "sn-51-website-common-swagger-json"
+      ],
+      "slug": "sn-51",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/51",
+        "https://backprop.finance/dtao/subnets/51-lium-io",
+        "https://docs.lium.io/bittensor-subnet/overview",
+        "https://github.com/Datura-ai/lium-io",
+        "https://github.com/Datura-ai/lium-io/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/51/subnet.json",
+        "https://lium.io/"
+      ],
+      "stale_candidate_count": 3,
+      "surface_count": 10,
+      "verified_candidate_count": 20
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Bitsota",
+      "netuid": 94,
+      "operational_interface_count": 0,
+      "priority_score": 121,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-94-backprop-dashboard",
+        "sn-94-subnetradar-dashboard",
+        "sn-94-taomarketcap-dashboard",
+        "sn-94-taomarketcap-source-repo",
+        "sn-94-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-94-website-common-openapi-json",
+        "sn-94-website-common-swagger",
+        "sn-94-website-common-swagger-json",
+        "sn-94-website-common-api",
+        "sn-94-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-94-website-common-openapi-json",
+        "sn-94-website-common-swagger",
+        "sn-94-website-common-swagger-json",
+        "sn-94-website-common-api",
+        "sn-94-website-common-health"
+      ],
+      "slug": "sn-94",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/94",
+        "https://backprop.finance/dtao/subnets/94-bitsota",
+        "https://bitsota.ai/",
+        "https://github.com/AlveusLabs/SN94-BitSota",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/94/subnet.json",
+        "https://subnetradar.com/subnet/94"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 8,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 31,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 4,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 4,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Zipcode",
+      "netuid": 46,
+      "operational_interface_count": 1,
+      "priority_score": 121,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-46-backprop-dashboard",
+        "sn-46-github-readme-resi-labs-ai-resi-dashboard-1",
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
+        "sn-46-github-readme-resi-labs-ai-resi-models-dashboard-1",
+        "sn-46-subnetradar-dashboard"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-46-website-link-zipcode-ai-subnet-api-3"
+      ],
+      "sample_stale_candidate_ids": [
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-46-website-link-zipcode-ai-subnet-api-3",
+        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
+        "sn-46-website-common-api",
+        "sn-46-website-common-health"
+      ],
+      "slug": "sn-46",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/46",
+        "https://backprop.finance/dtao/subnets/46-zipcode",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_46/index.mdx",
+        "https://github.com/resi-labs-ai/RESI-models",
+        "https://github.com/resi-labs-ai/RESI-models/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/46/subnet.json",
+        "https://subnetradar.com/subnet/46",
+        "https://zipcode.ai/"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 11,
+      "verified_candidate_count": 17
     },
     {
       "adapter_score": 7,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -3279,7 +3046,7 @@
       "name": "Vanta",
       "netuid": 8,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 120,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3291,10 +3058,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-8-backprop-dashboard",
+        "sn-8-subnetradar-dashboard",
         "sn-8-taomarketcap-dashboard",
         "sn-8-taomarketcap-source-repo",
-        "sn-8-taomarketcap-website",
-        "sn-8-taopedia-article"
+        "sn-8-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -3318,15 +3085,15 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx",
         "https://github.com/taoshidev/vanta-network",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/8/subnet.json",
-        "https://taostats.io/subnets/8/metagraph",
+        "https://subnetradar.com/subnet/8",
         "https://www.vantanetwork.io/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "adapter_score": 7,
+      "adapter_score": 9,
       "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 5,
@@ -3353,7 +3120,7 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 7,
+      "endpoint_count": 9,
       "evidence_action": "replace-stale-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -3363,10 +3130,10 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Yanez MIID",
-      "netuid": 54,
+      "name": "OxMarkets",
+      "netuid": 35,
       "operational_interface_count": 0,
-      "priority_score": 119,
+      "priority_score": 120,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3377,368 +3144,44 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-54-backprop-dashboard",
-        "sn-54-github-readme-yanez-compliance-miid-subnet-dashboard-1",
-        "sn-54-taomarketcap-dashboard",
-        "sn-54-taomarketcap-source-repo",
-        "sn-54-taomarketcap-website"
+        "sn-35-backprop-dashboard",
+        "sn-35-subnetradar-dashboard",
+        "sn-35-taomarketcap-dashboard",
+        "sn-35-taomarketcap-source-repo",
+        "sn-35-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
-        "sn-54-website-common-openapi-json",
-        "sn-54-website-common-swagger-json",
-        "sn-54-website-common-swagger",
-        "sn-54-website-common-api",
-        "sn-54-website-common-health"
+        "sn-35-website-common-openapi-json",
+        "sn-35-website-common-swagger",
+        "sn-35-website-common-swagger-json",
+        "sn-35-website-common-api",
+        "sn-35-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-54-website-common-openapi-json",
-        "sn-54-website-common-swagger-json",
-        "sn-54-website-common-swagger",
-        "sn-54-website-common-api",
-        "sn-54-website-common-health"
+        "sn-35-website-common-openapi-json",
+        "sn-35-website-common-swagger",
+        "sn-35-website-common-swagger-json",
+        "sn-35-website-common-api",
+        "sn-35-website-common-health"
       ],
-      "slug": "sn-54",
+      "slug": "sn-35",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/54",
-        "https://backprop.finance/dtao/subnets/54-yanez-miid",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_54/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/54/subnet.json",
-        "https://github.com/yanez-compliance/MIID-subnet",
-        "https://github.com/yanez-compliance/MIID-subnet/blob/main/README.md",
-        "https://www.yanez.ai/"
+        "https://api.taomarketcap.com/public/v1/subnets/35",
+        "https://backprop.finance/dtao/subnets/35-oxmarkets",
+        "https://github.com/General-Tao-Ventures/cartha-validator",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_35/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/35/subnet.json",
+        "https://subnetradar.com/subnet/35",
+        "https://www.0xmarkets.io/"
       ],
       "stale_candidate_count": 5,
-      "surface_count": 7,
+      "surface_count": 9,
       "verified_candidate_count": 10
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 16,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Harnyx",
-      "netuid": 67,
-      "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-67-backprop-dashboard",
-        "sn-67-github-readme-harnyx-harnyx-dashboard-1",
-        "sn-67-taomarketcap-dashboard",
-        "sn-67-taomarketcap-website",
-        "sn-67-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-67-website-common-openapi-json",
-        "sn-67-website-common-swagger",
-        "sn-67-website-common-swagger-json",
-        "sn-67-website-common-api",
-        "sn-67-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-67-website-common-openapi-json",
-        "sn-67-website-common-swagger",
-        "sn-67-website-common-swagger-json",
-        "sn-67-website-common-api",
-        "sn-67-website-common-health"
-      ],
-      "slug": "sn-67",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/67",
-        "https://backprop.finance/dtao/subnets/67-harnyx",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_67/index.mdx",
-        "https://github.com/harnyx/harnyx",
-        "https://github.com/harnyx/harnyx/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/67/subnet.json",
-        "https://harnyx.ai/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 10
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 17,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "source-repo"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "source-repo",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Bitstarter #1",
-      "netuid": 91,
-      "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-source-repo"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-91-backprop-dashboard",
-        "sn-91-taomarketcap-dashboard",
-        "sn-91-taomarketcap-website",
-        "sn-91-taopedia-article",
-        "sn-91-taostats-metagraph"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-91",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/91",
-        "https://app.bitstarter.ai/",
-        "https://backprop.finance/dtao/subnets/91-bitstarter-1",
-        "https://bitstarter.ai/",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_91/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/91/subnet.json",
-        "https://taomarketcap.com/subnets/91",
-        "https://taostats.io/subnets/91/metagraph"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 10
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 16,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Astrid",
-      "netuid": 127,
-      "operational_interface_count": 0,
-      "priority_score": 119,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-127-backprop-dashboard",
-        "sn-127-taomarketcap-dashboard",
-        "sn-127-taomarketcap-source-repo",
-        "sn-127-taomarketcap-website",
-        "sn-127-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-127-website-common-openapi-json",
-        "sn-127-website-common-swagger",
-        "sn-127-website-common-swagger-json",
-        "sn-127-website-common-api",
-        "sn-127-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-127-website-common-openapi-json",
-        "sn-127-website-common-swagger",
-        "sn-127-website-common-swagger-json",
-        "sn-127-website-common-api",
-        "sn-127-website-common-health"
-      ],
-      "slug": "sn-127",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/127",
-        "https://backprop.finance/dtao/subnets/127-astrid",
-        "https://github.com/astridintelligence/sn-127",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/127/subnet.json",
-        "https://taostats.io/subnets/127/metagraph",
-        "https://www.astrid.global/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 10
-    },
-    {
-      "adapter_score": 31,
-      "candidate_count": 23,
-      "candidate_evidence_summary": {
-        "candidate_count": 4,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 4,
-        "stale_kinds": [
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 11,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Zipcode",
-      "netuid": 46,
-      "operational_interface_count": 1,
-      "priority_score": 119,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-46-backprop-dashboard",
-        "sn-46-github-readme-resi-labs-ai-resi-dashboard-1",
-        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
-        "sn-46-github-readme-resi-labs-ai-resi-models-dashboard-1",
-        "sn-46-taomarketcap-dashboard"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-46-website-link-zipcode-ai-subnet-api-3"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-46-website-link-zipcode-ai-subnet-api-3",
-        "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1",
-        "sn-46-website-common-api",
-        "sn-46-website-common-health"
-      ],
-      "slug": "sn-46",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/46",
-        "https://backprop.finance/dtao/subnets/46-zipcode",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_46/index.mdx",
-        "https://github.com/resi-labs-ai/RESI-models",
-        "https://github.com/resi-labs-ai/RESI-models/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/46/subnet.json",
-        "https://zipcode.ai/"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 11,
-      "verified_candidate_count": 16
     },
     {
       "adapter_score": 8,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -3777,7 +3220,7 @@
       "name": "Score",
       "netuid": 44,
       "operational_interface_count": 0,
-      "priority_score": 118,
+      "priority_score": 120,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3789,10 +3232,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-44-backprop-dashboard",
+        "sn-44-subnetradar-dashboard",
         "sn-44-taomarketcap-dashboard",
         "sn-44-taomarketcap-source-repo",
-        "sn-44-taomarketcap-website",
-        "sn-44-taopedia-article"
+        "sn-44-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -3816,16 +3259,265 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_44/index.mdx",
         "https://github.com/score-technologies/turbovision",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/44/subnet.json",
-        "https://taostats.io/subnets/44/metagraph",
+        "https://subnetradar.com/subnet/44",
         "https://www.wearescore.com/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Yanez MIID",
+      "netuid": 54,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-54-backprop-dashboard",
+        "sn-54-github-readme-yanez-compliance-miid-subnet-dashboard-1",
+        "sn-54-subnetradar-dashboard",
+        "sn-54-taomarketcap-dashboard",
+        "sn-54-taomarketcap-source-repo"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-54-website-common-openapi-json",
+        "sn-54-website-common-swagger-json",
+        "sn-54-website-common-swagger",
+        "sn-54-website-common-api",
+        "sn-54-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-54-website-common-openapi-json",
+        "sn-54-website-common-swagger-json",
+        "sn-54-website-common-swagger",
+        "sn-54-website-common-api",
+        "sn-54-website-common-health"
+      ],
+      "slug": "sn-54",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/54",
+        "https://backprop.finance/dtao/subnets/54-yanez-miid",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_54/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/54/subnet.json",
+        "https://github.com/yanez-compliance/MIID-subnet",
+        "https://github.com/yanez-compliance/MIID-subnet/blob/main/README.md",
+        "https://subnetradar.com/subnet/54",
+        "https://www.yanez.ai/"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Harnyx",
+      "netuid": 67,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-67-backprop-dashboard",
+        "sn-67-github-readme-harnyx-harnyx-dashboard-1",
+        "sn-67-subnetradar-dashboard",
+        "sn-67-taomarketcap-dashboard",
+        "sn-67-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-67-website-common-openapi-json",
+        "sn-67-website-common-swagger",
+        "sn-67-website-common-swagger-json",
+        "sn-67-website-common-api",
+        "sn-67-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-67-website-common-openapi-json",
+        "sn-67-website-common-swagger",
+        "sn-67-website-common-swagger-json",
+        "sn-67-website-common-api",
+        "sn-67-website-common-health"
+      ],
+      "slug": "sn-67",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/67",
+        "https://backprop.finance/dtao/subnets/67-harnyx",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_67/index.mdx",
+        "https://github.com/harnyx/harnyx",
+        "https://github.com/harnyx/harnyx/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/67/subnet.json",
+        "https://harnyx.ai/",
+        "https://subnetradar.com/subnet/67"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 18,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Bitstarter #1",
+      "netuid": 91,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-91-backprop-dashboard",
+        "sn-91-subnetradar-dashboard",
+        "sn-91-taomarketcap-dashboard",
+        "sn-91-taomarketcap-website",
+        "sn-91-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-91",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/91",
+        "https://app.bitstarter.ai/",
+        "https://backprop.finance/dtao/subnets/91-bitstarter-1",
+        "https://bitstarter.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_91/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/91/subnet.json",
+        "https://subnetradar.com/subnet/91",
+        "https://taomarketcap.com/subnets/91"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 8,
-      "candidate_count": 14,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -3861,10 +3553,10 @@
         "sse",
         "subnet-api"
       ],
-      "name": "OxMarkets",
-      "netuid": 35,
+      "name": "minotaur",
+      "netuid": 112,
       "operational_interface_count": 0,
-      "priority_score": 117,
+      "priority_score": 120,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -3875,44 +3567,218 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-35-backprop-dashboard",
-        "sn-35-taomarketcap-dashboard",
-        "sn-35-taomarketcap-source-repo",
-        "sn-35-taomarketcap-website",
-        "sn-35-taopedia-article"
+        "sn-112-backprop-dashboard",
+        "sn-112-subnetradar-dashboard",
+        "sn-112-taomarketcap-dashboard",
+        "sn-112-taomarketcap-source-repo",
+        "sn-112-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
-        "sn-35-website-common-openapi-json",
-        "sn-35-website-common-swagger",
-        "sn-35-website-common-swagger-json",
-        "sn-35-website-common-api",
-        "sn-35-website-common-health"
+        "sn-112-website-common-openapi-json",
+        "sn-112-website-common-swagger",
+        "sn-112-website-common-swagger-json",
+        "sn-112-website-common-api",
+        "sn-112-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-35-website-common-openapi-json",
-        "sn-35-website-common-swagger",
-        "sn-35-website-common-swagger-json",
-        "sn-35-website-common-api",
-        "sn-35-website-common-health"
+        "sn-112-website-common-openapi-json",
+        "sn-112-website-common-swagger",
+        "sn-112-website-common-swagger-json",
+        "sn-112-website-common-api",
+        "sn-112-website-common-health"
       ],
-      "slug": "sn-35",
+      "slug": "sn-112",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/35",
-        "https://backprop.finance/dtao/subnets/35-oxmarkets",
-        "https://github.com/General-Tao-Ventures/cartha-validator",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_35/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/35/subnet.json",
-        "https://taostats.io/subnets/35/metagraph",
-        "https://www.0xmarkets.io/"
+        "https://api.taomarketcap.com/public/v1/subnets/112",
+        "https://backprop.finance/dtao/subnets/112-minotaur",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_112/index.mdx",
+        "https://github.com/subnet112/minotaur_subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/112/subnet.json",
+        "https://minotaursubnet.com/",
+        "https://subnetradar.com/subnet/112"
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 7,
+      "candidate_count": 17,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Astrid",
+      "netuid": 127,
+      "operational_interface_count": 0,
+      "priority_score": 120,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-127-backprop-dashboard",
+        "sn-127-subnetradar-dashboard",
+        "sn-127-taomarketcap-dashboard",
+        "sn-127-taomarketcap-source-repo",
+        "sn-127-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-127-website-common-openapi-json",
+        "sn-127-website-common-swagger",
+        "sn-127-website-common-swagger-json",
+        "sn-127-website-common-api",
+        "sn-127-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-127-website-common-openapi-json",
+        "sn-127-website-common-swagger",
+        "sn-127-website-common-swagger-json",
+        "sn-127-website-common-api",
+        "sn-127-website-common-health"
+      ],
+      "slug": "sn-127",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/127",
+        "https://backprop.finance/dtao/subnets/127-astrid",
+        "https://github.com/astridintelligence/sn-127",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/127/subnet.json",
+        "https://subnetradar.com/subnet/127",
+        "https://www.astrid.global/"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 11
+    },
+    {
+      "adapter_score": 8,
       "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 50,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Swap",
+      "netuid": 10,
+      "operational_interface_count": 0,
+      "priority_score": 118,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-10-backprop-dashboard",
+        "sn-10-subnetradar-dashboard",
+        "sn-10-taomarketcap-dashboard",
+        "sn-10-taomarketcap-source-repo",
+        "sn-10-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-10-website-common-openapi-json",
+        "sn-10-website-common-swagger",
+        "sn-10-website-common-swagger-json",
+        "sn-10-website-common-api",
+        "sn-10-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-10-website-common-openapi-json",
+        "sn-10-website-common-swagger",
+        "sn-10-website-common-swagger-json",
+        "sn-10-website-common-api",
+        "sn-10-website-common-health"
+      ],
+      "slug": "sn-10",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/10",
+        "https://backprop.finance/dtao/subnets/10-swap",
+        "https://github.com/Swap-Subnet/swap-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/10/subnet.json",
+        "https://subnetradar.com/subnet/10",
+        "https://www.taofi.com/pool"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 8,
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -3952,7 +3818,7 @@
       "name": "GroundLayer",
       "netuid": 20,
       "operational_interface_count": 0,
-      "priority_score": 116,
+      "priority_score": 117,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -3962,10 +3828,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-20-backprop-dashboard",
+        "sn-20-subnetradar-dashboard",
         "sn-20-taomarketcap-dashboard",
         "sn-20-taomarketcap-source-repo",
-        "sn-20-taomarketcap-website",
-        "sn-20-taopedia-article"
+        "sn-20-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -3980,191 +3846,17 @@
         "https://backprop.finance/dtao/subnets/20-groundlayer",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_20/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/20/subnet.json",
+        "https://subnetradar.com/subnet/20",
         "https://taomarketcap.com/subnets/20",
-        "https://taostats.io/subnets/20/metagraph",
         "https://www.groundlayer.xyz/"
       ],
       "stale_candidate_count": 6,
       "surface_count": 7,
-      "verified_candidate_count": 8
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 14,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "minotaur",
-      "netuid": 112,
-      "operational_interface_count": 0,
-      "priority_score": 116,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-112-backprop-dashboard",
-        "sn-112-taomarketcap-dashboard",
-        "sn-112-taomarketcap-source-repo",
-        "sn-112-taomarketcap-website",
-        "sn-112-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-112-website-common-openapi-json",
-        "sn-112-website-common-swagger",
-        "sn-112-website-common-swagger-json",
-        "sn-112-website-common-api",
-        "sn-112-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-112-website-common-openapi-json",
-        "sn-112-website-common-swagger",
-        "sn-112-website-common-swagger-json",
-        "sn-112-website-common-api",
-        "sn-112-website-common-health"
-      ],
-      "slug": "sn-112",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/112",
-        "https://backprop.finance/dtao/subnets/112-minotaur",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_112/index.mdx",
-        "https://github.com/subnet112/minotaur_subnet",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/112/subnet.json",
-        "https://minotaursubnet.com/",
-        "https://taostats.io/subnets/112/metagraph"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 8
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 14,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 50,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Affine",
-      "netuid": 120,
-      "operational_interface_count": 0,
-      "priority_score": 116,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-120-backprop-dashboard",
-        "sn-120-github-readme-affinefoundation-affine-dashboard-1",
-        "sn-120-taomarketcap-dashboard",
-        "sn-120-taomarketcap-source-repo",
-        "sn-120-taomarketcap-website"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-120-website-common-openapi-json",
-        "sn-120-website-common-swagger",
-        "sn-120-website-common-swagger-json",
-        "sn-120-website-common-api",
-        "sn-120-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-120-website-common-openapi-json",
-        "sn-120-website-common-swagger",
-        "sn-120-website-common-swagger-json",
-        "sn-120-website-common-api",
-        "sn-120-website-common-health"
-      ],
-      "slug": "sn-120",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/120",
-        "https://backprop.finance/dtao/subnets/120-affine",
-        "https://github.com/AffineFoundation/affine",
-        "https://github.com/AffineFoundation/affine/blob/main/README.md",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_120/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/120/subnet.json",
-        "https://www.affine.io/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 8,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -4203,7 +3895,7 @@
       "name": "VoidAI",
       "netuid": 106,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 117,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -4215,10 +3907,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-106-backprop-dashboard",
+        "sn-106-subnetradar-dashboard",
         "sn-106-taomarketcap-dashboard",
         "sn-106-taomarketcap-source-repo",
-        "sn-106-taomarketcap-website",
-        "sn-106-taopedia-article"
+        "sn-106-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -4242,164 +3934,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/106/subnet.json",
         "https://github.com/v0idai/SN106",
-        "https://taostats.io/subnets/106/metagraph",
+        "https://subnetradar.com/subnet/106",
         "https://voidai.com/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 8
-    },
-    {
-      "adapter_score": 31,
-      "candidate_count": 20,
-      "candidate_evidence_summary": {
-        "candidate_count": 3,
-        "kinds_with_candidates": [
-          "openapi"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "stale_kinds": [
-          "openapi"
-        ],
-        "stale_or_failed_count": 3,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 11,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse"
-      ],
-      "name": "Minos",
-      "netuid": 107,
-      "operational_interface_count": 1,
-      "priority_score": 115,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-107-backprop-dashboard",
-        "sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-1",
-        "sn-107-github-readme-tigerinvests-com-sn107-alpha-subnet-api-1",
-        "sn-107-taomarketcap-dashboard",
-        "sn-107-taomarketcap-source-repo"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-107-website-common-openapi-json",
-        "sn-107-website-common-swagger",
-        "sn-107-website-common-swagger-json"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-107-website-common-openapi-json",
-        "sn-107-website-common-swagger",
-        "sn-107-website-common-swagger-json"
-      ],
-      "slug": "sn-107",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/107",
-        "https://backprop.finance/dtao/subnets/107-minos",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
-        "https://github.com/minos-protocol/minos_subnet",
-        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/107/subnet.json",
-        "https://taostats.io/subnets/107/metagraph",
-        "https://theminos.ai/"
-      ],
-      "stale_candidate_count": 3,
-      "surface_count": 11,
-      "verified_candidate_count": 14
-    },
-    {
-      "adapter_score": 77,
-      "candidate_count": 28,
-      "candidate_evidence_summary": {
-        "candidate_count": 3,
-        "kinds_with_candidates": [
-          "openapi"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "stale_kinds": [
-          "openapi"
-        ],
-        "stale_or_failed_count": 3,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 78,
-      "contribution_hint": "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [],
-      "endpoint_count": 17,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "adapter-candidate",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "openapi",
-        "sse"
-      ],
-      "name": "Chutes",
-      "netuid": 64,
-      "operational_interface_count": 2,
-      "priority_score": 114,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate"
-      ],
-      "recommended_action": "evaluate adapter support for data-artifact, subnet-api",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-64-backprop-dashboard",
-        "sn-64-github-readme-chutesai-chutes-subnet-api-1",
-        "sn-64-github-readme-chutesai-chutes-subnet-api-2",
-        "sn-64-github-readme-rayonlabs-chutes-miner-subnet-api-1",
-        "sn-64-taomarketcap-dashboard"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-64-website-common-openapi-json",
-        "sn-64-website-common-swagger",
-        "sn-64-website-common-swagger-json"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-64-website-common-openapi-json",
-        "sn-64-website-common-swagger",
-        "sn-64-website-common-swagger-json"
-      ],
-      "slug": "sn-64",
-      "source_urls": [
-        "https://api.chutes.ai/pricing",
-        "https://api.taomarketcap.com/public/v1/subnets/64",
-        "https://backprop.finance/dtao/subnets/64-chutes",
-        "https://chutes.ai/",
-        "https://chutes.ai/app?type=llm",
-        "https://chutes.ai/docs",
-        "https://github.com/chutesai/chutes",
-        "https://github.com/chutesai/chutes-api"
-      ],
-      "stale_candidate_count": 3,
-      "surface_count": 17,
-      "verified_candidate_count": 21
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 7,
-      "candidate_count": 13,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -4435,10 +3979,10 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Swap",
-      "netuid": 10,
+      "name": "Affine",
+      "netuid": 120,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 117,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -4449,44 +3993,45 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-10-backprop-dashboard",
-        "sn-10-taomarketcap-dashboard",
-        "sn-10-taomarketcap-source-repo",
-        "sn-10-taomarketcap-website",
-        "sn-10-taopedia-article"
+        "sn-120-backprop-dashboard",
+        "sn-120-github-readme-affinefoundation-affine-dashboard-1",
+        "sn-120-subnetradar-dashboard",
+        "sn-120-taomarketcap-dashboard",
+        "sn-120-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
+        "sn-120-website-common-openapi-json",
+        "sn-120-website-common-swagger",
+        "sn-120-website-common-swagger-json",
+        "sn-120-website-common-api",
+        "sn-120-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
+        "sn-120-website-common-openapi-json",
+        "sn-120-website-common-swagger",
+        "sn-120-website-common-swagger-json",
+        "sn-120-website-common-api",
+        "sn-120-website-common-health"
       ],
-      "slug": "sn-10",
+      "slug": "sn-120",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/10",
-        "https://backprop.finance/dtao/subnets/10-swap",
-        "https://github.com/Swap-Subnet/swap-subnet",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/10/subnet.json",
-        "https://taostats.io/subnets/10/metagraph",
-        "https://www.taofi.com/pool"
+        "https://api.taomarketcap.com/public/v1/subnets/120",
+        "https://backprop.finance/dtao/subnets/120-affine",
+        "https://github.com/AffineFoundation/affine",
+        "https://github.com/AffineFoundation/affine/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_120/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/120/subnet.json",
+        "https://subnetradar.com/subnet/120",
+        "https://www.affine.io/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 7,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -4524,7 +4069,7 @@
       "name": "Endure Network",
       "netuid": 30,
       "operational_interface_count": 0,
-      "priority_score": 114,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -4534,10 +4079,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-30-backprop-dashboard",
+        "sn-30-subnetradar-dashboard",
         "sn-30-taomarketcap-dashboard",
         "sn-30-taomarketcap-website",
-        "sn-30-taopedia-article",
-        "sn-30-taostats-metagraph"
+        "sn-30-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -4550,16 +4095,315 @@
         "https://endure.network/",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_30/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/30/subnet.json",
-        "https://taomarketcap.com/subnets/30",
-        "https://taostats.io/subnets/30/metagraph"
+        "https://subnetradar.com/subnet/30",
+        "https://taomarketcap.com/subnets/30"
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 31,
+      "candidate_count": 21,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse"
+      ],
+      "name": "Minos",
+      "netuid": 107,
+      "operational_interface_count": 1,
+      "priority_score": 116,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-107-backprop-dashboard",
+        "sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-1",
+        "sn-107-github-readme-tigerinvests-com-sn107-alpha-subnet-api-1",
+        "sn-107-subnetradar-dashboard",
+        "sn-107-taomarketcap-dashboard"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-107-website-common-openapi-json",
+        "sn-107-website-common-swagger",
+        "sn-107-website-common-swagger-json"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-107-website-common-openapi-json",
+        "sn-107-website-common-swagger",
+        "sn-107-website-common-swagger-json"
+      ],
+      "slug": "sn-107",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/107",
+        "https://backprop.finance/dtao/subnets/107-minos",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx",
+        "https://github.com/minos-protocol/minos_subnet",
+        "https://github.com/minos-protocol/minos_subnet/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/107/subnet.json",
+        "https://subnetradar.com/subnet/107",
+        "https://theminos.ai/"
+      ],
+      "stale_candidate_count": 3,
+      "surface_count": 11,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 77,
+      "candidate_count": 29,
+      "candidate_evidence_summary": {
+        "candidate_count": 3,
+        "kinds_with_candidates": [
+          "openapi"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 3,
+        "stale_kinds": [
+          "openapi"
+        ],
+        "stale_or_failed_count": 3,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 78,
+      "contribution_hint": "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [],
+      "endpoint_count": 17,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "adapter-candidate",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "openapi",
+        "sse"
+      ],
+      "name": "Chutes",
+      "netuid": 64,
+      "operational_interface_count": 2,
+      "priority_score": 115,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate"
+      ],
+      "recommended_action": "evaluate adapter support for data-artifact, subnet-api",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-64-backprop-dashboard",
+        "sn-64-github-readme-chutesai-chutes-subnet-api-1",
+        "sn-64-github-readme-chutesai-chutes-subnet-api-2",
+        "sn-64-github-readme-rayonlabs-chutes-miner-subnet-api-1",
+        "sn-64-subnetradar-dashboard"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-64-website-common-openapi-json",
+        "sn-64-website-common-swagger",
+        "sn-64-website-common-swagger-json"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-64-website-common-openapi-json",
+        "sn-64-website-common-swagger",
+        "sn-64-website-common-swagger-json"
+      ],
+      "slug": "sn-64",
+      "source_urls": [
+        "https://api.chutes.ai/pricing",
+        "https://api.taomarketcap.com/public/v1/subnets/64",
+        "https://backprop.finance/dtao/subnets/64-chutes",
+        "https://chutes.ai/",
+        "https://chutes.ai/app?type=llm",
+        "https://chutes.ai/docs",
+        "https://github.com/chutesai/chutes",
+        "https://github.com/chutesai/chutes-api"
+      ],
+      "stale_candidate_count": 3,
+      "surface_count": 17,
+      "verified_candidate_count": 22
+    },
+    {
+      "adapter_score": 8,
+      "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "source-repo",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "source-repo",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Nodexo",
+      "netuid": 27,
+      "operational_interface_count": 0,
+      "priority_score": 115,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-27-backprop-dashboard",
+        "sn-27-subnetradar-dashboard",
+        "sn-27-taomarketcap-dashboard",
+        "sn-27-taomarketcap-source-repo",
+        "sn-27-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-27-taomarketcap-source-repo"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-27-taomarketcap-source-repo"
+      ],
+      "slug": "nodexo",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/27",
+        "https://backprop.finance/dtao/subnets/27-nodexo",
+        "https://console.nodexo.ai/",
+        "https://docs.nodexo.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json",
+        "https://nodexo.ai/",
+        "https://subnetradar.com/subnet/27"
+      ],
+      "stale_candidate_count": 6,
+      "surface_count": 8,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 30,
+      "candidate_count": 20,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TAO Private Network",
+      "netuid": 65,
+      "operational_interface_count": 1,
+      "priority_score": 115,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-65-backprop-dashboard",
+        "sn-65-subnetradar-dashboard",
+        "sn-65-taomarketcap-dashboard",
+        "sn-65-taomarketcap-source-repo",
+        "sn-65-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-65-website-common-api",
+        "sn-65-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-65-website-common-api",
+        "sn-65-website-common-health"
+      ],
+      "slug": "sn-65",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/65",
+        "https://backprop.finance/dtao/subnets/65-tao-private-network",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx",
+        "https://github.com/taofu-labs/tpn-subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/65/subnet.json",
+        "https://subnetradar.com/subnet/65",
+        "https://tpn.taofu.xyz/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 10,
+      "verified_candidate_count": 18
     },
     {
       "adapter_score": 6,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -4597,7 +4441,7 @@
       "name": "Byzantium",
       "netuid": 76,
       "operational_interface_count": 0,
-      "priority_score": 113,
+      "priority_score": 114,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -4607,10 +4451,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-76-backprop-dashboard",
+        "sn-76-subnetradar-dashboard",
         "sn-76-taomarketcap-dashboard",
         "sn-76-taomarketcap-website",
-        "sn-76-taopedia-article",
-        "sn-76-taostats-metagraph"
+        "sn-76-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -4621,17 +4465,17 @@
         "https://backprop.finance/dtao/subnets/76-byzantium",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_76/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/76/subnet.json",
+        "https://subnetradar.com/subnet/76",
         "https://taomarketcap.com/subnets/76",
-        "https://taostats.io/subnets/76/metagraph",
         "https://www.byzantiumai.net/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 6,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
       "adapter_score": 6,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -4671,7 +4515,7 @@
       "name": "InfiniteHash",
       "netuid": 89,
       "operational_interface_count": 0,
-      "priority_score": 113,
+      "priority_score": 114,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
@@ -4681,10 +4525,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-89-backprop-dashboard",
+        "sn-89-subnetradar-dashboard",
         "sn-89-taomarketcap-dashboard",
         "sn-89-taomarketcap-source-repo",
-        "sn-89-taomarketcap-website",
-        "sn-89-taopedia-article"
+        "sn-89-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -4700,88 +4544,16 @@
         "https://github.com/backend-developers-ltd/InfiniteHash",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_89/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/89/subnet.json",
-        "https://taomarketcap.com/subnets/89",
-        "https://taostats.io/subnets/89/metagraph"
+        "https://subnetradar.com/subnet/89",
+        "https://taomarketcap.com/subnets/89"
       ],
       "stale_candidate_count": 6,
       "surface_count": 6,
-      "verified_candidate_count": 6
-    },
-    {
-      "adapter_score": 30,
-      "candidate_count": 19,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 10,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "TAO Private Network",
-      "netuid": 65,
-      "operational_interface_count": 1,
-      "priority_score": 113,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-65-backprop-dashboard",
-        "sn-65-taomarketcap-dashboard",
-        "sn-65-taomarketcap-source-repo",
-        "sn-65-taomarketcap-website",
-        "sn-65-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-65-website-common-api",
-        "sn-65-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-65-website-common-api",
-        "sn-65-website-common-health"
-      ],
-      "slug": "sn-65",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/65",
-        "https://backprop.finance/dtao/subnets/65-tao-private-network",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx",
-        "https://github.com/taofu-labs/tpn-subnet",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/65/subnet.json",
-        "https://taostats.io/subnets/65/metagraph",
-        "https://tpn.taofu.xyz/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 10,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 29,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -4813,7 +4585,7 @@
       "name": "Bitcast",
       "netuid": 93,
       "operational_interface_count": 1,
-      "priority_score": 112,
+      "priority_score": 114,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -4824,9 +4596,9 @@
       "sample_candidate_ids": [
         "sn-93-backprop-dashboard",
         "sn-93-github-readme-bitcast-network-bitcast-dashboard-1",
+        "sn-93-subnetradar-dashboard",
         "sn-93-taomarketcap-dashboard",
-        "sn-93-taomarketcap-source-repo",
-        "sn-93-taomarketcap-website"
+        "sn-93-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [
         "sn-93-website-common-api",
@@ -4845,15 +4617,15 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_93/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/93/subnet.json",
         "https://stats.bitcast.network/",
-        "https://taostats.io/subnets/93/metagraph"
+        "https://subnetradar.com/subnet/93"
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
       "adapter_score": 28,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -4885,7 +4657,7 @@
       "name": "Babelbit",
       "netuid": 59,
       "operational_interface_count": 1,
-      "priority_score": 111,
+      "priority_score": 112,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -4896,9 +4668,9 @@
       "sample_candidate_ids": [
         "sn-59-backprop-dashboard",
         "sn-59-github-readme-babelbit-babelbit-subnet-subnet-api-1",
+        "sn-59-subnetradar-dashboard",
         "sn-59-taomarketcap-dashboard",
-        "sn-59-taomarketcap-source-repo",
-        "sn-59-taomarketcap-website"
+        "sn-59-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -4920,15 +4692,15 @@
         "https://github.com/babelbit/babelbit_subnet/blob/main/README.md",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_59/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/59/subnet.json",
-        "https://taostats.io/subnets/59/metagraph"
+        "https://subnetradar.com/subnet/59"
       ],
       "stale_candidate_count": 3,
       "surface_count": 8,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 31,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -4962,7 +4734,7 @@
       "name": "Albedo",
       "netuid": 97,
       "operational_interface_count": 1,
-      "priority_score": 110,
+      "priority_score": 112,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -4974,8 +4746,8 @@
         "sn-97-backprop-dashboard",
         "sn-97-github-readme-unitone-labs-flamewire-docs-1",
         "sn-97-github-readme-unitone-labs-flamewire-subnet-api-2",
-        "sn-97-taomarketcap-dashboard",
-        "sn-97-taomarketcap-source-repo"
+        "sn-97-subnetradar-dashboard",
+        "sn-97-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [
         "sn-97-website-common-health",
@@ -4998,15 +4770,15 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/97/subnet.json",
         "https://github.com/unarbos/albedo",
         "https://github.com/unitone-labs/FlameWire/blob/main/README.md",
-        "https://taostats.io/subnets/97/metagraph"
+        "https://subnetradar.com/subnet/97"
       ],
       "stale_candidate_count": 1,
       "surface_count": 11,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 30,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -5038,7 +4810,7 @@
       "name": "DSperse",
       "netuid": 2,
       "operational_interface_count": 1,
-      "priority_score": 109,
+      "priority_score": 110,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -5051,7 +4823,7 @@
         "sn-2-github-readme-inference-labs-inc-subnet-2-dashboard-2",
         "sn-2-github-readme-inference-labs-inc-subnet-2-dashboard-3",
         "sn-2-github-readme-inference-labs-inc-subnet-2-docs-1",
-        "sn-2-taomarketcap-dashboard"
+        "sn-2-subnetradar-dashboard"
       ],
       "sample_live_candidate_ids": [
         "sn-2-website-common-api",
@@ -5075,11 +4847,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 31,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -5111,7 +4883,7 @@
       "name": "Leoma",
       "netuid": 99,
       "operational_interface_count": 1,
-      "priority_score": 109,
+      "priority_score": 110,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -5123,8 +4895,8 @@
         "sn-99-backprop-dashboard",
         "sn-99-github-readme-rendixnetwork-leoma-docs-2",
         "sn-99-github-readme-rendixnetwork-leoma-subnet-api-1",
-        "sn-99-taomarketcap-dashboard",
-        "sn-99-taomarketcap-source-repo"
+        "sn-99-subnetradar-dashboard",
+        "sn-99-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [
         "sn-99-github-readme-rendixnetwork-leoma-subnet-api-1",
@@ -5150,11 +4922,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 11,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 29,
-      "candidate_count": 8,
+      "candidate_count": 9,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -5185,7 +4957,7 @@
       "name": "EvolAI",
       "netuid": 47,
       "operational_interface_count": 1,
-      "priority_score": 107,
+      "priority_score": 109,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -5196,9 +4968,9 @@
       "sample_candidate_ids": [
         "sn-47-backprop-dashboard",
         "sn-47-github-readme-openevolai-evolai-data-artifact-1",
+        "sn-47-subnetradar-dashboard",
         "sn-47-taomarketcap-dashboard",
-        "sn-47-taomarketcap-source-repo",
-        "sn-47-taopedia-article"
+        "sn-47-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -5211,16 +4983,16 @@
         "https://github.com/openevolai/evolai",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/47/subnet.json",
         "https://huggingface.co/datasets/evolai/universal_qa",
-        "https://taomarketcap.com/subnets/47",
-        "https://taostats.io/subnets/47/metagraph"
+        "https://subnetradar.com/subnet/47",
+        "https://taomarketcap.com/subnets/47"
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 32,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -5257,7 +5029,7 @@
       "name": "StreetVision by NATIX",
       "netuid": 72,
       "operational_interface_count": 1,
-      "priority_score": 107,
+      "priority_score": 109,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -5269,9 +5041,9 @@
       "sample_candidate_ids": [
         "sn-72-backprop-dashboard",
         "sn-72-github-readme-natixnetwork-streetvision-subnet-data-artifact-1",
+        "sn-72-subnetradar-dashboard",
         "sn-72-taomarketcap-dashboard",
-        "sn-72-taomarketcap-source-repo",
-        "sn-72-taomarketcap-website"
+        "sn-72-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -5297,15 +5069,238 @@
         "https://github.com/natixnetwork/streetvision-subnet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/72/subnet.json",
         "https://huggingface.co/natix-network-org",
-        "https://taostats.io/subnets/72/metagraph"
+        "https://subnetradar.com/subnet/72"
       ],
       "stale_candidate_count": 5,
       "surface_count": 12,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
+    },
+    {
+      "adapter_score": 31,
+      "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 2,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Bitsec.ai",
+      "netuid": 60,
+      "operational_interface_count": 1,
+      "priority_score": 109,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-60-backprop-dashboard",
+        "sn-60-github-readme-bitsec-ai-sandbox-docs-1",
+        "sn-60-subnetradar-dashboard",
+        "sn-60-taomarketcap-dashboard",
+        "sn-60-taomarketcap-source-repo"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-60-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [
+        "sn-60-website-common-api"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-60-website-common-health",
+        "sn-60-website-common-api"
+      ],
+      "slug": "sn-60",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/60",
+        "https://backprop.finance/dtao/subnets/60-bitsec-ai",
+        "https://bitsec.ai/",
+        "https://docs.bitsec.ai/",
+        "https://github.com/Bitsec-AI/sandbox",
+        "https://github.com/Bitsec-AI/sandbox/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/60/subnet.json"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 11,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 31,
+      "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 11,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Vocence",
+      "netuid": 78,
+      "operational_interface_count": 1,
+      "priority_score": 109,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-78-backprop-dashboard",
+        "sn-78-subnetradar-dashboard",
+        "sn-78-taomarketcap-dashboard",
+        "sn-78-taomarketcap-source-repo",
+        "sn-78-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-78-website-common-api",
+        "sn-78-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-78-website-common-api",
+        "sn-78-website-common-health"
+      ],
+      "slug": "sn-78",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/78",
+        "https://backprop.finance/dtao/subnets/78-vocence",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/78/subnet.json",
+        "https://github.com/vocence-78/vocence",
+        "https://subnetradar.com/subnet/78",
+        "https://www.vocence.ai/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "adapter_score": 30,
+      "candidate_count": 16,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 2,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 10,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "dogelayer",
+      "netuid": 80,
+      "operational_interface_count": 1,
+      "priority_score": 109,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-80-backprop-dashboard",
+        "sn-80-subnetradar-dashboard",
+        "sn-80-taomarketcap-dashboard",
+        "sn-80-taomarketcap-source-repo",
+        "sn-80-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-80-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [
+        "sn-80-website-common-api"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-80-website-common-health",
+        "sn-80-website-common-api"
+      ],
+      "slug": "sn-80",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/80",
+        "https://backprop.finance/dtao/subnets/80-dogelayer",
+        "https://dogelayer.ai/",
+        "https://github.com/dogelayer-ai/dogelayer",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/80/subnet.json",
+        "https://subnetradar.com/subnet/80"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 10,
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 11,
-      "candidate_count": 25,
+      "candidate_count": 26,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -5357,10 +5352,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-75-backprop-dashboard",
+        "sn-75-subnetradar-dashboard",
         "sn-75-taomarketcap-dashboard",
         "sn-75-taomarketcap-source-repo",
-        "sn-75-taomarketcap-website",
-        "sn-75-taopedia-article"
+        "sn-75-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [
         "sn-75-website-link-hippius-com-subnet-api-10"
@@ -5392,11 +5387,11 @@
       ],
       "stale_candidate_count": 5,
       "surface_count": 11,
-      "verified_candidate_count": 19
+      "verified_candidate_count": 20
     },
     {
       "adapter_score": 29,
-      "candidate_count": 25,
+      "candidate_count": 26,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -5445,9 +5440,9 @@
       "sample_candidate_ids": [
         "sn-79-backprop-dashboard",
         "sn-79-github-readme-taos-im-sn-79-docs-1",
+        "sn-79-subnetradar-dashboard",
         "sn-79-taomarketcap-dashboard",
-        "sn-79-taomarketcap-website",
-        "sn-79-taopedia-article"
+        "sn-79-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -5473,90 +5468,14 @@
         "https://github.com/taos-im/sn-79/blob/main/README.md",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/79/subnet.json",
         "https://simulate.trading/taos-im-paper",
-        "https://taomarketcap.com/subnets/79"
+        "https://subnetradar.com/subnet/79"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
     },
     {
-      "adapter_score": 31,
-      "candidate_count": 15,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 2,
-        "stale_kinds": [
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 11,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Bitsec.ai",
-      "netuid": 60,
-      "operational_interface_count": 1,
-      "priority_score": 107,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-60-backprop-dashboard",
-        "sn-60-github-readme-bitsec-ai-sandbox-docs-1",
-        "sn-60-taomarketcap-dashboard",
-        "sn-60-taomarketcap-source-repo",
-        "sn-60-taomarketcap-website"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-60-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-60-website-common-api"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-60-website-common-health",
-        "sn-60-website-common-api"
-      ],
-      "slug": "sn-60",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/60",
-        "https://backprop.finance/dtao/subnets/60-bitsec-ai",
-        "https://bitsec.ai/",
-        "https://docs.bitsec.ai/",
-        "https://github.com/Bitsec-AI/sandbox",
-        "https://github.com/Bitsec-AI/sandbox/blob/main/README.md",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/60/subnet.json"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 11,
-      "verified_candidate_count": 12
-    },
-    {
-      "adapter_score": 31,
+      "adapter_score": 30,
       "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 2,
@@ -5577,80 +5496,6 @@
       "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
       "curation_level": "machine-verified",
       "direct_submission_kinds": [],
-      "endpoint_count": 11,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Vocence",
-      "netuid": 78,
-      "operational_interface_count": 1,
-      "priority_score": 107,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-78-backprop-dashboard",
-        "sn-78-taomarketcap-dashboard",
-        "sn-78-taomarketcap-source-repo",
-        "sn-78-taomarketcap-website",
-        "sn-78-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-78-website-common-api",
-        "sn-78-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-78-website-common-api",
-        "sn-78-website-common-health"
-      ],
-      "slug": "sn-78",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/78",
-        "https://backprop.finance/dtao/subnets/78-vocence",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/78/subnet.json",
-        "https://github.com/vocence-78/vocence",
-        "https://taostats.io/subnets/78/metagraph",
-        "https://www.vocence.ai/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 11,
-      "verified_candidate_count": 13
-    },
-    {
-      "adapter_score": 30,
-      "candidate_count": 15,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 2,
-        "stale_kinds": [
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
       "endpoint_count": 10,
       "evidence_action": "maintainer-review-existing-evidence",
       "lane": "maintainer-review",
@@ -5660,8 +5505,8 @@
         "sse",
         "subnet-api"
       ],
-      "name": "dogelayer",
-      "netuid": 80,
+      "name": "ByteLeap",
+      "netuid": 128,
       "operational_interface_count": 1,
       "priority_score": 107,
       "profile_level": "operational",
@@ -5672,39 +5517,125 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-80-backprop-dashboard",
-        "sn-80-taomarketcap-dashboard",
-        "sn-80-taomarketcap-source-repo",
-        "sn-80-taomarketcap-website",
-        "sn-80-taopedia-article"
+        "sn-128-backprop-dashboard",
+        "sn-128-subnetradar-dashboard",
+        "sn-128-taomarketcap-dashboard",
+        "sn-128-taomarketcap-source-repo",
+        "sn-128-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [
-        "sn-80-website-common-health"
+        "sn-128-website-common-api",
+        "sn-128-website-common-health"
       ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-128-website-common-api",
+        "sn-128-website-common-health"
+      ],
+      "slug": "sn-128",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/128",
+        "https://backprop.finance/dtao/subnets/128-byteleap",
+        "https://byteleap.ai/",
+        "https://github.com/byteleapai/byteleap-Miner",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json",
+        "https://subnetradar.com/subnet/128"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 10,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 9,
+      "candidate_count": 25,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 9,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Targon",
+      "netuid": 4,
+      "operational_interface_count": 0,
+      "priority_score": 106,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-4-backprop-dashboard",
+        "sn-4-subnetradar-dashboard",
+        "sn-4-taomarketcap-dashboard",
+        "sn-4-taomarketcap-source-repo",
+        "sn-4-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
-        "sn-80-website-common-api"
+        "sn-4-website-common-openapi-json",
+        "sn-4-website-common-swagger",
+        "sn-4-website-common-swagger-json",
+        "sn-4-website-common-api",
+        "sn-4-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-80-website-common-health",
-        "sn-80-website-common-api"
+        "sn-4-website-common-openapi-json",
+        "sn-4-website-common-swagger",
+        "sn-4-website-common-swagger-json",
+        "sn-4-website-common-api",
+        "sn-4-website-common-health"
       ],
-      "slug": "sn-80",
+      "slug": "sn-4",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/80",
-        "https://backprop.finance/dtao/subnets/80-dogelayer",
-        "https://dogelayer.ai/",
-        "https://github.com/dogelayer-ai/dogelayer",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/80/subnet.json",
-        "https://taostats.io/subnets/80/metagraph"
+        "https://api.taomarketcap.com/public/v1/subnets/4",
+        "https://backprop.finance/dtao/subnets/4-targon",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_4/index.mdx",
+        "https://github.com/manifold-inc/targon",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/4/subnet.json",
+        "https://subnetradar.com/subnet/4",
+        "https://taomarketcap.com/subnets/4",
+        "https://targon.com/"
       ],
-      "stale_candidate_count": 1,
-      "surface_count": 10,
-      "verified_candidate_count": 12
+      "stale_candidate_count": 5,
+      "surface_count": 9,
+      "verified_candidate_count": 19
     },
     {
       "adapter_score": 8,
-      "candidate_count": 25,
+      "candidate_count": 26,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -5754,10 +5685,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-82-backprop-dashboard",
+        "sn-82-subnetradar-dashboard",
         "sn-82-taomarketcap-dashboard",
         "sn-82-taomarketcap-source-repo",
-        "sn-82-taomarketcap-website",
-        "sn-82-taopedia-article"
+        "sn-82-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -5782,88 +5713,16 @@
         "https://github.com/compelle/compelle-validator",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_82/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/82/subnet.json",
-        "https://taomarketcap.com/subnets/82",
-        "https://taostats.io/subnets/82/metagraph"
+        "https://subnetradar.com/subnet/82",
+        "https://taomarketcap.com/subnets/82"
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 18
-    },
-    {
-      "adapter_score": 30,
-      "candidate_count": 14,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 10,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "ByteLeap",
-      "netuid": 128,
-      "operational_interface_count": 1,
-      "priority_score": 106,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-128-backprop-dashboard",
-        "sn-128-taomarketcap-dashboard",
-        "sn-128-taomarketcap-source-repo",
-        "sn-128-taomarketcap-website",
-        "sn-128-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-128-website-common-api",
-        "sn-128-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-128-website-common-api",
-        "sn-128-website-common-health"
-      ],
-      "slug": "sn-128",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/128",
-        "https://backprop.finance/dtao/subnets/128-byteleap",
-        "https://byteleap.ai/",
-        "https://github.com/byteleapai/byteleap-Miner",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json",
-        "https://taostats.io/subnets/128/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 10,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 19
     },
     {
       "adapter_score": 29,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -5895,7 +5754,7 @@
       "name": "Almanac",
       "netuid": 41,
       "operational_interface_count": 1,
-      "priority_score": 105,
+      "priority_score": 106,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -5905,10 +5764,10 @@
       "review_state": "machine-generated",
       "sample_candidate_ids": [
         "sn-41-backprop-dashboard",
+        "sn-41-subnetradar-dashboard",
         "sn-41-taomarketcap-dashboard",
         "sn-41-taomarketcap-source-repo",
-        "sn-41-taomarketcap-website",
-        "sn-41-taopedia-article"
+        "sn-41-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [
         "sn-41-website-common-api",
@@ -5927,15 +5786,15 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx",
         "https://github.com/sportstensor/sn41",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json",
-        "https://taostats.io/subnets/41/metagraph"
+        "https://subnetradar.com/subnet/41"
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 29,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -5967,7 +5826,7 @@
       "name": "Synth",
       "netuid": 50,
       "operational_interface_count": 1,
-      "priority_score": 105,
+      "priority_score": 106,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -5978,9 +5837,9 @@
       "sample_candidate_ids": [
         "sn-50-backprop-dashboard",
         "sn-50-github-readme-mode-network-synth-subnet-subnet-api-1",
+        "sn-50-subnetradar-dashboard",
         "sn-50-taomarketcap-dashboard",
-        "sn-50-taomarketcap-source-repo",
-        "sn-50-taomarketcap-website"
+        "sn-50-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [
         "sn-50-github-readme-mode-network-synth-subnet-subnet-api-1",
@@ -6000,8 +5859,240 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx",
         "https://github.com/mode-network/synth-subnet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/50/subnet.json",
-        "https://synthdata.co/",
-        "https://taostats.io/subnets/50/metagraph"
+        "https://subnetradar.com/subnet/50",
+        "https://synthdata.co/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 9,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 15,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Swarm",
+      "netuid": 124,
+      "operational_interface_count": 1,
+      "priority_score": 106,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-124-backprop-dashboard",
+        "sn-124-github-readme-swarm-subnet-swarm-dashboard-1",
+        "sn-124-subnetradar-dashboard",
+        "sn-124-taomarketcap-dashboard",
+        "sn-124-taomarketcap-source-repo"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-124-website-common-api",
+        "sn-124-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-124-website-common-api",
+        "sn-124-website-common-health"
+      ],
+      "slug": "sn-124",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/124",
+        "https://backprop.finance/dtao/subnets/124-swarm",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_124/index.mdx",
+        "https://github.com/swarm-subnet/swarm",
+        "https://github.com/swarm-subnet/swarm/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/124/subnet.json",
+        "https://subnetradar.com/subnet/124",
+        "https://www.swarm124.com/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 9,
+      "verified_candidate_count": 13
+    },
+    {
+      "adapter_score": 13,
+      "candidate_count": 23,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 6,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 13,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Data Universe",
+      "netuid": 13,
+      "operational_interface_count": 0,
+      "priority_score": 105,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-13-backprop-dashboard",
+        "sn-13-github-readme-macrocosm-os-data-universe-dashboard-3",
+        "sn-13-github-readme-macrocosm-os-data-universe-docs-1",
+        "sn-13-github-readme-macrocosm-os-data-universe-subnet-api-2",
+        "sn-13-subnetradar-dashboard"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-13-website-common-openapi-json",
+        "sn-13-website-common-swagger",
+        "sn-13-website-common-swagger-json",
+        "sn-13-github-readme-macrocosm-os-data-universe-subnet-api-2",
+        "sn-13-website-common-api"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-13-website-common-openapi-json",
+        "sn-13-website-common-swagger",
+        "sn-13-website-common-swagger-json",
+        "sn-13-github-readme-macrocosm-os-data-universe-subnet-api-2",
+        "sn-13-website-common-api"
+      ],
+      "slug": "sn-13",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/13",
+        "https://backprop.finance/dtao/subnets/13-data-universe",
+        "https://datauniverse.macrocosmos.ai/",
+        "https://docs.macrocosmos.ai/product-and-services/gravity",
+        "https://docs.macrocosmos.ai/subnets/subnet-13-data-universe/macrocosmos-mcp",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_13/index.mdx",
+        "https://github.com/macrocosm-os/data-universe",
+        "https://github.com/macrocosm-os/data-universe/blob/main/README.md"
+      ],
+      "stale_candidate_count": 6,
+      "surface_count": 13,
+      "verified_candidate_count": 15
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "BitAds",
+      "netuid": 16,
+      "operational_interface_count": 1,
+      "priority_score": 105,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-16-backprop-dashboard",
+        "sn-16-subnetradar-dashboard",
+        "sn-16-taomarketcap-dashboard",
+        "sn-16-taomarketcap-source-repo",
+        "sn-16-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-16-website-common-api",
+        "sn-16-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-16-website-common-api",
+        "sn-16-website-common-health"
+      ],
+      "slug": "sn-16",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/16",
+        "https://backprop.finance/dtao/subnets/16-bitads",
+        "https://bitads.ai/",
+        "https://github.com/FirstTensorLabs/BitAds",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
+        "https://subnetradar.com/subnet/16"
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
@@ -6038,8 +6129,8 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Swarm",
-      "netuid": 124,
+      "name": "colosseum",
+      "netuid": 38,
       "operational_interface_count": 1,
       "priority_score": 105,
       "profile_level": "operational",
@@ -6050,121 +6141,322 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-124-backprop-dashboard",
-        "sn-124-github-readme-swarm-subnet-swarm-dashboard-1",
-        "sn-124-taomarketcap-dashboard",
-        "sn-124-taomarketcap-source-repo",
-        "sn-124-taomarketcap-website"
+        "sn-38-backprop-dashboard",
+        "sn-38-subnetradar-dashboard",
+        "sn-38-taomarketcap-dashboard",
+        "sn-38-taomarketcap-source-repo",
+        "sn-38-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [
-        "sn-124-website-common-api",
-        "sn-124-website-common-health"
+        "sn-38-website-common-api",
+        "sn-38-website-common-health"
       ],
       "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [
-        "sn-124-website-common-api",
-        "sn-124-website-common-health"
+        "sn-38-website-common-api",
+        "sn-38-website-common-health"
       ],
-      "slug": "sn-124",
+      "slug": "sn-38",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/124",
-        "https://backprop.finance/dtao/subnets/124-swarm",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_124/index.mdx",
-        "https://github.com/swarm-subnet/swarm",
-        "https://github.com/swarm-subnet/swarm/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/124/subnet.json",
-        "https://www.swarm124.com/"
+        "https://api.taomarketcap.com/public/v1/subnets/38",
+        "https://backprop.finance/dtao/subnets/38-colosseum",
+        "https://github.com/TAO-Colosseum/tao-colosseum-subnet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/38/subnet.json",
+        "https://subnetradar.com/subnet/38",
+        "https://www.taocolosseum.com/"
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
       "verified_candidate_count": 12
     },
     {
-      "adapter_score": 9,
-      "candidate_count": 24,
+      "adapter_score": 29,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
+        "candidate_count": 2,
         "kinds_with_candidates": [
-          "openapi",
           "subnet-api"
         ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
+        "live_kinds": [
           "subnet-api"
         ],
-        "stale_or_failed_count": 5,
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
       "endpoint_count": 9,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
       "missing_kinds": [
         "data-artifact",
-        "openapi",
         "sse",
         "subnet-api"
       ],
-      "name": "Targon",
-      "netuid": 4,
-      "operational_interface_count": 0,
-      "priority_score": 104,
-      "profile_level": "identity-complete",
+      "name": "Leadpoet",
+      "netuid": 71,
+      "operational_interface_count": 1,
+      "priority_score": 105,
+      "profile_level": "operational",
       "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
+        "adapter-candidate",
+        "needs-maintainer-review"
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
+      "review_state": "machine-generated",
       "sample_candidate_ids": [
-        "sn-4-backprop-dashboard",
-        "sn-4-taomarketcap-dashboard",
-        "sn-4-taomarketcap-source-repo",
-        "sn-4-taomarketcap-website",
-        "sn-4-taopedia-article"
+        "sn-71-backprop-dashboard",
+        "sn-71-subnetradar-dashboard",
+        "sn-71-taomarketcap-dashboard",
+        "sn-71-taomarketcap-source-repo",
+        "sn-71-taomarketcap-website"
       ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-4-website-common-openapi-json",
-        "sn-4-website-common-swagger",
-        "sn-4-website-common-swagger-json",
-        "sn-4-website-common-api",
-        "sn-4-website-common-health"
+      "sample_live_candidate_ids": [
+        "sn-71-website-common-api",
+        "sn-71-website-common-health"
       ],
+      "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [
-        "sn-4-website-common-openapi-json",
-        "sn-4-website-common-swagger",
-        "sn-4-website-common-swagger-json",
-        "sn-4-website-common-api",
-        "sn-4-website-common-health"
+        "sn-71-website-common-api",
+        "sn-71-website-common-health"
       ],
-      "slug": "sn-4",
+      "slug": "sn-71",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/4",
-        "https://backprop.finance/dtao/subnets/4-targon",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_4/index.mdx",
-        "https://github.com/manifold-inc/targon",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/4/subnet.json",
-        "https://taomarketcap.com/subnets/4",
-        "https://taostats.io/subnets/4/metagraph",
-        "https://targon.com/"
+        "https://api.taomarketcap.com/public/v1/subnets/71",
+        "https://backprop.finance/dtao/subnets/71-leadpoet",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx",
+        "https://github.com/leadpoet/leadpoet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/71/subnet.json",
+        "https://leadpoet.com/",
+        "https://subnetradar.com/subnet/71"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Liquidity",
+      "netuid": 77,
+      "operational_interface_count": 1,
+      "priority_score": 105,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-77-backprop-dashboard",
+        "sn-77-subnetradar-dashboard",
+        "sn-77-taomarketcap-dashboard",
+        "sn-77-taomarketcap-source-repo",
+        "sn-77-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-77-website-common-api",
+        "sn-77-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-77-website-common-api",
+        "sn-77-website-common-health"
+      ],
+      "slug": "sn-77",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/77",
+        "https://backprop.finance/dtao/subnets/77-liquidity",
+        "https://github.com/creativebuilds/sn77",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/77/subnet.json",
+        "https://sn77.xyz/",
+        "https://subnetradar.com/subnet/77"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 9,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "CliqueAI",
+      "netuid": 83,
+      "operational_interface_count": 1,
+      "priority_score": 105,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-83-backprop-dashboard",
+        "sn-83-subnetradar-dashboard",
+        "sn-83-taomarketcap-dashboard",
+        "sn-83-taomarketcap-source-repo",
+        "sn-83-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-83-website-common-api",
+        "sn-83-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-83-website-common-api",
+        "sn-83-website-common-health"
+      ],
+      "slug": "sn-83",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/83",
+        "https://backprop.finance/dtao/subnets/83-cliqueai",
+        "https://cliqueai.toptensor.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/83/subnet.json",
+        "https://github.com/toptensor/CliqueAI",
+        "https://subnetradar.com/subnet/83"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 9,
+      "verified_candidate_count": 12
+    },
+    {
+      "adapter_score": 29,
+      "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 2,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 2,
+        "reviewable_count": 2,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 65,
+      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
+      "curation_level": "machine-verified",
+      "direct_submission_kinds": [],
+      "endpoint_count": 9,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "maintainer-review",
+      "manual_review_required": true,
+      "missing_kinds": [
+        "data-artifact",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Beam",
+      "netuid": 105,
+      "operational_interface_count": 1,
+      "priority_score": 105,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "machine-generated",
+      "sample_candidate_ids": [
+        "sn-105-backprop-dashboard",
+        "sn-105-subnetradar-dashboard",
+        "sn-105-taomarketcap-dashboard",
+        "sn-105-taomarketcap-source-repo",
+        "sn-105-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-105-website-common-api",
+        "sn-105-website-common-health"
+      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-105-website-common-api",
+        "sn-105-website-common-health"
+      ],
+      "slug": "sn-105",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/105",
+        "https://b1m.ai/",
+        "https://backprop.finance/dtao/subnets/105-beam",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx",
+        "https://github.com/orgs/Beam-Network/repositories",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json",
+        "https://subnetradar.com/subnet/105"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 9,
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 9,
@@ -6220,8 +6512,8 @@
         "sn-9-backprop-dashboard",
         "sn-9-github-readme-macrocosm-os-iota-dashboard-1",
         "sn-9-github-readme-macrocosm-os-iota-docs-2",
-        "sn-9-taomarketcap-dashboard",
-        "sn-9-taomarketcap-source-repo"
+        "sn-9-subnetradar-dashboard",
+        "sn-9-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -6240,200 +6532,22 @@
       ],
       "slug": "sn-9",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/9",
         "https://backprop.finance/dtao/subnets/9-iota",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_9/index.mdx",
         "https://github.com/macrocosm-os/iota",
         "https://github.com/macrocosm-os/iota/blob/main/README.md",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/9/subnet.json",
         "https://iota.macrocosmos.ai/",
-        "https://iota.macrocosmos.ai/dashboard/mainnet"
+        "https://iota.macrocosmos.ai/dashboard/mainnet",
+        "https://subnetradar.com/subnet/9"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 16
-    },
-    {
-      "adapter_score": 8,
-      "candidate_count": 24,
-      "candidate_evidence_summary": {
-        "candidate_count": 6,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 6,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "ItsAI",
-      "netuid": 32,
-      "operational_interface_count": 0,
-      "priority_score": 104,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-32-backprop-dashboard",
-        "sn-32-taomarketcap-dashboard",
-        "sn-32-taomarketcap-source-repo",
-        "sn-32-taomarketcap-website",
-        "sn-32-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-32-website-link-its-ai-org-subnet-api-5"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-32-website-common-openapi-json",
-        "sn-32-website-common-swagger-json",
-        "sn-32-website-common-swagger",
-        "sn-32-website-common-api",
-        "sn-32-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-32-website-link-its-ai-org-subnet-api-5",
-        "sn-32-website-common-openapi-json",
-        "sn-32-website-common-swagger-json",
-        "sn-32-website-common-swagger",
-        "sn-32-website-common-api"
-      ],
-      "slug": "sn-32",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/32",
-        "https://backprop.finance/dtao/subnets/32-itsai",
-        "https://github.com/It-s-AI/llm-detection",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_32/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/32/subnet.json",
-        "https://its-ai.org/en",
-        "https://taomarketcap.com/subnets/32",
-        "https://taostats.io/subnets/32/metagraph"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 18
-    },
-    {
-      "adapter_score": 13,
-      "candidate_count": 22,
-      "candidate_evidence_summary": {
-        "candidate_count": 6,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 6,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 6,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 13,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Data Universe",
-      "netuid": 13,
-      "operational_interface_count": 0,
-      "priority_score": 103,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-13-backprop-dashboard",
-        "sn-13-github-readme-macrocosm-os-data-universe-dashboard-3",
-        "sn-13-github-readme-macrocosm-os-data-universe-docs-1",
-        "sn-13-github-readme-macrocosm-os-data-universe-subnet-api-2",
-        "sn-13-taomarketcap-dashboard"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-13-website-common-openapi-json",
-        "sn-13-website-common-swagger",
-        "sn-13-website-common-swagger-json",
-        "sn-13-github-readme-macrocosm-os-data-universe-subnet-api-2",
-        "sn-13-website-common-api"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-13-website-common-openapi-json",
-        "sn-13-website-common-swagger",
-        "sn-13-website-common-swagger-json",
-        "sn-13-github-readme-macrocosm-os-data-universe-subnet-api-2",
-        "sn-13-website-common-api"
-      ],
-      "slug": "sn-13",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/13",
-        "https://backprop.finance/dtao/subnets/13-data-universe",
-        "https://datauniverse.macrocosmos.ai/",
-        "https://docs.macrocosmos.ai/product-and-services/gravity",
-        "https://docs.macrocosmos.ai/subnets/subnet-13-data-universe/macrocosmos-mcp",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_13/index.mdx",
-        "https://github.com/macrocosm-os/data-universe",
-        "https://github.com/macrocosm-os/data-universe/blob/main/README.md"
-      ],
-      "stale_candidate_count": 6,
-      "surface_count": 13,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 17
     },
     {
       "adapter_score": 9,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -6472,7 +6586,7 @@
       "name": "blockmachine",
       "netuid": 19,
       "operational_interface_count": 0,
-      "priority_score": 103,
+      "priority_score": 104,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -6484,9 +6598,9 @@
       "sample_candidate_ids": [
         "sn-19-backprop-dashboard",
         "sn-19-github-readme-taostat-blockmachine-docs-1",
+        "sn-19-subnetradar-dashboard",
         "sn-19-taomarketcap-dashboard",
-        "sn-19-taomarketcap-source-repo",
-        "sn-19-taomarketcap-website"
+        "sn-19-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -6512,15 +6626,15 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_19/index.mdx",
         "https://github.com/taostat/blockmachine",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/19/subnet.json",
-        "https://taomarketcap.com/subnets/19"
+        "https://subnetradar.com/subnet/19"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
     },
     {
       "adapter_score": 9,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -6559,7 +6673,7 @@
       "name": "Mainframe",
       "netuid": 25,
       "operational_interface_count": 0,
-      "priority_score": 103,
+      "priority_score": 104,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -6573,7 +6687,7 @@
         "sn-25-github-readme-macrocosm-os-mainframe-dashboard-1",
         "sn-25-github-readme-macrocosm-os-mainframe-docs-2",
         "sn-25-github-readme-macrocosm-os-mainframe-subnet-api-3",
-        "sn-25-taomarketcap-dashboard"
+        "sn-25-subnetradar-dashboard"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -6599,15 +6713,15 @@
         "https://github.com/macrocosm-os/mainframe/blob/main/README.md",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/25/subnet.json",
         "https://macrocosmos.ai/sn25",
-        "https://taomarketcap.com/subnets/25"
+        "https://subnetradar.com/subnet/25"
       ],
       "stale_candidate_count": 6,
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 9,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -6646,7 +6760,7 @@
       "name": "Talisman AI",
       "netuid": 45,
       "operational_interface_count": 0,
-      "priority_score": 103,
+      "priority_score": 104,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -6657,10 +6771,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-45-backprop-dashboard",
+        "sn-45-subnetradar-dashboard",
         "sn-45-taomarketcap-dashboard",
         "sn-45-taomarketcap-source-repo",
-        "sn-45-taomarketcap-website",
-        "sn-45-taopedia-article"
+        "sn-45-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -6685,11 +6799,363 @@
         "https://github.com/Team-Rizzo/talisman-ai",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_45/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/45/subnet.json",
-        "https://taomarketcap.com/subnets/45",
-        "https://taostats.io/subnets/45/metagraph"
+        "https://subnetradar.com/subnet/45",
+        "https://taomarketcap.com/subnets/45"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "AdTAO",
+      "netuid": 21,
+      "operational_interface_count": 0,
+      "priority_score": 103,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-21-backprop-dashboard",
+        "sn-21-subnetradar-dashboard",
+        "sn-21-taomarketcap-dashboard",
+        "sn-21-taomarketcap-source-repo",
+        "sn-21-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-21-website-common-openapi-json",
+        "sn-21-website-common-swagger",
+        "sn-21-website-common-swagger-json",
+        "sn-21-website-common-api",
+        "sn-21-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-21-website-common-openapi-json",
+        "sn-21-website-common-swagger",
+        "sn-21-website-common-swagger-json",
+        "sn-21-website-common-api",
+        "sn-21-website-common-health"
+      ],
+      "slug": "sn-21",
+      "source_urls": [
+        "https://adtao.io/",
+        "https://api.taomarketcap.com/public/v1/subnets/21",
+        "https://backprop.finance/dtao/subnets/21-adtao",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_21/index.mdx",
+        "https://github.com/ippcteam/SN21-adtao",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/21/subnet.json",
+        "https://subnetradar.com/subnet/21",
+        "https://taomarketcap.com/subnets/21"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ItsAI",
+      "netuid": 32,
+      "operational_interface_count": 0,
+      "priority_score": 103,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-32-backprop-dashboard",
+        "sn-32-subnetradar-dashboard",
+        "sn-32-taomarketcap-dashboard",
+        "sn-32-taomarketcap-source-repo",
+        "sn-32-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-32-website-link-its-ai-org-subnet-api-5"
+      ],
+      "sample_stale_candidate_ids": [
+        "sn-32-website-common-openapi-json",
+        "sn-32-website-common-swagger-json",
+        "sn-32-website-common-swagger",
+        "sn-32-website-common-api",
+        "sn-32-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-32-website-link-its-ai-org-subnet-api-5",
+        "sn-32-website-common-openapi-json",
+        "sn-32-website-common-swagger-json",
+        "sn-32-website-common-swagger",
+        "sn-32-website-common-api"
+      ],
+      "slug": "sn-32",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/32",
+        "https://backprop.finance/dtao/subnets/32-itsai",
+        "https://github.com/It-s-AI/llm-detection",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_32/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/32/subnet.json",
+        "https://its-ai.org/en",
+        "https://subnetradar.com/subnet/32",
+        "https://taomarketcap.com/subnets/32"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 18
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Quantum Compute",
+      "netuid": 48,
+      "operational_interface_count": 0,
+      "priority_score": 103,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-48-backprop-dashboard",
+        "sn-48-subnetradar-dashboard",
+        "sn-48-taomarketcap-dashboard",
+        "sn-48-taomarketcap-source-repo",
+        "sn-48-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-48-website-common-openapi-json",
+        "sn-48-website-common-swagger",
+        "sn-48-website-common-swagger-json",
+        "sn-48-website-common-api",
+        "sn-48-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-48-website-common-openapi-json",
+        "sn-48-website-common-swagger",
+        "sn-48-website-common-swagger-json",
+        "sn-48-website-common-api",
+        "sn-48-website-common-health"
+      ],
+      "slug": "sn-48",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/48",
+        "https://backprop.finance/dtao/subnets/48-quantum-compute",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_48/index.mdx",
+        "https://github.com/qbittensor-labs/quantum-compute",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/48/subnet.json",
+        "https://subnetradar.com/subnet/48",
+        "https://taomarketcap.com/subnets/48",
+        "https://www.qbittensorlabs.com/"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
+      "verified_candidate_count": 17
+    },
+    {
+      "adapter_score": 7,
+      "candidate_count": 24,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Enigma",
+      "netuid": 63,
+      "operational_interface_count": 0,
+      "priority_score": 103,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-63-backprop-dashboard",
+        "sn-63-subnetradar-dashboard",
+        "sn-63-taomarketcap-dashboard",
+        "sn-63-taomarketcap-source-repo",
+        "sn-63-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-63-website-common-openapi-json",
+        "sn-63-website-common-swagger",
+        "sn-63-website-common-swagger-json",
+        "sn-63-website-common-api",
+        "sn-63-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-63-website-common-openapi-json",
+        "sn-63-website-common-swagger",
+        "sn-63-website-common-swagger-json",
+        "sn-63-website-common-api",
+        "sn-63-website-common-health"
+      ],
+      "slug": "sn-63",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/63",
+        "https://backprop.finance/dtao/subnets/63-enigma",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_63/index.mdx",
+        "https://github.com/qbittensor-labs/enigma",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/63/subnet.json",
+        "https://subnetradar.com/subnet/63",
+        "https://taomarketcap.com/subnets/63",
+        "https://www.qbittensorlabs.com/"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 7,
       "verified_candidate_count": 17
     },
     {
@@ -6744,10 +7210,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-103-backprop-dashboard",
+        "sn-103-subnetradar-dashboard",
         "sn-103-taomarketcap-dashboard",
         "sn-103-taomarketcap-source-repo",
-        "sn-103-taomarketcap-website",
-        "sn-103-taopedia-article"
+        "sn-103-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -6772,637 +7238,16 @@
         "https://github.com/Djinn-Inc/djinn",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_103/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/103/subnet.json",
-        "https://taomarketcap.com/subnets/103",
-        "https://taostats.io/subnets/103/metagraph"
+        "https://subnetradar.com/subnet/103",
+        "https://taomarketcap.com/subnets/103"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 17
-    },
-    {
-      "adapter_score": 29,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 9,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "BitAds",
-      "netuid": 16,
-      "operational_interface_count": 1,
-      "priority_score": 103,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-16-backprop-dashboard",
-        "sn-16-taomarketcap-dashboard",
-        "sn-16-taomarketcap-source-repo",
-        "sn-16-taomarketcap-website",
-        "sn-16-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health"
-      ],
-      "slug": "sn-16",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/16",
-        "https://backprop.finance/dtao/subnets/16-bitads",
-        "https://bitads.ai/",
-        "https://github.com/FirstTensorLabs/BitAds",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
-        "https://taostats.io/subnets/16/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 29,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 9,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Leadpoet",
-      "netuid": 71,
-      "operational_interface_count": 1,
-      "priority_score": 103,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-71-backprop-dashboard",
-        "sn-71-taomarketcap-dashboard",
-        "sn-71-taomarketcap-source-repo",
-        "sn-71-taomarketcap-website",
-        "sn-71-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-71-website-common-api",
-        "sn-71-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-71-website-common-api",
-        "sn-71-website-common-health"
-      ],
-      "slug": "sn-71",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/71",
-        "https://backprop.finance/dtao/subnets/71-leadpoet",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx",
-        "https://github.com/leadpoet/leadpoet",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/71/subnet.json",
-        "https://leadpoet.com/",
-        "https://taostats.io/subnets/71/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 29,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 9,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Liquidity",
-      "netuid": 77,
-      "operational_interface_count": 1,
-      "priority_score": 103,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-77-backprop-dashboard",
-        "sn-77-taomarketcap-dashboard",
-        "sn-77-taomarketcap-source-repo",
-        "sn-77-taomarketcap-website",
-        "sn-77-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-77-website-common-api",
-        "sn-77-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-77-website-common-api",
-        "sn-77-website-common-health"
-      ],
-      "slug": "sn-77",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/77",
-        "https://backprop.finance/dtao/subnets/77-liquidity",
-        "https://github.com/creativebuilds/sn77",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/77/subnet.json",
-        "https://sn77.xyz/",
-        "https://taostats.io/subnets/77/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 29,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 9,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "CliqueAI",
-      "netuid": 83,
-      "operational_interface_count": 1,
-      "priority_score": 103,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-83-backprop-dashboard",
-        "sn-83-taomarketcap-dashboard",
-        "sn-83-taomarketcap-source-repo",
-        "sn-83-taomarketcap-website",
-        "sn-83-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-83-website-common-api",
-        "sn-83-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-83-website-common-api",
-        "sn-83-website-common-health"
-      ],
-      "slug": "sn-83",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/83",
-        "https://backprop.finance/dtao/subnets/83-cliqueai",
-        "https://cliqueai.toptensor.ai/",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/83/subnet.json",
-        "https://github.com/toptensor/CliqueAI",
-        "https://taostats.io/subnets/83/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 11
-    },
-    {
-      "adapter_score": 29,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 2,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 65,
-      "contribution_hint": "Maintainer should review current machine-verified surfaces and promote only source-backed entries.",
-      "curation_level": "machine-verified",
-      "direct_submission_kinds": [],
-      "endpoint_count": 9,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "maintainer-review",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Beam",
-      "netuid": 105,
-      "operational_interface_count": 1,
-      "priority_score": 103,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "machine-generated",
-      "sample_candidate_ids": [
-        "sn-105-backprop-dashboard",
-        "sn-105-taomarketcap-dashboard",
-        "sn-105-taomarketcap-source-repo",
-        "sn-105-taomarketcap-website",
-        "sn-105-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-105-website-common-api",
-        "sn-105-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-105-website-common-api",
-        "sn-105-website-common-health"
-      ],
-      "slug": "sn-105",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/105",
-        "https://b1m.ai/",
-        "https://backprop.finance/dtao/subnets/105-beam",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx",
-        "https://github.com/orgs/Beam-Network/repositories",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json",
-        "https://taostats.io/subnets/105/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 18
     },
     {
       "adapter_score": 7,
-      "candidate_count": 23,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "AdTAO",
-      "netuid": 21,
-      "operational_interface_count": 0,
-      "priority_score": 102,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-21-backprop-dashboard",
-        "sn-21-taomarketcap-dashboard",
-        "sn-21-taomarketcap-source-repo",
-        "sn-21-taomarketcap-website",
-        "sn-21-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-21-website-common-openapi-json",
-        "sn-21-website-common-swagger",
-        "sn-21-website-common-swagger-json",
-        "sn-21-website-common-api",
-        "sn-21-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-21-website-common-openapi-json",
-        "sn-21-website-common-swagger",
-        "sn-21-website-common-swagger-json",
-        "sn-21-website-common-api",
-        "sn-21-website-common-health"
-      ],
-      "slug": "sn-21",
-      "source_urls": [
-        "https://adtao.io/",
-        "https://api.taomarketcap.com/public/v1/subnets/21",
-        "https://backprop.finance/dtao/subnets/21-adtao",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_21/index.mdx",
-        "https://github.com/ippcteam/SN21-adtao",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/21/subnet.json",
-        "https://taomarketcap.com/subnets/21",
-        "https://taostats.io/subnets/21/metagraph"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 15
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 23,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Quantum Compute",
-      "netuid": 48,
-      "operational_interface_count": 0,
-      "priority_score": 102,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-48-backprop-dashboard",
-        "sn-48-taomarketcap-dashboard",
-        "sn-48-taomarketcap-source-repo",
-        "sn-48-taomarketcap-website",
-        "sn-48-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-48-website-common-openapi-json",
-        "sn-48-website-common-swagger",
-        "sn-48-website-common-swagger-json",
-        "sn-48-website-common-api",
-        "sn-48-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-48-website-common-openapi-json",
-        "sn-48-website-common-swagger",
-        "sn-48-website-common-swagger-json",
-        "sn-48-website-common-api",
-        "sn-48-website-common-health"
-      ],
-      "slug": "sn-48",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/48",
-        "https://backprop.finance/dtao/subnets/48-quantum-compute",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_48/index.mdx",
-        "https://github.com/qbittensor-labs/quantum-compute",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/48/subnet.json",
-        "https://taomarketcap.com/subnets/48",
-        "https://taostats.io/subnets/48/metagraph",
-        "https://www.qbittensorlabs.com/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 16
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 23,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Enigma",
-      "netuid": 63,
-      "operational_interface_count": 0,
-      "priority_score": 102,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-63-backprop-dashboard",
-        "sn-63-taomarketcap-dashboard",
-        "sn-63-taomarketcap-source-repo",
-        "sn-63-taomarketcap-website",
-        "sn-63-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-63-website-common-openapi-json",
-        "sn-63-website-common-swagger",
-        "sn-63-website-common-swagger-json",
-        "sn-63-website-common-api",
-        "sn-63-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-63-website-common-openapi-json",
-        "sn-63-website-common-swagger",
-        "sn-63-website-common-swagger-json",
-        "sn-63-website-common-api",
-        "sn-63-website-common-health"
-      ],
-      "slug": "sn-63",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/63",
-        "https://backprop.finance/dtao/subnets/63-enigma",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_63/index.mdx",
-        "https://github.com/qbittensor-labs/enigma",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/63/subnet.json",
-        "https://taomarketcap.com/subnets/63",
-        "https://taostats.io/subnets/63/metagraph",
-        "https://www.qbittensorlabs.com/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 7,
-      "verified_candidate_count": 16
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -7441,7 +7286,7 @@
       "name": "sundae_bar",
       "netuid": 121,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -7452,10 +7297,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-121-backprop-dashboard",
+        "sn-121-subnetradar-dashboard",
         "sn-121-taomarketcap-dashboard",
         "sn-121-taomarketcap-source-repo",
-        "sn-121-taomarketcap-website",
-        "sn-121-taopedia-article"
+        "sn-121-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -7479,17 +7324,17 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_121/index.mdx",
         "https://github.com/sundae-bar/bittensor-subnet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/121/subnet.json",
+        "https://subnetradar.com/subnet/121",
         "https://taomarketcap.com/subnets/121",
-        "https://taostats.io/subnets/121/metagraph",
         "https://www.sundaebar.ai/"
       ],
       "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
       "adapter_score": 9,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "candidate_evidence_summary": {
         "candidate_count": 6,
         "kinds_with_candidates": [
@@ -7528,7 +7373,7 @@
       "name": "ORO",
       "netuid": 15,
       "operational_interface_count": 0,
-      "priority_score": 100,
+      "priority_score": 101,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -7542,7 +7387,7 @@
         "sn-15-github-readme-oro-ai-oro-dashboard-1",
         "sn-15-github-readme-oro-ai-oro-docs-2",
         "sn-15-github-readme-oro-ai-oro-subnet-api-3",
-        "sn-15-taomarketcap-dashboard"
+        "sn-15-subnetradar-dashboard"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -7561,18 +7406,450 @@
       ],
       "slug": "sn-15",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/15",
         "https://backprop.finance/dtao/subnets/15-oro",
         "https://docs.oroagents.com/docs/miners/quick-start",
         "https://github.com/ORO-AI/oro",
         "https://github.com/ORO-AI/oro/blob/main/README.md",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_15/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/15/subnet.json",
-        "https://oroagents.com/"
+        "https://oroagents.com/",
+        "https://subnetradar.com/subnet/15"
       ],
       "stale_candidate_count": 6,
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "source-repo"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 7,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "EfficientFrontier",
+      "netuid": 53,
+      "operational_interface_count": 0,
+      "priority_score": 101,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-53-backprop-dashboard",
+        "sn-53-subnetradar-dashboard",
+        "sn-53-taomarketcap-dashboard",
+        "sn-53-taomarketcap-source-repo",
+        "sn-53-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-53-taomarketcap-source-repo"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-53-taomarketcap-source-repo"
+      ],
+      "slug": "efficientfrontier",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/53",
+        "https://backprop.finance/dtao/subnets/53-efficientfrontier",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
+        "https://subnetradar.com/subnet/53",
+        "https://t.signalplus.com/mining",
+        "https://www.signalplus.com/"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 7,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 9,
+      "candidate_count": 22,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 9,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ForeverMoney",
+      "netuid": 98,
+      "operational_interface_count": 0,
+      "priority_score": 101,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-98-backprop-dashboard",
+        "sn-98-subnetradar-dashboard",
+        "sn-98-taomarketcap-dashboard",
+        "sn-98-taomarketcap-source-repo",
+        "sn-98-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-98-website-common-openapi-json",
+        "sn-98-website-common-swagger",
+        "sn-98-website-common-swagger-json",
+        "sn-98-website-common-api",
+        "sn-98-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-98-website-common-openapi-json",
+        "sn-98-website-common-swagger",
+        "sn-98-website-common-swagger-json",
+        "sn-98-website-common-api",
+        "sn-98-website-common-health"
+      ],
+      "slug": "sn-98",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/98",
+        "https://backprop.finance/dtao/subnets/98-forevermoney",
+        "https://forevermoney.ai/",
+        "https://github.com/SN98-ForeverMoney/forever-money",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_98/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/98/subnet.json",
+        "https://subnetradar.com/subnet/98",
+        "https://taomarketcap.com/subnets/98"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 9,
+      "verified_candidate_count": 16
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 6,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "Academia",
+      "netuid": 109,
+      "operational_interface_count": 0,
+      "priority_score": 101,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-109-backprop-dashboard",
+        "sn-109-subnetradar-dashboard",
+        "sn-109-taomarketcap-dashboard",
+        "sn-109-taomarketcap-source-repo",
+        "sn-109-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-109",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/109",
+        "https://backprop.finance/dtao/subnets/109-academia",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_109/index.mdx",
+        "https://github.com/fx-integral/academia",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/109/subnet.json",
+        "https://subnetradar.com/subnet/109",
+        "https://taomarketcap.com/subnets/109"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 6,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 6,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "HashiChain",
+      "netuid": 115,
+      "operational_interface_count": 0,
+      "priority_score": 101,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-115-backprop-dashboard",
+        "sn-115-subnetradar-dashboard",
+        "sn-115-taomarketcap-dashboard",
+        "sn-115-taomarketcap-source-repo",
+        "sn-115-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-115",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/115",
+        "https://backprop.finance/dtao/subnets/115-hashichain",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_115/index.mdx",
+        "https://github.com/hashi115/hashichain",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/115/subnet.json",
+        "https://subnetradar.com/subnet/115",
+        "https://taomarketcap.com/subnets/115"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 6,
+      "verified_candidate_count": 7
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "source-repo"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "source-repo"
+      ],
+      "endpoint_count": 6,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "source-repo",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "TaoLend",
+      "netuid": 116,
+      "operational_interface_count": 0,
+      "priority_score": 101,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-source-repo"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-116-backprop-dashboard",
+        "sn-116-subnetradar-dashboard",
+        "sn-116-taomarketcap-dashboard",
+        "sn-116-taopedia-article",
+        "sn-116-taostats-metagraph"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-116-tensorplex-source-repo-1"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-116-tensorplex-source-repo-1"
+      ],
+      "slug": "taolend",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/116",
+        "https://backprop.finance/dtao/subnets/116-hard-sign",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json",
+        "https://subnetradar.com/subnet/116",
+        "https://taolend.io/"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 6,
+      "verified_candidate_count": 6
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 7,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 40,
+      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "website"
+      ],
+      "endpoint_count": 6,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api",
+        "website"
+      ],
+      "name": "MANTIS",
+      "netuid": 123,
+      "operational_interface_count": 0,
+      "priority_score": 101,
+      "profile_level": "directory-only",
+      "reason_codes": [
+        "directory-only-profile",
+        "missing-website"
+      ],
+      "recommended_action": "submit official docs, website, or source repository evidence",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-123-backprop-dashboard",
+        "sn-123-subnetradar-dashboard",
+        "sn-123-taomarketcap-dashboard",
+        "sn-123-taomarketcap-source-repo",
+        "sn-123-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-123",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/123",
+        "https://backprop.finance/dtao/subnets/123-mantis",
+        "https://github.com/Barbariandev/MANTIS",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/123/subnet.json",
+        "https://subnetradar.com/subnet/123",
+        "https://taomarketcap.com/subnets/123"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 6,
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 9,
@@ -7612,8 +7889,8 @@
         "sse",
         "subnet-api"
       ],
-      "name": "ForeverMoney",
-      "netuid": 98,
+      "name": "Apex",
+      "netuid": 1,
       "operational_interface_count": 0,
       "priority_score": 100,
       "profile_level": "identity-complete",
@@ -7625,45 +7902,45 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-98-backprop-dashboard",
-        "sn-98-taomarketcap-dashboard",
-        "sn-98-taomarketcap-source-repo",
-        "sn-98-taomarketcap-website",
-        "sn-98-taopedia-article"
+        "sn-1-backprop-dashboard",
+        "sn-1-github-readme-macrocosm-os-apex-docs-1",
+        "sn-1-subnetradar-dashboard",
+        "sn-1-taomarketcap-dashboard",
+        "sn-1-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
-        "sn-98-website-common-openapi-json",
-        "sn-98-website-common-swagger",
-        "sn-98-website-common-swagger-json",
-        "sn-98-website-common-api",
-        "sn-98-website-common-health"
+        "sn-1-website-common-openapi-json",
+        "sn-1-website-common-swagger",
+        "sn-1-website-common-swagger-json",
+        "sn-1-website-common-api",
+        "sn-1-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-98-website-common-openapi-json",
-        "sn-98-website-common-swagger",
-        "sn-98-website-common-swagger-json",
-        "sn-98-website-common-api",
-        "sn-98-website-common-health"
+        "sn-1-website-common-openapi-json",
+        "sn-1-website-common-swagger",
+        "sn-1-website-common-swagger-json",
+        "sn-1-website-common-api",
+        "sn-1-website-common-health"
       ],
-      "slug": "sn-98",
+      "slug": "sn-1",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/98",
-        "https://backprop.finance/dtao/subnets/98-forevermoney",
-        "https://forevermoney.ai/",
-        "https://github.com/SN98-ForeverMoney/forever-money",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_98/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/98/subnet.json",
-        "https://taomarketcap.com/subnets/98",
-        "https://taostats.io/subnets/98/metagraph"
+        "https://apex.macrocosmos.ai/",
+        "https://api.taomarketcap.com/public/v1/subnets/1",
+        "https://backprop.finance/dtao/subnets/1-apex",
+        "https://docs.macrocosmos.ai/subnets/subnet-1-apex",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_1_apex/index.mdx",
+        "https://github.com/macrocosm-os/apex",
+        "https://github.com/macrocosm-os/apex/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/1/subnet.json"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 7,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -7704,7 +7981,7 @@
       "name": "Vidaio",
       "netuid": 85,
       "operational_interface_count": 0,
-      "priority_score": 99,
+      "priority_score": 100,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -7715,10 +7992,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-85-backprop-dashboard",
+        "sn-85-subnetradar-dashboard",
         "sn-85-taomarketcap-dashboard",
         "sn-85-taomarketcap-source-repo",
-        "sn-85-taomarketcap-website",
-        "sn-85-taopedia-article"
+        "sn-85-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [
         "sn-85-website-common-swagger",
@@ -7743,13 +8020,83 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_85/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/85/subnet.json",
         "https://github.com/vidaio-subnet/vidaio-subnet",
+        "https://subnetradar.com/subnet/85",
         "https://taomarketcap.com/subnets/85",
-        "https://taostats.io/subnets/85/metagraph",
         "https://vidaio.io/"
       ],
       "stale_candidate_count": 2,
       "surface_count": 7,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 8,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Basilica",
+      "netuid": 39,
+      "operational_interface_count": 0,
+      "priority_score": 99,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "needs-review",
+      "sample_candidate_ids": [
+        "sn-39-backprop-dashboard",
+        "sn-39-subnetradar-dashboard",
+        "sn-39-taomarketcap-dashboard",
+        "sn-39-taomarketcap-source-repo",
+        "sn-39-taopedia-article"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-39",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/39",
+        "https://backprop.finance/dtao/subnets/39-deprecated",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_39/index.mdx",
+        "https://github.com/one-covenant/basilica",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/39/subnet.json",
+        "https://subnetradar.com/subnet/39",
+        "https://taomarketcap.com/subnets/39",
+        "https://www.basilica.ai/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 8,
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 0,
@@ -7766,55 +8113,56 @@
         "unverified_kinds": []
       },
       "completeness_score": 40,
-      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
       "curation_level": "maintainer-reviewed",
       "direct_submission_kinds": [
-        "website"
+        "source-repo"
       ],
-      "endpoint_count": 6,
+      "endpoint_count": 8,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
         "data-artifact",
         "openapi",
+        "source-repo",
         "sse",
-        "subnet-api",
-        "website"
+        "subnet-api"
       ],
-      "name": "Academia",
-      "netuid": 109,
+      "name": "Luminar Network",
+      "netuid": 87,
       "operational_interface_count": 0,
       "priority_score": 99,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
-        "missing-website"
+        "missing-source-repo"
       ],
       "recommended_action": "submit official docs, website, or source repository evidence",
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-109-backprop-dashboard",
-        "sn-109-taomarketcap-dashboard",
-        "sn-109-taomarketcap-source-repo",
-        "sn-109-taopedia-article",
-        "sn-109-taostats-metagraph"
+        "sn-87-backprop-dashboard",
+        "sn-87-subnetradar-dashboard",
+        "sn-87-taomarketcap-dashboard",
+        "sn-87-taopedia-article",
+        "sn-87-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [],
-      "slug": "sn-109",
+      "slug": "sn-87",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/109",
-        "https://backprop.finance/dtao/subnets/109-academia",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_109/index.mdx",
-        "https://github.com/fx-integral/academia",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/109/subnet.json",
-        "https://taomarketcap.com/subnets/109",
-        "https://taostats.io/subnets/109/metagraph"
+        "https://api.taomarketcap.com/public/v1/subnets/87",
+        "https://backprop.finance/dtao/subnets/87-luminar-network",
+        "https://demo.luminar.network/",
+        "https://docs.luminar.network/",
+        "https://docs.luminar.network/introduction.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/87/subnet.json",
+        "https://luminar.network/"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 6,
+      "surface_count": 8,
       "verified_candidate_count": 6
     },
     {
@@ -7832,60 +8180,60 @@
         "unverified_kinds": []
       },
       "completeness_score": 40,
-      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
       "curation_level": "maintainer-reviewed",
       "direct_submission_kinds": [
-        "website"
+        "source-repo"
       ],
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
       "missing_kinds": [
         "data-artifact",
         "openapi",
+        "source-repo",
         "sse",
-        "subnet-api",
-        "website"
+        "subnet-api"
       ],
-      "name": "HashiChain",
-      "netuid": 115,
+      "name": "DegenBrain",
+      "netuid": 90,
       "operational_interface_count": 0,
       "priority_score": 99,
       "profile_level": "directory-only",
       "reason_codes": [
         "directory-only-profile",
-        "missing-website"
+        "missing-source-repo"
       ],
       "recommended_action": "submit official docs, website, or source repository evidence",
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-115-backprop-dashboard",
-        "sn-115-taomarketcap-dashboard",
-        "sn-115-taomarketcap-source-repo",
-        "sn-115-taopedia-article",
-        "sn-115-taostats-metagraph"
+        "sn-90-backprop-dashboard",
+        "sn-90-subnetradar-dashboard",
+        "sn-90-taomarketcap-dashboard",
+        "sn-90-taopedia-article",
+        "sn-90-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [],
-      "slug": "sn-115",
+      "slug": "sn-90",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/115",
-        "https://backprop.finance/dtao/subnets/115-hashichain",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_115/index.mdx",
-        "https://github.com/hashi115/hashichain",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/115/subnet.json",
-        "https://taomarketcap.com/subnets/115",
-        "https://taostats.io/subnets/115/metagraph"
+        "https://api.taomarketcap.com/public/v1/subnets/90",
+        "https://backprop.finance/dtao/subnets/90-ogham",
+        "https://degenbrain.com/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json",
+        "https://subnet90.com/",
+        "https://subnetradar.com/subnet/90"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 6,
+      "surface_count": 7,
       "verified_candidate_count": 6
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 8,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -7897,13 +8245,15 @@
         "unverified_count": 0,
         "unverified_kinds": []
       },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public website candidate with npm run candidate:new.",
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
       "curation_level": "maintainer-reviewed",
       "direct_submission_kinds": [
-        "website"
+        "openapi",
+        "subnet-api",
+        "data-artifact"
       ],
-      "endpoint_count": 6,
+      "endpoint_count": 8,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -7911,43 +8261,209 @@
         "data-artifact",
         "openapi",
         "sse",
-        "subnet-api",
-        "website"
+        "subnet-api"
       ],
-      "name": "MANTIS",
-      "netuid": 123,
+      "name": "BrainPlay",
+      "netuid": 117,
       "operational_interface_count": 0,
       "priority_score": 99,
-      "profile_level": "directory-only",
+      "profile_level": "identity-complete",
       "reason_codes": [
-        "directory-only-profile",
-        "missing-website"
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api",
+        "needs-maintainer-review"
       ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "maintainer-reviewed",
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "needs-review",
       "sample_candidate_ids": [
-        "sn-123-backprop-dashboard",
-        "sn-123-taomarketcap-dashboard",
-        "sn-123-taomarketcap-source-repo",
-        "sn-123-taopedia-article",
-        "sn-123-taostats-metagraph"
+        "sn-117-backprop-dashboard",
+        "sn-117-subnetradar-dashboard",
+        "sn-117-taomarketcap-dashboard",
+        "sn-117-taomarketcap-source-repo",
+        "sn-117-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [],
-      "slug": "sn-123",
+      "slug": "sn-117",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/123",
-        "https://backprop.finance/dtao/subnets/123-mantis",
-        "https://github.com/Barbariandev/MANTIS",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/123/subnet.json",
-        "https://taomarketcap.com/subnets/123",
-        "https://taostats.io/subnets/123/metagraph"
+        "https://api.taomarketcap.com/public/v1/subnets/117",
+        "https://backprop.finance/dtao/subnets/117-brainplay",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_117/index.mdx",
+        "https://github.com/shiftlayer-llc/brainplay-subnet",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/117/subnet.json",
+        "https://play.shiftlayer.ai/",
+        "https://subnetradar.com/subnet/117",
+        "https://taomarketcap.com/subnets/117"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 6,
-      "verified_candidate_count": 6
+      "surface_count": 8,
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 50,
+      "candidate_count": 9,
+      "candidate_evidence_summary": {
+        "candidate_count": 1,
+        "kinds_with_candidates": [
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 1,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 63,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 10,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ReadyAI",
+      "netuid": 33,
+      "operational_interface_count": 1,
+      "priority_score": 98,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-33-backprop-dashboard",
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-data-artifact-1",
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-subnet-api-2",
+        "sn-33-subnetradar-dashboard",
+        "sn-33-taomarketcap-dashboard"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-subnet-api-2"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-subnet-api-2"
+      ],
+      "slug": "sn-33",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/33",
+        "https://backprop.finance/dtao/subnets/33-readyai",
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project",
+        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md",
+        "https://github.com/afterpartyai/llms_txt_store",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_33/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/33/subnet.json",
+        "https://huggingface.co/datasets/ReadyAi/5000-podcast-conversations-with-metadata-and-embedding-dataset"
+      ],
+      "stale_candidate_count": 1,
+      "surface_count": 10,
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 28,
+      "candidate_count": 19,
+      "candidate_evidence_summary": {
+        "candidate_count": 6,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [
+          "subnet-api"
+        ],
+        "live_or_redirected_count": 1,
+        "reviewable_count": 6,
+        "stale_kinds": [
+          "openapi",
+          "subnet-api"
+        ],
+        "stale_or_failed_count": 5,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 63,
+      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api"
+      ],
+      "endpoint_count": 8,
+      "evidence_action": "replace-stale-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Investing",
+      "netuid": 88,
+      "operational_interface_count": 1,
+      "priority_score": 98,
+      "profile_level": "operational",
+      "reason_codes": [
+        "adapter-candidate",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-88-backprop-dashboard",
+        "sn-88-github-readme-mobiusfund-investing-dashboard-1",
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
+        "sn-88-subnetradar-dashboard",
+        "sn-88-taomarketcap-dashboard"
+      ],
+      "sample_live_candidate_ids": [
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-2"
+      ],
+      "sample_stale_candidate_ids": [
+        "sn-88-website-common-openapi-json",
+        "sn-88-website-common-swagger",
+        "sn-88-website-common-swagger-json",
+        "sn-88-website-common-api",
+        "sn-88-website-common-health"
+      ],
+      "sample_target_candidate_ids": [
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
+        "sn-88-website-common-openapi-json",
+        "sn-88-website-common-swagger",
+        "sn-88-website-common-swagger-json",
+        "sn-88-website-common-api"
+      ],
+      "slug": "sn-88",
+      "source_urls": [
+        "https://backprop.finance/dtao/subnets/88-investing",
+        "https://db.investing88.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_88/index.mdx",
+        "https://github.com/mobiusfund/investing",
+        "https://github.com/mobiusfund/investing/blob/main/README.md",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/88/subnet.json",
+        "https://investing88.ai/",
+        "https://subnetradar.com/subnet/88"
+      ],
+      "stale_candidate_count": 5,
+      "surface_count": 8,
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 9,
@@ -7987,8 +8503,8 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Apex",
-      "netuid": 1,
+      "name": "TensorUSD",
+      "netuid": 113,
       "operational_interface_count": 0,
       "priority_score": 98,
       "profile_level": "identity-complete",
@@ -8000,45 +8516,45 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-1-backprop-dashboard",
-        "sn-1-github-readme-macrocosm-os-apex-docs-1",
-        "sn-1-taomarketcap-dashboard",
-        "sn-1-taomarketcap-source-repo",
-        "sn-1-taomarketcap-website"
+        "sn-113-backprop-dashboard",
+        "sn-113-github-readme-tensorusd-subnet-docs-1",
+        "sn-113-subnetradar-dashboard",
+        "sn-113-taomarketcap-dashboard",
+        "sn-113-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
-        "sn-1-website-common-openapi-json",
-        "sn-1-website-common-swagger",
-        "sn-1-website-common-swagger-json",
-        "sn-1-website-common-api",
-        "sn-1-website-common-health"
+        "sn-113-website-common-openapi-json",
+        "sn-113-website-common-swagger",
+        "sn-113-website-common-swagger-json",
+        "sn-113-website-common-api",
+        "sn-113-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-1-website-common-openapi-json",
-        "sn-1-website-common-swagger",
-        "sn-1-website-common-swagger-json",
-        "sn-1-website-common-api",
-        "sn-1-website-common-health"
+        "sn-113-website-common-openapi-json",
+        "sn-113-website-common-swagger",
+        "sn-113-website-common-swagger-json",
+        "sn-113-website-common-api",
+        "sn-113-website-common-health"
       ],
-      "slug": "sn-1",
+      "slug": "sn-113",
       "source_urls": [
-        "https://apex.macrocosmos.ai/",
-        "https://api.taomarketcap.com/public/v1/subnets/1",
-        "https://backprop.finance/dtao/subnets/1-apex",
-        "https://docs.macrocosmos.ai/subnets/subnet-1-apex",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_1_apex/index.mdx",
-        "https://github.com/macrocosm-os/apex",
-        "https://github.com/macrocosm-os/apex/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/1/subnet.json"
+        "https://api.taomarketcap.com/public/v1/subnets/113",
+        "https://backprop.finance/dtao/subnets/113-tensorusd",
+        "https://docs.tensorusd.com/components/subnet",
+        "https://github.com/TensorUSD/subnet",
+        "https://github.com/TensorUSD/subnet/blob/main/README.md",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_113/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/113/subnet.json",
+        "https://subnetradar.com/subnet/113"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
       "verified_candidate_count": 13
     },
     {
-      "adapter_score": 0,
-      "candidate_count": 5,
+      "adapter_score": 96,
+      "candidate_count": 14,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -8050,124 +8566,52 @@
         "unverified_count": 0,
         "unverified_kinds": []
       },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
+      "completeness_score": 85,
+      "contribution_hint": "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
       "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "source-repo"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
+      "direct_submission_kinds": [],
+      "endpoint_count": 16,
+      "evidence_action": "maintainer-review-existing-evidence",
+      "lane": "adapter-candidate",
+      "manual_review_required": true,
       "missing_kinds": [
         "data-artifact",
-        "openapi",
-        "source-repo",
-        "sse",
-        "subnet-api"
+        "sse"
       ],
-      "name": "Luminar Network",
-      "netuid": 87,
-      "operational_interface_count": 0,
-      "priority_score": 98,
-      "profile_level": "directory-only",
+      "name": "Desearch",
+      "netuid": 22,
+      "operational_interface_count": 2,
+      "priority_score": 97,
+      "profile_level": "operational",
       "reason_codes": [
-        "directory-only-profile",
-        "missing-source-repo"
+        "adapter-candidate"
       ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
+      "recommended_action": "evaluate adapter support for openapi, subnet-api",
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-87-backprop-dashboard",
-        "sn-87-taomarketcap-dashboard",
-        "sn-87-taopedia-article",
-        "sn-87-taostats-metagraph",
-        "sn-87-tensorplex-docs"
+        "sn-22-backprop-dashboard",
+        "sn-22-subnetradar-dashboard",
+        "sn-22-taomarketcap-dashboard",
+        "sn-22-taomarketcap-source-repo",
+        "sn-22-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [],
-      "slug": "sn-87",
+      "slug": "sn-22",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/87",
-        "https://backprop.finance/dtao/subnets/87-luminar-network",
-        "https://demo.luminar.network/",
-        "https://docs.luminar.network/",
-        "https://docs.luminar.network/introduction.md",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/87/subnet.json",
-        "https://luminar.network/"
+        "https://api.desearch.ai",
+        "https://api.taomarketcap.com/public/v1/subnets/22",
+        "https://backprop.finance/dtao/subnets/22-desearch",
+        "https://console.desearch.ai/",
+        "https://desearch.ai/",
+        "https://github.com/Desearch-ai/subnet-22",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_22/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/22/subnet.json"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 5
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 5,
-      "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 40,
-      "contribution_hint": "Submit one official public source-repo candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "source-repo"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "source-repo",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "DegenBrain",
-      "netuid": 90,
-      "operational_interface_count": 0,
-      "priority_score": 98,
-      "profile_level": "directory-only",
-      "reason_codes": [
-        "directory-only-profile",
-        "missing-source-repo"
-      ],
-      "recommended_action": "submit official docs, website, or source repository evidence",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-90-backprop-dashboard",
-        "sn-90-taomarketcap-dashboard",
-        "sn-90-taopedia-article",
-        "sn-90-taostats-metagraph",
-        "sn-90-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-90",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/90",
-        "https://backprop.finance/dtao/subnets/90-ogham",
-        "https://degenbrain.com/",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/90/subnet.json",
-        "https://subnet90.com/",
-        "https://taostats.io/subnets/90/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 7,
-      "verified_candidate_count": 5
+      "surface_count": 16,
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 0,
@@ -8191,7 +8635,7 @@
         "subnet-api",
         "data-artifact"
       ],
-      "endpoint_count": 8,
+      "endpoint_count": 11,
       "evidence_action": "submit-new-evidence",
       "lane": "direct-submission",
       "manual_review_required": false,
@@ -8201,8 +8645,8 @@
         "sse",
         "subnet-api"
       ],
-      "name": "Basilica",
-      "netuid": 39,
+      "name": "Templar",
+      "netuid": 3,
       "operational_interface_count": 0,
       "priority_score": 97,
       "profile_level": "identity-complete",
@@ -8215,29 +8659,29 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "needs-review",
       "sample_candidate_ids": [
-        "sn-39-backprop-dashboard",
-        "sn-39-taomarketcap-dashboard",
-        "sn-39-taomarketcap-source-repo",
-        "sn-39-taopedia-article",
-        "sn-39-taostats-metagraph"
+        "sn-3-backprop-dashboard",
+        "sn-3-subnetradar-dashboard",
+        "sn-3-taomarketcap-dashboard",
+        "sn-3-taopedia-article",
+        "sn-3-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [],
-      "slug": "sn-39",
+      "slug": "sn-3",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/39",
-        "https://backprop.finance/dtao/subnets/39-deprecated",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_39/index.mdx",
-        "https://github.com/one-covenant/basilica",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/39/subnet.json",
-        "https://taomarketcap.com/subnets/39",
-        "https://taostats.io/subnets/39/metagraph",
-        "https://www.basilica.ai/"
+        "https://api.taomarketcap.com/public/v1/subnets/3",
+        "https://backprop.finance/dtao/subnets/3-deprecated",
+        "https://docs.tplr.ai/",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_3/index.mdx",
+        "https://github.com/one-covenant/templar",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/3/subnet.json",
+        "https://subnetradar.com/subnet/3",
+        "https://wandb.ai/tplr/templar"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 6
+      "surface_count": 11,
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 9,
@@ -8277,462 +8721,10 @@
         "sse",
         "subnet-api"
       ],
-      "name": "TensorUSD",
-      "netuid": 113,
-      "operational_interface_count": 0,
-      "priority_score": 97,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-113-backprop-dashboard",
-        "sn-113-github-readme-tensorusd-subnet-docs-1",
-        "sn-113-taomarketcap-dashboard",
-        "sn-113-taomarketcap-source-repo",
-        "sn-113-taomarketcap-website"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-113-website-common-openapi-json",
-        "sn-113-website-common-swagger",
-        "sn-113-website-common-swagger-json",
-        "sn-113-website-common-api",
-        "sn-113-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-113-website-common-openapi-json",
-        "sn-113-website-common-swagger",
-        "sn-113-website-common-swagger-json",
-        "sn-113-website-common-api",
-        "sn-113-website-common-health"
-      ],
-      "slug": "sn-113",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/113",
-        "https://backprop.finance/dtao/subnets/113-tensorusd",
-        "https://docs.tensorusd.com/components/subnet",
-        "https://github.com/TensorUSD/subnet",
-        "https://github.com/TensorUSD/subnet/blob/main/README.md",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_113/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/113/subnet.json",
-        "https://taomarketcap.com/subnets/113"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 9,
-      "verified_candidate_count": 12
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 7,
-      "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "BrainPlay",
-      "netuid": 117,
-      "operational_interface_count": 0,
-      "priority_score": 97,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "needs-review",
-      "sample_candidate_ids": [
-        "sn-117-backprop-dashboard",
-        "sn-117-taomarketcap-dashboard",
-        "sn-117-taomarketcap-source-repo",
-        "sn-117-taopedia-article",
-        "sn-117-taostats-metagraph"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-117",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/117",
-        "https://backprop.finance/dtao/subnets/117-brainplay",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_117/index.mdx",
-        "https://github.com/shiftlayer-llc/brainplay-subnet",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/117/subnet.json",
-        "https://play.shiftlayer.ai/",
-        "https://taomarketcap.com/subnets/117",
-        "https://taostats.io/subnets/117/metagraph"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 8,
-      "verified_candidate_count": 7
-    },
-    {
-      "adapter_score": 96,
-      "candidate_count": 13,
-      "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 85,
-      "contribution_hint": "Maintainer should evaluate whether subnet-specific adapter metrics add useful public operational data.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [],
-      "endpoint_count": 16,
-      "evidence_action": "maintainer-review-existing-evidence",
-      "lane": "adapter-candidate",
-      "manual_review_required": true,
-      "missing_kinds": [
-        "data-artifact",
-        "sse"
-      ],
-      "name": "Desearch",
-      "netuid": 22,
-      "operational_interface_count": 2,
-      "priority_score": 96,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate"
-      ],
-      "recommended_action": "evaluate adapter support for openapi, subnet-api",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-22-backprop-dashboard",
-        "sn-22-taomarketcap-dashboard",
-        "sn-22-taomarketcap-source-repo",
-        "sn-22-taomarketcap-website",
-        "sn-22-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-22",
-      "source_urls": [
-        "https://api.desearch.ai",
-        "https://api.taomarketcap.com/public/v1/subnets/22",
-        "https://backprop.finance/dtao/subnets/22-desearch",
-        "https://console.desearch.ai/",
-        "https://desearch.ai/",
-        "https://github.com/Desearch-ai/subnet-22",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_22/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/22/subnet.json"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 16,
-      "verified_candidate_count": 12
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 6,
-      "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 11,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Templar",
-      "netuid": 3,
-      "operational_interface_count": 0,
-      "priority_score": 96,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api",
-        "needs-maintainer-review"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "needs-review",
-      "sample_candidate_ids": [
-        "sn-3-backprop-dashboard",
-        "sn-3-taomarketcap-dashboard",
-        "sn-3-taopedia-article",
-        "sn-3-taostats-metagraph",
-        "sn-3-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-3",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/3",
-        "https://backprop.finance/dtao/subnets/3-deprecated",
-        "https://docs.tplr.ai/",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_3/index.mdx",
-        "https://github.com/one-covenant/templar",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/3/subnet.json",
-        "https://taostats.io/subnets/3/metagraph",
-        "https://wandb.ai/tplr/templar"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 11,
-      "verified_candidate_count": 6
-    },
-    {
-      "adapter_score": 50,
-      "candidate_count": 8,
-      "candidate_evidence_summary": {
-        "candidate_count": 1,
-        "kinds_with_candidates": [
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 1,
-        "stale_kinds": [
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 1,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 63,
-      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api"
-      ],
-      "endpoint_count": 10,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "ReadyAI",
-      "netuid": 33,
-      "operational_interface_count": 1,
-      "priority_score": 96,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-33-backprop-dashboard",
-        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-data-artifact-1",
-        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-subnet-api-2",
-        "sn-33-taomarketcap-dashboard",
-        "sn-33-taomarketcap-source-repo"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-subnet-api-2"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-33-github-readme-afterpartyai-bittensor-conversation-genome-project-subnet-api-2"
-      ],
-      "slug": "sn-33",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/33",
-        "https://backprop.finance/dtao/subnets/33-readyai",
-        "https://github.com/afterpartyai/bittensor-conversation-genome-project",
-        "https://github.com/afterpartyai/bittensor-conversation-genome-project/blob/main/README.md",
-        "https://github.com/afterpartyai/llms_txt_store",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_33/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/33/subnet.json",
-        "https://huggingface.co/datasets/ReadyAi/5000-podcast-conversations-with-metadata-and-embedding-dataset"
-      ],
-      "stale_candidate_count": 1,
-      "surface_count": 10,
-      "verified_candidate_count": 7
-    },
-    {
-      "adapter_score": 28,
-      "candidate_count": 18,
-      "candidate_evidence_summary": {
-        "candidate_count": 6,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 6,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 63,
-      "contribution_hint": "Submit one official public openapi, subnet-api candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api"
-      ],
-      "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Investing",
-      "netuid": 88,
-      "operational_interface_count": 1,
-      "priority_score": 96,
-      "profile_level": "operational",
-      "reason_codes": [
-        "adapter-candidate",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-88-backprop-dashboard",
-        "sn-88-github-readme-mobiusfund-investing-dashboard-1",
-        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
-        "sn-88-taomarketcap-dashboard",
-        "sn-88-taomarketcap-source-repo"
-      ],
-      "sample_live_candidate_ids": [
-        "sn-88-github-readme-mobiusfund-investing-subnet-api-2"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-88-website-common-openapi-json",
-        "sn-88-website-common-swagger",
-        "sn-88-website-common-swagger-json",
-        "sn-88-website-common-api",
-        "sn-88-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
-        "sn-88-website-common-openapi-json",
-        "sn-88-website-common-swagger",
-        "sn-88-website-common-swagger-json",
-        "sn-88-website-common-api"
-      ],
-      "slug": "sn-88",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/88",
-        "https://backprop.finance/dtao/subnets/88-investing",
-        "https://db.investing88.ai/",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_88/index.mdx",
-        "https://github.com/mobiusfund/investing",
-        "https://github.com/mobiusfund/investing/blob/main/README.md",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/88/subnet.json",
-        "https://investing88.ai/"
-      ],
-      "stale_candidate_count": 5,
-      "surface_count": 8,
-      "verified_candidate_count": 12
-    },
-    {
-      "adapter_score": 9,
-      "candidate_count": 18,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 9,
-      "evidence_action": "replace-stale-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
       "name": "ConnitoAI",
       "netuid": 102,
       "operational_interface_count": 0,
-      "priority_score": 95,
+      "priority_score": 97,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -8744,9 +8736,9 @@
       "sample_candidate_ids": [
         "sn-102-backprop-dashboard",
         "sn-102-github-readme-connito-ai-connito-docs-1",
+        "sn-102-subnetradar-dashboard",
         "sn-102-taomarketcap-dashboard",
-        "sn-102-taomarketcap-source-repo",
-        "sn-102-taomarketcap-website"
+        "sn-102-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -8771,16 +8763,16 @@
         "https://github.com/Connito-AI/Connito",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_102/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/102/subnet.json",
-        "https://taomarketcap.com/subnets/102",
-        "https://taostats.io/subnets/102/metagraph"
+        "https://subnetradar.com/subnet/102",
+        "https://taomarketcap.com/subnets/102"
       ],
       "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 77,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 2,
         "kinds_with_candidates": [
@@ -8811,7 +8803,7 @@
       "name": "Gittensor",
       "netuid": 74,
       "operational_interface_count": 2,
-      "priority_score": 94,
+      "priority_score": 96,
       "profile_level": "adapter-backed",
       "reason_codes": [
         "adapter-candidate"
@@ -8822,8 +8814,8 @@
         "community-sn-74-openapi-api-gittensor-io",
         "sn-74-backprop-dashboard",
         "sn-74-github-readme-entrius-gittensor-docs-1",
-        "sn-74-taomarketcap-dashboard",
-        "sn-74-taomarketcap-source-repo"
+        "sn-74-subnetradar-dashboard",
+        "sn-74-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [
         "sn-74-website-common-api",
@@ -8847,11 +8839,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 17,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 8,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 5,
         "kinds_with_candidates": [
@@ -8890,7 +8882,7 @@
       "name": "RedTeam",
       "netuid": 61,
       "operational_interface_count": 0,
-      "priority_score": 91,
+      "priority_score": 92,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -8903,8 +8895,8 @@
         "sn-61-backprop-dashboard",
         "sn-61-github-readme-redteamsubnet-redteam-dashboard-1",
         "sn-61-github-readme-redteamsubnet-redteam-docs-2",
-        "sn-61-taomarketcap-dashboard",
-        "sn-61-taomarketcap-source-repo"
+        "sn-61-subnetradar-dashboard",
+        "sn-61-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -8923,100 +8915,22 @@
       ],
       "slug": "sn-61",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/61",
         "https://backprop.finance/dtao/subnets/61-redteam",
         "https://dashboard.theredteam.io/",
         "https://docs.theredteam.io/",
         "https://github.com/RedTeamSubnet/RedTeam",
         "https://github.com/RedTeamSubnet/RedTeam/blob/main/README.md",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_61/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/61/subnet.json"
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/61/subnet.json",
+        "https://subnetradar.com/subnet/61"
       ],
       "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 9
-    },
-    {
-      "adapter_score": 7,
-      "candidate_count": 14,
-      "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 7,
-      "evidence_action": "verify-existing-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "Ridges",
-      "netuid": 62,
-      "operational_interface_count": 0,
-      "priority_score": 88,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
-        "sn-62-backprop-dashboard",
-        "sn-62-taomarketcap-dashboard",
-        "sn-62-taomarketcap-source-repo",
-        "sn-62-taomarketcap-website",
-        "sn-62-taopedia-article"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-62-website-common-openapi-json",
-        "sn-62-website-common-swagger",
-        "sn-62-website-common-swagger-json",
-        "sn-62-website-common-api",
-        "sn-62-website-common-health"
-      ],
-      "slug": "sn-62",
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/62",
-        "https://backprop.finance/dtao/subnets/62-ridges",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_62/index.mdx",
-        "https://github.com/ridgesai/ridges",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/62/subnet.json",
-        "https://taomarketcap.com/subnets/62",
-        "https://taostats.io/subnets/62/metagraph",
-        "https://www.ridges.ai/"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 7,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 93,
-      "candidate_count": 8,
+      "candidate_count": 9,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9043,7 +8957,7 @@
       "name": "Handshake58",
       "netuid": 58,
       "operational_interface_count": 2,
-      "priority_score": 86,
+      "priority_score": 88,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9054,8 +8968,8 @@
         "sn-58-backprop-dashboard",
         "sn-58-github-readme-handshake58-hs58-docs-1",
         "sn-58-github-readme-handshake58-hs58-subnet-api-2",
-        "sn-58-taomarketcap-dashboard",
-        "sn-58-taopedia-article"
+        "sn-58-subnetradar-dashboard",
+        "sn-58-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9073,11 +8987,89 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 13,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
+    },
+    {
+      "adapter_score": 6,
+      "candidate_count": 14,
+      "candidate_evidence_summary": {
+        "candidate_count": 5,
+        "kinds_with_candidates": [
+          "openapi",
+          "subnet-api"
+        ],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 6,
+      "evidence_action": "verify-existing-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "Ridges",
+      "netuid": 62,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-62-backprop-dashboard",
+        "sn-62-subnetradar-dashboard",
+        "sn-62-taomarketcap-dashboard",
+        "sn-62-taomarketcap-source-repo",
+        "sn-62-taomarketcap-website"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [
+        "sn-62-website-common-openapi-json",
+        "sn-62-website-common-swagger",
+        "sn-62-website-common-swagger-json",
+        "sn-62-website-common-api",
+        "sn-62-website-common-health"
+      ],
+      "slug": "sn-62",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/62",
+        "https://backprop.finance/dtao/subnets/62-ridges",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_62/index.mdx",
+        "https://github.com/ridgesai/ridges",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/62/subnet.json",
+        "https://subnetradar.com/subnet/62",
+        "https://taomarketcap.com/subnets/62",
+        "https://www.ridges.ai/"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 6,
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 31,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "candidate_evidence_summary": {
         "candidate_count": 3,
         "kinds_with_candidates": [
@@ -9109,7 +9101,7 @@
       "name": "Trishool",
       "netuid": 23,
       "operational_interface_count": 1,
-      "priority_score": 84,
+      "priority_score": 86,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9120,8 +9112,8 @@
         "sn-23-backprop-dashboard",
         "sn-23-github-readme-trishoolai-trishool-phase2-dashboard-1",
         "sn-23-github-readme-trishoolai-trishool-phase2-subnet-api-2",
-        "sn-23-taomarketcap-dashboard",
-        "sn-23-taomarketcap-source-repo"
+        "sn-23-subnetradar-dashboard",
+        "sn-23-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
@@ -9142,16 +9134,16 @@
         "https://github.com/TrishoolAI/trishool-phase2/blob/main/README.md",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_23/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/23/subnet.json",
-        "https://trishool.ai/",
-        "https://trishool.ai/dashboard"
+        "https://subnetradar.com/subnet/23",
+        "https://trishool.ai/"
       ],
       "stale_candidate_count": 3,
       "surface_count": 11,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 73,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9178,7 +9170,7 @@
       "name": "Verathos",
       "netuid": 96,
       "operational_interface_count": 2,
-      "priority_score": 83,
+      "priority_score": 84,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9189,8 +9181,8 @@
         "sn-96-backprop-dashboard",
         "sn-96-github-readme-verathos-ai-verathos-docs-1",
         "sn-96-github-readme-verathos-ai-verathos-subnet-api-2",
-        "sn-96-taomarketcap-dashboard",
-        "sn-96-taomarketcap-source-repo"
+        "sn-96-subnetradar-dashboard",
+        "sn-96-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9203,16 +9195,16 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_96/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/96/subnet.json",
         "https://github.com/verathos-ai/verathos",
-        "https://taostats.io/subnets/96/metagraph",
+        "https://subnetradar.com/subnet/96",
         "https://verathos.ai/"
       ],
       "stale_candidate_count": 0,
       "surface_count": 13,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 31,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9243,7 +9235,7 @@
       "name": "Coldint",
       "netuid": 29,
       "operational_interface_count": 1,
-      "priority_score": 81,
+      "priority_score": 82,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate",
@@ -9254,10 +9246,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-29-backprop-dashboard",
+        "sn-29-subnetradar-dashboard",
         "sn-29-taomarketcap-dashboard",
         "sn-29-taomarketcap-source-repo",
-        "sn-29-taopedia-article",
-        "sn-29-taostats-metagraph"
+        "sn-29-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9275,11 +9267,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 11,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
       "adapter_score": 0,
-      "candidate_count": 10,
+      "candidate_count": 11,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9312,7 +9304,7 @@
       "name": "Dojo",
       "netuid": 52,
       "operational_interface_count": 0,
-      "priority_score": 79,
+      "priority_score": 81,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9324,9 +9316,9 @@
       "sample_candidate_ids": [
         "sn-52-backprop-dashboard",
         "sn-52-github-readme-tensorplex-labs-dojo-docs-1",
+        "sn-52-subnetradar-dashboard",
         "sn-52-taomarketcap-dashboard",
-        "sn-52-taomarketcap-source-repo",
-        "sn-52-taopedia-article"
+        "sn-52-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9344,11 +9336,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 10,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 7,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "candidate_evidence_summary": {
         "candidate_count": 1,
         "kinds_with_candidates": [
@@ -9385,7 +9377,7 @@
       "name": "Compute Horde",
       "netuid": 12,
       "operational_interface_count": 0,
-      "priority_score": 78,
+      "priority_score": 79,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9397,9 +9389,9 @@
       "sample_candidate_ids": [
         "sn-12-backprop-dashboard",
         "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1",
+        "sn-12-subnetradar-dashboard",
         "sn-12-taomarketcap-dashboard",
-        "sn-12-taomarketcap-source-repo",
-        "sn-12-taopedia-article"
+        "sn-12-taomarketcap-source-repo"
       ],
       "sample_live_candidate_ids": [
         "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1"
@@ -9417,11 +9409,80 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_12/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/12/subnet.json",
         "https://learnbittensor.org/subnets/12",
-        "https://taomarketcap.com/subnets/12"
+        "https://subnetradar.com/subnet/12"
       ],
       "stale_candidate_count": 0,
       "surface_count": 7,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
+    },
+    {
+      "adapter_score": 0,
+      "candidate_count": 8,
+      "candidate_evidence_summary": {
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
+        "unverified_count": 0,
+        "unverified_kinds": []
+      },
+      "completeness_score": 55,
+      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
+      "curation_level": "maintainer-reviewed",
+      "direct_submission_kinds": [
+        "openapi",
+        "subnet-api",
+        "data-artifact"
+      ],
+      "endpoint_count": 9,
+      "evidence_action": "submit-new-evidence",
+      "lane": "direct-submission",
+      "manual_review_required": false,
+      "missing_kinds": [
+        "data-artifact",
+        "openapi",
+        "sse",
+        "subnet-api"
+      ],
+      "name": "ansuz",
+      "netuid": 84,
+      "operational_interface_count": 0,
+      "priority_score": 76,
+      "profile_level": "identity-complete",
+      "reason_codes": [
+        "missing-data-artifact",
+        "missing-openapi",
+        "missing-subnet-api"
+      ],
+      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "review_state": "maintainer-reviewed",
+      "sample_candidate_ids": [
+        "sn-84-backprop-dashboard",
+        "sn-84-subnetradar-dashboard",
+        "sn-84-taomarketcap-dashboard",
+        "sn-84-taopedia-article",
+        "sn-84-taostats-metagraph"
+      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
+      "slug": "sn-84",
+      "source_urls": [
+        "https://api.github.com/repos/TatsuProject/ChipForge_SN84",
+        "https://api.taomarketcap.com/public/v1/subnets/84",
+        "https://backprop.finance/dtao/subnets/84-ansuz",
+        "https://docs.chipforge.io/",
+        "https://github.com/TatsuProject/ChipForge_SN84",
+        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_84/index.mdx",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/84/subnet.json",
+        "https://subnetradar.com/subnet/84"
+      ],
+      "stale_candidate_count": 0,
+      "surface_count": 9,
+      "verified_candidate_count": 8
     },
     {
       "adapter_score": 0,
@@ -9455,8 +9516,8 @@
         "sse",
         "subnet-api"
       ],
-      "name": "ansuz",
-      "netuid": 84,
+      "name": "BitMind",
+      "netuid": 34,
       "operational_interface_count": 0,
       "priority_score": 75,
       "profile_level": "identity-complete",
@@ -9468,80 +9529,11 @@
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
-        "sn-84-backprop-dashboard",
-        "sn-84-taomarketcap-dashboard",
-        "sn-84-taopedia-article",
-        "sn-84-taostats-metagraph",
-        "sn-84-tensorplex-docs"
-      ],
-      "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [],
-      "slug": "sn-84",
-      "source_urls": [
-        "https://api.github.com/repos/TatsuProject/ChipForge_SN84",
-        "https://api.taomarketcap.com/public/v1/subnets/84",
-        "https://backprop.finance/dtao/subnets/84-ansuz",
-        "https://docs.chipforge.io/",
-        "https://github.com/TatsuProject/ChipForge_SN84",
-        "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_84/index.mdx",
-        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/84/subnet.json",
-        "https://taomarketcap.com/subnets/84"
-      ],
-      "stale_candidate_count": 0,
-      "surface_count": 9,
-      "verified_candidate_count": 7
-    },
-    {
-      "adapter_score": 0,
-      "candidate_count": 6,
-      "candidate_evidence_summary": {
-        "candidate_count": 0,
-        "kinds_with_candidates": [],
-        "live_kinds": [],
-        "live_or_redirected_count": 0,
-        "reviewable_count": 0,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
-        "unverified_count": 0,
-        "unverified_kinds": []
-      },
-      "completeness_score": 55,
-      "contribution_hint": "Submit one official public openapi, subnet-api, data-artifact candidate with npm run candidate:new.",
-      "curation_level": "maintainer-reviewed",
-      "direct_submission_kinds": [
-        "openapi",
-        "subnet-api",
-        "data-artifact"
-      ],
-      "endpoint_count": 9,
-      "evidence_action": "submit-new-evidence",
-      "lane": "direct-submission",
-      "manual_review_required": false,
-      "missing_kinds": [
-        "data-artifact",
-        "openapi",
-        "sse",
-        "subnet-api"
-      ],
-      "name": "BitMind",
-      "netuid": 34,
-      "operational_interface_count": 0,
-      "priority_score": 73,
-      "profile_level": "identity-complete",
-      "reason_codes": [
-        "missing-data-artifact",
-        "missing-openapi",
-        "missing-subnet-api"
-      ],
-      "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "review_state": "maintainer-reviewed",
-      "sample_candidate_ids": [
         "sn-34-backprop-dashboard",
+        "sn-34-subnetradar-dashboard",
         "sn-34-taomarketcap-dashboard",
         "sn-34-taomarketcap-source-repo",
-        "sn-34-taopedia-article",
-        "sn-34-taostats-metagraph"
+        "sn-34-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9559,11 +9551,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 9,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9596,7 +9588,7 @@
       "name": "Graphite",
       "netuid": 43,
       "operational_interface_count": 0,
-      "priority_score": 73,
+      "priority_score": 75,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9607,10 +9599,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-43-backprop-dashboard",
+        "sn-43-subnetradar-dashboard",
         "sn-43-taomarketcap-dashboard",
         "sn-43-taomarketcap-source-repo",
-        "sn-43-taopedia-article",
-        "sn-43-taostats-metagraph"
+        "sn-43-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9624,15 +9616,15 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/43/subnet.json",
         "https://graphite-ai.net/",
         "https://learnbittensor.org/subnets/43",
-        "https://taomarketcap.com/subnets/43"
+        "https://subnetradar.com/subnet/43"
       ],
       "stale_candidate_count": 0,
       "surface_count": 7,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9665,7 +9657,7 @@
       "name": "Sparket",
       "netuid": 57,
       "operational_interface_count": 0,
-      "priority_score": 73,
+      "priority_score": 75,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9676,10 +9668,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-57-backprop-dashboard",
+        "sn-57-subnetradar-dashboard",
         "sn-57-taomarketcap-dashboard",
         "sn-57-taopedia-article",
-        "sn-57-taostats-metagraph",
-        "sn-57-tensorplex-docs"
+        "sn-57-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9693,15 +9685,15 @@
         "https://github.com/sparket-ai/sparket-ai",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/57/subnet.json",
         "https://sparket.ai/",
-        "https://taomarketcap.com/subnets/57"
+        "https://subnetradar.com/subnet/57"
       ],
       "stale_candidate_count": 0,
       "surface_count": 7,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9734,7 +9726,7 @@
       "name": "oneoneone",
       "netuid": 111,
       "operational_interface_count": 0,
-      "priority_score": 73,
+      "priority_score": 75,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9745,10 +9737,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-111-backprop-dashboard",
+        "sn-111-subnetradar-dashboard",
         "sn-111-taomarketcap-dashboard",
         "sn-111-taomarketcap-source-repo",
-        "sn-111-taopedia-article",
-        "sn-111-taostats-metagraph"
+        "sn-111-taopedia-article"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9762,15 +9754,15 @@
         "https://github.com/oneoneone-io/subnet-111",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/111/subnet.json",
         "https://oneoneone.io/",
-        "https://taomarketcap.com/subnets/111"
+        "https://subnetradar.com/subnet/111"
       ],
       "stale_candidate_count": 0,
       "surface_count": 7,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 0,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9803,7 +9795,7 @@
       "name": "Bitrecs",
       "netuid": 122,
       "operational_interface_count": 0,
-      "priority_score": 73,
+      "priority_score": 75,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9814,10 +9806,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-122-backprop-dashboard",
+        "sn-122-subnetradar-dashboard",
         "sn-122-taomarketcap-dashboard",
         "sn-122-taopedia-article",
-        "sn-122-taostats-metagraph",
-        "sn-122-tensorplex-docs"
+        "sn-122-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9831,15 +9823,15 @@
         "https://github.com/bitrecs/bitrecs-subnet",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_122/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/122/subnet.json",
-        "https://taomarketcap.com/subnets/122"
+        "https://subnetradar.com/subnet/122"
       ],
       "stale_candidate_count": 0,
       "surface_count": 8,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 53,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9866,7 +9858,7 @@
       "name": "ninja",
       "netuid": 66,
       "operational_interface_count": 2,
-      "priority_score": 70,
+      "priority_score": 72,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -9875,10 +9867,10 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-66-backprop-dashboard",
+        "sn-66-subnetradar-dashboard",
         "sn-66-taomarketcap-dashboard",
         "sn-66-taomarketcap-source-repo",
-        "sn-66-taomarketcap-website",
-        "sn-66-taopedia-article"
+        "sn-66-taomarketcap-website"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -9896,11 +9888,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 13,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 0,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9933,7 +9925,7 @@
       "name": "root",
       "netuid": 0,
       "operational_interface_count": 0,
-      "priority_score": 70,
+      "priority_score": 72,
       "profile_level": "identity-complete",
       "reason_codes": [
         "missing-data-artifact",
@@ -9944,6 +9936,7 @@
       "review_state": "maintainer-reviewed",
       "sample_candidate_ids": [
         "sn-0-backprop-dashboard",
+        "sn-0-subnetradar-dashboard",
         "sn-0-taomarketcap-dashboard",
         "sn-0-taostats-metagraph",
         "sn-0-tensorplex-docs"
@@ -9964,11 +9957,11 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 14,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     },
     {
       "adapter_score": 51,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "candidate_evidence_summary": {
         "candidate_count": 0,
         "kinds_with_candidates": [],
@@ -9995,7 +9988,7 @@
       "name": "Nepher Robotics",
       "netuid": 49,
       "operational_interface_count": 2,
-      "priority_score": 68,
+      "priority_score": 69,
       "profile_level": "operational",
       "reason_codes": [
         "adapter-candidate"
@@ -10006,8 +9999,8 @@
         "sn-49-backprop-dashboard",
         "sn-49-github-readme-nepher-ai-nepher-subnet-docs-1",
         "sn-49-github-readme-nepher-ai-nepher-subnet-subnet-api-2",
-        "sn-49-taomarketcap-dashboard",
-        "sn-49-taomarketcap-source-repo"
+        "sn-49-subnetradar-dashboard",
+        "sn-49-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
@@ -10021,41 +10014,41 @@
         "https://github.com/nepher-ai/nepher-subnet",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/49/subnet.json",
         "https://nepher.ai",
-        "https://taostats.io/subnets/49/metagraph"
+        "https://subnetradar.com/subnet/49"
       ],
       "stale_candidate_count": 0,
       "surface_count": 11,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     }
   ],
   "schema_version": 1,
   "summary": {
     "adapter_candidate_count": 10,
     "baseline_monitoring_count": 0,
-    "direct_submission_count": 97,
+    "direct_submission_count": 96,
     "evidence_action_counts": {
-      "maintainer-review-existing-evidence": 32,
-      "replace-stale-evidence": 63,
+      "maintainer-review-existing-evidence": 33,
+      "replace-stale-evidence": 62,
       "review-existing-evidence": 2,
       "submit-new-evidence": 30,
       "verify-existing-evidence": 2
     },
     "lane_counts": {
       "adapter-candidate": 10,
-      "direct-submission": 97,
-      "maintainer-review": 22
+      "direct-submission": 96,
+      "maintainer-review": 23
     },
-    "maintainer_review_count": 22,
-    "manual_review_required_count": 32,
+    "maintainer_review_count": 23,
+    "manual_review_required_count": 33,
     "monitoring_followup_count": 0,
     "queue_count": 129,
     "subnet_count": 129,
     "top_direct_submission_kinds": {
       "data-artifact": 59,
       "openapi": 68,
-      "source-repo": 22,
+      "source-repo": 21,
       "subnet-api": 68,
-      "website": 21
+      "website": 18
     }
   }
 }

--- a/public/metagraph/review/gap-priorities.json
+++ b/public/metagraph/review/gap-priorities.json
@@ -3,42 +3,22 @@
   "generated_at": "1970-01-01T00:00:00.000Z",
   "priorities": [
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "data-artifact"
       ],
       "name": "Allways",
       "netuid": 7,
-      "priority_score": 101,
+      "priority_score": 102,
       "review_state": "maintainer-reviewed",
       "slug": "allways",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 23,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 14,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "website",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Nodexo",
-      "netuid": 27,
-      "priority_score": 82,
-      "review_state": "machine-generated",
-      "slug": "sn-27",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -50,55 +30,15 @@
       ],
       "name": "Chunking",
       "netuid": 40,
-      "priority_score": 74,
+      "priority_score": 75,
       "review_state": "machine-generated",
       "slug": "sn-40",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "website",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "EfficientFrontier",
-      "netuid": 53,
-      "priority_score": 74,
-      "review_state": "machine-generated",
-      "slug": "sn-53",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "website",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Parked",
-      "netuid": 73,
-      "priority_score": 74,
-      "review_state": "machine-generated",
-      "slug": "sn-73",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -110,35 +50,15 @@
       ],
       "name": "luis",
       "netuid": 92,
-      "priority_score": 74,
+      "priority_score": 75,
       "review_state": "stale",
       "slug": "sn-92",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "website",
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "hard_sign",
-      "netuid": 116,
-      "priority_score": 74,
-      "review_state": "machine-generated",
-      "slug": "sn-116",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 5,
-      "verified_candidate_count": 5
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -150,15 +70,15 @@
       ],
       "name": "Satori",
       "netuid": 119,
-      "priority_score": 74,
+      "priority_score": 75,
       "review_state": "machine-generated",
       "slug": "sn-119",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -167,15 +87,15 @@
       ],
       "name": "SOMA",
       "netuid": 114,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-114",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -187,15 +107,15 @@
       ],
       "name": "gm",
       "netuid": 28,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-28",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -207,15 +127,15 @@
       ],
       "name": "Recall",
       "netuid": 31,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-31",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -227,15 +147,15 @@
       ],
       "name": "ain",
       "netuid": 69,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-69",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -247,15 +167,15 @@
       ],
       "name": "Subnet 86",
       "netuid": 86,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-86",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -267,15 +187,15 @@
       ],
       "name": "eni",
       "netuid": 101,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-101",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -287,15 +207,15 @@
       ],
       "name": "for sale (burn to uid1)",
       "netuid": 104,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-104",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -307,15 +227,15 @@
       ],
       "name": "8 Ball",
       "netuid": 125,
-      "priority_score": 73,
+      "priority_score": 74,
       "review_state": "machine-generated",
       "slug": "sn-125",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 5,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -323,15 +243,15 @@
       ],
       "name": "Gradients",
       "netuid": 56,
-      "priority_score": 72,
+      "priority_score": 73,
       "review_state": "machine-generated",
       "slug": "sn-56",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 22
+      "verified_candidate_count": 23
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -340,15 +260,15 @@
       ],
       "name": "NOVA",
       "netuid": 68,
-      "priority_score": 70,
+      "priority_score": 71,
       "review_state": "machine-generated",
       "slug": "sn-68",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -357,15 +277,15 @@
       ],
       "name": "NexisGen",
       "netuid": 70,
-      "priority_score": 70,
+      "priority_score": 71,
       "review_state": "machine-generated",
       "slug": "sn-70",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -375,15 +295,15 @@
       ],
       "name": "Ditto",
       "netuid": 118,
-      "priority_score": 68,
+      "priority_score": 69,
       "review_state": "machine-generated",
       "slug": "sn-118",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "source-repo",
@@ -393,33 +313,15 @@
       ],
       "name": "Actual",
       "netuid": 95,
-      "priority_score": 67,
+      "priority_score": 68,
       "review_state": "machine-generated",
       "slug": "sn-95",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "source-repo",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "colosseum",
-      "netuid": 38,
-      "priority_score": 65,
-      "review_state": "machine-generated",
-      "slug": "sn-38",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -428,15 +330,15 @@
       ],
       "name": "lium.io",
       "netuid": 51,
-      "priority_score": 64,
+      "priority_score": 65,
       "review_state": "machine-generated",
       "slug": "sn-51",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 19
+      "verified_candidate_count": 20
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -445,15 +347,15 @@
       ],
       "name": "Zipcode",
       "netuid": 46,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-46",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -463,15 +365,15 @@
       ],
       "name": "Cacheon",
       "netuid": 14,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-14",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -481,15 +383,15 @@
       ],
       "name": "404—GEN",
       "netuid": 17,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-17",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -499,15 +401,15 @@
       ],
       "name": "Plaτform",
       "netuid": 100,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-100",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -517,15 +419,15 @@
       ],
       "name": "TalkHead",
       "netuid": 108,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "machine-generated",
       "slug": "sn-108",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -536,15 +438,15 @@
       ],
       "name": "Grail",
       "netuid": 81,
-      "priority_score": 63,
+      "priority_score": 64,
       "review_state": "needs-review",
       "slug": "sn-81",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -554,15 +456,15 @@
       ],
       "name": "Numinous",
       "netuid": 6,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-6",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -572,9 +474,27 @@
       ],
       "name": "Zeus",
       "netuid": 18,
-      "priority_score": 62,
+      "priority_score": 63,
       "review_state": "machine-generated",
       "slug": "sn-18",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 14
+    },
+    {
+      "candidate_count": 19,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Aurelius",
+      "netuid": 37,
+      "priority_score": 63,
+      "review_state": "machine-generated",
+      "slug": "sn-37",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
       "verified_candidate_count": 13
@@ -588,35 +508,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Aurelius",
-      "netuid": 37,
-      "priority_score": 62,
-      "review_state": "machine-generated",
-      "slug": "sn-37",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 12
-    },
-    {
-      "candidate_count": 17,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Hone",
       "netuid": 5,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-5",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -626,15 +528,15 @@
       ],
       "name": "TrajectoryRL",
       "netuid": 11,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-11",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -644,15 +546,15 @@
       ],
       "name": "Perturb",
       "netuid": 26,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-26",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -662,15 +564,15 @@
       ],
       "name": "Eirel",
       "netuid": 36,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-36",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -680,15 +582,15 @@
       ],
       "name": "NIOME",
       "netuid": 55,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-55",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -698,15 +600,15 @@
       ],
       "name": "Poker44",
       "netuid": 126,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "machine-generated",
       "slug": "sn-126",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -717,15 +619,15 @@
       ],
       "name": "Gopher",
       "netuid": 42,
-      "priority_score": 61,
+      "priority_score": 62,
       "review_state": "needs-review",
       "slug": "sn-42",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -734,15 +636,15 @@
       ],
       "name": "Minos",
       "netuid": 107,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-107",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -752,15 +654,15 @@
       ],
       "name": "Vanta",
       "netuid": 8,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-8",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -770,15 +672,15 @@
       ],
       "name": "Yanez MIID",
       "netuid": 54,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-54",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -788,15 +690,15 @@
       ],
       "name": "Harnyx",
       "netuid": 67,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-67",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -806,15 +708,15 @@
       ],
       "name": "Bitsota",
       "netuid": 94,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-94",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -824,15 +726,15 @@
       ],
       "name": "Astrid",
       "netuid": 127,
-      "priority_score": 60,
+      "priority_score": 61,
       "review_state": "machine-generated",
       "slug": "sn-127",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -841,15 +743,15 @@
       ],
       "name": "TAO Private Network",
       "netuid": 65,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-65",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -858,50 +760,15 @@
       ],
       "name": "Bitcast",
       "netuid": 93,
-      "priority_score": 59,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-93",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 15,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Score",
-      "netuid": 44,
-      "priority_score": 59,
-      "review_state": "machine-generated",
-      "slug": "sn-44",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 9
-    },
-    {
-      "candidate_count": 18,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Babelbit",
-      "netuid": 59,
-      "priority_score": 58,
-      "review_state": "machine-generated",
-      "slug": "sn-59",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 10
-    },
-    {
-      "candidate_count": 14,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -911,15 +778,33 @@
       ],
       "name": "OxMarkets",
       "netuid": 35,
-      "priority_score": 58,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-35",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 8
+      "surface_count": 9,
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 16,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Score",
+      "netuid": 44,
+      "priority_score": 60,
+      "review_state": "machine-generated",
+      "slug": "sn-44",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "openapi",
@@ -929,12 +814,82 @@
       ],
       "name": "minotaur",
       "netuid": 112,
-      "priority_score": 58,
+      "priority_score": 60,
       "review_state": "machine-generated",
       "slug": "sn-112",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 10
+    },
+    {
+      "candidate_count": 19,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Babelbit",
+      "netuid": 59,
+      "priority_score": 59,
+      "review_state": "machine-generated",
+      "slug": "sn-59",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 11
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Swap",
+      "netuid": 10,
+      "priority_score": 59,
+      "review_state": "machine-generated",
+      "slug": "sn-10",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 9
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Affine",
+      "netuid": 120,
+      "priority_score": 59,
+      "review_state": "machine-generated",
+      "slug": "sn-120",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 7,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
+    },
+    {
+      "candidate_count": 18,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Albedo",
+      "netuid": 97,
+      "priority_score": 58,
+      "review_state": "machine-generated",
+      "slug": "sn-97",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 11,
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 14,
@@ -945,14 +900,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Affine",
-      "netuid": 120,
+      "name": "VoidAI",
+      "netuid": 106,
       "priority_score": 58,
       "review_state": "machine-generated",
-      "slug": "sn-120",
+      "slug": "sn-106",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 8
+      "surface_count": 8,
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 17,
@@ -962,70 +917,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Albedo",
-      "netuid": 97,
-      "priority_score": 57,
-      "review_state": "machine-generated",
-      "slug": "sn-97",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 11,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Swap",
-      "netuid": 10,
-      "priority_score": 57,
-      "review_state": "machine-generated",
-      "slug": "sn-10",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 7,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "VoidAI",
-      "netuid": 106,
-      "priority_score": 57,
-      "review_state": "machine-generated",
-      "slug": "sn-106",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 8
-    },
-    {
-      "candidate_count": 16,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "DSperse",
       "netuid": 2,
-      "priority_score": 56,
+      "priority_score": 57,
       "review_state": "machine-generated",
       "slug": "sn-2",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1034,15 +936,15 @@
       ],
       "name": "Leoma",
       "netuid": 99,
-      "priority_score": 56,
+      "priority_score": 57,
       "review_state": "machine-generated",
       "slug": "sn-99",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1051,15 +953,15 @@
       ],
       "name": "Bitsec.ai",
       "netuid": 60,
-      "priority_score": 55,
+      "priority_score": 56,
       "review_state": "machine-generated",
       "slug": "sn-60",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1068,11 +970,28 @@
       ],
       "name": "Vocence",
       "netuid": 78,
-      "priority_score": 55,
+      "priority_score": 56,
       "review_state": "machine-generated",
       "slug": "sn-78",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
+      "verified_candidate_count": 14
+    },
+    {
+      "candidate_count": 16,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "dogelayer",
+      "netuid": 80,
+      "priority_score": 56,
+      "review_state": "machine-generated",
+      "slug": "sn-80",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 10,
       "verified_candidate_count": 13
     },
     {
@@ -1083,34 +1002,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "dogelayer",
-      "netuid": 80,
-      "priority_score": 55,
-      "review_state": "machine-generated",
-      "slug": "sn-80",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
-      "verified_candidate_count": 12
-    },
-    {
-      "candidate_count": 14,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Almanac",
       "netuid": 41,
-      "priority_score": 54,
+      "priority_score": 55,
       "review_state": "machine-generated",
       "slug": "sn-41",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1119,15 +1021,15 @@
       ],
       "name": "Synth",
       "netuid": 50,
-      "priority_score": 54,
+      "priority_score": 55,
       "review_state": "machine-generated",
       "slug": "sn-50",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1136,9 +1038,43 @@
       ],
       "name": "Swarm",
       "netuid": 124,
-      "priority_score": 54,
+      "priority_score": 55,
       "review_state": "machine-generated",
       "slug": "sn-124",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 9,
+      "verified_candidate_count": 13
+    },
+    {
+      "candidate_count": 15,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ByteLeap",
+      "netuid": 128,
+      "priority_score": 55,
+      "review_state": "machine-generated",
+      "slug": "sn-128",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 10,
+      "verified_candidate_count": 13
+    },
+    {
+      "candidate_count": 14,
+      "curation_level": "machine-verified",
+      "missing_kinds": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "BitAds",
+      "netuid": 16,
+      "priority_score": 54,
+      "review_state": "machine-generated",
+      "slug": "sn-16",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
       "verified_candidate_count": 12
@@ -1151,34 +1087,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ByteLeap",
-      "netuid": 128,
+      "name": "colosseum",
+      "netuid": 38,
       "priority_score": 54,
       "review_state": "machine-generated",
-      "slug": "sn-128",
+      "slug": "sn-38",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 10,
+      "surface_count": 9,
       "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
-      "curation_level": "machine-verified",
-      "missing_kinds": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "BitAds",
-      "netuid": 16,
-      "priority_score": 53,
-      "review_state": "machine-generated",
-      "slug": "sn-16",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 9,
-      "verified_candidate_count": 11
-    },
-    {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1187,15 +1106,15 @@
       ],
       "name": "Leadpoet",
       "netuid": 71,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-71",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1204,15 +1123,15 @@
       ],
       "name": "Liquidity",
       "netuid": 77,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-77",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1221,15 +1140,15 @@
       ],
       "name": "CliqueAI",
       "netuid": 83,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-83",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "machine-verified",
       "missing_kinds": [
         "subnet-api",
@@ -1238,15 +1157,15 @@
       ],
       "name": "Beam",
       "netuid": 105,
-      "priority_score": 53,
+      "priority_score": 54,
       "review_state": "machine-generated",
       "slug": "sn-105",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1256,12 +1175,30 @@
       ],
       "name": "Basilica",
       "netuid": 39,
-      "priority_score": 51,
+      "priority_score": 52,
       "review_state": "needs-review",
       "slug": "sn-39",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
+    },
+    {
+      "candidate_count": 8,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "BrainPlay",
+      "netuid": 117,
+      "priority_score": 52,
+      "review_state": "needs-review",
+      "slug": "sn-117",
+      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
+      "surface_count": 8,
+      "verified_candidate_count": 8
     },
     {
       "candidate_count": 7,
@@ -1272,35 +1209,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "BrainPlay",
-      "netuid": 117,
-      "priority_score": 51,
-      "review_state": "needs-review",
-      "slug": "sn-117",
-      "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
-      "surface_count": 8,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Templar",
       "netuid": 3,
-      "priority_score": 50,
+      "priority_score": 51,
       "review_state": "needs-review",
       "slug": "sn-3",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1308,15 +1227,15 @@
       ],
       "name": "Green Compute",
       "netuid": 110,
-      "priority_score": 42,
+      "priority_score": 43,
       "review_state": "maintainer-reviewed",
       "slug": "sn-110",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1325,15 +1244,15 @@
       ],
       "name": "Quasar",
       "netuid": 24,
-      "priority_score": 40,
+      "priority_score": 41,
       "review_state": "maintainer-reviewed",
       "slug": "sn-24",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 12
     },
     {
-      "candidate_count": 28,
+      "candidate_count": 29,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1341,12 +1260,29 @@
       ],
       "name": "Chutes",
       "netuid": 64,
-      "priority_score": 39,
+      "priority_score": 40,
       "review_state": "maintainer-reviewed",
       "slug": "sn-64",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 17,
-      "verified_candidate_count": 21
+      "verified_candidate_count": 22
+    },
+    {
+      "candidate_count": 26,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "MVTRX",
+      "netuid": 79,
+      "priority_score": 33,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-79",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 19
     },
     {
       "candidate_count": 25,
@@ -1356,34 +1292,37 @@
         "subnet-api",
         "sse"
       ],
-      "name": "MVTRX",
-      "netuid": 79,
-      "priority_score": 32,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-79",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 18
-    },
-    {
-      "candidate_count": 24,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
       "name": "StreetVision by NATIX",
       "netuid": 72,
-      "priority_score": 31,
+      "priority_score": 32,
       "review_state": "maintainer-reviewed",
       "slug": "sn-72",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 12,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "source-repo",
+        "website",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "MetaHash",
+      "netuid": 73,
+      "priority_score": 30,
+      "review_state": "maintainer-reviewed",
+      "slug": "metahash",
+      "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
+      "surface_count": 5,
+      "verified_candidate_count": 6
+    },
+    {
+      "candidate_count": 18,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -1394,15 +1333,15 @@
       ],
       "name": "Bitstarter #1",
       "netuid": 91,
-      "priority_score": 28,
+      "priority_score": 29,
       "review_state": "maintainer-reviewed",
       "slug": "sn-91",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 11
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "curation_level": "adapter-backed",
       "missing_kinds": [
         "subnet-api",
@@ -1410,15 +1349,15 @@
       ],
       "name": "Gittensor",
       "netuid": 74,
-      "priority_score": 27,
+      "priority_score": 28,
       "review_state": "maintainer-reviewed",
       "slug": "gittensor",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 17,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 15
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -1428,12 +1367,48 @@
       ],
       "name": "EvolAI",
       "netuid": 47,
-      "priority_score": 27,
+      "priority_score": 28,
       "review_state": "maintainer-reviewed",
       "slug": "sn-47",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
+    },
+    {
+      "candidate_count": 16,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "source-repo",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "GroundLayer",
+      "netuid": 20,
+      "priority_score": 27,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-20",
+      "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
+      "surface_count": 7,
+      "verified_candidate_count": 9
+    },
+    {
+      "candidate_count": 19,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "Investing",
+      "netuid": 88,
+      "priority_score": 26,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-88",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 8,
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 15,
@@ -1445,31 +1420,50 @@
         "sse",
         "data-artifact"
       ],
-      "name": "GroundLayer",
-      "netuid": 20,
+      "name": "Endure Network",
+      "netuid": 30,
       "priority_score": 26,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-20",
+      "slug": "sn-30",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 7,
       "verified_candidate_count": 8
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 26,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
         "subnet-api",
-        "sse"
+        "sse",
+        "data-artifact"
       ],
-      "name": "Investing",
-      "netuid": 88,
+      "name": "Hippius",
+      "netuid": 75,
       "priority_score": 25,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-88",
+      "slug": "sn-75",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 11,
+      "verified_candidate_count": 20
+    },
+    {
+      "candidate_count": 26,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Compelle",
+      "netuid": 82,
+      "priority_score": 25,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-82",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 19
     },
     {
       "candidate_count": 14,
@@ -1481,53 +1475,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Endure Network",
-      "netuid": 30,
+      "name": "Nodexo",
+      "netuid": 27,
       "priority_score": 25,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-30",
+      "slug": "nodexo",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
-      "surface_count": 7,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 25,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Hippius",
-      "netuid": 75,
-      "priority_score": 24,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-75",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 11,
-      "verified_candidate_count": 19
-    },
-    {
-      "candidate_count": 25,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Compelle",
-      "netuid": 82,
-      "priority_score": 24,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-82",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -1538,15 +1496,15 @@
       ],
       "name": "Byzantium",
       "netuid": 76,
-      "priority_score": 24,
+      "priority_score": 25,
       "review_state": "maintainer-reviewed",
       "slug": "sn-76",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 6,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -1557,15 +1515,15 @@
       ],
       "name": "InfiniteHash",
       "netuid": 89,
-      "priority_score": 24,
+      "priority_score": 25,
       "review_state": "maintainer-reviewed",
       "slug": "sn-89",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1575,12 +1533,29 @@
       ],
       "name": "Targon",
       "netuid": 4,
-      "priority_score": 23,
+      "priority_score": 24,
       "review_state": "maintainer-reviewed",
       "slug": "sn-4",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
+    },
+    {
+      "candidate_count": 9,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "name": "ReadyAI",
+      "netuid": 33,
+      "priority_score": 24,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-33",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 10,
+      "verified_candidate_count": 8
     },
     {
       "candidate_count": 24,
@@ -1596,6 +1571,60 @@
       "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-9",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 17
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "blockmachine",
+      "netuid": 19,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-19",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 19
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "AdTAO",
+      "netuid": 21,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-21",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 7,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Mainframe",
+      "netuid": 25,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-25",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
       "verified_candidate_count": 16
@@ -1615,82 +1644,11 @@
       "review_state": "maintainer-reviewed",
       "slug": "sn-32",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 8,
-      "verified_candidate_count": 18
-    },
-    {
-      "candidate_count": 8,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "name": "ReadyAI",
-      "netuid": 33,
-      "priority_score": 23,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-33",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 10,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "blockmachine",
-      "netuid": 19,
-      "priority_score": 22,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-19",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 18
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "AdTAO",
-      "netuid": 21,
-      "priority_score": 22,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-21",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Mainframe",
-      "netuid": 25,
-      "priority_score": 22,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-25",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1700,15 +1658,15 @@
       ],
       "name": "Talisman AI",
       "netuid": 45,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-45",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1718,12 +1676,48 @@
       ],
       "name": "Quantum Compute",
       "netuid": 48,
-      "priority_score": 22,
+      "priority_score": 23,
       "review_state": "maintainer-reviewed",
       "slug": "sn-48",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 17
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Enigma",
+      "netuid": 63,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-63",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 7,
+      "verified_candidate_count": 17
+    },
+    {
+      "candidate_count": 24,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "sundae_bar",
+      "netuid": 121,
+      "priority_score": 23,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-121",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 7,
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 23,
@@ -1734,14 +1728,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Enigma",
-      "netuid": 63,
+      "name": "Data Universe",
+      "netuid": 13,
       "priority_score": 22,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-63",
+      "slug": "sn-13",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 7,
-      "verified_candidate_count": 16
+      "surface_count": 13,
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 23,
@@ -1759,25 +1753,7 @@
       "slug": "sn-103",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 17
-    },
-    {
-      "candidate_count": 23,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "sundae_bar",
-      "netuid": 121,
-      "priority_score": 22,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-121",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 7,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 22,
@@ -1788,35 +1764,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Data Universe",
-      "netuid": 13,
-      "priority_score": 21,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-13",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 13,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 21,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "ORO",
       "netuid": 15,
-      "priority_score": 20,
+      "priority_score": 21,
       "review_state": "maintainer-reviewed",
       "slug": "sn-15",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 16
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -1826,12 +1784,46 @@
       ],
       "name": "Vidaio",
       "netuid": 85,
-      "priority_score": 20,
+      "priority_score": 21,
       "review_state": "maintainer-reviewed",
       "slug": "sn-85",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 19
+    },
+    {
+      "candidate_count": 22,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ForeverMoney",
+      "netuid": 98,
+      "priority_score": 21,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-98",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 16
+    },
+    {
+      "candidate_count": 14,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Desearch",
+      "netuid": 22,
+      "priority_score": 21,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-22",
+      "suggested_next_action": "evaluate for subnet-specific adapter",
+      "surface_count": 16,
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 21,
@@ -1842,30 +1834,14 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ForeverMoney",
-      "netuid": 98,
+      "name": "Apex",
+      "netuid": 1,
       "priority_score": 20,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-98",
+      "slug": "sn-1",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 15
-    },
-    {
-      "candidate_count": 13,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Desearch",
-      "netuid": 22,
-      "priority_score": 20,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-22",
-      "suggested_next_action": "evaluate for subnet-specific adapter",
-      "surface_count": 16,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 14
     },
     {
       "candidate_count": 20,
@@ -1876,11 +1852,11 @@
         "sse",
         "data-artifact"
       ],
-      "name": "Apex",
-      "netuid": 1,
+      "name": "TensorUSD",
+      "netuid": 113,
       "priority_score": 19,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-1",
+      "slug": "sn-113",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
       "verified_candidate_count": 13
@@ -1894,35 +1870,36 @@
         "sse",
         "data-artifact"
       ],
-      "name": "TensorUSD",
-      "netuid": 113,
+      "name": "ConnitoAI",
+      "netuid": 102,
       "priority_score": 18,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-113",
+      "slug": "sn-102",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
+        "source-repo",
         "openapi",
         "subnet-api",
         "sse",
         "data-artifact"
       ],
-      "name": "ConnitoAI",
-      "netuid": 102,
-      "priority_score": 17,
+      "name": "EfficientFrontier",
+      "netuid": 53,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
-      "slug": "sn-102",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 12
+      "slug": "efficientfrontier",
+      "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
+      "surface_count": 7,
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -1933,15 +1910,15 @@
       ],
       "name": "Academia",
       "netuid": 109,
-      "priority_score": 17,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
       "slug": "sn-109",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -1952,15 +1929,34 @@
       ],
       "name": "HashiChain",
       "netuid": 115,
-      "priority_score": 17,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
       "slug": "sn-115",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
+      "verified_candidate_count": 7
+    },
+    {
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "source-repo",
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "TaoLend",
+      "netuid": 116,
+      "priority_score": 18,
+      "review_state": "maintainer-reviewed",
+      "slug": "taolend",
+      "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
+      "surface_count": 6,
       "verified_candidate_count": 6
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "website",
@@ -1971,15 +1967,15 @@
       ],
       "name": "MANTIS",
       "netuid": 123,
-      "priority_score": 17,
+      "priority_score": 18,
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 6,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -1990,15 +1986,15 @@
       ],
       "name": "Luminar Network",
       "netuid": 87,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-87",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 8,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "source-repo",
@@ -2009,15 +2005,15 @@
       ],
       "name": "DegenBrain",
       "netuid": 90,
-      "priority_score": 16,
+      "priority_score": 17,
       "review_state": "maintainer-reviewed",
       "slug": "sn-90",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 7,
-      "verified_candidate_count": 5
+      "verified_candidate_count": 6
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -2025,15 +2021,15 @@
       ],
       "name": "Handshake58",
       "netuid": 58,
-      "priority_score": 15,
+      "priority_score": 16,
       "review_state": "maintainer-reviewed",
       "slug": "sn-58",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 13,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 9
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2043,15 +2039,15 @@
       ],
       "name": "RedTeam",
       "netuid": 61,
-      "priority_score": 14,
+      "priority_score": 15,
       "review_state": "maintainer-reviewed",
       "slug": "sn-61",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "sse",
@@ -2059,15 +2055,15 @@
       ],
       "name": "Verathos",
       "netuid": 96,
-      "priority_score": 14,
+      "priority_score": 15,
       "review_state": "maintainer-reviewed",
       "slug": "sn-96",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 13,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 14
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2076,15 +2072,15 @@
       ],
       "name": "Coldint",
       "netuid": 29,
-      "priority_score": 14,
+      "priority_score": 15,
       "review_state": "maintainer-reviewed",
       "slug": "sn-29",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2093,12 +2089,12 @@
       ],
       "name": "Trishool",
       "netuid": 23,
-      "priority_score": 13,
+      "priority_score": 14,
       "review_state": "maintainer-reviewed",
       "slug": "sn-23",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 14,
@@ -2115,11 +2111,11 @@
       "review_state": "maintainer-reviewed",
       "slug": "sn-62",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 7,
+      "surface_count": 6,
       "verified_candidate_count": 7
     },
     {
-      "candidate_count": 10,
+      "candidate_count": 11,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2129,12 +2125,28 @@
       ],
       "name": "Dojo",
       "netuid": 52,
-      "priority_score": 9,
+      "priority_score": 10,
       "review_state": "maintainer-reviewed",
       "slug": "sn-52",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 10,
-      "verified_candidate_count": 9
+      "verified_candidate_count": 10
+    },
+    {
+      "candidate_count": 17,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ninja",
+      "netuid": 66,
+      "priority_score": 8,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-66",
+      "suggested_next_action": "evaluate for subnet-specific adapter",
+      "surface_count": 13,
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 16,
@@ -2143,33 +2155,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ninja",
-      "netuid": 66,
-      "priority_score": 7,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-66",
-      "suggested_next_action": "evaluate for subnet-specific adapter",
-      "surface_count": 13,
-      "verified_candidate_count": 14
-    },
-    {
-      "candidate_count": 15,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "sse",
-        "data-artifact"
-      ],
       "name": "Nepher Robotics",
       "netuid": 49,
-      "priority_score": 6,
+      "priority_score": 7,
       "review_state": "maintainer-reviewed",
       "slug": "sn-49",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 7
+      "verified_candidate_count": 8
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2179,9 +2175,63 @@
       ],
       "name": "Compute Horde",
       "netuid": 12,
-      "priority_score": 6,
+      "priority_score": 7,
       "review_state": "maintainer-reviewed",
       "slug": "sn-12",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 7,
+      "verified_candidate_count": 8
+    },
+    {
+      "candidate_count": 8,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "ansuz",
+      "netuid": 84,
+      "priority_score": 7,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-84",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 8
+    },
+    {
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "BitMind",
+      "netuid": 34,
+      "priority_score": 6,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-34",
+      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
+      "surface_count": 9,
+      "verified_candidate_count": 7
+    },
+    {
+      "candidate_count": 7,
+      "curation_level": "maintainer-reviewed",
+      "missing_kinds": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "name": "Graphite",
+      "netuid": 43,
+      "priority_score": 6,
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-43",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
       "verified_candidate_count": 7
@@ -2195,71 +2245,17 @@
         "sse",
         "data-artifact"
       ],
-      "name": "ansuz",
-      "netuid": 84,
-      "priority_score": 6,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-84",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 7
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "BitMind",
-      "netuid": 34,
-      "priority_score": 5,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-34",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 9,
-      "verified_candidate_count": 6
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "name": "Graphite",
-      "netuid": 43,
-      "priority_score": 5,
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-43",
-      "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 7,
-      "verified_candidate_count": 6
-    },
-    {
-      "candidate_count": 6,
-      "curation_level": "maintainer-reviewed",
-      "missing_kinds": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
       "name": "Sparket",
       "netuid": 57,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-57",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2269,15 +2265,15 @@
       ],
       "name": "oneoneone",
       "netuid": 111,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-111",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2287,15 +2283,15 @@
       ],
       "name": "Bitrecs",
       "netuid": 122,
-      "priority_score": 5,
+      "priority_score": 6,
       "review_state": "maintainer-reviewed",
       "slug": "sn-122",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 6
+      "verified_candidate_count": 7
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "curation_level": "maintainer-reviewed",
       "missing_kinds": [
         "openapi",
@@ -2305,12 +2301,12 @@
       ],
       "name": "root",
       "netuid": 0,
-      "priority_score": 3,
+      "priority_score": 4,
       "review_state": "maintainer-reviewed",
       "slug": "root",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 14,
-      "verified_candidate_count": 4
+      "verified_candidate_count": 5
     }
   ],
   "schema_version": 1

--- a/public/metagraph/review/profile-completeness.json
+++ b/public/metagraph/review/profile-completeness.json
@@ -3,46 +3,7 @@
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profiles": [
     {
-      "candidate_count": 14,
-      "completeness_score": 20,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-source-repo",
-        "missing-website",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 6,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [
-        "source-repo",
-        "website"
-      ],
-      "name": "Nodexo",
-      "native_name_quality": "chain",
-      "netuid": 27,
-      "operational_interface_count": 0,
-      "priority_score": 124,
-      "profile_level": "directory-only",
-      "review_state": "machine-generated",
-      "slug": "sn-27",
-      "source_count": 5,
-      "suggested_next_action": "submit official docs, website, or source repository evidence",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs"
-      ]
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -69,7 +30,7 @@
       "native_name_quality": "chain",
       "netuid": 40,
       "operational_interface_count": 0,
-      "priority_score": 116,
+      "priority_score": 117,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-40",
@@ -81,85 +42,7 @@
       ]
     },
     {
-      "candidate_count": 6,
-      "completeness_score": 20,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-source-repo",
-        "missing-website",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 6,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [
-        "source-repo",
-        "website"
-      ],
-      "name": "EfficientFrontier",
-      "native_name_quality": "chain",
-      "netuid": 53,
-      "operational_interface_count": 0,
-      "priority_score": 116,
-      "profile_level": "directory-only",
-      "review_state": "machine-generated",
-      "slug": "sn-53",
-      "source_count": 5,
-      "suggested_next_action": "submit official docs, website, or source repository evidence",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs"
-      ]
-    },
-    {
-      "candidate_count": 6,
-      "completeness_score": 20,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-source-repo",
-        "missing-website",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 6,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [
-        "source-repo",
-        "website"
-      ],
-      "name": "Parked",
-      "native_name_quality": "chain",
-      "netuid": 73,
-      "operational_interface_count": 0,
-      "priority_score": 116,
-      "profile_level": "directory-only",
-      "review_state": "machine-generated",
-      "slug": "sn-73",
-      "source_count": 5,
-      "suggested_next_action": "submit official docs, website, or source repository evidence",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs"
-      ]
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -186,7 +69,7 @@
       "native_name_quality": "chain",
       "netuid": 92,
       "operational_interface_count": 0,
-      "priority_score": 116,
+      "priority_score": 117,
       "profile_level": "directory-only",
       "review_state": "stale",
       "slug": "sn-92",
@@ -198,46 +81,7 @@
       ]
     },
     {
-      "candidate_count": 6,
-      "completeness_score": 20,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-source-repo",
-        "missing-website",
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 6,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [
-        "source-repo",
-        "website"
-      ],
-      "name": "hard_sign",
-      "native_name_quality": "chain",
-      "netuid": 116,
-      "operational_interface_count": 0,
-      "priority_score": 116,
-      "profile_level": "directory-only",
-      "review_state": "machine-generated",
-      "slug": "sn-116",
-      "source_count": 5,
-      "suggested_next_action": "submit official docs, website, or source repository evidence",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs"
-      ]
-    },
-    {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -264,7 +108,7 @@
       "native_name_quality": "chain",
       "netuid": 119,
       "operational_interface_count": 0,
-      "priority_score": 116,
+      "priority_score": 117,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-119",
@@ -276,7 +120,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -303,7 +147,7 @@
       "native_name_quality": "chain",
       "netuid": 28,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-28",
@@ -315,7 +159,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -342,7 +186,7 @@
       "native_name_quality": "chain",
       "netuid": 31,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-31",
@@ -354,7 +198,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -381,7 +225,7 @@
       "native_name_quality": "chain",
       "netuid": 69,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-69",
@@ -393,7 +237,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -420,7 +264,7 @@
       "native_name_quality": "placeholder",
       "netuid": 86,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-86",
@@ -432,7 +276,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -459,7 +303,7 @@
       "native_name_quality": "chain",
       "netuid": 101,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-101",
@@ -471,7 +315,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -498,7 +342,7 @@
       "native_name_quality": "chain",
       "netuid": 104,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-104",
@@ -510,7 +354,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 20,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -537,7 +381,7 @@
       "native_name_quality": "chain",
       "netuid": 125,
       "operational_interface_count": 0,
-      "priority_score": 115,
+      "priority_score": 116,
       "profile_level": "directory-only",
       "review_state": "machine-generated",
       "slug": "sn-125",
@@ -549,7 +393,46 @@
       ]
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 7,
+      "completeness_score": 25,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-source-repo",
+        "missing-website",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 6,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [
+        "source-repo",
+        "website"
+      ],
+      "name": "MetaHash",
+      "native_name_quality": "chain",
+      "netuid": 73,
+      "operational_interface_count": 0,
+      "priority_score": 112,
+      "profile_level": "directory-only",
+      "review_state": "maintainer-reviewed",
+      "slug": "metahash",
+      "source_count": 5,
+      "suggested_next_action": "submit official docs, website, or source repository evidence",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs"
+      ]
+    },
+    {
+      "candidate_count": 18,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -574,11 +457,49 @@
       "native_name_quality": "chain",
       "netuid": 91,
       "operational_interface_count": 0,
-      "priority_score": 102,
+      "priority_score": 103,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-91",
       "source_count": 8,
+      "suggested_next_action": "submit official docs, website, or source repository evidence",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 16,
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-source-repo",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 5,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [
+        "source-repo"
+      ],
+      "name": "GroundLayer",
+      "native_name_quality": "chain",
+      "netuid": 20,
+      "operational_interface_count": 0,
+      "priority_score": 101,
+      "profile_level": "directory-only",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-20",
+      "source_count": 7,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -608,15 +529,15 @@
       "missing_required": [
         "source-repo"
       ],
-      "name": "GroundLayer",
+      "name": "Endure Network",
       "native_name_quality": "chain",
-      "netuid": 20,
+      "netuid": 30,
       "operational_interface_count": 0,
       "priority_score": 100,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
-      "slug": "sn-20",
-      "source_count": 7,
+      "slug": "sn-30",
+      "source_count": 8,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
@@ -646,14 +567,14 @@
       "missing_required": [
         "source-repo"
       ],
-      "name": "Endure Network",
+      "name": "Nodexo",
       "native_name_quality": "chain",
-      "netuid": 30,
+      "netuid": 27,
       "operational_interface_count": 0,
       "priority_score": 99,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
-      "slug": "sn-30",
+      "slug": "nodexo",
       "source_count": 8,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
@@ -663,7 +584,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -688,7 +609,7 @@
       "native_name_quality": "chain",
       "netuid": 76,
       "operational_interface_count": 0,
-      "priority_score": 98,
+      "priority_score": 99,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-76",
@@ -701,7 +622,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -726,7 +647,7 @@
       "native_name_quality": "chain",
       "netuid": 89,
       "operational_interface_count": 0,
-      "priority_score": 98,
+      "priority_score": 99,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-89",
@@ -739,7 +660,7 @@
       ]
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -761,7 +682,7 @@
       "native_name_quality": "chain",
       "netuid": 118,
       "operational_interface_count": 0,
-      "priority_score": 94,
+      "priority_score": 95,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-118",
@@ -775,7 +696,7 @@
       ]
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "completeness_score": 40,
       "confidence": "low",
       "curation_level": "maintainer-reviewed",
@@ -800,7 +721,7 @@
       "native_name_quality": "chain",
       "netuid": 81,
       "operational_interface_count": 0,
-      "priority_score": 92,
+      "priority_score": 93,
       "profile_level": "directory-only",
       "review_state": "needs-review",
       "slug": "sn-81",
@@ -813,7 +734,45 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-source-repo",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 5,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [
+        "source-repo"
+      ],
+      "name": "EfficientFrontier",
+      "native_name_quality": "chain",
+      "netuid": 53,
+      "operational_interface_count": 0,
+      "priority_score": 92,
+      "profile_level": "directory-only",
+      "review_state": "maintainer-reviewed",
+      "slug": "efficientfrontier",
+      "source_count": 7,
+      "suggested_next_action": "submit official docs, website, or source repository evidence",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 7,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -838,7 +797,7 @@
       "native_name_quality": "chain",
       "netuid": 109,
       "operational_interface_count": 0,
-      "priority_score": 91,
+      "priority_score": 92,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-109",
@@ -851,7 +810,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -876,7 +835,7 @@
       "native_name_quality": "chain",
       "netuid": 115,
       "operational_interface_count": 0,
-      "priority_score": 91,
+      "priority_score": 92,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-115",
@@ -889,7 +848,45 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
+      "completeness_score": 40,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-source-repo",
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 5,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [
+        "source-repo"
+      ],
+      "name": "TaoLend",
+      "native_name_quality": "chain",
+      "netuid": 116,
+      "operational_interface_count": 0,
+      "priority_score": 92,
+      "profile_level": "directory-only",
+      "review_state": "maintainer-reviewed",
+      "slug": "taolend",
+      "source_count": 6,
+      "suggested_next_action": "submit official docs, website, or source repository evidence",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 7,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -914,7 +911,7 @@
       "native_name_quality": "chain",
       "netuid": 123,
       "operational_interface_count": 0,
-      "priority_score": 91,
+      "priority_score": 92,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
@@ -927,7 +924,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 40,
       "confidence": "low",
       "curation_level": "maintainer-reviewed",
@@ -952,7 +949,7 @@
       "native_name_quality": "placeholder",
       "netuid": 42,
       "operational_interface_count": 0,
-      "priority_score": 90,
+      "priority_score": 91,
       "profile_level": "directory-only",
       "review_state": "needs-review",
       "slug": "sn-42",
@@ -965,7 +962,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -990,7 +987,7 @@
       "native_name_quality": "placeholder",
       "netuid": 87,
       "operational_interface_count": 0,
-      "priority_score": 90,
+      "priority_score": 91,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-87",
@@ -1003,7 +1000,7 @@
       ]
     },
     {
-      "candidate_count": 5,
+      "candidate_count": 6,
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1028,7 +1025,7 @@
       "native_name_quality": "chain",
       "netuid": 90,
       "operational_interface_count": 0,
-      "priority_score": 90,
+      "priority_score": 91,
       "profile_level": "directory-only",
       "review_state": "maintainer-reviewed",
       "slug": "sn-90",
@@ -1041,7 +1038,187 @@
       ]
     },
     {
+      "candidate_count": 20,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Cacheon",
+      "native_name_quality": "chain",
+      "netuid": 14,
+      "operational_interface_count": 0,
+      "priority_score": 90,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-14",
+      "source_count": 10,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 20,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "404—GEN",
+      "native_name_quality": "chain",
+      "netuid": 17,
+      "operational_interface_count": 0,
+      "priority_score": 90,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-17",
+      "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 20,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Plaτform",
+      "native_name_quality": "chain",
+      "netuid": 100,
+      "operational_interface_count": 0,
+      "priority_score": 90,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-100",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 20,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "TalkHead",
+      "native_name_quality": "chain",
+      "netuid": 108,
+      "operational_interface_count": 0,
+      "priority_score": 90,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-108",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
       "candidate_count": 25,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Targon",
+      "native_name_quality": "chain",
+      "netuid": 4,
+      "operational_interface_count": 0,
+      "priority_score": 90,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-4",
+      "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 26,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1077,7 +1254,7 @@
       ]
     },
     {
-      "candidate_count": 25,
+      "candidate_count": 26,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1131,159 +1308,87 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Cacheon",
+      "name": "Numinous",
       "native_name_quality": "chain",
-      "netuid": 14,
+      "netuid": 6,
       "operational_interface_count": 0,
       "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-14",
-      "source_count": 9,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 19,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "404—GEN",
-      "native_name_quality": "chain",
-      "netuid": 17,
-      "operational_interface_count": 0,
-      "priority_score": 89,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-17",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 19,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Plaτform",
-      "native_name_quality": "chain",
-      "netuid": 100,
-      "operational_interface_count": 0,
-      "priority_score": 89,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-100",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 19,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "TalkHead",
-      "native_name_quality": "chain",
-      "netuid": 108,
-      "operational_interface_count": 0,
-      "priority_score": 89,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-108",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 24,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Targon",
-      "native_name_quality": "chain",
-      "netuid": 4,
-      "operational_interface_count": 0,
-      "priority_score": 89,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-4",
+      "slug": "sn-6",
       "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 19,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Zeus",
+      "native_name_quality": "chain",
+      "netuid": 18,
+      "operational_interface_count": 0,
+      "priority_score": 89,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-18",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 19,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Aurelius",
+      "native_name_quality": "chain",
+      "netuid": 37,
+      "operational_interface_count": 0,
+      "priority_score": 89,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-37",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -1347,155 +1452,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "ItsAI",
-      "native_name_quality": "chain",
-      "netuid": 32,
-      "operational_interface_count": 0,
-      "priority_score": 89,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-32",
-      "source_count": 8,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 18,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Numinous",
-      "native_name_quality": "chain",
-      "netuid": 6,
-      "operational_interface_count": 0,
-      "priority_score": 88,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-6",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 18,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Zeus",
-      "native_name_quality": "chain",
-      "netuid": 18,
-      "operational_interface_count": 0,
-      "priority_score": 88,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-18",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 18,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Aurelius",
-      "native_name_quality": "chain",
-      "netuid": 37,
-      "operational_interface_count": 0,
-      "priority_score": 88,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-37",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 23,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "blockmachine",
       "native_name_quality": "chain",
       "netuid": 19,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-19",
@@ -1509,7 +1470,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1531,7 +1492,7 @@
       "native_name_quality": "chain",
       "netuid": 21,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-21",
@@ -1545,7 +1506,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1567,10 +1528,46 @@
       "native_name_quality": "chain",
       "netuid": 25,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-25",
+      "source_count": 9,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 24,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "ItsAI",
+      "native_name_quality": "chain",
+      "netuid": 32,
+      "operational_interface_count": 0,
+      "priority_score": 89,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-32",
       "source_count": 8,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1581,7 +1578,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1603,7 +1600,7 @@
       "native_name_quality": "chain",
       "netuid": 45,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-45",
@@ -1617,7 +1614,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -1639,11 +1636,299 @@
       "native_name_quality": "chain",
       "netuid": 48,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 89,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-48",
       "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 24,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Enigma",
+      "native_name_quality": "chain",
+      "netuid": 63,
+      "operational_interface_count": 0,
+      "priority_score": 89,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-63",
+      "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 24,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "sundae_bar",
+      "native_name_quality": "chain",
+      "netuid": 121,
+      "operational_interface_count": 0,
+      "priority_score": 89,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-121",
+      "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Hone",
+      "native_name_quality": "chain",
+      "netuid": 5,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-5",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "TrajectoryRL",
+      "native_name_quality": "chain",
+      "netuid": 11,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-11",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Perturb",
+      "native_name_quality": "chain",
+      "netuid": 26,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-26",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Eirel",
+      "native_name_quality": "chain",
+      "netuid": 36,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-36",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "NIOME",
+      "native_name_quality": "chain",
+      "netuid": 55,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-55",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Poker44",
+      "native_name_quality": "chain",
+      "netuid": 126,
+      "operational_interface_count": 0,
+      "priority_score": 88,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-126",
+      "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -1671,15 +1956,15 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Enigma",
+      "name": "Data Universe",
       "native_name_quality": "chain",
-      "netuid": 63,
+      "netuid": 13,
       "operational_interface_count": 0,
       "priority_score": 88,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
-      "slug": "sn-63",
-      "source_count": 8,
+      "slug": "sn-13",
+      "source_count": 12,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -1725,10 +2010,10 @@
       ]
     },
     {
-      "candidate_count": 23,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
       "gap_reasons": [
         "missing-openapi",
         "missing-subnet-api",
@@ -1743,14 +2028,50 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "sundae_bar",
+      "name": "Vanta",
       "native_name_quality": "chain",
-      "netuid": 121,
+      "netuid": 8,
       "operational_interface_count": 0,
-      "priority_score": 88,
+      "priority_score": 87,
       "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-121",
+      "review_state": "machine-generated",
+      "slug": "sn-8",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Yanez MIID",
+      "native_name_quality": "chain",
+      "netuid": 54,
+      "operational_interface_count": 0,
+      "priority_score": 87,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-54",
       "source_count": 8,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1779,14 +2100,50 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Hone",
+      "name": "Harnyx",
       "native_name_quality": "chain",
-      "netuid": 5,
+      "netuid": 67,
       "operational_interface_count": 0,
       "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-5",
+      "slug": "sn-67",
+      "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 17,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Bitsota",
+      "native_name_quality": "chain",
+      "netuid": 94,
+      "operational_interface_count": 0,
+      "priority_score": 87,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-94",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1815,158 +2172,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "TrajectoryRL",
+      "name": "Astrid",
       "native_name_quality": "chain",
-      "netuid": 11,
+      "netuid": 127,
       "operational_interface_count": 0,
       "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-11",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 17,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Perturb",
-      "native_name_quality": "chain",
-      "netuid": 26,
-      "operational_interface_count": 0,
-      "priority_score": 87,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-26",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 17,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Eirel",
-      "native_name_quality": "chain",
-      "netuid": 36,
-      "operational_interface_count": 0,
-      "priority_score": 87,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-36",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 17,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "NIOME",
-      "native_name_quality": "chain",
-      "netuid": 55,
-      "operational_interface_count": 0,
-      "priority_score": 87,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-55",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 17,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Poker44",
-      "native_name_quality": "chain",
-      "netuid": 126,
-      "operational_interface_count": 0,
-      "priority_score": 87,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-126",
+      "slug": "sn-127",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -1995,227 +2208,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Data Universe",
-      "native_name_quality": "chain",
-      "netuid": 13,
-      "operational_interface_count": 0,
-      "priority_score": 87,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-13",
-      "source_count": 12,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 16,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Vanta",
-      "native_name_quality": "chain",
-      "netuid": 8,
-      "operational_interface_count": 0,
-      "priority_score": 86,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-8",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 16,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Yanez MIID",
-      "native_name_quality": "chain",
-      "netuid": 54,
-      "operational_interface_count": 0,
-      "priority_score": 86,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-54",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 16,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Harnyx",
-      "native_name_quality": "chain",
-      "netuid": 67,
-      "operational_interface_count": 0,
-      "priority_score": 86,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-67",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 16,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Bitsota",
-      "native_name_quality": "chain",
-      "netuid": 94,
-      "operational_interface_count": 0,
-      "priority_score": 86,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-94",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 16,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Astrid",
-      "native_name_quality": "chain",
-      "netuid": 127,
-      "operational_interface_count": 0,
-      "priority_score": 86,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-127",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 21,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "ORO",
       "native_name_quality": "chain",
       "netuid": 15,
       "operational_interface_count": 0,
-      "priority_score": 86,
+      "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-15",
@@ -2229,7 +2226,7 @@
       ]
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -2251,7 +2248,7 @@
       "native_name_quality": "chain",
       "netuid": 85,
       "operational_interface_count": 0,
-      "priority_score": 86,
+      "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-85",
@@ -2265,7 +2262,7 @@
       ]
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -2287,7 +2284,7 @@
       "native_name_quality": "chain",
       "netuid": 98,
       "operational_interface_count": 0,
-      "priority_score": 86,
+      "priority_score": 87,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-98",
@@ -2301,7 +2298,43 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "OxMarkets",
+      "native_name_quality": "chain",
+      "netuid": 35,
+      "operational_interface_count": 0,
+      "priority_score": 86,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-35",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 16,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -2323,7 +2356,7 @@
       "native_name_quality": "chain",
       "netuid": 44,
       "operational_interface_count": 0,
-      "priority_score": 85,
+      "priority_score": 86,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
       "slug": "sn-44",
@@ -2337,7 +2370,7 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "completeness_score": 50,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -2360,7 +2393,7 @@
       "native_name_quality": "chain",
       "netuid": 95,
       "operational_interface_count": 1,
-      "priority_score": 85,
+      "priority_score": 86,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-95",
@@ -2370,6 +2403,150 @@
         "dashboard",
         "docs",
         "openapi",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 16,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "minotaur",
+      "native_name_quality": "chain",
+      "netuid": 112,
+      "operational_interface_count": 0,
+      "priority_score": 86,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-112",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 21,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Apex",
+      "native_name_quality": "chain",
+      "netuid": 1,
+      "operational_interface_count": 0,
+      "priority_score": 86,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-1",
+      "source_count": 10,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 15,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Swap",
+      "native_name_quality": "chain",
+      "netuid": 10,
+      "operational_interface_count": 0,
+      "priority_score": 85,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-10",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 15,
+      "completeness_score": 50,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 4,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Affine",
+      "native_name_quality": "chain",
+      "netuid": 120,
+      "operational_interface_count": 0,
+      "priority_score": 85,
+      "profile_level": "identity-complete",
+      "review_state": "machine-generated",
+      "slug": "sn-120",
+      "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
         "website"
       ]
     },
@@ -2392,14 +2569,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Apex",
+      "name": "TensorUSD",
       "native_name_quality": "chain",
-      "netuid": 1,
+      "netuid": 113,
       "operational_interface_count": 0,
       "priority_score": 85,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
-      "slug": "sn-1",
+      "slug": "sn-113",
       "source_count": 10,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -2428,86 +2605,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "OxMarkets",
+      "name": "VoidAI",
       "native_name_quality": "chain",
-      "netuid": 35,
+      "netuid": 106,
       "operational_interface_count": 0,
       "priority_score": 84,
       "profile_level": "identity-complete",
       "review_state": "machine-generated",
-      "slug": "sn-35",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 14,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "minotaur",
-      "native_name_quality": "chain",
-      "netuid": 112,
-      "operational_interface_count": 0,
-      "priority_score": 84,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-112",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 14,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Affine",
-      "native_name_quality": "chain",
-      "netuid": 120,
-      "operational_interface_count": 0,
-      "priority_score": 84,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-120",
+      "slug": "sn-106",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -2536,156 +2641,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "TensorUSD",
-      "native_name_quality": "chain",
-      "netuid": 113,
-      "operational_interface_count": 0,
-      "priority_score": 84,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-113",
-      "source_count": 10,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 13,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Swap",
-      "native_name_quality": "chain",
-      "netuid": 10,
-      "operational_interface_count": 0,
-      "priority_score": 83,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-10",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 13,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-source-repo",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [
-        "source-repo"
-      ],
-      "name": "colosseum",
-      "native_name_quality": "chain",
-      "netuid": 38,
-      "operational_interface_count": 1,
-      "priority_score": 83,
-      "profile_level": "operational",
-      "review_state": "machine-generated",
-      "slug": "sn-38",
-      "source_count": 6,
-      "suggested_next_action": "submit official docs, website, or source repository evidence",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "openapi",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 13,
-      "completeness_score": 50,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "VoidAI",
-      "native_name_quality": "chain",
-      "netuid": 106,
-      "operational_interface_count": 0,
-      "priority_score": 83,
-      "profile_level": "identity-complete",
-      "review_state": "machine-generated",
-      "slug": "sn-106",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 18,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 4,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "ConnitoAI",
       "native_name_quality": "chain",
       "netuid": 102,
       "operational_interface_count": 0,
-      "priority_score": 83,
+      "priority_score": 84,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-102",
@@ -2699,7 +2659,7 @@
       ]
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "completeness_score": 48,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -2722,7 +2682,7 @@
       "native_name_quality": "chain",
       "netuid": 47,
       "operational_interface_count": 1,
-      "priority_score": 80,
+      "priority_score": 81,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-47",
@@ -2736,7 +2696,7 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -2758,7 +2718,7 @@
       "native_name_quality": "chain",
       "netuid": 61,
       "operational_interface_count": 0,
-      "priority_score": 80,
+      "priority_score": 81,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-61",
@@ -2808,7 +2768,7 @@
       ]
     },
     {
-      "candidate_count": 21,
+      "candidate_count": 22,
       "completeness_score": 58,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -2828,7 +2788,7 @@
       "native_name_quality": "chain",
       "netuid": 114,
       "operational_interface_count": 1,
-      "priority_score": 78,
+      "priority_score": 79,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-114",
@@ -2844,6 +2804,41 @@
     },
     {
       "candidate_count": 25,
+      "completeness_score": 63,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "missing_required": [],
+      "name": "StreetVision by NATIX",
+      "native_name_quality": "chain",
+      "netuid": 72,
+      "operational_interface_count": 1,
+      "priority_score": 77,
+      "profile_level": "operational",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-72",
+      "source_count": 10,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "data-artifact",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 26,
       "completeness_score": 63,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -2878,42 +2873,7 @@
       ]
     },
     {
-      "candidate_count": 24,
-      "completeness_score": 63,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse"
-      ],
-      "missing_critical_count": 3,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "missing_required": [],
-      "name": "StreetVision by NATIX",
-      "native_name_quality": "chain",
-      "netuid": 72,
-      "operational_interface_count": 1,
-      "priority_score": 76,
-      "profile_level": "operational",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-72",
-      "source_count": 10,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "data-artifact",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 10,
+      "candidate_count": 11,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -2935,7 +2895,7 @@
       "native_name_quality": "chain",
       "netuid": 52,
       "operational_interface_count": 0,
-      "priority_score": 75,
+      "priority_score": 76,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-52",
@@ -2949,7 +2909,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 58,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -2969,7 +2929,7 @@
       "native_name_quality": "chain",
       "netuid": 68,
       "operational_interface_count": 1,
-      "priority_score": 75,
+      "priority_score": 76,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-68",
@@ -2984,7 +2944,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 58,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3004,7 +2964,7 @@
       "native_name_quality": "chain",
       "netuid": 70,
       "operational_interface_count": 1,
-      "priority_score": 75,
+      "priority_score": 76,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-70",
@@ -3019,7 +2979,7 @@
       ]
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3039,7 +2999,7 @@
       "native_name_quality": "chain",
       "netuid": 51,
       "operational_interface_count": 1,
-      "priority_score": 74,
+      "priority_score": 75,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-51",
@@ -3054,7 +3014,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3074,11 +3034,11 @@
       "native_name_quality": "chain",
       "netuid": 46,
       "operational_interface_count": 1,
-      "priority_score": 73,
+      "priority_score": 74,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-46",
-      "source_count": 7,
+      "source_count": 8,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -3089,7 +3049,7 @@
       ]
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3111,7 +3071,7 @@
       "native_name_quality": "chain",
       "netuid": 12,
       "operational_interface_count": 0,
-      "priority_score": 72,
+      "priority_score": 73,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-12",
@@ -3125,7 +3085,7 @@
       ]
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "completeness_score": 55,
       "confidence": "low",
       "curation_level": "maintainer-reviewed",
@@ -3147,7 +3107,7 @@
       "native_name_quality": "chain",
       "netuid": 39,
       "operational_interface_count": 0,
-      "priority_score": 72,
+      "priority_score": 73,
       "profile_level": "identity-complete",
       "review_state": "needs-review",
       "slug": "sn-39",
@@ -3161,7 +3121,7 @@
       ]
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3183,7 +3143,7 @@
       "native_name_quality": "chain",
       "netuid": 84,
       "operational_interface_count": 0,
-      "priority_score": 72,
+      "priority_score": 73,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-84",
@@ -3197,7 +3157,7 @@
       ]
     },
     {
-      "candidate_count": 7,
+      "candidate_count": 8,
       "completeness_score": 55,
       "confidence": "low",
       "curation_level": "maintainer-reviewed",
@@ -3219,7 +3179,7 @@
       "native_name_quality": "placeholder",
       "netuid": 117,
       "operational_interface_count": 0,
-      "priority_score": 72,
+      "priority_score": 73,
       "profile_level": "identity-complete",
       "review_state": "needs-review",
       "slug": "sn-117",
@@ -3233,7 +3193,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 55,
       "confidence": "low",
       "curation_level": "maintainer-reviewed",
@@ -3255,7 +3215,7 @@
       "native_name_quality": "chain",
       "netuid": 3,
       "operational_interface_count": 0,
-      "priority_score": 71,
+      "priority_score": 72,
       "profile_level": "identity-complete",
       "review_state": "needs-review",
       "slug": "sn-3",
@@ -3269,7 +3229,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3291,7 +3251,7 @@
       "native_name_quality": "chain",
       "netuid": 34,
       "operational_interface_count": 0,
-      "priority_score": 71,
+      "priority_score": 72,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-34",
@@ -3305,7 +3265,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3327,7 +3287,7 @@
       "native_name_quality": "chain",
       "netuid": 43,
       "operational_interface_count": 0,
-      "priority_score": 71,
+      "priority_score": 72,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-43",
@@ -3341,7 +3301,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3363,7 +3323,7 @@
       "native_name_quality": "chain",
       "netuid": 57,
       "operational_interface_count": 0,
-      "priority_score": 71,
+      "priority_score": 72,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-57",
@@ -3377,7 +3337,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3399,7 +3359,7 @@
       "native_name_quality": "chain",
       "netuid": 111,
       "operational_interface_count": 0,
-      "priority_score": 71,
+      "priority_score": 72,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-111",
@@ -3413,7 +3373,7 @@
       ]
     },
     {
-      "candidate_count": 6,
+      "candidate_count": 7,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3435,7 +3395,7 @@
       "native_name_quality": "chain",
       "netuid": 122,
       "operational_interface_count": 0,
-      "priority_score": 71,
+      "priority_score": 72,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "sn-122",
@@ -3449,7 +3409,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 63,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3469,7 +3429,7 @@
       "native_name_quality": "chain",
       "netuid": 88,
       "operational_interface_count": 1,
-      "priority_score": 70,
+      "priority_score": 71,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-88",
@@ -3484,7 +3444,7 @@
       ]
     },
     {
-      "candidate_count": 20,
+      "candidate_count": 21,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3504,7 +3464,7 @@
       "native_name_quality": "chain",
       "netuid": 107,
       "operational_interface_count": 1,
-      "priority_score": 70,
+      "priority_score": 71,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-107",
@@ -3519,7 +3479,7 @@
       ]
     },
     {
-      "candidate_count": 4,
+      "candidate_count": 5,
       "completeness_score": 55,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3541,7 +3501,7 @@
       "native_name_quality": "chain",
       "netuid": 0,
       "operational_interface_count": 0,
-      "priority_score": 69,
+      "priority_score": 70,
       "profile_level": "identity-complete",
       "review_state": "maintainer-reviewed",
       "slug": "root",
@@ -3557,7 +3517,7 @@
       ]
     },
     {
-      "candidate_count": 17,
+      "candidate_count": 18,
       "completeness_score": 63,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -3577,7 +3537,7 @@
       "native_name_quality": "chain",
       "netuid": 24,
       "operational_interface_count": 1,
-      "priority_score": 69,
+      "priority_score": 70,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-24",
@@ -3592,7 +3552,7 @@
       ]
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3612,7 +3572,7 @@
       "native_name_quality": "chain",
       "netuid": 65,
       "operational_interface_count": 1,
-      "priority_score": 69,
+      "priority_score": 70,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-65",
@@ -3627,7 +3587,7 @@
       ]
     },
     {
-      "candidate_count": 19,
+      "candidate_count": 20,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3647,7 +3607,7 @@
       "native_name_quality": "chain",
       "netuid": 93,
       "operational_interface_count": 1,
-      "priority_score": 69,
+      "priority_score": 70,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-93",
@@ -3662,7 +3622,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3682,7 +3642,7 @@
       "native_name_quality": "chain",
       "netuid": 59,
       "operational_interface_count": 1,
-      "priority_score": 68,
+      "priority_score": 69,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-59",
@@ -3693,6 +3653,41 @@
         "docs",
         "source-repo",
         "subnet-api",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 18,
+      "completeness_score": 65,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Albedo",
+      "native_name_quality": "chain",
+      "netuid": 97,
+      "operational_interface_count": 1,
+      "priority_score": 68,
+      "profile_level": "operational",
+      "review_state": "machine-generated",
+      "slug": "sn-97",
+      "source_count": 9,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "openapi",
+        "source-repo",
         "website"
       ]
     },
@@ -3713,46 +3708,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "Albedo",
-      "native_name_quality": "chain",
-      "netuid": 97,
-      "operational_interface_count": 1,
-      "priority_score": 67,
-      "profile_level": "operational",
-      "review_state": "machine-generated",
-      "slug": "sn-97",
-      "source_count": 9,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "openapi",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 16,
-      "completeness_score": 65,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 3,
-      "missing_operational": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "DSperse",
       "native_name_quality": "chain",
       "netuid": 2,
       "operational_interface_count": 1,
-      "priority_score": 66,
+      "priority_score": 67,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-2",
@@ -3767,7 +3727,7 @@
       ]
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3787,7 +3747,7 @@
       "native_name_quality": "chain",
       "netuid": 99,
       "operational_interface_count": 1,
-      "priority_score": 66,
+      "priority_score": 67,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-99",
@@ -3802,7 +3762,7 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3822,7 +3782,7 @@
       "native_name_quality": "chain",
       "netuid": 60,
       "operational_interface_count": 1,
-      "priority_score": 65,
+      "priority_score": 66,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-60",
@@ -3837,7 +3797,7 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3857,10 +3817,45 @@
       "native_name_quality": "chain",
       "netuid": 78,
       "operational_interface_count": 1,
-      "priority_score": 65,
+      "priority_score": 66,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-78",
+      "source_count": 7,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "openapi",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 16,
+      "completeness_score": 65,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "dogelayer",
+      "native_name_quality": "chain",
+      "netuid": 80,
+      "operational_interface_count": 1,
+      "priority_score": 66,
+      "profile_level": "operational",
+      "review_state": "machine-generated",
+      "slug": "sn-80",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -3888,46 +3883,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "dogelayer",
-      "native_name_quality": "chain",
-      "netuid": 80,
-      "operational_interface_count": 1,
-      "priority_score": 65,
-      "profile_level": "operational",
-      "review_state": "machine-generated",
-      "slug": "sn-80",
-      "source_count": 7,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "openapi",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 14,
-      "completeness_score": 65,
-      "confidence": "medium",
-      "curation_level": "machine-verified",
-      "gap_reasons": [
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 3,
-      "missing_operational": [
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "Almanac",
       "native_name_quality": "chain",
       "netuid": 41,
       "operational_interface_count": 1,
-      "priority_score": 64,
+      "priority_score": 65,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-41",
@@ -3942,7 +3902,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3962,7 +3922,7 @@
       "native_name_quality": "chain",
       "netuid": 50,
       "operational_interface_count": 1,
-      "priority_score": 64,
+      "priority_score": 65,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-50",
@@ -3977,7 +3937,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -3997,10 +3957,45 @@
       "native_name_quality": "chain",
       "netuid": 124,
       "operational_interface_count": 1,
-      "priority_score": 64,
+      "priority_score": 65,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-124",
+      "source_count": 8,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "openapi",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 15,
+      "completeness_score": 65,
+      "confidence": "medium",
+      "curation_level": "machine-verified",
+      "gap_reasons": [
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "ByteLeap",
+      "native_name_quality": "chain",
+      "netuid": 128,
+      "operational_interface_count": 1,
+      "priority_score": 65,
+      "profile_level": "operational",
+      "review_state": "machine-generated",
+      "slug": "sn-128",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -4028,14 +4023,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "ByteLeap",
+      "name": "BitAds",
       "native_name_quality": "chain",
-      "netuid": 128,
+      "netuid": 16,
       "operational_interface_count": 1,
       "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
-      "slug": "sn-128",
+      "slug": "sn-16",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -4047,7 +4042,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4063,14 +4058,14 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "BitAds",
+      "name": "colosseum",
       "native_name_quality": "chain",
-      "netuid": 16,
+      "netuid": 38,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
-      "slug": "sn-16",
+      "slug": "sn-38",
       "source_count": 7,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
@@ -4082,7 +4077,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4102,7 +4097,7 @@
       "native_name_quality": "chain",
       "netuid": 71,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-71",
@@ -4117,7 +4112,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4137,7 +4132,7 @@
       "native_name_quality": "chain",
       "netuid": 77,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-77",
@@ -4152,7 +4147,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4172,7 +4167,7 @@
       "native_name_quality": "chain",
       "netuid": 83,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-83",
@@ -4187,7 +4182,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 65,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4207,7 +4202,7 @@
       "native_name_quality": "chain",
       "netuid": 105,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-105",
@@ -4222,7 +4217,7 @@
       ]
     },
     {
-      "candidate_count": 18,
+      "candidate_count": 19,
       "completeness_score": 70,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4242,11 +4237,11 @@
       "native_name_quality": "chain",
       "netuid": 23,
       "operational_interface_count": 1,
-      "priority_score": 63,
+      "priority_score": 64,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-23",
-      "source_count": 8,
+      "source_count": 9,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",
@@ -4257,7 +4252,7 @@
       ]
     },
     {
-      "candidate_count": 24,
+      "candidate_count": 25,
       "completeness_score": 73,
       "confidence": "medium",
       "curation_level": "machine-verified",
@@ -4275,7 +4270,7 @@
       "native_name_quality": "chain",
       "netuid": 56,
       "operational_interface_count": 2,
-      "priority_score": 61,
+      "priority_score": 62,
       "profile_level": "operational",
       "review_state": "machine-generated",
       "slug": "sn-56",
@@ -4286,6 +4281,41 @@
         "data-artifact",
         "docs",
         "openapi",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 9,
+      "completeness_score": 63,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse"
+      ],
+      "missing_critical_count": 3,
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse"
+      ],
+      "missing_required": [],
+      "name": "ReadyAI",
+      "native_name_quality": "chain",
+      "netuid": 33,
+      "operational_interface_count": 1,
+      "priority_score": 61,
+      "profile_level": "operational",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-33",
+      "source_count": 10,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "data-artifact",
+        "docs",
         "source-repo",
         "website"
       ]
@@ -4307,46 +4337,11 @@
         "sse"
       ],
       "missing_required": [],
-      "name": "ReadyAI",
-      "native_name_quality": "chain",
-      "netuid": 33,
-      "operational_interface_count": 1,
-      "priority_score": 60,
-      "profile_level": "operational",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-33",
-      "source_count": 10,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "data-artifact",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 7,
-      "completeness_score": 63,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse"
-      ],
-      "missing_critical_count": 3,
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse"
-      ],
-      "missing_required": [],
       "name": "Coldint",
       "native_name_quality": "chain",
       "netuid": 29,
       "operational_interface_count": 1,
-      "priority_score": 59,
+      "priority_score": 60,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-29",
@@ -4361,7 +4356,7 @@
       ]
     },
     {
-      "candidate_count": 28,
+      "candidate_count": 29,
       "completeness_score": 78,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4395,7 +4390,7 @@
       ]
     },
     {
-      "candidate_count": 23,
+      "candidate_count": 24,
       "completeness_score": 78,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4413,7 +4408,7 @@
       "native_name_quality": "chain",
       "netuid": 110,
       "operational_interface_count": 2,
-      "priority_score": 55,
+      "priority_score": 56,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-110",
@@ -4429,7 +4424,7 @@
       ]
     },
     {
-      "candidate_count": 16,
+      "candidate_count": 17,
       "completeness_score": 83,
       "confidence": "high",
       "curation_level": "adapter-backed",
@@ -4447,7 +4442,7 @@
       "native_name_quality": "chain",
       "netuid": 74,
       "operational_interface_count": 2,
-      "priority_score": 43,
+      "priority_score": 44,
       "profile_level": "adapter-backed",
       "review_state": "maintainer-reviewed",
       "slug": "gittensor",
@@ -4460,6 +4455,40 @@
         "openapi",
         "repo-registry",
         "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 17,
+      "completeness_score": 85,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "missing_critical_count": 2,
+      "missing_operational": [
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "ninja",
+      "native_name_quality": "chain",
+      "netuid": 66,
+      "operational_interface_count": 2,
+      "priority_score": 42,
+      "profile_level": "operational",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-66",
+      "source_count": 11,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "openapi",
+        "source-repo",
+        "subnet-api",
         "website"
       ]
     },
@@ -4478,45 +4507,11 @@
         "data-artifact"
       ],
       "missing_required": [],
-      "name": "ninja",
-      "native_name_quality": "chain",
-      "netuid": 66,
-      "operational_interface_count": 2,
-      "priority_score": 41,
-      "profile_level": "operational",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-66",
-      "source_count": 11,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "openapi",
-        "source-repo",
-        "subnet-api",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 15,
-      "completeness_score": 85,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "missing_critical_count": 2,
-      "missing_operational": [
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
       "name": "Nepher Robotics",
       "native_name_quality": "chain",
       "netuid": 49,
       "operational_interface_count": 2,
-      "priority_score": 40,
+      "priority_score": 41,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-49",
@@ -4532,7 +4527,7 @@
       ]
     },
     {
-      "candidate_count": 15,
+      "candidate_count": 16,
       "completeness_score": 85,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4550,7 +4545,7 @@
       "native_name_quality": "chain",
       "netuid": 96,
       "operational_interface_count": 2,
-      "priority_score": 40,
+      "priority_score": 41,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-96",
@@ -4566,7 +4561,7 @@
       ]
     },
     {
-      "candidate_count": 13,
+      "candidate_count": 14,
       "completeness_score": 85,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4584,7 +4579,7 @@
       "native_name_quality": "chain",
       "netuid": 22,
       "operational_interface_count": 2,
-      "priority_score": 38,
+      "priority_score": 39,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-22",
@@ -4600,7 +4595,7 @@
       ]
     },
     {
-      "candidate_count": 8,
+      "candidate_count": 9,
       "completeness_score": 85,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
@@ -4618,7 +4613,7 @@
       "native_name_quality": "chain",
       "netuid": 58,
       "operational_interface_count": 2,
-      "priority_score": 33,
+      "priority_score": 34,
       "profile_level": "operational",
       "review_state": "maintainer-reviewed",
       "slug": "sn-58",
@@ -4634,7 +4629,7 @@
       ]
     },
     {
-      "candidate_count": 14,
+      "candidate_count": 15,
       "completeness_score": 97,
       "confidence": "high",
       "curation_level": "adapter-backed",
@@ -4650,7 +4645,7 @@
       "native_name_quality": "chain",
       "netuid": 7,
       "operational_interface_count": 3,
-      "priority_score": 22,
+      "priority_score": 23,
       "profile_level": "adapter-backed",
       "review_state": "maintainer-reviewed",
       "slug": "allways",
@@ -4669,11 +4664,11 @@
   ],
   "schema_version": 1,
   "summary": {
-    "average_completeness_score": 53,
+    "average_completeness_score": 54,
     "by_confidence": {
-      "high": 58,
+      "high": 62,
       "low": 5,
-      "medium": 66
+      "medium": 62
     },
     "by_profile_level": {
       "adapter-backed": 2,
@@ -4684,12 +4679,12 @@
     "critical_gap_counts": {
       "missing-data-artifact": 115,
       "missing-openapi": 101,
-      "missing-source-repo": 22,
+      "missing-source-repo": 21,
       "missing-sse": 128,
       "missing-subnet-api": 117,
-      "missing-website": 21
+      "missing-website": 18
     },
-    "needs_identity_count": 29,
+    "needs_identity_count": 28,
     "needs_operational_count": 85,
     "profile_count": 129
   }

--- a/public/metagraph/search.json
+++ b/public/metagraph/search.json
@@ -1,6 +1,6 @@
 {
   "contract_version": "2026-06-06.1",
-  "document_count": 1311,
+  "document_count": 1323,
   "documents": [
     {
       "artifact_path": "/metagraph/providers.json",
@@ -592,6 +592,21 @@
     },
     {
       "artifact_path": "/metagraph/providers.json",
+      "id": "provider:nodexo",
+      "subtitle": "subnet-team",
+      "title": "Nodexo",
+      "tokens": [
+        "claimed",
+        "nodexo",
+        "provider",
+        "subnet",
+        "team"
+      ],
+      "type": "provider",
+      "url": "https://nodexo.ai/"
+    },
+    {
+      "artifact_path": "/metagraph/providers.json",
       "id": "provider:nodies",
       "subtitle": "infrastructure-provider",
       "title": "Nodies",
@@ -750,6 +765,21 @@
     },
     {
       "artifact_path": "/metagraph/providers.json",
+      "id": "provider:signalplus",
+      "subtitle": "subnet-team",
+      "title": "SignalPlus",
+      "tokens": [
+        "claimed",
+        "provider",
+        "signalplus",
+        "subnet",
+        "team"
+      ],
+      "type": "provider",
+      "url": "https://www.signalplus.com/"
+    },
+    {
+      "artifact_path": "/metagraph/providers.json",
       "id": "provider:silx-labs",
       "subtitle": "subnet-team",
       "title": "SILX Labs",
@@ -776,6 +806,20 @@
       ],
       "type": "provider",
       "url": "https://sparket.ai/"
+    },
+    {
+      "artifact_path": "/metagraph/providers.json",
+      "id": "provider:subnetradar",
+      "subtitle": "data-provider",
+      "title": "SubnetRadar",
+      "tokens": [
+        "claimed",
+        "data",
+        "provider",
+        "subnetradar"
+      ],
+      "type": "provider",
+      "url": "https://subnetradar.com/"
     },
     {
       "artifact_path": "/metagraph/providers.json",
@@ -806,6 +850,21 @@
       ],
       "type": "provider",
       "url": "https://ai.talisman.xyz/"
+    },
+    {
+      "artifact_path": "/metagraph/providers.json",
+      "id": "provider:taolend",
+      "subtitle": "subnet-team",
+      "title": "TaoLend",
+      "tokens": [
+        "claimed",
+        "provider",
+        "subnet",
+        "taolend",
+        "team"
+      ],
+      "type": "provider",
+      "url": "https://taolend.io/"
     },
     {
       "artifact_path": "/metagraph/providers.json",
@@ -1932,15 +1991,22 @@
       "artifact_path": "/metagraph/subnets/53.json",
       "id": "subnet:53",
       "netuid": 53,
-      "slug": "sn-53",
+      "slug": "efficientfrontier",
       "subtitle": "SN53 ب",
       "title": "EfficientFrontier",
       "tokens": [
-        "53",
+        "augmented",
         "baseline",
         "curated",
+        "defi",
         "efficientfrontier",
-        "sn"
+        "financial",
+        "identity",
+        "official",
+        "reviewed",
+        "strategies",
+        "trading",
+        "website"
       ],
       "type": "subnet",
       "url": "/subnets/53"
@@ -2311,24 +2377,6 @@
       "url": "/subnets/58"
     },
     {
-      "artifact_path": "/metagraph/subnets/116.json",
-      "id": "subnet:116",
-      "netuid": 116,
-      "slug": "sn-116",
-      "subtitle": "SN116 ъ",
-      "title": "hard_sign",
-      "tokens": [
-        "116",
-        "baseline",
-        "curated",
-        "hard",
-        "sign",
-        "sn"
-      ],
-      "type": "subnet",
-      "url": "/subnets/116"
-    },
-    {
       "artifact_path": "/metagraph/subnets/67.json",
       "id": "subnet:67",
       "netuid": 67,
@@ -2679,6 +2727,27 @@
       "url": "/subnets/123"
     },
     {
+      "artifact_path": "/metagraph/subnets/73.json",
+      "id": "subnet:73",
+      "netuid": 73,
+      "slug": "metahash",
+      "subtitle": "SN73 ك",
+      "title": "MetaHash",
+      "tokens": [
+        "augmented",
+        "baseline",
+        "curated",
+        "defi",
+        "identity",
+        "metahash",
+        "otc",
+        "reviewed",
+        "treasury"
+      ],
+      "type": "subnet",
+      "url": "/subnets/73"
+    },
+    {
       "artifact_path": "/metagraph/subnets/107.json",
       "id": "subnet:107",
       "netuid": 107,
@@ -2832,15 +2901,21 @@
       "artifact_path": "/metagraph/subnets/27.json",
       "id": "subnet:27",
       "netuid": 27,
-      "slug": "sn-27",
+      "slug": "nodexo",
       "subtitle": "SN27 ג",
       "title": "Nodexo",
       "tokens": [
-        "27",
+        "augmented",
         "baseline",
+        "compute",
         "curated",
+        "docs",
+        "gpu",
+        "identity",
         "nodexo",
-        "sn"
+        "official",
+        "reviewed",
+        "website"
       ],
       "type": "subnet",
       "url": "/subnets/27"
@@ -2946,23 +3021,6 @@
       ],
       "type": "subnet",
       "url": "/subnets/35"
-    },
-    {
-      "artifact_path": "/metagraph/subnets/73.json",
-      "id": "subnet:73",
-      "netuid": 73,
-      "slug": "sn-73",
-      "subtitle": "SN73 ك",
-      "title": "Parked",
-      "tokens": [
-        "73",
-        "baseline",
-        "curated",
-        "parked",
-        "sn"
-      ],
-      "type": "subnet",
-      "url": "/subnets/73"
     },
     {
       "artifact_path": "/metagraph/subnets/26.json",
@@ -3447,6 +3505,28 @@
       "url": "/subnets/65"
     },
     {
+      "artifact_path": "/metagraph/subnets/116.json",
+      "id": "subnet:116",
+      "netuid": 116,
+      "slug": "taolend",
+      "subtitle": "SN116 ъ",
+      "title": "TaoLend",
+      "tokens": [
+        "augmented",
+        "baseline",
+        "curated",
+        "defi",
+        "identity",
+        "lending",
+        "official",
+        "reviewed",
+        "taolend",
+        "website"
+      ],
+      "type": "subnet",
+      "url": "/subnets/116"
+    },
+    {
       "artifact_path": "/metagraph/subnets/4.json",
       "id": "subnet:4",
       "netuid": 4,
@@ -3805,21 +3885,21 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-17-taomarketcap-dashboard",
+      "id": "surface:sn-17-subnetradar-dashboard",
       "netuid": 17,
       "slug": "sn-17",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "404—GEN TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "404—GEN SubnetRadar dashboard",
       "tokens": [
         "17",
         "404",
         "dashboard",
         "gen",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/17"
+      "url": "https://subnetradar.com/subnet/17"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -3899,6 +3979,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-125-subnetradar-dashboard",
+      "netuid": 125,
+      "slug": "sn-125",
+      "subtitle": "dashboard / subnetradar",
+      "title": "8 Ball SubnetRadar dashboard",
+      "tokens": [
+        "125",
+        "8",
+        "ball",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/125"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-125-taomarketcap-dashboard",
       "netuid": 125,
       "slug": "sn-125",
@@ -3934,25 +4032,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_125/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-125-taostats-metagraph",
-      "netuid": 125,
-      "slug": "sn-125",
-      "subtitle": "dashboard / taostats",
-      "title": "8 Ball Taostats metagraph",
-      "tokens": [
-        "125",
-        "8",
-        "ball",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/125/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -4011,6 +4090,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-109-subnetradar-dashboard",
+      "netuid": 109,
+      "slug": "sn-109",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Academia SubnetRadar dashboard",
+      "tokens": [
+        "109",
+        "academia",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/109"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-109-taomarketcap-dashboard",
       "netuid": 109,
       "slug": "sn-109",
@@ -4044,24 +4140,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_109/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-109-taostats-metagraph",
-      "netuid": 109,
-      "slug": "sn-109",
-      "subtitle": "dashboard / taostats",
-      "title": "Academia Taostats metagraph",
-      "tokens": [
-        "109",
-        "academia",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/109/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -4118,6 +4196,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-95-subnetradar-dashboard",
+      "netuid": 95,
+      "slug": "sn-95",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Actual SubnetRadar dashboard",
+      "tokens": [
+        "95",
+        "actual",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/95"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-95-website-common-swagger",
       "netuid": 95,
       "slug": "sn-95",
@@ -4170,24 +4265,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-95-taostats-metagraph",
-      "netuid": 95,
-      "slug": "sn-95",
-      "subtitle": "dashboard / taostats",
-      "title": "Actual Taostats metagraph",
-      "tokens": [
-        "95",
-        "actual",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/95/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -4262,6 +4339,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-21-subnetradar-dashboard",
+      "netuid": 21,
+      "slug": "sn-21",
+      "subtitle": "dashboard / subnetradar",
+      "title": "AdTAO SubnetRadar dashboard",
+      "tokens": [
+        "21",
+        "adtao",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/21"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-21-taomarketcap-dashboard",
       "netuid": 21,
       "slug": "sn-21",
@@ -4295,24 +4389,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_21/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-21-taostats-metagraph",
-      "netuid": 21,
-      "slug": "sn-21",
-      "subtitle": "dashboard / taostats",
-      "title": "AdTAO Taostats metagraph",
-      "tokens": [
-        "21",
-        "adtao",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/21/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -4404,20 +4480,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-120-taomarketcap-dashboard",
+      "id": "surface:sn-120-subnetradar-dashboard",
       "netuid": 120,
       "slug": "sn-120",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Affine TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Affine SubnetRadar dashboard",
       "tokens": [
         "120",
         "affine",
         "dashboard",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/120"
+      "url": "https://subnetradar.com/subnet/120"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -4493,6 +4569,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-69-subnetradar-dashboard",
+      "netuid": 69,
+      "slug": "sn-69",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ain SubnetRadar dashboard",
+      "tokens": [
+        "69",
+        "ain",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/69"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-69-taomarketcap-dashboard",
       "netuid": 69,
       "slug": "sn-69",
@@ -4526,24 +4619,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-69-taostats-metagraph",
-      "netuid": 69,
-      "slug": "sn-69",
-      "subtitle": "dashboard / taostats",
-      "title": "ain Taostats metagraph",
-      "tokens": [
-        "69",
-        "ain",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/69/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -4676,6 +4751,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-97-subnetradar-dashboard",
+      "netuid": 97,
+      "slug": "sn-97",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Albedo SubnetRadar dashboard",
+      "tokens": [
+        "97",
+        "albedo",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/97"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-97-taomarketcap-dashboard",
       "netuid": 97,
       "slug": "sn-97",
@@ -4709,24 +4801,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_97/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-97-taostats-metagraph",
-      "netuid": 97,
-      "slug": "sn-97",
-      "subtitle": "dashboard / taostats",
-      "title": "Albedo Taostats metagraph",
-      "tokens": [
-        "97",
-        "albedo",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/97/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5009,6 +5083,21 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-7-subnetradar-dashboard",
+      "netuid": 7,
+      "slug": "allways",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Allways SubnetRadar dashboard",
+      "tokens": [
+        "allways",
+        "dashboard",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/7"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:allways-swagger",
       "netuid": 7,
       "slug": "allways",
@@ -5087,22 +5176,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_7/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-7-taostats-metagraph",
-      "netuid": 7,
-      "slug": "allways",
-      "subtitle": "dashboard / taostats",
-      "title": "Allways Taostats metagraph",
-      "tokens": [
-        "allways",
-        "dashboard",
-        "metagraph",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/7/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5190,6 +5263,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-41-subnetradar-dashboard",
+      "netuid": 41,
+      "slug": "sn-41",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Almanac SubnetRadar dashboard",
+      "tokens": [
+        "41",
+        "almanac",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/41"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-41-website-common-swagger",
       "netuid": 41,
       "slug": "sn-41",
@@ -5242,24 +5332,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-41-taostats-metagraph",
-      "netuid": 41,
-      "slug": "sn-41",
-      "subtitle": "dashboard / taostats",
-      "title": "Almanac Taostats metagraph",
-      "tokens": [
-        "41",
-        "almanac",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/41/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5337,6 +5409,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-84-subnetradar-dashboard",
+      "netuid": 84,
+      "slug": "sn-84",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ansuz SubnetRadar dashboard",
+      "tokens": [
+        "84",
+        "ansuz",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/84"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-84-taomarketcap-dashboard",
       "netuid": 84,
       "slug": "sn-84",
@@ -5370,24 +5459,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_84/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-84-taostats-metagraph",
-      "netuid": 84,
-      "slug": "sn-84",
-      "subtitle": "dashboard / taostats",
-      "title": "ansuz Taostats metagraph",
-      "tokens": [
-        "84",
-        "ansuz",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/84/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5480,6 +5551,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-1-subnetradar-dashboard",
+      "netuid": 1,
+      "slug": "sn-1",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Apex SubnetRadar dashboard",
+      "tokens": [
+        "1",
+        "apex",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/1"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-1-taomarketcap-dashboard",
       "netuid": 1,
       "slug": "sn-1",
@@ -5513,24 +5601,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_1_apex/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-1-taostats-metagraph",
-      "netuid": 1,
-      "slug": "sn-1",
-      "subtitle": "dashboard / taostats",
-      "title": "Apex Taostats metagraph",
-      "tokens": [
-        "1",
-        "apex",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/1/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5606,6 +5676,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-127-subnetradar-dashboard",
+      "netuid": 127,
+      "slug": "sn-127",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Astrid SubnetRadar dashboard",
+      "tokens": [
+        "127",
+        "astrid",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/127"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-127-taomarketcap-dashboard",
       "netuid": 127,
       "slug": "sn-127",
@@ -5639,24 +5726,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_127/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-127-taostats-metagraph",
-      "netuid": 127,
-      "slug": "sn-127",
-      "subtitle": "dashboard / taostats",
-      "title": "Astrid Taostats metagraph",
-      "tokens": [
-        "127",
-        "astrid",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/127/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5753,6 +5822,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-37-subnetradar-dashboard",
+      "netuid": 37,
+      "slug": "sn-37",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Aurelius SubnetRadar dashboard",
+      "tokens": [
+        "37",
+        "aurelius",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/37"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-37-taomarketcap-dashboard",
       "netuid": 37,
       "slug": "sn-37",
@@ -5786,24 +5872,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-37-taostats-metagraph",
-      "netuid": 37,
-      "slug": "sn-37",
-      "subtitle": "dashboard / taostats",
-      "title": "Aurelius Taostats metagraph",
-      "tokens": [
-        "37",
-        "aurelius",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/37/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -5898,6 +5966,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-59-subnetradar-dashboard",
+      "netuid": 59,
+      "slug": "sn-59",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Babelbit SubnetRadar dashboard",
+      "tokens": [
+        "59",
+        "babelbit",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/59"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-59-taomarketcap-dashboard",
       "netuid": 59,
       "slug": "sn-59",
@@ -5931,24 +6016,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_59/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-59-taostats-metagraph",
-      "netuid": 59,
-      "slug": "sn-59",
-      "subtitle": "dashboard / taostats",
-      "title": "Babelbit Taostats metagraph",
-      "tokens": [
-        "59",
-        "babelbit",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/59/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6079,6 +6146,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-105-subnetradar-dashboard",
+      "netuid": 105,
+      "slug": "sn-105",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Beam SubnetRadar dashboard",
+      "tokens": [
+        "105",
+        "beam",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/105"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-105-website-common-swagger",
       "netuid": 105,
       "slug": "sn-105",
@@ -6131,24 +6215,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-105-taostats-metagraph",
-      "netuid": 105,
-      "slug": "sn-105",
-      "subtitle": "dashboard / taostats",
-      "title": "Beam Taostats metagraph",
-      "tokens": [
-        "105",
-        "beam",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/105/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6241,6 +6307,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-16-subnetradar-dashboard",
+      "netuid": 16,
+      "slug": "sn-16",
+      "subtitle": "dashboard / subnetradar",
+      "title": "BitAds SubnetRadar dashboard",
+      "tokens": [
+        "16",
+        "bitads",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/16"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-16-website-common-swagger",
       "netuid": 16,
       "slug": "sn-16",
@@ -6293,24 +6376,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-16-taostats-metagraph",
-      "netuid": 16,
-      "slug": "sn-16",
-      "subtitle": "dashboard / taostats",
-      "title": "BitAds Taostats metagraph",
-      "tokens": [
-        "16",
-        "bitads",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/16/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6403,6 +6468,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-93-subnetradar-dashboard",
+      "netuid": 93,
+      "slug": "sn-93",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Bitcast SubnetRadar dashboard",
+      "tokens": [
+        "93",
+        "bitcast",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/93"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-93-website-common-swagger",
       "netuid": 93,
       "slug": "sn-93",
@@ -6455,24 +6537,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_93/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-93-taostats-metagraph",
-      "netuid": 93,
-      "slug": "sn-93",
-      "subtitle": "dashboard / taostats",
-      "title": "Bitcast Taostats metagraph",
-      "tokens": [
-        "93",
-        "bitcast",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/93/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6582,6 +6646,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-34-subnetradar-dashboard",
+      "netuid": 34,
+      "slug": "sn-34",
+      "subtitle": "dashboard / subnetradar",
+      "title": "BitMind SubnetRadar dashboard",
+      "tokens": [
+        "34",
+        "bitmind",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/34"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-34-taomarketcap-dashboard",
       "netuid": 34,
       "slug": "sn-34",
@@ -6615,24 +6696,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_34/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-34-taostats-metagraph",
-      "netuid": 34,
-      "slug": "sn-34",
-      "subtitle": "dashboard / taostats",
-      "title": "BitMind Taostats metagraph",
-      "tokens": [
-        "34",
-        "bitmind",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/34/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6818,6 +6881,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-60-subnetradar-dashboard",
+      "netuid": 60,
+      "slug": "sn-60",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Bitsec.ai SubnetRadar dashboard",
+      "tokens": [
+        "60",
+        "ai",
+        "bitsec",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/60"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-60-website-common-swagger",
       "netuid": 60,
       "slug": "sn-60",
@@ -6873,25 +6954,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-60-taostats-metagraph",
-      "netuid": 60,
-      "slug": "sn-60",
-      "subtitle": "dashboard / taostats",
-      "title": "Bitsec.ai Taostats metagraph",
-      "tokens": [
-        "60",
-        "ai",
-        "bitsec",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/60/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -6986,6 +7048,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-94-subnetradar-dashboard",
+      "netuid": 94,
+      "slug": "sn-94",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Bitsota SubnetRadar dashboard",
+      "tokens": [
+        "94",
+        "bitsota",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/94"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-94-taomarketcap-dashboard",
       "netuid": 94,
       "slug": "sn-94",
@@ -7019,24 +7098,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-94-taostats-metagraph",
-      "netuid": 94,
-      "slug": "sn-94",
-      "subtitle": "dashboard / taostats",
-      "title": "Bitsota Taostats metagraph",
-      "tokens": [
-        "94",
-        "bitsota",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/94/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -7094,6 +7155,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-91-subnetradar-dashboard",
+      "netuid": 91,
+      "slug": "sn-91",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Bitstarter #1 SubnetRadar dashboard",
+      "tokens": [
+        "1",
+        "91",
+        "bitstarter",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/91"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-91-taomarketcap-dashboard",
       "netuid": 91,
       "slug": "sn-91",
@@ -7129,25 +7208,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_91/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-91-taostats-metagraph",
-      "netuid": 91,
-      "slug": "sn-91",
-      "subtitle": "dashboard / taostats",
-      "title": "Bitstarter #1 Taostats metagraph",
-      "tokens": [
-        "1",
-        "91",
-        "bitstarter",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/91/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -7310,6 +7370,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-19-subnetradar-dashboard",
+      "netuid": 19,
+      "slug": "sn-19",
+      "subtitle": "dashboard / subnetradar",
+      "title": "blockmachine SubnetRadar dashboard",
+      "tokens": [
+        "19",
+        "blockmachine",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/19"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-19-taomarketcap-dashboard",
       "netuid": 19,
       "slug": "sn-19",
@@ -7343,24 +7420,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_19/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-19-taostats-metagraph",
-      "netuid": 19,
-      "slug": "sn-19",
-      "subtitle": "dashboard / taostats",
-      "title": "blockmachine Taostats metagraph",
-      "tokens": [
-        "19",
-        "blockmachine",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/19/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -7471,6 +7530,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-117-subnetradar-dashboard",
+      "netuid": 117,
+      "slug": "sn-117",
+      "subtitle": "dashboard / subnetradar",
+      "title": "BrainPlay SubnetRadar dashboard",
+      "tokens": [
+        "117",
+        "brainplay",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/117"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-117-taomarketcap-dashboard",
       "netuid": 117,
       "slug": "sn-117",
@@ -7504,24 +7580,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_117/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-117-taostats-metagraph",
-      "netuid": 117,
-      "slug": "sn-117",
-      "subtitle": "dashboard / taostats",
-      "title": "BrainPlay Taostats metagraph",
-      "tokens": [
-        "117",
-        "brainplay",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/117/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -7618,6 +7676,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-128-subnetradar-dashboard",
+      "netuid": 128,
+      "slug": "sn-128",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ByteLeap SubnetRadar dashboard",
+      "tokens": [
+        "128",
+        "byteleap",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/128"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-128-website-common-swagger",
       "netuid": 128,
       "slug": "sn-128",
@@ -7670,24 +7745,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-128-taostats-metagraph",
-      "netuid": 128,
-      "slug": "sn-128",
-      "subtitle": "dashboard / taostats",
-      "title": "ByteLeap Taostats metagraph",
-      "tokens": [
-        "128",
-        "byteleap",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/128/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -7744,6 +7801,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-76-subnetradar-dashboard",
+      "netuid": 76,
+      "slug": "sn-76",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Byzantium SubnetRadar dashboard",
+      "tokens": [
+        "76",
+        "byzantium",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/76"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-76-taomarketcap-dashboard",
       "netuid": 76,
       "slug": "sn-76",
@@ -7777,24 +7851,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_76/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-76-taostats-metagraph",
-      "netuid": 76,
-      "slug": "sn-76",
-      "subtitle": "dashboard / taostats",
-      "title": "Byzantium Taostats metagraph",
-      "tokens": [
-        "76",
-        "byzantium",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/76/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -7943,20 +7999,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-14-taomarketcap-dashboard",
+      "id": "surface:sn-14-subnetradar-dashboard",
       "netuid": 14,
       "slug": "sn-14",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Cacheon TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Cacheon SubnetRadar dashboard",
       "tokens": [
         "14",
         "cacheon",
         "dashboard",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/14"
+      "url": "https://subnetradar.com/subnet/14"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8086,6 +8142,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-40-subnetradar-dashboard",
+      "netuid": 40,
+      "slug": "sn-40",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Chunking SubnetRadar dashboard",
+      "tokens": [
+        "40",
+        "chunking",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/40"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-40-taomarketcap-dashboard",
       "netuid": 40,
       "slug": "sn-40",
@@ -8119,24 +8192,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_40/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-40-taostats-metagraph",
-      "netuid": 40,
-      "slug": "sn-40",
-      "subtitle": "dashboard / taostats",
-      "title": "Chunking Taostats metagraph",
-      "tokens": [
-        "40",
-        "chunking",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/40/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8383,6 +8438,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-64-subnetradar-dashboard",
+      "netuid": 64,
+      "slug": "sn-64",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Chutes SubnetRadar dashboard",
+      "tokens": [
+        "64",
+        "chutes",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/64"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-64-taomarketcap-dashboard",
       "netuid": 64,
       "slug": "sn-64",
@@ -8416,24 +8488,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_64/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-64-taostats-metagraph",
-      "netuid": 64,
-      "slug": "sn-64",
-      "subtitle": "dashboard / taostats",
-      "title": "Chutes Taostats metagraph",
-      "tokens": [
-        "64",
-        "chutes",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/64/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8525,6 +8579,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-83-subnetradar-dashboard",
+      "netuid": 83,
+      "slug": "sn-83",
+      "subtitle": "dashboard / subnetradar",
+      "title": "CliqueAI SubnetRadar dashboard",
+      "tokens": [
+        "83",
+        "cliqueai",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/83"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-83-website-common-swagger",
       "netuid": 83,
       "slug": "sn-83",
@@ -8577,24 +8648,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-83-taostats-metagraph",
-      "netuid": 83,
-      "slug": "sn-83",
-      "subtitle": "dashboard / taostats",
-      "title": "CliqueAI Taostats metagraph",
-      "tokens": [
-        "83",
-        "cliqueai",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/83/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8688,6 +8741,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-29-subnetradar-dashboard",
+      "netuid": 29,
+      "slug": "sn-29",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Coldint SubnetRadar dashboard",
+      "tokens": [
+        "29",
+        "coldint",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/29"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-29-taomarketcap-dashboard",
       "netuid": 29,
       "slug": "sn-29",
@@ -8738,24 +8808,6 @@
       ],
       "type": "surface",
       "url": "https://taostats.io/subnets/netuid-29"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-29-taostats-metagraph",
-      "netuid": 29,
-      "slug": "sn-29",
-      "subtitle": "dashboard / taostats",
-      "title": "Coldint Taostats metagraph",
-      "tokens": [
-        "29",
-        "coldint",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/29/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8847,6 +8899,42 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-38-taomarketcap-source-repo",
+      "netuid": 38,
+      "slug": "sn-38",
+      "subtitle": "source-repo / taomarketcap",
+      "title": "colosseum source repository",
+      "tokens": [
+        "38",
+        "colosseum",
+        "repo",
+        "repository",
+        "sn",
+        "source",
+        "taomarketcap"
+      ],
+      "type": "surface",
+      "url": "https://github.com/TAO-Colosseum/tao-colosseum-subnet"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-38-subnetradar-dashboard",
+      "netuid": 38,
+      "slug": "sn-38",
+      "subtitle": "dashboard / subnetradar",
+      "title": "colosseum SubnetRadar dashboard",
+      "tokens": [
+        "38",
+        "colosseum",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/38"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-38-website-common-swagger",
       "netuid": 38,
       "slug": "sn-38",
@@ -8899,24 +8987,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-38-taostats-metagraph",
-      "netuid": 38,
-      "slug": "sn-38",
-      "subtitle": "dashboard / taostats",
-      "title": "colosseum Taostats metagraph",
-      "tokens": [
-        "38",
-        "colosseum",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/38/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -8994,6 +9064,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-82-subnetradar-dashboard",
+      "netuid": 82,
+      "slug": "sn-82",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Compelle SubnetRadar dashboard",
+      "tokens": [
+        "82",
+        "compelle",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/82"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-82-taomarketcap-dashboard",
       "netuid": 82,
       "slug": "sn-82",
@@ -9027,24 +9114,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_82/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-82-taostats-metagraph",
-      "netuid": 82,
-      "slug": "sn-82",
-      "subtitle": "dashboard / taostats",
-      "title": "Compelle Taostats metagraph",
-      "tokens": [
-        "82",
-        "compelle",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/82/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -9139,6 +9208,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-12-subnetradar-dashboard",
+      "netuid": 12,
+      "slug": "sn-12",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Compute Horde SubnetRadar dashboard",
+      "tokens": [
+        "12",
+        "compute",
+        "dashboard",
+        "horde",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/12"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-12-taomarketcap-dashboard",
       "netuid": 12,
       "slug": "sn-12",
@@ -9174,25 +9261,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_12/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-12-taostats-metagraph",
-      "netuid": 12,
-      "slug": "sn-12",
-      "subtitle": "dashboard / taostats",
-      "title": "Compute Horde Taostats metagraph",
-      "tokens": [
-        "12",
-        "compute",
-        "dashboard",
-        "horde",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/12/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -9303,6 +9371,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-102-subnetradar-dashboard",
+      "netuid": 102,
+      "slug": "sn-102",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ConnitoAI SubnetRadar dashboard",
+      "tokens": [
+        "102",
+        "connitoai",
+        "dashboard",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/102"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-102-taomarketcap-dashboard",
       "netuid": 102,
       "slug": "sn-102",
@@ -9336,24 +9421,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_102/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-102-taostats-metagraph",
-      "netuid": 102,
-      "slug": "sn-102",
-      "subtitle": "dashboard / taostats",
-      "title": "ConnitoAI Taostats metagraph",
-      "tokens": [
-        "102",
-        "connitoai",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/102/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -9467,6 +9534,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-13-subnetradar-dashboard",
+      "netuid": 13,
+      "slug": "sn-13",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Data Universe SubnetRadar dashboard",
+      "tokens": [
+        "13",
+        "dashboard",
+        "data",
+        "sn",
+        "subnetradar",
+        "universe"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/13"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-13-taomarketcap-dashboard",
       "netuid": 13,
       "slug": "sn-13",
@@ -9502,25 +9587,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_13/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-13-taostats-metagraph",
-      "netuid": 13,
-      "slug": "sn-13",
-      "subtitle": "dashboard / taostats",
-      "title": "Data Universe Taostats metagraph",
-      "tokens": [
-        "13",
-        "dashboard",
-        "data",
-        "metagraph",
-        "sn",
-        "taostats",
-        "universe"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/13/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -9737,6 +9803,60 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-3-subnetradar-dashboard",
+      "netuid": 3,
+      "slug": "sn-3",
+      "subtitle": "dashboard / subnetradar",
+      "title": "deprecated SubnetRadar dashboard",
+      "tokens": [
+        "3",
+        "dashboard",
+        "deprecated",
+        "sn",
+        "subnetradar",
+        "templar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/3"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-39-subnetradar-dashboard",
+      "netuid": 39,
+      "slug": "sn-39",
+      "subtitle": "dashboard / subnetradar",
+      "title": "deprecated SubnetRadar dashboard",
+      "tokens": [
+        "39",
+        "basilica",
+        "dashboard",
+        "deprecated",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/39"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-81-subnetradar-dashboard",
+      "netuid": 81,
+      "slug": "sn-81",
+      "subtitle": "dashboard / subnetradar",
+      "title": "deprecated SubnetRadar dashboard",
+      "tokens": [
+        "81",
+        "dashboard",
+        "deprecated",
+        "grail",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/81"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-3-taomarketcap-dashboard",
       "netuid": 3,
       "slug": "sn-3",
@@ -9848,63 +9968,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_81/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-3-taostats-metagraph",
-      "netuid": 3,
-      "slug": "sn-3",
-      "subtitle": "dashboard / taostats",
-      "title": "deprecated Taostats metagraph",
-      "tokens": [
-        "3",
-        "dashboard",
-        "deprecated",
-        "metagraph",
-        "sn",
-        "taostats",
-        "templar"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/3/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-39-taostats-metagraph",
-      "netuid": 39,
-      "slug": "sn-39",
-      "subtitle": "dashboard / taostats",
-      "title": "deprecated Taostats metagraph",
-      "tokens": [
-        "39",
-        "basilica",
-        "dashboard",
-        "deprecated",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/39/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-81-taostats-metagraph",
-      "netuid": 81,
-      "slug": "sn-81",
-      "subtitle": "dashboard / taostats",
-      "title": "deprecated Taostats metagraph",
-      "tokens": [
-        "81",
-        "dashboard",
-        "deprecated",
-        "grail",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/81/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -10122,6 +10185,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-22-subnetradar-dashboard",
+      "netuid": 22,
+      "slug": "sn-22",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Desearch SubnetRadar dashboard",
+      "tokens": [
+        "22",
+        "dashboard",
+        "desearch",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/22"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-22-website-common-swagger",
       "netuid": 22,
       "slug": "sn-22",
@@ -10174,24 +10254,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_22/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-22-taostats-metagraph",
-      "netuid": 22,
-      "slug": "sn-22",
-      "subtitle": "dashboard / taostats",
-      "title": "Desearch Taostats metagraph",
-      "tokens": [
-        "22",
-        "dashboard",
-        "desearch",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/22/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -10338,6 +10400,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-118-subnetradar-dashboard",
+      "netuid": 118,
+      "slug": "sn-118",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Ditto SubnetRadar dashboard",
+      "tokens": [
+        "118",
+        "dashboard",
+        "ditto",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/118"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-118-taomarketcap-dashboard",
       "netuid": 118,
       "slug": "sn-118",
@@ -10371,24 +10450,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_118/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-118-taostats-metagraph",
-      "netuid": 118,
-      "slug": "sn-118",
-      "subtitle": "dashboard / taostats",
-      "title": "Ditto Taostats metagraph",
-      "tokens": [
-        "118",
-        "dashboard",
-        "ditto",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/118/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -10480,6 +10541,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-103-subnetradar-dashboard",
+      "netuid": 103,
+      "slug": "sn-103",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Djinn SubnetRadar dashboard",
+      "tokens": [
+        "103",
+        "dashboard",
+        "djinn",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/103"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-103-taomarketcap-dashboard",
       "netuid": 103,
       "slug": "sn-103",
@@ -10513,24 +10591,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_103/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-103-taostats-metagraph",
-      "netuid": 103,
-      "slug": "sn-103",
-      "subtitle": "dashboard / taostats",
-      "title": "Djinn Taostats metagraph",
-      "tokens": [
-        "103",
-        "dashboard",
-        "djinn",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/103/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -10656,6 +10716,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-80-subnetradar-dashboard",
+      "netuid": 80,
+      "slug": "sn-80",
+      "subtitle": "dashboard / subnetradar",
+      "title": "dogelayer SubnetRadar dashboard",
+      "tokens": [
+        "80",
+        "dashboard",
+        "dogelayer",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/80"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-80-website-common-swagger",
       "netuid": 80,
       "slug": "sn-80",
@@ -10708,24 +10785,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-80-taostats-metagraph",
-      "netuid": 80,
-      "slug": "sn-80",
-      "subtitle": "dashboard / taostats",
-      "title": "dogelayer Taostats metagraph",
-      "tokens": [
-        "80",
-        "dashboard",
-        "dogelayer",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/80/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -10820,6 +10879,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-52-subnetradar-dashboard",
+      "netuid": 52,
+      "slug": "sn-52",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Dojo SubnetRadar dashboard",
+      "tokens": [
+        "52",
+        "dashboard",
+        "dojo",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/52"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-52-taomarketcap-dashboard",
       "netuid": 52,
       "slug": "sn-52",
@@ -10853,24 +10929,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_52/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-52-taostats-metagraph",
-      "netuid": 52,
-      "slug": "sn-52",
-      "subtitle": "dashboard / taostats",
-      "title": "Dojo Taostats metagraph",
-      "tokens": [
-        "52",
-        "dashboard",
-        "dojo",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/52/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -11113,32 +11171,60 @@
       "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-53-backprop-dashboard",
       "netuid": 53,
-      "slug": "sn-53",
+      "slug": "efficientfrontier",
       "subtitle": "dashboard / backprop-finance",
       "title": "EfficientFrontier Backprop Finance dashboard",
       "tokens": [
-        "53",
         "backprop",
         "dashboard",
         "efficientfrontier",
-        "finance",
-        "sn"
+        "finance"
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/53-efficientfrontier"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-53-signalplus-mining",
+      "netuid": 53,
+      "slug": "efficientfrontier",
+      "subtitle": "dashboard / signalplus",
+      "title": "EfficientFrontier mining app",
+      "tokens": [
+        "app",
+        "dashboard",
+        "efficientfrontier",
+        "mining",
+        "signalplus"
+      ],
+      "type": "surface",
+      "url": "https://t.signalplus.com/mining"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-53-subnetradar-dashboard",
+      "netuid": 53,
+      "slug": "efficientfrontier",
+      "subtitle": "dashboard / subnetradar",
+      "title": "EfficientFrontier SubnetRadar dashboard",
+      "tokens": [
+        "dashboard",
+        "efficientfrontier",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/53"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-53-taomarketcap-dashboard",
       "netuid": 53,
-      "slug": "sn-53",
+      "slug": "efficientfrontier",
       "subtitle": "dashboard / taomarketcap",
       "title": "EfficientFrontier TaoMarketCap dashboard",
       "tokens": [
-        "53",
         "dashboard",
         "efficientfrontier",
-        "sn",
         "taomarketcap"
       ],
       "type": "surface",
@@ -11148,16 +11234,14 @@
       "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-53-taopedia-article",
       "netuid": 53,
-      "slug": "sn-53",
+      "slug": "efficientfrontier",
       "subtitle": "docs / taopedia-articles",
       "title": "EfficientFrontier Taopedia article",
       "tokens": [
-        "53",
         "article",
         "articles",
         "docs",
         "efficientfrontier",
-        "sn",
         "taopedia"
       ],
       "type": "surface",
@@ -11165,34 +11249,14 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-53-taostats-metagraph",
-      "netuid": 53,
-      "slug": "sn-53",
-      "subtitle": "dashboard / taostats",
-      "title": "EfficientFrontier Taostats metagraph",
-      "tokens": [
-        "53",
-        "dashboard",
-        "efficientfrontier",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/53/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-53-tensorplex-docs",
       "netuid": 53,
-      "slug": "sn-53",
+      "slug": "efficientfrontier",
       "subtitle": "docs / tensorplex-subnet-docs",
       "title": "EfficientFrontier Tensorplex subnet docs",
       "tokens": [
-        "53",
         "docs",
         "efficientfrontier",
-        "sn",
         "subnet",
         "tensorplex"
       ],
@@ -11255,6 +11319,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-36-subnetradar-dashboard",
+      "netuid": 36,
+      "slug": "sn-36",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Eirel SubnetRadar dashboard",
+      "tokens": [
+        "36",
+        "dashboard",
+        "eirel",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/36"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-36-taomarketcap-dashboard",
       "netuid": 36,
       "slug": "sn-36",
@@ -11288,24 +11369,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-36-taostats-metagraph",
-      "netuid": 36,
-      "slug": "sn-36",
-      "subtitle": "dashboard / taostats",
-      "title": "Eirel Taostats metagraph",
-      "tokens": [
-        "36",
-        "dashboard",
-        "eirel",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/36/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -11381,6 +11444,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-30-subnetradar-dashboard",
+      "netuid": 30,
+      "slug": "sn-30",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Endure Network SubnetRadar dashboard",
+      "tokens": [
+        "30",
+        "dashboard",
+        "endure",
+        "network",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/30"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-30-taomarketcap-dashboard",
       "netuid": 30,
       "slug": "sn-30",
@@ -11416,25 +11497,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_30/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-30-taostats-metagraph",
-      "netuid": 30,
-      "slug": "sn-30",
-      "subtitle": "dashboard / taostats",
-      "title": "Endure Network Taostats metagraph",
-      "tokens": [
-        "30",
-        "dashboard",
-        "endure",
-        "metagraph",
-        "network",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/30/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -11492,6 +11554,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-101-subnetradar-dashboard",
+      "netuid": 101,
+      "slug": "sn-101",
+      "subtitle": "dashboard / subnetradar",
+      "title": "eni SubnetRadar dashboard",
+      "tokens": [
+        "101",
+        "dashboard",
+        "eni",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/101"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-101-taomarketcap-dashboard",
       "netuid": 101,
       "slug": "sn-101",
@@ -11525,24 +11604,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-101-taostats-metagraph",
-      "netuid": 101,
-      "slug": "sn-101",
-      "subtitle": "dashboard / taostats",
-      "title": "eni Taostats metagraph",
-      "tokens": [
-        "101",
-        "dashboard",
-        "eni",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/101/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -11602,6 +11663,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-63-subnetradar-dashboard",
+      "netuid": 63,
+      "slug": "sn-63",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Enigma SubnetRadar dashboard",
+      "tokens": [
+        "63",
+        "dashboard",
+        "enigma",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/63"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-63-taomarketcap-dashboard",
       "netuid": 63,
       "slug": "sn-63",
@@ -11635,24 +11713,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_63/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-63-taostats-metagraph",
-      "netuid": 63,
-      "slug": "sn-63",
-      "subtitle": "dashboard / taostats",
-      "title": "Enigma Taostats metagraph",
-      "tokens": [
-        "63",
-        "dashboard",
-        "enigma",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/63/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -11750,6 +11810,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-47-subnetradar-dashboard",
+      "netuid": 47,
+      "slug": "sn-47",
+      "subtitle": "dashboard / subnetradar",
+      "title": "EvolAI SubnetRadar dashboard",
+      "tokens": [
+        "47",
+        "dashboard",
+        "evolai",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/47"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-47-taomarketcap-dashboard",
       "netuid": 47,
       "slug": "sn-47",
@@ -11783,24 +11860,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_47/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-47-taostats-metagraph",
-      "netuid": 47,
-      "slug": "sn-47",
-      "subtitle": "dashboard / taostats",
-      "title": "EvolAI Taostats metagraph",
-      "tokens": [
-        "47",
-        "dashboard",
-        "evolai",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/47/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -11886,6 +11945,27 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-104-subnetradar-dashboard",
+      "netuid": 104,
+      "slug": "sn-104",
+      "subtitle": "dashboard / subnetradar",
+      "title": "for sale (burn to uid1) SubnetRadar dashboard",
+      "tokens": [
+        "104",
+        "burn",
+        "dashboard",
+        "for",
+        "sale",
+        "sn",
+        "subnetradar",
+        "to",
+        "uid1"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/104"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-104-taomarketcap-dashboard",
       "netuid": 104,
       "slug": "sn-104",
@@ -11930,28 +12010,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-104-taostats-metagraph",
-      "netuid": 104,
-      "slug": "sn-104",
-      "subtitle": "dashboard / taostats",
-      "title": "for sale (burn to uid1) Taostats metagraph",
-      "tokens": [
-        "104",
-        "burn",
-        "dashboard",
-        "for",
-        "metagraph",
-        "sale",
-        "sn",
-        "taostats",
-        "to",
-        "uid1"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/104/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-104-tensorplex-docs",
       "netuid": 104,
       "slug": "sn-104",
@@ -11992,17 +12050,16 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-98-website-subdomain-docs-docs-forevermoney-ai",
+      "id": "surface:sn-98-website-link-forevermoney-ai-docs-2",
       "netuid": 98,
       "slug": "sn-98",
       "subtitle": "docs / taomarketcap",
-      "title": "ForeverMoney docs subdomain",
+      "title": "ForeverMoney docs",
       "tokens": [
         "98",
         "docs",
         "forevermoney",
         "sn",
-        "subdomain",
         "taomarketcap"
       ],
       "type": "surface",
@@ -12049,6 +12106,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-98-subnetradar-dashboard",
+      "netuid": 98,
+      "slug": "sn-98",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ForeverMoney SubnetRadar dashboard",
+      "tokens": [
+        "98",
+        "dashboard",
+        "forevermoney",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/98"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-98-taomarketcap-dashboard",
       "netuid": 98,
       "slug": "sn-98",
@@ -12082,24 +12156,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_98/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-98-taostats-metagraph",
-      "netuid": 98,
-      "slug": "sn-98",
-      "subtitle": "dashboard / taostats",
-      "title": "ForeverMoney Taostats metagraph",
-      "tokens": [
-        "98",
-        "dashboard",
-        "forevermoney",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/98/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12156,6 +12212,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-57-subnetradar-dashboard",
+      "netuid": 57,
+      "slug": "sn-57",
+      "subtitle": "dashboard / subnetradar",
+      "title": "gaia SubnetRadar dashboard",
+      "tokens": [
+        "57",
+        "dashboard",
+        "gaia",
+        "sn",
+        "sparket",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/57"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-57-taomarketcap-dashboard",
       "netuid": 57,
       "slug": "sn-57",
@@ -12191,25 +12265,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_57/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-57-taostats-metagraph",
-      "netuid": 57,
-      "slug": "sn-57",
-      "subtitle": "dashboard / taostats",
-      "title": "gaia Taostats metagraph",
-      "tokens": [
-        "57",
-        "dashboard",
-        "gaia",
-        "metagraph",
-        "sn",
-        "sparket",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/57/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12252,6 +12307,25 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-122-subnetradar-dashboard",
+      "netuid": 122,
+      "slug": "sn-122",
+      "subtitle": "dashboard / subnetradar",
+      "title": "gamma_small SubnetRadar dashboard",
+      "tokens": [
+        "122",
+        "bitrecs",
+        "dashboard",
+        "gamma",
+        "small",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/122"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-122-taomarketcap-dashboard",
       "netuid": 122,
       "slug": "sn-122",
@@ -12289,26 +12363,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_122/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-122-taostats-metagraph",
-      "netuid": 122,
-      "slug": "sn-122",
-      "subtitle": "dashboard / taostats",
-      "title": "gamma_small Taostats metagraph",
-      "tokens": [
-        "122",
-        "bitrecs",
-        "dashboard",
-        "gamma",
-        "metagraph",
-        "small",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/122/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12508,6 +12562,21 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-74-subnetradar-dashboard",
+      "netuid": 74,
+      "slug": "gittensor",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Gittensor SubnetRadar dashboard",
+      "tokens": [
+        "dashboard",
+        "gittensor",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/74"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-74-website-common-swagger",
       "netuid": 74,
       "slug": "gittensor",
@@ -12554,22 +12623,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_74/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-74-taostats-metagraph",
-      "netuid": 74,
-      "slug": "gittensor",
-      "subtitle": "dashboard / taostats",
-      "title": "Gittensor Taostats metagraph",
-      "tokens": [
-        "dashboard",
-        "gittensor",
-        "metagraph",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/74/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12621,6 +12674,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-28-subnetradar-dashboard",
+      "netuid": 28,
+      "slug": "sn-28",
+      "subtitle": "dashboard / subnetradar",
+      "title": "gm SubnetRadar dashboard",
+      "tokens": [
+        "28",
+        "dashboard",
+        "gm",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/28"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-28-taomarketcap-dashboard",
       "netuid": 28,
       "slug": "sn-28",
@@ -12654,24 +12724,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-28-taostats-metagraph",
-      "netuid": 28,
-      "slug": "sn-28",
-      "subtitle": "dashboard / taostats",
-      "title": "gm Taostats metagraph",
-      "tokens": [
-        "28",
-        "dashboard",
-        "gm",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/28/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12750,6 +12802,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-42-subnetradar-dashboard",
+      "netuid": 42,
+      "slug": "sn-42",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Gopher SubnetRadar dashboard",
+      "tokens": [
+        "42",
+        "dashboard",
+        "gopher",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/42"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-42-taomarketcap-dashboard",
       "netuid": 42,
       "slug": "sn-42",
@@ -12783,24 +12852,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_42/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-42-taostats-metagraph",
-      "netuid": 42,
-      "slug": "sn-42",
-      "subtitle": "dashboard / taostats",
-      "title": "Gopher Taostats metagraph",
-      "tokens": [
-        "42",
-        "dashboard",
-        "gopher",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/42/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -12915,6 +12966,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-56-subnetradar-dashboard",
+      "netuid": 56,
+      "slug": "sn-56",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Gradients SubnetRadar dashboard",
+      "tokens": [
+        "56",
+        "dashboard",
+        "gradients",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/56"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-56-website-common-swagger",
       "netuid": 56,
       "slug": "sn-56",
@@ -12967,24 +13035,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_56/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-56-taostats-metagraph",
-      "netuid": 56,
-      "slug": "sn-56",
-      "subtitle": "dashboard / taostats",
-      "title": "Gradients Taostats metagraph",
-      "tokens": [
-        "56",
-        "dashboard",
-        "gradients",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/56/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -13119,6 +13169,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-43-subnetradar-dashboard",
+      "netuid": 43,
+      "slug": "sn-43",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Graphite SubnetRadar dashboard",
+      "tokens": [
+        "43",
+        "dashboard",
+        "graphite",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/43"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-43-taomarketcap-dashboard",
       "netuid": 43,
       "slug": "sn-43",
@@ -13152,24 +13219,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_43/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-43-taostats-metagraph",
-      "netuid": 43,
-      "slug": "sn-43",
-      "subtitle": "dashboard / taostats",
-      "title": "Graphite Taostats metagraph",
-      "tokens": [
-        "43",
-        "dashboard",
-        "graphite",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/43/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -13347,6 +13396,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-110-subnetradar-dashboard",
+      "netuid": 110,
+      "slug": "sn-110",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Green Compute SubnetRadar dashboard",
+      "tokens": [
+        "110",
+        "compute",
+        "dashboard",
+        "green",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/110"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-110-taomarketcap-dashboard",
       "netuid": 110,
       "slug": "sn-110",
@@ -13382,25 +13449,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-110-taostats-metagraph",
-      "netuid": 110,
-      "slug": "sn-110",
-      "subtitle": "dashboard / taostats",
-      "title": "Green Compute Taostats metagraph",
-      "tokens": [
-        "110",
-        "compute",
-        "dashboard",
-        "green",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/110/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -13458,6 +13506,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-20-subnetradar-dashboard",
+      "netuid": 20,
+      "slug": "sn-20",
+      "subtitle": "dashboard / subnetradar",
+      "title": "GroundLayer SubnetRadar dashboard",
+      "tokens": [
+        "20",
+        "dashboard",
+        "groundlayer",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/20"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-20-taomarketcap-dashboard",
       "netuid": 20,
       "slug": "sn-20",
@@ -13491,24 +13556,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_20/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-20-taostats-metagraph",
-      "netuid": 20,
-      "slug": "sn-20",
-      "subtitle": "dashboard / taostats",
-      "title": "GroundLayer Taostats metagraph",
-      "tokens": [
-        "20",
-        "dashboard",
-        "groundlayer",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/20/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -13744,34 +13791,49 @@
       "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-116-backprop-dashboard",
       "netuid": 116,
-      "slug": "sn-116",
+      "slug": "taolend",
       "subtitle": "dashboard / backprop-finance",
       "title": "hard_sign Backprop Finance dashboard",
       "tokens": [
-        "116",
         "backprop",
         "dashboard",
         "finance",
         "hard",
         "sign",
-        "sn"
+        "taolend"
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/116-hard-sign"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-116-taomarketcap-dashboard",
+      "id": "surface:sn-116-subnetradar-dashboard",
       "netuid": 116,
-      "slug": "sn-116",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "hard_sign TaoMarketCap dashboard",
+      "slug": "taolend",
+      "subtitle": "dashboard / subnetradar",
+      "title": "hard_sign SubnetRadar dashboard",
       "tokens": [
-        "116",
         "dashboard",
         "hard",
         "sign",
-        "sn",
+        "subnetradar",
+        "taolend"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/116"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-116-taomarketcap-dashboard",
+      "netuid": 116,
+      "slug": "taolend",
+      "subtitle": "dashboard / taomarketcap",
+      "title": "hard_sign TaoMarketCap dashboard",
+      "tokens": [
+        "dashboard",
+        "hard",
+        "sign",
+        "taolend",
         "taomarketcap"
       ],
       "type": "surface",
@@ -13781,17 +13843,16 @@
       "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-116-taopedia-article",
       "netuid": 116,
-      "slug": "sn-116",
+      "slug": "taolend",
       "subtitle": "docs / taopedia-articles",
       "title": "hard_sign Taopedia article",
       "tokens": [
-        "116",
         "article",
         "articles",
         "docs",
         "hard",
         "sign",
-        "sn",
+        "taolend",
         "taopedia"
       ],
       "type": "surface",
@@ -13799,37 +13860,17 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-116-taostats-metagraph",
-      "netuid": 116,
-      "slug": "sn-116",
-      "subtitle": "dashboard / taostats",
-      "title": "hard_sign Taostats metagraph",
-      "tokens": [
-        "116",
-        "dashboard",
-        "hard",
-        "metagraph",
-        "sign",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/116/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-116-tensorplex-docs",
       "netuid": 116,
-      "slug": "sn-116",
+      "slug": "taolend",
       "subtitle": "docs / tensorplex-subnet-docs",
       "title": "hard_sign Tensorplex subnet docs",
       "tokens": [
-        "116",
         "docs",
         "hard",
         "sign",
-        "sn",
         "subnet",
+        "taolend",
         "tensorplex"
       ],
       "type": "surface",
@@ -13895,20 +13936,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-67-taomarketcap-dashboard",
+      "id": "surface:sn-67-subnetradar-dashboard",
       "netuid": 67,
       "slug": "sn-67",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Harnyx TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Harnyx SubnetRadar dashboard",
       "tokens": [
         "67",
         "dashboard",
         "harnyx",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/67"
+      "url": "https://subnetradar.com/subnet/67"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14002,6 +14043,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-115-subnetradar-dashboard",
+      "netuid": 115,
+      "slug": "sn-115",
+      "subtitle": "dashboard / subnetradar",
+      "title": "HashiChain SubnetRadar dashboard",
+      "tokens": [
+        "115",
+        "dashboard",
+        "hashichain",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/115"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-115-taomarketcap-dashboard",
       "netuid": 115,
       "slug": "sn-115",
@@ -14035,24 +14093,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_115/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-115-taostats-metagraph",
-      "netuid": 115,
-      "slug": "sn-115",
-      "subtitle": "dashboard / taostats",
-      "title": "HashiChain Taostats metagraph",
-      "tokens": [
-        "115",
-        "dashboard",
-        "hashichain",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/115/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14165,6 +14205,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-75-subnetradar-dashboard",
+      "netuid": 75,
+      "slug": "sn-75",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Hippius SubnetRadar dashboard",
+      "tokens": [
+        "75",
+        "dashboard",
+        "hippius",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/75"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-75-taomarketcap-dashboard",
       "netuid": 75,
       "slug": "sn-75",
@@ -14198,24 +14255,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_75/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-75-taostats-metagraph",
-      "netuid": 75,
-      "slug": "sn-75",
-      "subtitle": "dashboard / taostats",
-      "title": "Hippius Taostats metagraph",
-      "tokens": [
-        "75",
-        "dashboard",
-        "hippius",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/75/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14309,6 +14348,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-5-subnetradar-dashboard",
+      "netuid": 5,
+      "slug": "sn-5",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Hone SubnetRadar dashboard",
+      "tokens": [
+        "5",
+        "dashboard",
+        "hone",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/5"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-5-taomarketcap-dashboard",
       "netuid": 5,
       "slug": "sn-5",
@@ -14342,24 +14398,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-5-taostats-metagraph",
-      "netuid": 5,
-      "slug": "sn-5",
-      "subtitle": "dashboard / taostats",
-      "title": "Hone Taostats metagraph",
-      "tokens": [
-        "5",
-        "dashboard",
-        "hone",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/5/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14434,6 +14472,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-89-subnetradar-dashboard",
+      "netuid": 89,
+      "slug": "sn-89",
+      "subtitle": "dashboard / subnetradar",
+      "title": "InfiniteHash SubnetRadar dashboard",
+      "tokens": [
+        "89",
+        "dashboard",
+        "infinitehash",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/89"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-89-taomarketcap-dashboard",
       "netuid": 89,
       "slug": "sn-89",
@@ -14467,24 +14522,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_89/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-89-taostats-metagraph",
-      "netuid": 89,
-      "slug": "sn-89",
-      "subtitle": "dashboard / taostats",
-      "title": "InfiniteHash Taostats metagraph",
-      "tokens": [
-        "89",
-        "dashboard",
-        "infinitehash",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/89/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14580,20 +14617,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-88-taomarketcap-dashboard",
+      "id": "surface:sn-88-subnetradar-dashboard",
       "netuid": 88,
       "slug": "sn-88",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Investing TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Investing SubnetRadar dashboard",
       "tokens": [
         "88",
         "dashboard",
         "investing",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/88"
+      "url": "https://subnetradar.com/subnet/88"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14739,20 +14776,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-9-taomarketcap-dashboard",
+      "id": "surface:sn-9-subnetradar-dashboard",
       "netuid": 9,
       "slug": "sn-9",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "iota TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "iota SubnetRadar dashboard",
       "tokens": [
         "9",
         "dashboard",
         "iota",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/9"
+      "url": "https://subnetradar.com/subnet/9"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14828,24 +14865,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-32-website-subdomain-docs-docs-its-ai-org",
-      "netuid": 32,
-      "slug": "sn-32",
-      "subtitle": "docs / taomarketcap",
-      "title": "ItsAI docs subdomain",
-      "tokens": [
-        "32",
-        "docs",
-        "itsai",
-        "sn",
-        "subdomain",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://docs.its-ai.org/"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-32-itsai-source",
       "netuid": 32,
       "slug": "sn-32",
@@ -14863,6 +14882,23 @@
       ],
       "type": "surface",
       "url": "https://github.com/It-s-AI/llm-detection"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-32-subnetradar-dashboard",
+      "netuid": 32,
+      "slug": "sn-32",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ItsAI SubnetRadar dashboard",
+      "tokens": [
+        "32",
+        "dashboard",
+        "itsai",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/32"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -14899,24 +14935,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_32/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-32-taostats-metagraph",
-      "netuid": 32,
-      "slug": "sn-32",
-      "subtitle": "dashboard / taostats",
-      "title": "ItsAI Taostats metagraph",
-      "tokens": [
-        "32",
-        "dashboard",
-        "itsai",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/32/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15010,6 +15028,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-71-subnetradar-dashboard",
+      "netuid": 71,
+      "slug": "sn-71",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Leadpoet SubnetRadar dashboard",
+      "tokens": [
+        "71",
+        "dashboard",
+        "leadpoet",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/71"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-71-website-common-swagger",
       "netuid": 71,
       "slug": "sn-71",
@@ -15062,24 +15097,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-71-taostats-metagraph",
-      "netuid": 71,
-      "slug": "sn-71",
-      "subtitle": "dashboard / taostats",
-      "title": "Leadpoet Taostats metagraph",
-      "tokens": [
-        "71",
-        "dashboard",
-        "leadpoet",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/71/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15210,6 +15227,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-99-subnetradar-dashboard",
+      "netuid": 99,
+      "slug": "sn-99",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Leoma SubnetRadar dashboard",
+      "tokens": [
+        "99",
+        "dashboard",
+        "leoma",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/99"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-99-website-common-swagger",
       "netuid": 99,
       "slug": "sn-99",
@@ -15262,24 +15296,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_99/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-99-taostats-metagraph",
-      "netuid": 99,
-      "slug": "sn-99",
-      "subtitle": "dashboard / taostats",
-      "title": "Leoma Taostats metagraph",
-      "tokens": [
-        "99",
-        "dashboard",
-        "leoma",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/99/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15372,6 +15388,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-77-subnetradar-dashboard",
+      "netuid": 77,
+      "slug": "sn-77",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Liquidity SubnetRadar dashboard",
+      "tokens": [
+        "77",
+        "dashboard",
+        "liquidity",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/77"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-77-website-common-swagger",
       "netuid": 77,
       "slug": "sn-77",
@@ -15424,24 +15457,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-77-taostats-metagraph",
-      "netuid": 77,
-      "slug": "sn-77",
-      "subtitle": "dashboard / taostats",
-      "title": "Liquidity Taostats metagraph",
-      "tokens": [
-        "77",
-        "dashboard",
-        "liquidity",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/77/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15574,6 +15589,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-51-subnetradar-dashboard",
+      "netuid": 51,
+      "slug": "sn-51",
+      "subtitle": "dashboard / subnetradar",
+      "title": "lium.io SubnetRadar dashboard",
+      "tokens": [
+        "51",
+        "dashboard",
+        "io",
+        "lium",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/51"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-51-taomarketcap-dashboard",
       "netuid": 51,
       "slug": "sn-51",
@@ -15609,25 +15642,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-51-taostats-metagraph",
-      "netuid": 51,
-      "slug": "sn-51",
-      "subtitle": "dashboard / taostats",
-      "title": "lium.io Taostats metagraph",
-      "tokens": [
-        "51",
-        "dashboard",
-        "io",
-        "lium",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/51/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15686,6 +15700,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-92-subnetradar-dashboard",
+      "netuid": 92,
+      "slug": "sn-92",
+      "subtitle": "dashboard / subnetradar",
+      "title": "luis SubnetRadar dashboard",
+      "tokens": [
+        "92",
+        "dashboard",
+        "luis",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/92"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-92-taopedia-article",
       "netuid": 92,
       "slug": "sn-92",
@@ -15702,24 +15733,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_92/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-92-taostats-metagraph",
-      "netuid": 92,
-      "slug": "sn-92",
-      "subtitle": "dashboard / taostats",
-      "title": "luis Taostats metagraph",
-      "tokens": [
-        "92",
-        "dashboard",
-        "luis",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/92/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15759,6 +15772,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-87-subnetradar-dashboard",
+      "netuid": 87,
+      "slug": "sn-87",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Luminar Network SubnetRadar dashboard",
+      "tokens": [
+        "87",
+        "dashboard",
+        "luminar",
+        "network",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/87"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-87-taomarketcap-dashboard",
       "netuid": 87,
       "slug": "sn-87",
@@ -15794,25 +15825,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-87-taostats-metagraph",
-      "netuid": 87,
-      "slug": "sn-87",
-      "subtitle": "dashboard / taostats",
-      "title": "Luminar Network Taostats metagraph",
-      "tokens": [
-        "87",
-        "dashboard",
-        "luminar",
-        "metagraph",
-        "network",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/87/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -15946,6 +15958,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-25-website-link-macrocosmos-ai-docs-3",
+      "netuid": 25,
+      "slug": "sn-25",
+      "subtitle": "docs / taomarketcap",
+      "title": "Mainframe docs",
+      "tokens": [
+        "25",
+        "docs",
+        "mainframe",
+        "sn",
+        "taomarketcap"
+      ],
+      "type": "surface",
+      "url": "https://docs.macrocosmos.ai/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-25-website-link-macrocosmos-ai-docs-6",
       "netuid": 25,
       "slug": "sn-25",
@@ -15960,24 +15989,6 @@
       ],
       "type": "surface",
       "url": "https://macrocosmos.ai/delegation-guide"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-25-website-subdomain-docs-docs-macrocosmos-ai",
-      "netuid": 25,
-      "slug": "sn-25",
-      "subtitle": "docs / taomarketcap",
-      "title": "Mainframe docs subdomain",
-      "tokens": [
-        "25",
-        "docs",
-        "mainframe",
-        "sn",
-        "subdomain",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://docs.macrocosmos.ai/"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16000,20 +16011,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-25-taomarketcap-dashboard",
+      "id": "surface:sn-25-subnetradar-dashboard",
       "netuid": 25,
       "slug": "sn-25",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Mainframe TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Mainframe SubnetRadar dashboard",
       "tokens": [
         "25",
         "dashboard",
         "mainframe",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/25"
+      "url": "https://subnetradar.com/subnet/25"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16107,6 +16118,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-123-subnetradar-dashboard",
+      "netuid": 123,
+      "slug": "sn-123",
+      "subtitle": "dashboard / subnetradar",
+      "title": "MANTIS SubnetRadar dashboard",
+      "tokens": [
+        "123",
+        "dashboard",
+        "mantis",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/123"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-123-taomarketcap-dashboard",
       "netuid": 123,
       "slug": "sn-123",
@@ -16140,24 +16168,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-123-taostats-metagraph",
-      "netuid": 123,
-      "slug": "sn-123",
-      "subtitle": "dashboard / taostats",
-      "title": "MANTIS Taostats metagraph",
-      "tokens": [
-        "123",
-        "dashboard",
-        "mantis",
-        "metagraph",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/123/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16290,6 +16300,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-107-subnetradar-dashboard",
+      "netuid": 107,
+      "slug": "sn-107",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Minos SubnetRadar dashboard",
+      "tokens": [
+        "107",
+        "dashboard",
+        "minos",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/107"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-107-taomarketcap-dashboard",
       "netuid": 107,
       "slug": "sn-107",
@@ -16323,24 +16350,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_107/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-107-taostats-metagraph",
-      "netuid": 107,
-      "slug": "sn-107",
-      "subtitle": "dashboard / taostats",
-      "title": "Minos Taostats metagraph",
-      "tokens": [
-        "107",
-        "dashboard",
-        "metagraph",
-        "minos",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/107/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16397,6 +16406,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-112-website-subdomain-docs-docs-minotaursubnet-com",
+      "netuid": 112,
+      "slug": "sn-112",
+      "subtitle": "docs / taomarketcap",
+      "title": "minotaur docs subdomain",
+      "tokens": [
+        "112",
+        "docs",
+        "minotaur",
+        "sn",
+        "subdomain",
+        "taomarketcap"
+      ],
+      "type": "surface",
+      "url": "https://docs.minotaursubnet.com/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-112-taomarketcap-source-repo",
       "netuid": 112,
       "slug": "sn-112",
@@ -16413,6 +16440,23 @@
       ],
       "type": "surface",
       "url": "https://github.com/subnet112/minotaur_subnet"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-112-subnetradar-dashboard",
+      "netuid": 112,
+      "slug": "sn-112",
+      "subtitle": "dashboard / subnetradar",
+      "title": "minotaur SubnetRadar dashboard",
+      "tokens": [
+        "112",
+        "dashboard",
+        "minotaur",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/112"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16449,24 +16493,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_112/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-112-taostats-metagraph",
-      "netuid": 112,
-      "slug": "sn-112",
-      "subtitle": "dashboard / taostats",
-      "title": "minotaur Taostats metagraph",
-      "tokens": [
-        "112",
-        "dashboard",
-        "metagraph",
-        "minotaur",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/112/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16561,6 +16587,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-79-subnetradar-dashboard",
+      "netuid": 79,
+      "slug": "sn-79",
+      "subtitle": "dashboard / subnetradar",
+      "title": "MVTRX SubnetRadar dashboard",
+      "tokens": [
+        "79",
+        "dashboard",
+        "mvtrx",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/79"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-79-taomarketcap-dashboard",
       "netuid": 79,
       "slug": "sn-79",
@@ -16594,24 +16637,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_79/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-79-taostats-metagraph",
-      "netuid": 79,
-      "slug": "sn-79",
-      "subtitle": "dashboard / taostats",
-      "title": "MVTRX Taostats metagraph",
-      "tokens": [
-        "79",
-        "dashboard",
-        "metagraph",
-        "mvtrx",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/79/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16768,6 +16793,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-49-subnetradar-dashboard",
+      "netuid": 49,
+      "slug": "sn-49",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Nepher Robotics SubnetRadar dashboard",
+      "tokens": [
+        "49",
+        "dashboard",
+        "nepher",
+        "robotics",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/49"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-49-taomarketcap-dashboard",
       "netuid": 49,
       "slug": "sn-49",
@@ -16803,25 +16846,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_49/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-49-taostats-metagraph",
-      "netuid": 49,
-      "slug": "sn-49",
-      "subtitle": "dashboard / taostats",
-      "title": "Nepher Robotics Taostats metagraph",
-      "tokens": [
-        "49",
-        "dashboard",
-        "metagraph",
-        "nepher",
-        "robotics",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/49/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -16989,6 +17013,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-70-subnetradar-dashboard",
+      "netuid": 70,
+      "slug": "sn-70",
+      "subtitle": "dashboard / subnetradar",
+      "title": "NexisGen SubnetRadar dashboard",
+      "tokens": [
+        "70",
+        "dashboard",
+        "nexisgen",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/70"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-70-taomarketcap-dashboard",
       "netuid": 70,
       "slug": "sn-70",
@@ -17022,24 +17063,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-70-taostats-metagraph",
-      "netuid": 70,
-      "slug": "sn-70",
-      "subtitle": "dashboard / taostats",
-      "title": "NexisGen Taostats metagraph",
-      "tokens": [
-        "70",
-        "dashboard",
-        "metagraph",
-        "nexisgen",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/70/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -17172,6 +17195,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-66-subnetradar-dashboard",
+      "netuid": 66,
+      "slug": "sn-66",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ninja SubnetRadar dashboard",
+      "tokens": [
+        "66",
+        "dashboard",
+        "ninja",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/66"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-66-website-common-swagger",
       "netuid": 66,
       "slug": "sn-66",
@@ -17243,24 +17283,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_66/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-66-taostats-metagraph",
-      "netuid": 66,
-      "slug": "sn-66",
-      "subtitle": "dashboard / taostats",
-      "title": "ninja Taostats metagraph",
-      "tokens": [
-        "66",
-        "dashboard",
-        "metagraph",
-        "ninja",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/66/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -17356,6 +17378,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-55-subnetradar-dashboard",
+      "netuid": 55,
+      "slug": "sn-55",
+      "subtitle": "dashboard / subnetradar",
+      "title": "NIOME SubnetRadar dashboard",
+      "tokens": [
+        "55",
+        "dashboard",
+        "niome",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/55"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-55-taomarketcap-dashboard",
       "netuid": 55,
       "slug": "sn-55",
@@ -17389,24 +17428,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_55/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-55-taostats-metagraph",
-      "netuid": 55,
-      "slug": "sn-55",
-      "subtitle": "dashboard / taostats",
-      "title": "NIOME Taostats metagraph",
-      "tokens": [
-        "55",
-        "dashboard",
-        "metagraph",
-        "niome",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/55/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -17447,32 +17468,72 @@
       "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-27-backprop-dashboard",
       "netuid": 27,
-      "slug": "sn-27",
+      "slug": "nodexo",
       "subtitle": "dashboard / backprop-finance",
       "title": "Nodexo Backprop Finance dashboard",
       "tokens": [
-        "27",
         "backprop",
         "dashboard",
         "finance",
-        "nodexo",
-        "sn"
+        "nodexo"
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/27-nodexo"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-27-nodexo-console",
+      "netuid": 27,
+      "slug": "nodexo",
+      "subtitle": "dashboard / nodexo",
+      "title": "Nodexo console",
+      "tokens": [
+        "console",
+        "dashboard",
+        "nodexo"
+      ],
+      "type": "surface",
+      "url": "https://console.nodexo.ai/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-27-nodexo-docs",
+      "netuid": 27,
+      "slug": "nodexo",
+      "subtitle": "docs / nodexo",
+      "title": "Nodexo docs",
+      "tokens": [
+        "docs",
+        "nodexo"
+      ],
+      "type": "surface",
+      "url": "https://docs.nodexo.ai/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-27-subnetradar-dashboard",
+      "netuid": 27,
+      "slug": "nodexo",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Nodexo SubnetRadar dashboard",
+      "tokens": [
+        "dashboard",
+        "nodexo",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/27"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-27-taomarketcap-dashboard",
       "netuid": 27,
-      "slug": "sn-27",
+      "slug": "nodexo",
       "subtitle": "dashboard / taomarketcap",
       "title": "Nodexo TaoMarketCap dashboard",
       "tokens": [
-        "27",
         "dashboard",
         "nodexo",
-        "sn",
         "taomarketcap"
       ],
       "type": "surface",
@@ -17482,16 +17543,14 @@
       "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-27-taopedia-article",
       "netuid": 27,
-      "slug": "sn-27",
+      "slug": "nodexo",
       "subtitle": "docs / taopedia-articles",
       "title": "Nodexo Taopedia article",
       "tokens": [
-        "27",
         "article",
         "articles",
         "docs",
         "nodexo",
-        "sn",
         "taopedia"
       ],
       "type": "surface",
@@ -17499,39 +17558,33 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-27-taostats-metagraph",
-      "netuid": 27,
-      "slug": "sn-27",
-      "subtitle": "dashboard / taostats",
-      "title": "Nodexo Taostats metagraph",
-      "tokens": [
-        "27",
-        "dashboard",
-        "metagraph",
-        "nodexo",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/27/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-27-tensorplex-docs",
       "netuid": 27,
-      "slug": "sn-27",
+      "slug": "nodexo",
       "subtitle": "docs / tensorplex-subnet-docs",
       "title": "Nodexo Tensorplex subnet docs",
       "tokens": [
-        "27",
         "docs",
         "nodexo",
-        "sn",
         "subnet",
         "tensorplex"
       ],
       "type": "surface",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/27"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-27-nodexo-website",
+      "netuid": 27,
+      "slug": "nodexo",
+      "subtitle": "website / nodexo",
+      "title": "Nodexo website",
+      "tokens": [
+        "nodexo",
+        "website"
+      ],
+      "type": "surface",
+      "url": "https://nodexo.ai/"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -17625,6 +17678,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-68-subnetradar-dashboard",
+      "netuid": 68,
+      "slug": "sn-68",
+      "subtitle": "dashboard / subnetradar",
+      "title": "NOVA SubnetRadar dashboard",
+      "tokens": [
+        "68",
+        "dashboard",
+        "nova",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/68"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-68-taomarketcap-dashboard",
       "netuid": 68,
       "slug": "sn-68",
@@ -17658,24 +17728,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-68-taostats-metagraph",
-      "netuid": 68,
-      "slug": "sn-68",
-      "subtitle": "dashboard / taostats",
-      "title": "NOVA Taostats metagraph",
-      "tokens": [
-        "68",
-        "dashboard",
-        "metagraph",
-        "nova",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/68/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -17768,20 +17820,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-6-taomarketcap-dashboard",
+      "id": "surface:sn-6-subnetradar-dashboard",
       "netuid": 6,
       "slug": "sn-6",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Numinous TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Numinous SubnetRadar dashboard",
       "tokens": [
         "6",
         "dashboard",
         "numinous",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/6"
+      "url": "https://subnetradar.com/subnet/6"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -17858,6 +17910,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-90-subnetradar-dashboard",
+      "netuid": 90,
+      "slug": "sn-90",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ogham SubnetRadar dashboard",
+      "tokens": [
+        "90",
+        "dashboard",
+        "degenbrain",
+        "ogham",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/90"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-90-taomarketcap-dashboard",
       "netuid": 90,
       "slug": "sn-90",
@@ -17893,25 +17963,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-90-taostats-metagraph",
-      "netuid": 90,
-      "slug": "sn-90",
-      "subtitle": "dashboard / taostats",
-      "title": "ogham Taostats metagraph",
-      "tokens": [
-        "90",
-        "dashboard",
-        "degenbrain",
-        "metagraph",
-        "ogham",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/90/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -17970,6 +18021,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-111-subnetradar-dashboard",
+      "netuid": 111,
+      "slug": "sn-111",
+      "subtitle": "dashboard / subnetradar",
+      "title": "oneoneone SubnetRadar dashboard",
+      "tokens": [
+        "111",
+        "dashboard",
+        "oneoneone",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/111"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-111-taomarketcap-dashboard",
       "netuid": 111,
       "slug": "sn-111",
@@ -18003,24 +18071,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_111/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-111-taostats-metagraph",
-      "netuid": 111,
-      "slug": "sn-111",
-      "subtitle": "dashboard / taostats",
-      "title": "oneoneone Taostats metagraph",
-      "tokens": [
-        "111",
-        "dashboard",
-        "metagraph",
-        "oneoneone",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/111/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -18233,20 +18283,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-15-taomarketcap-dashboard",
+      "id": "surface:sn-15-subnetradar-dashboard",
       "netuid": 15,
       "slug": "sn-15",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "ORO TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ORO SubnetRadar dashboard",
       "tokens": [
         "15",
         "dashboard",
         "oro",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/15"
+      "url": "https://subnetradar.com/subnet/15"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -18321,6 +18371,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-35-website-subdomain-docs-docs-0xmarkets-io",
+      "netuid": 35,
+      "slug": "sn-35",
+      "subtitle": "docs / taomarketcap",
+      "title": "OxMarkets docs subdomain",
+      "tokens": [
+        "35",
+        "docs",
+        "oxmarkets",
+        "sn",
+        "subdomain",
+        "taomarketcap"
+      ],
+      "type": "surface",
+      "url": "https://docs.0xmarkets.io/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-35-taomarketcap-source-repo",
       "netuid": 35,
       "slug": "sn-35",
@@ -18361,6 +18429,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-35-subnetradar-dashboard",
+      "netuid": 35,
+      "slug": "sn-35",
+      "subtitle": "dashboard / subnetradar",
+      "title": "OxMarkets SubnetRadar dashboard",
+      "tokens": [
+        "35",
+        "dashboard",
+        "oxmarkets",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/35"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-35-taomarketcap-dashboard",
       "netuid": 35,
       "slug": "sn-35",
@@ -18394,24 +18479,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_35/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-35-taostats-metagraph",
-      "netuid": 35,
-      "slug": "sn-35",
-      "subtitle": "dashboard / taostats",
-      "title": "OxMarkets Taostats metagraph",
-      "tokens": [
-        "35",
-        "dashboard",
-        "metagraph",
-        "oxmarkets",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/35/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -18452,32 +18519,46 @@
       "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-73-backprop-dashboard",
       "netuid": 73,
-      "slug": "sn-73",
+      "slug": "metahash",
       "subtitle": "dashboard / backprop-finance",
       "title": "Parked Backprop Finance dashboard",
       "tokens": [
-        "73",
         "backprop",
         "dashboard",
         "finance",
-        "parked",
-        "sn"
+        "metahash",
+        "parked"
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/73-parked"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-73-subnetradar-dashboard",
+      "netuid": 73,
+      "slug": "metahash",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Parked SubnetRadar dashboard",
+      "tokens": [
+        "dashboard",
+        "metahash",
+        "parked",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/73"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-73-taomarketcap-dashboard",
       "netuid": 73,
-      "slug": "sn-73",
+      "slug": "metahash",
       "subtitle": "dashboard / taomarketcap",
       "title": "Parked TaoMarketCap dashboard",
       "tokens": [
-        "73",
         "dashboard",
+        "metahash",
         "parked",
-        "sn",
         "taomarketcap"
       ],
       "type": "surface",
@@ -18487,16 +18568,15 @@
       "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-73-taopedia-article",
       "netuid": 73,
-      "slug": "sn-73",
+      "slug": "metahash",
       "subtitle": "docs / taopedia-articles",
       "title": "Parked Taopedia article",
       "tokens": [
-        "73",
         "article",
         "articles",
         "docs",
+        "metahash",
         "parked",
-        "sn",
         "taopedia"
       ],
       "type": "surface",
@@ -18504,34 +18584,15 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-73-taostats-metagraph",
-      "netuid": 73,
-      "slug": "sn-73",
-      "subtitle": "dashboard / taostats",
-      "title": "Parked Taostats metagraph",
-      "tokens": [
-        "73",
-        "dashboard",
-        "metagraph",
-        "parked",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/73/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-73-tensorplex-docs",
       "netuid": 73,
-      "slug": "sn-73",
+      "slug": "metahash",
       "subtitle": "docs / tensorplex-subnet-docs",
       "title": "Parked Tensorplex subnet docs",
       "tokens": [
-        "73",
         "docs",
+        "metahash",
         "parked",
-        "sn",
         "subnet",
         "tensorplex"
       ],
@@ -18580,22 +18641,21 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-58-taostats-metagraph",
+      "id": "surface:sn-58-subnetradar-dashboard",
       "netuid": 58,
       "slug": "sn-58",
-      "subtitle": "dashboard / taostats",
-      "title": "Pending Taostats metagraph",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Pending SubnetRadar dashboard",
       "tokens": [
         "58",
         "dashboard",
         "handshake58",
-        "metagraph",
         "pending",
         "sn",
-        "taostats"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taostats.io/subnets/58/metagraph"
+      "url": "https://subnetradar.com/subnet/58"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -18653,6 +18713,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-26-subnetradar-dashboard",
+      "netuid": 26,
+      "slug": "sn-26",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Perturb SubnetRadar dashboard",
+      "tokens": [
+        "26",
+        "dashboard",
+        "perturb",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/26"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-26-taomarketcap-dashboard",
       "netuid": 26,
       "slug": "sn-26",
@@ -18686,24 +18763,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_26/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-26-taostats-metagraph",
-      "netuid": 26,
-      "slug": "sn-26",
-      "subtitle": "dashboard / taostats",
-      "title": "Perturb Taostats metagraph",
-      "tokens": [
-        "26",
-        "dashboard",
-        "metagraph",
-        "perturb",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/26/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -18843,6 +18902,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-100-subnetradar-dashboard",
+      "netuid": 100,
+      "slug": "sn-100",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Plaτform SubnetRadar dashboard",
+      "tokens": [
+        "100",
+        "dashboard",
+        "form",
+        "pla",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/100"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-100-taomarketcap-dashboard",
       "netuid": 100,
       "slug": "sn-100",
@@ -18878,25 +18955,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_100/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-100-taostats-metagraph",
-      "netuid": 100,
-      "slug": "sn-100",
-      "subtitle": "dashboard / taostats",
-      "title": "Plaτform Taostats metagraph",
-      "tokens": [
-        "100",
-        "dashboard",
-        "form",
-        "metagraph",
-        "pla",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/100/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -18974,6 +19032,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-126-subnetradar-dashboard",
+      "netuid": 126,
+      "slug": "sn-126",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Poker44 SubnetRadar dashboard",
+      "tokens": [
+        "126",
+        "dashboard",
+        "poker44",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/126"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-126-taomarketcap-dashboard",
       "netuid": 126,
       "slug": "sn-126",
@@ -19007,24 +19082,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_126/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-126-taostats-metagraph",
-      "netuid": 126,
-      "slug": "sn-126",
-      "subtitle": "dashboard / taostats",
-      "title": "Poker44 Taostats metagraph",
-      "tokens": [
-        "126",
-        "dashboard",
-        "metagraph",
-        "poker44",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/126/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -19140,6 +19197,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-48-subnetradar-dashboard",
+      "netuid": 48,
+      "slug": "sn-48",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Quantum Compute SubnetRadar dashboard",
+      "tokens": [
+        "48",
+        "compute",
+        "dashboard",
+        "quantum",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/48"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-48-taomarketcap-dashboard",
       "netuid": 48,
       "slug": "sn-48",
@@ -19175,25 +19250,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_48/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-48-taostats-metagraph",
-      "netuid": 48,
-      "slug": "sn-48",
-      "subtitle": "dashboard / taostats",
-      "title": "Quantum Compute Taostats metagraph",
-      "tokens": [
-        "48",
-        "compute",
-        "dashboard",
-        "metagraph",
-        "quantum",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/48/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -19334,6 +19390,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-24-subnetradar-dashboard",
+      "netuid": 24,
+      "slug": "sn-24",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Quasar SubnetRadar dashboard",
+      "tokens": [
+        "24",
+        "dashboard",
+        "quasar",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/24"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-24-taomarketcap-dashboard",
       "netuid": 24,
       "slug": "sn-24",
@@ -19367,24 +19440,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_24/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-24-taostats-metagraph",
-      "netuid": 24,
-      "slug": "sn-24",
-      "subtitle": "dashboard / taostats",
-      "title": "Quasar Taostats metagraph",
-      "tokens": [
-        "24",
-        "dashboard",
-        "metagraph",
-        "quasar",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/24/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -19518,6 +19573,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-33-subnetradar-dashboard",
+      "netuid": 33,
+      "slug": "sn-33",
+      "subtitle": "dashboard / subnetradar",
+      "title": "ReadyAI SubnetRadar dashboard",
+      "tokens": [
+        "33",
+        "dashboard",
+        "readyai",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/33"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-33-taomarketcap-dashboard",
       "netuid": 33,
       "slug": "sn-33",
@@ -19551,24 +19623,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_33/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-33-taostats-metagraph",
-      "netuid": 33,
-      "slug": "sn-33",
-      "subtitle": "dashboard / taostats",
-      "title": "ReadyAI Taostats metagraph",
-      "tokens": [
-        "33",
-        "dashboard",
-        "metagraph",
-        "readyai",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/33/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -19624,6 +19678,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-31-subnetradar-dashboard",
+      "netuid": 31,
+      "slug": "sn-31",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Recall SubnetRadar dashboard",
+      "tokens": [
+        "31",
+        "dashboard",
+        "recall",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/31"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-31-taomarketcap-dashboard",
       "netuid": 31,
       "slug": "sn-31",
@@ -19657,24 +19728,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-31-taostats-metagraph",
-      "netuid": 31,
-      "slug": "sn-31",
-      "subtitle": "dashboard / taostats",
-      "title": "Recall Taostats metagraph",
-      "tokens": [
-        "31",
-        "dashboard",
-        "metagraph",
-        "recall",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/31/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -19764,20 +19817,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-61-taomarketcap-dashboard",
+      "id": "surface:sn-61-subnetradar-dashboard",
       "netuid": 61,
       "slug": "sn-61",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "RedTeam TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "RedTeam SubnetRadar dashboard",
       "tokens": [
         "61",
         "dashboard",
         "redteam",
         "sn",
-        "taomarketcap"
+        "subnetradar"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/61"
+      "url": "https://subnetradar.com/subnet/61"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -19852,24 +19905,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-62-website-subdomain-docs-docs-ridges-ai",
-      "netuid": 62,
-      "slug": "sn-62",
-      "subtitle": "docs / taomarketcap",
-      "title": "Ridges docs subdomain",
-      "tokens": [
-        "62",
-        "docs",
-        "ridges",
-        "sn",
-        "subdomain",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://docs.ridges.ai/"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-62-ridges-source",
       "netuid": 62,
       "slug": "sn-62",
@@ -19885,6 +19920,23 @@
       ],
       "type": "surface",
       "url": "https://github.com/ridgesai/ridges"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-62-subnetradar-dashboard",
+      "netuid": 62,
+      "slug": "sn-62",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Ridges SubnetRadar dashboard",
+      "tokens": [
+        "62",
+        "dashboard",
+        "ridges",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/62"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -19924,24 +19976,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-62-taostats-metagraph",
-      "netuid": 62,
-      "slug": "sn-62",
-      "subtitle": "dashboard / taostats",
-      "title": "Ridges Taostats metagraph",
-      "tokens": [
-        "62",
-        "dashboard",
-        "metagraph",
-        "ridges",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/62/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-62-tensorplex-docs",
       "netuid": 62,
       "slug": "sn-62",
@@ -19976,6 +20010,21 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-0-subnetradar-dashboard",
+      "netuid": 0,
+      "slug": "root",
+      "subtitle": "dashboard / subnetradar",
+      "title": "root SubnetRadar dashboard",
+      "tokens": [
+        "dashboard",
+        "root",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/0"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-0-taomarketcap-dashboard",
       "netuid": 0,
       "slug": "root",
@@ -19988,22 +20037,6 @@
       ],
       "type": "surface",
       "url": "https://taomarketcap.com/subnets/0"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-0-taostats-metagraph",
-      "netuid": 0,
-      "slug": "root",
-      "subtitle": "dashboard / taostats",
-      "title": "root Taostats metagraph",
-      "tokens": [
-        "dashboard",
-        "metagraph",
-        "root",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/0/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -20041,6 +20074,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-119-subnetradar-dashboard",
+      "netuid": 119,
+      "slug": "sn-119",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Satori SubnetRadar dashboard",
+      "tokens": [
+        "119",
+        "dashboard",
+        "satori",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/119"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-119-taomarketcap-dashboard",
       "netuid": 119,
       "slug": "sn-119",
@@ -20074,24 +20124,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-119-taostats-metagraph",
-      "netuid": 119,
-      "slug": "sn-119",
-      "subtitle": "dashboard / taostats",
-      "title": "Satori Taostats metagraph",
-      "tokens": [
-        "119",
-        "dashboard",
-        "metagraph",
-        "satori",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/119/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -20171,6 +20203,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-44-subnetradar-dashboard",
+      "netuid": 44,
+      "slug": "sn-44",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Score SubnetRadar dashboard",
+      "tokens": [
+        "44",
+        "dashboard",
+        "score",
+        "sn",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/44"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-44-taomarketcap-dashboard",
       "netuid": 44,
       "slug": "sn-44",
@@ -20207,24 +20256,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-44-taostats-metagraph",
-      "netuid": 44,
-      "slug": "sn-44",
-      "subtitle": "dashboard / taostats",
-      "title": "Score Taostats metagraph",
-      "tokens": [
-        "44",
-        "dashboard",
-        "metagraph",
-        "score",
-        "sn",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/44/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-44-tensorplex-docs",
       "netuid": 44,
       "slug": "sn-44",
@@ -20257,6 +20288,21 @@
       ],
       "type": "surface",
       "url": "https://www.wearescore.com/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-53-signalplus-website",
+      "netuid": 53,
+      "slug": "efficientfrontier",
+      "subtitle": "website / signalplus",
+      "title": "SignalPlus website",
+      "tokens": [
+        "efficientfrontier",
+        "signalplus",
+        "website"
+      ],
+      "type": "surface",
+      "url": "https://www.signalplus.com/"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -20374,6 +20420,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-114-subnetradar-dashboard",
+      "netuid": 114,
+      "slug": "sn-114",
+      "subtitle": "dashboard / subnetradar",
+      "title": "SOMA SubnetRadar dashboard",
+      "tokens": [
+        "114",
+        "dashboard",
+        "sn",
+        "soma",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/114"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-114-taomarketcap-dashboard",
       "netuid": 114,
       "slug": "sn-114",
@@ -20407,24 +20470,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_114/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-114-taostats-metagraph",
-      "netuid": 114,
-      "slug": "sn-114",
-      "subtitle": "dashboard / taostats",
-      "title": "SOMA Taostats metagraph",
-      "tokens": [
-        "114",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "soma",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/114/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -20517,6 +20562,25 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-72-subnetradar-dashboard",
+      "netuid": 72,
+      "slug": "sn-72",
+      "subtitle": "dashboard / subnetradar",
+      "title": "StreetVision by NATIX SubnetRadar dashboard",
+      "tokens": [
+        "72",
+        "by",
+        "dashboard",
+        "natix",
+        "sn",
+        "streetvision",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/72"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-72-taomarketcap-dashboard",
       "netuid": 72,
       "slug": "sn-72",
@@ -20554,26 +20618,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_72/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-72-taostats-metagraph",
-      "netuid": 72,
-      "slug": "sn-72",
-      "subtitle": "dashboard / taostats",
-      "title": "StreetVision by NATIX Taostats metagraph",
-      "tokens": [
-        "72",
-        "by",
-        "dashboard",
-        "metagraph",
-        "natix",
-        "sn",
-        "streetvision",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/72/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -20673,6 +20717,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-86-subnetradar-dashboard",
+      "netuid": 86,
+      "slug": "sn-86",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Subnet 86 SubnetRadar dashboard",
+      "tokens": [
+        "86",
+        "dashboard",
+        "sn",
+        "subnet",
+        "subnetradar"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/86"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-86-taomarketcap-dashboard",
       "netuid": 86,
       "slug": "sn-86",
@@ -20706,24 +20767,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-86-taostats-metagraph",
-      "netuid": 86,
-      "slug": "sn-86",
-      "subtitle": "dashboard / taostats",
-      "title": "Subnet 86 Taostats metagraph",
-      "tokens": [
-        "86",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "subnet",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/86/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -20817,6 +20860,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-121-subnetradar-dashboard",
+      "netuid": 121,
+      "slug": "sn-121",
+      "subtitle": "dashboard / subnetradar",
+      "title": "sundae_bar SubnetRadar dashboard",
+      "tokens": [
+        "121",
+        "bar",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "sundae"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/121"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-121-taomarketcap-dashboard",
       "netuid": 121,
       "slug": "sn-121",
@@ -20852,25 +20913,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_121/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-121-taostats-metagraph",
-      "netuid": 121,
-      "slug": "sn-121",
-      "subtitle": "dashboard / taostats",
-      "title": "sundae_bar Taostats metagraph",
-      "tokens": [
-        "121",
-        "bar",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "sundae",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/121/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -20911,6 +20953,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-10-website-subdomain-docs-docs-taofi-com",
+      "netuid": 10,
+      "slug": "sn-10",
+      "subtitle": "docs / taomarketcap",
+      "title": "Swap docs subdomain",
+      "tokens": [
+        "10",
+        "docs",
+        "sn",
+        "subdomain",
+        "swap",
+        "taomarketcap"
+      ],
+      "type": "surface",
+      "url": "https://docs.taofi.com/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-10-taomarketcap-source-repo",
       "netuid": 10,
       "slug": "sn-10",
@@ -20927,6 +20987,23 @@
       ],
       "type": "surface",
       "url": "https://github.com/Swap-Subnet/swap-subnet"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-10-subnetradar-dashboard",
+      "netuid": 10,
+      "slug": "sn-10",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Swap SubnetRadar dashboard",
+      "tokens": [
+        "10",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "swap"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/10"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -20963,24 +21040,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_10/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-10-taostats-metagraph",
-      "netuid": 10,
-      "slug": "sn-10",
-      "subtitle": "dashboard / taostats",
-      "title": "Swap Taostats metagraph",
-      "tokens": [
-        "10",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "swap",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/10/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -21090,6 +21149,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-124-subnetradar-dashboard",
+      "netuid": 124,
+      "slug": "sn-124",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Swarm SubnetRadar dashboard",
+      "tokens": [
+        "124",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "swarm"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/124"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-124-website-common-swagger",
       "netuid": 124,
       "slug": "sn-124",
@@ -21106,23 +21182,6 @@
       ],
       "type": "surface",
       "url": "https://www.swarm124.com/swagger"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-124-taomarketcap-dashboard",
-      "netuid": 124,
-      "slug": "sn-124",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Swarm TaoMarketCap dashboard",
-      "tokens": [
-        "124",
-        "dashboard",
-        "sn",
-        "swarm",
-        "taomarketcap"
-      ],
-      "type": "surface",
-      "url": "https://taomarketcap.com/subnets/124"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -21234,6 +21293,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-50-subnetradar-dashboard",
+      "netuid": 50,
+      "slug": "sn-50",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Synth SubnetRadar dashboard",
+      "tokens": [
+        "50",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "synth"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/50"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-50-website-common-swagger",
       "netuid": 50,
       "slug": "sn-50",
@@ -21286,24 +21362,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-50-taostats-metagraph",
-      "netuid": 50,
-      "slug": "sn-50",
-      "subtitle": "dashboard / taostats",
-      "title": "Synth Taostats metagraph",
-      "tokens": [
-        "50",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "synth",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/50/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -21416,6 +21474,24 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-45-subnetradar-dashboard",
+      "netuid": 45,
+      "slug": "sn-45",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Talisman AI SubnetRadar dashboard",
+      "tokens": [
+        "45",
+        "ai",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "talisman"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/45"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-45-taomarketcap-dashboard",
       "netuid": 45,
       "slug": "sn-45",
@@ -21451,25 +21527,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_45/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-45-taostats-metagraph",
-      "netuid": 45,
-      "slug": "sn-45",
-      "subtitle": "dashboard / taostats",
-      "title": "Talisman AI Taostats metagraph",
-      "tokens": [
-        "45",
-        "ai",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "talisman",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/45/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -21546,6 +21603,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-108-subnetradar-dashboard",
+      "netuid": 108,
+      "slug": "sn-108",
+      "subtitle": "dashboard / subnetradar",
+      "title": "TalkHead SubnetRadar dashboard",
+      "tokens": [
+        "108",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "talkhead"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/108"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-108-taomarketcap-dashboard",
       "netuid": 108,
       "slug": "sn-108",
@@ -21579,24 +21653,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-108-taostats-metagraph",
-      "netuid": 108,
-      "slug": "sn-108",
-      "subtitle": "dashboard / taostats",
-      "title": "TalkHead Taostats metagraph",
-      "tokens": [
-        "108",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "talkhead",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/108/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -21714,6 +21770,25 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-65-subnetradar-dashboard",
+      "netuid": 65,
+      "slug": "sn-65",
+      "subtitle": "dashboard / subnetradar",
+      "title": "TAO Private Network SubnetRadar dashboard",
+      "tokens": [
+        "65",
+        "dashboard",
+        "network",
+        "private",
+        "sn",
+        "subnetradar",
+        "tao"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/65"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-65-website-common-swagger",
       "netuid": 65,
       "slug": "sn-65",
@@ -21775,26 +21850,6 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-65-taostats-metagraph",
-      "netuid": 65,
-      "slug": "sn-65",
-      "subtitle": "dashboard / taostats",
-      "title": "TAO Private Network Taostats metagraph",
-      "tokens": [
-        "65",
-        "dashboard",
-        "metagraph",
-        "network",
-        "private",
-        "sn",
-        "tao",
-        "taostats"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/65/metagraph"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-65-tensorplex-docs",
       "netuid": 65,
       "slug": "sn-65",
@@ -21831,6 +21886,20 @@
       ],
       "type": "surface",
       "url": "https://tpn.taofu.xyz/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-116-taolend-website",
+      "netuid": 116,
+      "slug": "taolend",
+      "subtitle": "website / taolend",
+      "title": "TaoLend website",
+      "tokens": [
+        "taolend",
+        "website"
+      ],
+      "type": "surface",
+      "url": "https://taolend.io/"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -21890,7 +21959,7 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-4-website-link-targon-com-docs-9",
+      "id": "surface:sn-4-website-link-targon-com-docs-4",
       "netuid": 4,
       "slug": "sn-4",
       "subtitle": "docs / taomarketcap",
@@ -21903,7 +21972,7 @@
         "targon"
       ],
       "type": "surface",
-      "url": "https://targon.com/releases/intel-whitepaper"
+      "url": "https://docs.targon.com/"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -21945,6 +22014,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-4-subnetradar-dashboard",
+      "netuid": 4,
+      "slug": "sn-4",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Targon SubnetRadar dashboard",
+      "tokens": [
+        "4",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "targon"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/4"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-4-taomarketcap-dashboard",
       "netuid": 4,
       "slug": "sn-4",
@@ -21978,24 +22064,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_4/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-4-taostats-metagraph",
-      "netuid": 4,
-      "slug": "sn-4",
-      "subtitle": "dashboard / taostats",
-      "title": "Targon Taostats metagraph",
-      "tokens": [
-        "4",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "targon"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/4/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -22215,6 +22283,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-113-subnetradar-dashboard",
+      "netuid": 113,
+      "slug": "sn-113",
+      "subtitle": "dashboard / subnetradar",
+      "title": "TensorUSD SubnetRadar dashboard",
+      "tokens": [
+        "113",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "tensorusd"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/113"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-113-taomarketcap-dashboard",
       "netuid": 113,
       "slug": "sn-113",
@@ -22248,24 +22333,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_113/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-113-taostats-metagraph",
-      "netuid": 113,
-      "slug": "sn-113",
-      "subtitle": "dashboard / taostats",
-      "title": "TensorUSD Taostats metagraph",
-      "tokens": [
-        "113",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "tensorusd"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/113/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -22357,6 +22424,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-11-subnetradar-dashboard",
+      "netuid": 11,
+      "slug": "sn-11",
+      "subtitle": "dashboard / subnetradar",
+      "title": "TrajectoryRL SubnetRadar dashboard",
+      "tokens": [
+        "11",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "trajectoryrl"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/11"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-11-taomarketcap-dashboard",
       "netuid": 11,
       "slug": "sn-11",
@@ -22390,24 +22474,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-11-taostats-metagraph",
-      "netuid": 11,
-      "slug": "sn-11",
-      "subtitle": "dashboard / taostats",
-      "title": "TrajectoryRL Taostats metagraph",
-      "tokens": [
-        "11",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "trajectoryrl"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/11/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -22498,6 +22564,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-23-website-link-trishool-ai-docs-1",
+      "netuid": 23,
+      "slug": "sn-23",
+      "subtitle": "docs / taomarketcap",
+      "title": "Trishool docs",
+      "tokens": [
+        "23",
+        "docs",
+        "sn",
+        "taomarketcap",
+        "trishool"
+      ],
+      "type": "surface",
+      "url": "https://docs.trishool.ai/"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-23-website-link-trishool-ai-docs-2",
       "netuid": 23,
       "slug": "sn-23",
@@ -22512,24 +22595,6 @@
       ],
       "type": "surface",
       "url": "https://litepaper.trishool.ai/"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-23-website-subdomain-docs-docs-trishool-ai",
-      "netuid": 23,
-      "slug": "sn-23",
-      "subtitle": "docs / taomarketcap",
-      "title": "Trishool docs subdomain",
-      "tokens": [
-        "23",
-        "docs",
-        "sn",
-        "subdomain",
-        "taomarketcap",
-        "trishool"
-      ],
-      "type": "surface",
-      "url": "https://docs.trishool.ai/"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -22574,20 +22639,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-23-taomarketcap-dashboard",
+      "id": "surface:sn-23-subnetradar-dashboard",
       "netuid": 23,
       "slug": "sn-23",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Trishool TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Trishool SubnetRadar dashboard",
       "tokens": [
         "23",
         "dashboard",
         "sn",
-        "taomarketcap",
+        "subnetradar",
         "trishool"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/23"
+      "url": "https://subnetradar.com/subnet/23"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -22702,6 +22767,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-8-subnetradar-dashboard",
+      "netuid": 8,
+      "slug": "sn-8",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Vanta SubnetRadar dashboard",
+      "tokens": [
+        "8",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "vanta"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/8"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-8-taomarketcap-dashboard",
       "netuid": 8,
       "slug": "sn-8",
@@ -22735,24 +22817,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-8-taostats-metagraph",
-      "netuid": 8,
-      "slug": "sn-8",
-      "subtitle": "dashboard / taostats",
-      "title": "Vanta Taostats metagraph",
-      "tokens": [
-        "8",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "vanta"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/8/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -22917,6 +22981,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-96-subnetradar-dashboard",
+      "netuid": 96,
+      "slug": "sn-96",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Verathos SubnetRadar dashboard",
+      "tokens": [
+        "96",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "verathos"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/96"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-96-website-common-swagger",
       "netuid": 96,
       "slug": "sn-96",
@@ -22969,24 +23050,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_96/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-96-taostats-metagraph",
-      "netuid": 96,
-      "slug": "sn-96",
-      "subtitle": "dashboard / taostats",
-      "title": "Verathos Taostats metagraph",
-      "tokens": [
-        "96",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "verathos"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/96/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -23060,6 +23123,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-85-subnetradar-dashboard",
+      "netuid": 85,
+      "slug": "sn-85",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Vidaio SubnetRadar dashboard",
+      "tokens": [
+        "85",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "vidaio"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/85"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-85-taomarketcap-dashboard",
       "netuid": 85,
       "slug": "sn-85",
@@ -23093,24 +23173,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_85/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-85-taostats-metagraph",
-      "netuid": 85,
-      "slug": "sn-85",
-      "subtitle": "dashboard / taostats",
-      "title": "Vidaio Taostats metagraph",
-      "tokens": [
-        "85",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "vidaio"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/85/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -23244,6 +23306,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-78-subnetradar-dashboard",
+      "netuid": 78,
+      "slug": "sn-78",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Vocence SubnetRadar dashboard",
+      "tokens": [
+        "78",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "vocence"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/78"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-78-website-common-swagger",
       "netuid": 78,
       "slug": "sn-78",
@@ -23296,24 +23375,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-78-taostats-metagraph",
-      "netuid": 78,
-      "slug": "sn-78",
-      "subtitle": "dashboard / taostats",
-      "title": "Vocence Taostats metagraph",
-      "tokens": [
-        "78",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "vocence"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/78/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -23406,6 +23467,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-106-subnetradar-dashboard",
+      "netuid": 106,
+      "slug": "sn-106",
+      "subtitle": "dashboard / subnetradar",
+      "title": "VoidAI SubnetRadar dashboard",
+      "tokens": [
+        "106",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "voidai"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/106"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-106-taomarketcap-dashboard",
       "netuid": 106,
       "slug": "sn-106",
@@ -23439,24 +23517,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-106-taostats-metagraph",
-      "netuid": 106,
-      "slug": "sn-106",
-      "subtitle": "dashboard / taostats",
-      "title": "VoidAI Taostats metagraph",
-      "tokens": [
-        "106",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "voidai"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/106/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -23552,21 +23612,21 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-54-taomarketcap-dashboard",
+      "id": "surface:sn-54-subnetradar-dashboard",
       "netuid": 54,
       "slug": "sn-54",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Yanez MIID TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Yanez MIID SubnetRadar dashboard",
       "tokens": [
         "54",
         "dashboard",
         "miid",
         "sn",
-        "taomarketcap",
+        "subnetradar",
         "yanez"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/54"
+      "url": "https://subnetradar.com/subnet/54"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -23681,6 +23741,23 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-18-subnetradar-dashboard",
+      "netuid": 18,
+      "slug": "sn-18",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Zeus SubnetRadar dashboard",
+      "tokens": [
+        "18",
+        "dashboard",
+        "sn",
+        "subnetradar",
+        "zeus"
+      ],
+      "type": "surface",
+      "url": "https://subnetradar.com/subnet/18"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
       "id": "surface:sn-18-taomarketcap-dashboard",
       "netuid": 18,
       "slug": "sn-18",
@@ -23714,24 +23791,6 @@
       ],
       "type": "surface",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx"
-    },
-    {
-      "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-18-taostats-metagraph",
-      "netuid": 18,
-      "slug": "sn-18",
-      "subtitle": "dashboard / taostats",
-      "title": "Zeus Taostats metagraph",
-      "tokens": [
-        "18",
-        "dashboard",
-        "metagraph",
-        "sn",
-        "taostats",
-        "zeus"
-      ],
-      "type": "surface",
-      "url": "https://taostats.io/subnets/18/metagraph"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
@@ -23901,20 +23960,20 @@
     },
     {
       "artifact_path": "/metagraph/surfaces.json",
-      "id": "surface:sn-46-taomarketcap-dashboard",
+      "id": "surface:sn-46-subnetradar-dashboard",
       "netuid": 46,
       "slug": "sn-46",
-      "subtitle": "dashboard / taomarketcap",
-      "title": "Zipcode TaoMarketCap dashboard",
+      "subtitle": "dashboard / subnetradar",
+      "title": "Zipcode SubnetRadar dashboard",
       "tokens": [
         "46",
         "dashboard",
         "sn",
-        "taomarketcap",
+        "subnetradar",
         "zipcode"
       ],
       "type": "surface",
-      "url": "https://taomarketcap.com/subnets/46"
+      "url": "https://subnetradar.com/subnet/46"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",

--- a/public/metagraph/subnets.json
+++ b/public/metagraph/subnets.json
@@ -13,7 +13,7 @@
   "subnets": [
     {
       "block": 8357554,
-      "candidate_count": 4,
+      "candidate_count": 5,
       "categories": [
         "baseline-augmented",
         "chain-rpc",
@@ -44,7 +44,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -78,7 +78,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -106,7 +106,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -139,7 +139,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -171,7 +171,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -199,7 +199,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -227,7 +227,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-augmented",
         "bitcoin",
@@ -258,7 +258,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -320,7 +320,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -335,20 +335,20 @@
       "native_name_quality": "chain",
       "netuid": 10,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 2869647,
       "slug": "sn-10",
       "source_repo": "https://github.com/Swap-Subnet/swap-subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "κ",
       "tempo": 360,
       "website_url": "https://www.taofi.com/pool"
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -376,7 +376,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -409,7 +409,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 22,
+      "candidate_count": 23,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -444,7 +444,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -472,7 +472,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -505,7 +505,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -533,7 +533,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -561,7 +561,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -589,7 +589,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -622,7 +622,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -653,7 +653,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "advertising",
         "baseline-augmented",
@@ -686,7 +686,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -723,7 +723,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -756,7 +756,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -791,7 +791,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -824,7 +824,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -854,13 +854,19 @@
       "block": 8357554,
       "candidate_count": 14,
       "categories": [
-        "baseline-curated"
+        "baseline-augmented",
+        "baseline-curated",
+        "compute",
+        "gpu",
+        "identity-reviewed",
+        "official-docs",
+        "official-website"
       ],
       "coverage_level": "probed",
-      "curation_level": "machine-verified",
-      "dashboard_url": "https://backprop.finance/dtao/subnets/27-nodexo",
-      "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx",
-      "gap_count": 6,
+      "curation_level": "maintainer-reviewed",
+      "dashboard_url": "https://console.nodexo.ai/",
+      "docs_url": "https://docs.nodexo.ai/",
+      "gap_count": 5,
       "mechanism_count": 1,
       "name": "Nodexo",
       "native_name": "Nodexo",
@@ -869,18 +875,18 @@
       "participant_count": 256,
       "probed_surface_count": 5,
       "registered_at_block": 1727132,
-      "slug": "sn-27",
+      "slug": "nodexo",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 5,
+      "surface_count": 8,
       "symbol": "ג",
       "tempo": 360,
-      "website_url": null
+      "website_url": "https://nodexo.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -908,7 +914,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -943,7 +949,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -977,7 +983,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -1024,20 +1030,20 @@
       "native_name_quality": "chain",
       "netuid": 32,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 7,
       "registered_at_block": 2515294,
       "slug": "sn-32",
       "source_repo": "https://github.com/It-s-AI/llm-detection",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 7,
       "symbol": "ח",
       "tempo": 360,
       "website_url": "https://its-ai.org/en"
     },
     {
       "block": 8357554,
-      "candidate_count": 8,
+      "candidate_count": 9,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1072,7 +1078,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1107,7 +1113,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -1122,20 +1128,20 @@
       "native_name_quality": "chain",
       "netuid": 35,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 3037158,
       "slug": "sn-35",
       "source_repo": "https://github.com/General-Tao-Ventures/cartha-validator",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ך",
       "tempo": 360,
       "website_url": "https://www.0xmarkets.io/"
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -1163,7 +1169,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -1191,7 +1197,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -1199,27 +1205,27 @@
       "curation_level": "machine-verified",
       "dashboard_url": "https://backprop.finance/dtao/subnets/38-colosseum",
       "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx",
-      "gap_count": 4,
+      "gap_count": 3,
       "mechanism_count": 1,
       "name": "colosseum",
       "native_name": "colosseum",
       "native_name_quality": "chain",
       "netuid": 38,
       "participant_count": 256,
-      "probed_surface_count": 8,
+      "probed_surface_count": 9,
       "registered_at_block": 7284230,
       "slug": "sn-38",
-      "source_repo": null,
+      "source_repo": "https://github.com/TAO-Colosseum/tao-colosseum-subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 8,
+      "surface_count": 9,
       "symbol": "ם",
       "tempo": 360,
       "website_url": "https://www.taocolosseum.com/"
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1252,7 +1258,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated"
       ],
@@ -1280,7 +1286,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -1308,7 +1314,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1343,7 +1349,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1377,7 +1383,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -1405,7 +1411,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1437,7 +1443,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-curated"
       ],
@@ -1465,7 +1471,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 8,
+      "candidate_count": 9,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1497,7 +1503,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1531,7 +1537,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1568,7 +1574,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -1596,7 +1602,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-curated"
       ],
@@ -1624,7 +1630,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 10,
+      "candidate_count": 11,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1658,35 +1664,41 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
-        "baseline-curated"
+        "baseline-augmented",
+        "baseline-curated",
+        "defi",
+        "financial-trading",
+        "identity-reviewed",
+        "official-website",
+        "trading-strategies"
       ],
       "coverage_level": "probed",
-      "curation_level": "machine-verified",
-      "dashboard_url": "https://backprop.finance/dtao/subnets/53-efficientfrontier",
+      "curation_level": "maintainer-reviewed",
+      "dashboard_url": "https://t.signalplus.com/mining",
       "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx",
-      "gap_count": 6,
+      "gap_count": 5,
       "mechanism_count": 1,
       "name": "EfficientFrontier",
       "native_name": "EfficientFrontier",
       "native_name_quality": "chain",
       "netuid": 53,
       "participant_count": 256,
-      "probed_surface_count": 5,
+      "probed_surface_count": 7,
       "registered_at_block": 4203869,
-      "slug": "sn-53",
+      "slug": "efficientfrontier",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 5,
+      "surface_count": 7,
       "symbol": "ب",
       "tempo": 360,
-      "website_url": null
+      "website_url": "https://www.signalplus.com/"
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -1714,7 +1726,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -1742,7 +1754,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-curated"
       ],
@@ -1770,7 +1782,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1804,7 +1816,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 8,
+      "candidate_count": 9,
       "categories": [
         "ai-marketplace",
         "baseline-augmented",
@@ -1840,7 +1852,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -1868,7 +1880,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -1896,7 +1908,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1950,20 +1962,20 @@
       "native_name_quality": "chain",
       "netuid": 62,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 6,
       "registered_at_block": 4474225,
       "slug": "sn-62",
       "source_repo": "https://github.com/ridgesai/ridges",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 6,
       "symbol": "ز",
       "tempo": 360,
       "website_url": "https://www.ridges.ai/"
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -1996,7 +2008,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 28,
+      "candidate_count": 29,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2032,7 +2044,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -2060,7 +2072,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2096,7 +2108,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -2124,7 +2136,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -2152,7 +2164,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -2180,7 +2192,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-curated"
       ],
@@ -2208,7 +2220,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -2236,7 +2248,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2272,24 +2284,29 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
-        "baseline-curated"
+        "baseline-augmented",
+        "baseline-curated",
+        "defi",
+        "identity-reviewed",
+        "otc",
+        "treasury"
       ],
       "coverage_level": "probed",
-      "curation_level": "machine-verified",
+      "curation_level": "maintainer-reviewed",
       "dashboard_url": "https://backprop.finance/dtao/subnets/73-parked",
       "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx",
       "gap_count": 6,
       "mechanism_count": 1,
-      "name": "Parked",
+      "name": "MetaHash",
       "native_name": "Parked",
       "native_name_quality": "chain",
       "netuid": 73,
       "participant_count": 256,
       "probed_surface_count": 5,
       "registered_at_block": 5160047,
-      "slug": "sn-73",
+      "slug": "metahash",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
@@ -2300,7 +2317,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-augmented",
         "developer-tools",
@@ -2331,7 +2348,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 25,
+      "candidate_count": 26,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2366,7 +2383,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2397,7 +2414,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -2425,7 +2442,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -2453,7 +2470,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 25,
+      "candidate_count": 26,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2485,7 +2502,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -2513,7 +2530,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2546,7 +2563,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 25,
+      "candidate_count": 26,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2578,7 +2595,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -2606,7 +2623,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2641,7 +2658,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2672,7 +2689,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -2700,7 +2717,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2734,7 +2751,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2769,7 +2786,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2800,7 +2817,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2833,7 +2850,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2864,7 +2881,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -2894,7 +2911,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -2922,7 +2939,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -2950,7 +2967,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -2978,7 +2995,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 15,
+      "candidate_count": 16,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3015,7 +3032,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -3043,7 +3060,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3076,7 +3093,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -3104,7 +3121,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -3132,7 +3149,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -3160,7 +3177,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 18,
+      "candidate_count": 19,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3224,7 +3241,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -3252,7 +3269,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -3280,7 +3297,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 13,
+      "candidate_count": 14,
       "categories": [
         "baseline-curated"
       ],
@@ -3308,7 +3325,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 20,
+      "candidate_count": 21,
       "categories": [
         "baseline-curated"
       ],
@@ -3336,7 +3353,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-curated"
       ],
@@ -3364,7 +3381,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3395,7 +3412,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3428,7 +3445,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3462,7 +3479,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 16,
       "categories": [
         "baseline-curated"
       ],
@@ -3477,20 +3494,20 @@
       "native_name_quality": "chain",
       "netuid": 112,
       "participant_count": 256,
-      "probed_surface_count": 7,
+      "probed_surface_count": 8,
       "registered_at_block": 5633022,
       "slug": "sn-112",
       "source_repo": "https://github.com/subnet112/minotaur_subnet",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 7,
+      "surface_count": 8,
       "symbol": "Ђ",
       "tempo": 360,
       "website_url": "https://minotaursubnet.com/"
     },
     {
       "block": 8357554,
-      "candidate_count": 19,
+      "candidate_count": 20,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3524,7 +3541,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 21,
+      "candidate_count": 22,
       "categories": [
         "baseline-curated"
       ],
@@ -3552,7 +3569,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3583,35 +3600,40 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
-        "baseline-curated"
+        "baseline-augmented",
+        "baseline-curated",
+        "defi",
+        "identity-reviewed",
+        "lending",
+        "official-website"
       ],
       "coverage_level": "probed",
-      "curation_level": "machine-verified",
+      "curation_level": "maintainer-reviewed",
       "dashboard_url": "https://backprop.finance/dtao/subnets/116-hard-sign",
       "docs_url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx",
-      "gap_count": 6,
+      "gap_count": 5,
       "mechanism_count": 1,
-      "name": "hard_sign",
+      "name": "TaoLend",
       "native_name": "hard_sign",
       "native_name_quality": "chain",
       "netuid": 116,
       "participant_count": 73,
-      "probed_surface_count": 5,
+      "probed_surface_count": 6,
       "registered_at_block": 8294730,
-      "slug": "sn-116",
+      "slug": "taolend",
       "source_repo": null,
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 5,
+      "surface_count": 6,
       "symbol": "ъ",
       "tempo": 360,
-      "website_url": null
+      "website_url": "https://taolend.io/"
     },
     {
       "block": 8357554,
-      "candidate_count": 7,
+      "candidate_count": 8,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3643,7 +3665,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 24,
+      "candidate_count": 25,
       "categories": [
         "baseline-curated"
       ],
@@ -3671,7 +3693,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-curated"
       ],
@@ -3699,7 +3721,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -3727,7 +3749,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3759,7 +3781,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3793,7 +3815,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 6,
+      "candidate_count": 7,
       "categories": [
         "baseline-augmented",
         "baseline-curated",
@@ -3824,7 +3846,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],
@@ -3852,7 +3874,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 5,
+      "candidate_count": 6,
       "categories": [
         "baseline-curated"
       ],
@@ -3880,7 +3902,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 17,
+      "candidate_count": 18,
       "categories": [
         "baseline-curated"
       ],
@@ -3908,7 +3930,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 16,
+      "candidate_count": 17,
       "categories": [
         "baseline-curated"
       ],
@@ -3936,7 +3958,7 @@
     },
     {
       "block": 8357554,
-      "candidate_count": 14,
+      "candidate_count": 15,
       "categories": [
         "baseline-curated"
       ],

--- a/public/metagraph/surfaces.json
+++ b/public/metagraph/surfaces.json
@@ -250,6 +250,38 @@
     },
     {
       "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-0-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "root SubnetRadar dashboard",
+      "netuid": 0,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/0"
+      ],
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "url": "https://subnetradar.com/subnet/0"
+    },
+    {
+      "auth_required": false,
       "authority": "provider-claimed",
       "id": "sn-0-taomarketcap-dashboard",
       "kind": "dashboard",
@@ -270,38 +302,6 @@
       "subnet_name": "root",
       "subnet_slug": "root",
       "url": "https://taomarketcap.com/subnets/0"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-0-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "root Taostats metagraph",
-      "netuid": 0,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/0/metagraph"
-      ],
-      "subnet_name": "root",
-      "subnet_slug": "root",
-      "url": "https://taostats.io/subnets/0/metagraph"
     },
     {
       "auth_required": false,
@@ -430,6 +430,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-1-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Apex SubnetRadar dashboard",
+      "netuid": 1,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/1"
+      ],
+      "subnet_name": "Apex",
+      "subnet_slug": "sn-1",
+      "url": "https://subnetradar.com/subnet/1"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-1-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Apex TaoMarketCap dashboard",
@@ -490,38 +522,6 @@
       "subnet_name": "Apex",
       "subnet_slug": "sn-1",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_1_apex/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-1-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Apex Taostats metagraph",
-      "netuid": 1,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/1/metagraph"
-      ],
-      "subnet_name": "Apex",
-      "subnet_slug": "sn-1",
-      "url": "https://taostats.io/subnets/1/metagraph"
     },
     {
       "auth_required": false,
@@ -943,6 +943,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-3-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "deprecated SubnetRadar dashboard",
+      "netuid": 3,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/3"
+      ],
+      "subnet_name": "Templar",
+      "subnet_slug": "sn-3",
+      "url": "https://subnetradar.com/subnet/3"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-3-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "deprecated TaoMarketCap dashboard",
@@ -1003,38 +1035,6 @@
       "subnet_name": "Templar",
       "subnet_slug": "sn-3",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_3/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-3-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "deprecated Taostats metagraph",
-      "netuid": 3,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/3/metagraph"
-      ],
-      "subnet_name": "Templar",
-      "subnet_slug": "sn-3",
-      "url": "https://taostats.io/subnets/3/metagraph"
     },
     {
       "auth_required": false,
@@ -1251,6 +1251,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-4-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Targon SubnetRadar dashboard",
+      "netuid": 4,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/4"
+      ],
+      "subnet_name": "Targon",
+      "subnet_slug": "sn-4",
+      "url": "https://subnetradar.com/subnet/4"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-4-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Targon TaoMarketCap dashboard",
@@ -1311,38 +1343,6 @@
       "subnet_name": "Targon",
       "subnet_slug": "sn-4",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_4/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-4-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Targon Taostats metagraph",
-      "netuid": 4,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/4/metagraph"
-      ],
-      "subnet_name": "Targon",
-      "subnet_slug": "sn-4",
-      "url": "https://taostats.io/subnets/4/metagraph"
     },
     {
       "auth_required": false,
@@ -1457,7 +1457,7 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-4-website-link-targon-com-docs-9",
+      "id": "sn-4-website-link-targon-com-docs-4",
       "kind": "docs",
       "name": "Targon docs",
       "netuid": 4,
@@ -1484,7 +1484,7 @@
       ],
       "subnet_name": "Targon",
       "subnet_slug": "sn-4",
-      "url": "https://targon.com/releases/intel-whitepaper"
+      "url": "https://docs.targon.com/"
     },
     {
       "auth_required": false,
@@ -1517,6 +1517,38 @@
       "subnet_name": "Hone",
       "subnet_slug": "sn-5",
       "url": "https://backprop.finance/dtao/subnets/5-hone"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-5-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Hone SubnetRadar dashboard",
+      "netuid": 5,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/5"
+      ],
+      "subnet_name": "Hone",
+      "subnet_slug": "sn-5",
+      "url": "https://subnetradar.com/subnet/5"
     },
     {
       "auth_required": false,
@@ -1649,38 +1681,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-5-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Hone Taostats metagraph",
-      "netuid": 5,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/5/metagraph"
-      ],
-      "subnet_name": "Hone",
-      "subnet_slug": "sn-5",
-      "url": "https://taostats.io/subnets/5/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-5-tensorplex-docs",
       "kind": "docs",
       "name": "Hone Tensorplex subnet docs",
@@ -1777,18 +1777,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-6-taomarketcap-dashboard",
+      "id": "sn-6-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Numinous TaoMarketCap dashboard",
+      "name": "Numinous SubnetRadar dashboard",
       "netuid": 6,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1800,11 +1800,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/6"
+        "https://subnetradar.com/subnet/6"
       ],
       "subnet_name": "Numinous",
       "subnet_slug": "sn-6",
-      "url": "https://taomarketcap.com/subnets/6"
+      "url": "https://subnetradar.com/subnet/6"
     },
     {
       "auth_required": false,
@@ -2275,6 +2275,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-7-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Allways SubnetRadar dashboard",
+      "netuid": 7,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/7"
+      ],
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "url": "https://subnetradar.com/subnet/7"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-7-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Allways TaoMarketCap dashboard",
@@ -2335,38 +2367,6 @@
       "subnet_name": "Allways",
       "subnet_slug": "allways",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_7/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-7-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Allways Taostats metagraph",
-      "netuid": 7,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/7/metagraph"
-      ],
-      "subnet_name": "Allways",
-      "subnet_slug": "allways",
-      "url": "https://taostats.io/subnets/7/metagraph"
     },
     {
       "auth_required": false,
@@ -2500,6 +2500,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-8-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Vanta SubnetRadar dashboard",
+      "netuid": 8,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/8"
+      ],
+      "subnet_name": "Vanta",
+      "subnet_slug": "sn-8",
+      "url": "https://subnetradar.com/subnet/8"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-8-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Vanta TaoMarketCap dashboard",
@@ -2624,38 +2656,6 @@
       "subnet_name": "Vanta",
       "subnet_slug": "sn-8",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-8-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Vanta Taostats metagraph",
-      "netuid": 8,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/8/metagraph"
-      ],
-      "subnet_name": "Vanta",
-      "subnet_slug": "sn-8",
-      "url": "https://taostats.io/subnets/8/metagraph"
     },
     {
       "auth_required": false,
@@ -2793,18 +2793,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-9-taomarketcap-dashboard",
+      "id": "sn-9-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "iota TaoMarketCap dashboard",
+      "name": "iota SubnetRadar dashboard",
       "netuid": 9,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2816,11 +2816,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/9"
+        "https://subnetradar.com/subnet/9"
       ],
       "subnet_name": "iota",
       "subnet_slug": "sn-9",
-      "url": "https://taomarketcap.com/subnets/9"
+      "url": "https://subnetradar.com/subnet/9"
     },
     {
       "auth_required": false,
@@ -2985,6 +2985,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-10-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Swap SubnetRadar dashboard",
+      "netuid": 10,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/10"
+      ],
+      "subnet_name": "Swap",
+      "subnet_slug": "sn-10",
+      "url": "https://subnetradar.com/subnet/10"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-10-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Swap TaoMarketCap dashboard",
@@ -3113,38 +3145,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-10-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Swap Taostats metagraph",
-      "netuid": 10,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/10/metagraph"
-      ],
-      "subnet_name": "Swap",
-      "subnet_slug": "sn-10",
-      "url": "https://taostats.io/subnets/10/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-10-tensorplex-docs",
       "kind": "docs",
       "name": "Swap Tensorplex subnet docs",
@@ -3177,6 +3177,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-10-website-subdomain-docs-docs-taofi-com",
+      "kind": "docs",
+      "name": "Swap docs subdomain",
+      "netuid": 10,
+      "notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://www.taofi.com/pool"
+      ],
+      "subnet_name": "Swap",
+      "subnet_slug": "sn-10",
+      "url": "https://docs.taofi.com/"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-11-backprop-dashboard",
       "kind": "dashboard",
       "name": "TrajectoryRL Backprop Finance dashboard",
@@ -3205,6 +3237,38 @@
       "subnet_name": "TrajectoryRL",
       "subnet_slug": "sn-11",
       "url": "https://backprop.finance/dtao/subnets/11-trajectoryrl"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-11-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "TrajectoryRL SubnetRadar dashboard",
+      "netuid": 11,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/11"
+      ],
+      "subnet_name": "TrajectoryRL",
+      "subnet_slug": "sn-11",
+      "url": "https://subnetradar.com/subnet/11"
     },
     {
       "auth_required": false,
@@ -3333,38 +3397,6 @@
       "subnet_name": "TrajectoryRL",
       "subnet_slug": "sn-11",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-11-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "TrajectoryRL Taostats metagraph",
-      "netuid": 11,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/11/metagraph"
-      ],
-      "subnet_name": "TrajectoryRL",
-      "subnet_slug": "sn-11",
-      "url": "https://taostats.io/subnets/11/metagraph"
     },
     {
       "auth_required": false,
@@ -3513,6 +3545,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-12-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Compute Horde SubnetRadar dashboard",
+      "netuid": 12,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/12"
+      ],
+      "subnet_name": "Compute Horde",
+      "subnet_slug": "sn-12",
+      "url": "https://subnetradar.com/subnet/12"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-12-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Compute Horde TaoMarketCap dashboard",
@@ -3573,38 +3637,6 @@
       "subnet_name": "Compute Horde",
       "subnet_slug": "sn-12",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_12/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-12-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Compute Horde Taostats metagraph",
-      "netuid": 12,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/12/metagraph"
-      ],
-      "subnet_name": "Compute Horde",
-      "subnet_slug": "sn-12",
-      "url": "https://taostats.io/subnets/12/metagraph"
     },
     {
       "auth_required": false,
@@ -3824,6 +3856,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-13-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Data Universe SubnetRadar dashboard",
+      "netuid": 13,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/13"
+      ],
+      "subnet_name": "Data Universe",
+      "subnet_slug": "sn-13",
+      "url": "https://subnetradar.com/subnet/13"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-13-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Data Universe TaoMarketCap dashboard",
@@ -3898,38 +3962,6 @@
       "subnet_name": "Data Universe",
       "subnet_slug": "sn-13",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_13/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-13-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Data Universe Taostats metagraph",
-      "netuid": 13,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/13/metagraph"
-      ],
-      "subnet_name": "Data Universe",
-      "subnet_slug": "sn-13",
-      "url": "https://taostats.io/subnets/13/metagraph"
     },
     {
       "auth_required": false,
@@ -4086,18 +4118,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-14-taomarketcap-dashboard",
+      "id": "sn-14-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Cacheon TaoMarketCap dashboard",
+      "name": "Cacheon SubnetRadar dashboard",
       "netuid": 14,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4109,11 +4141,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/14"
+        "https://subnetradar.com/subnet/14"
       ],
       "subnet_name": "Cacheon",
       "subnet_slug": "sn-14",
-      "url": "https://taomarketcap.com/subnets/14"
+      "url": "https://subnetradar.com/subnet/14"
     },
     {
       "auth_required": false,
@@ -4441,18 +4473,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-15-taomarketcap-dashboard",
+      "id": "sn-15-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "ORO TaoMarketCap dashboard",
+      "name": "ORO SubnetRadar dashboard",
       "netuid": 15,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4464,11 +4496,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/15"
+        "https://subnetradar.com/subnet/15"
       ],
       "subnet_name": "ORO",
       "subnet_slug": "sn-15",
-      "url": "https://taomarketcap.com/subnets/15"
+      "url": "https://subnetradar.com/subnet/15"
     },
     {
       "auth_required": false,
@@ -4601,6 +4633,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-16-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "BitAds SubnetRadar dashboard",
+      "netuid": 16,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/16"
+      ],
+      "subnet_name": "BitAds",
+      "subnet_slug": "sn-16",
+      "url": "https://subnetradar.com/subnet/16"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-16-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "BitAds TaoMarketCap dashboard",
@@ -4724,38 +4788,6 @@
       "subnet_name": "BitAds",
       "subnet_slug": "sn-16",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_16/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-16-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "BitAds Taostats metagraph",
-      "netuid": 16,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/16/metagraph"
-      ],
-      "subnet_name": "BitAds",
-      "subnet_slug": "sn-16",
-      "url": "https://taostats.io/subnets/16/metagraph"
     },
     {
       "auth_required": false,
@@ -4921,18 +4953,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-17-taomarketcap-dashboard",
+      "id": "sn-17-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "404—GEN TaoMarketCap dashboard",
+      "name": "404—GEN SubnetRadar dashboard",
       "netuid": 17,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4944,11 +4976,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/17"
+        "https://subnetradar.com/subnet/17"
       ],
       "subnet_name": "404—GEN",
       "subnet_slug": "sn-17",
-      "url": "https://taomarketcap.com/subnets/17"
+      "url": "https://subnetradar.com/subnet/17"
     },
     {
       "auth_required": false,
@@ -5143,6 +5175,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-18-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Zeus SubnetRadar dashboard",
+      "netuid": 18,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/18"
+      ],
+      "subnet_name": "Zeus",
+      "subnet_slug": "sn-18",
+      "url": "https://subnetradar.com/subnet/18"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-18-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Zeus TaoMarketCap dashboard",
@@ -5267,38 +5331,6 @@
       "subnet_name": "Zeus",
       "subnet_slug": "sn-18",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_18/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-18-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Zeus Taostats metagraph",
-      "netuid": 18,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/18/metagraph"
-      ],
-      "subnet_name": "Zeus",
-      "subnet_slug": "sn-18",
-      "url": "https://taostats.io/subnets/18/metagraph"
     },
     {
       "auth_required": false,
@@ -5468,6 +5500,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-19-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "blockmachine SubnetRadar dashboard",
+      "netuid": 19,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/19"
+      ],
+      "subnet_name": "blockmachine",
+      "subnet_slug": "sn-19",
+      "url": "https://subnetradar.com/subnet/19"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-19-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "blockmachine TaoMarketCap dashboard",
@@ -5528,38 +5592,6 @@
       "subnet_name": "blockmachine",
       "subnet_slug": "sn-19",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_19/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-19-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "blockmachine Taostats metagraph",
-      "netuid": 19,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/19/metagraph"
-      ],
-      "subnet_name": "blockmachine",
-      "subnet_slug": "sn-19",
-      "url": "https://taostats.io/subnets/19/metagraph"
     },
     {
       "auth_required": false,
@@ -5684,6 +5716,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-20-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "GroundLayer SubnetRadar dashboard",
+      "netuid": 20,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/20"
+      ],
+      "subnet_name": "GroundLayer",
+      "subnet_slug": "sn-20",
+      "url": "https://subnetradar.com/subnet/20"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-20-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "GroundLayer TaoMarketCap dashboard",
@@ -5776,38 +5840,6 @@
       "subnet_name": "GroundLayer",
       "subnet_slug": "sn-20",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_20/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-20-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "GroundLayer Taostats metagraph",
-      "netuid": 20,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/20/metagraph"
-      ],
-      "subnet_name": "GroundLayer",
-      "subnet_slug": "sn-20",
-      "url": "https://taostats.io/subnets/20/metagraph"
     },
     {
       "auth_required": false,
@@ -5922,6 +5954,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-21-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "AdTAO SubnetRadar dashboard",
+      "netuid": 21,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/21"
+      ],
+      "subnet_name": "AdTAO",
+      "subnet_slug": "sn-21",
+      "url": "https://subnetradar.com/subnet/21"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-21-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "AdTAO TaoMarketCap dashboard",
@@ -5982,38 +6046,6 @@
       "subnet_name": "AdTAO",
       "subnet_slug": "sn-21",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_21/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-21-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "AdTAO Taostats metagraph",
-      "netuid": 21,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/21/metagraph"
-      ],
-      "subnet_name": "AdTAO",
-      "subnet_slug": "sn-21",
-      "url": "https://taostats.io/subnets/21/metagraph"
     },
     {
       "auth_required": false,
@@ -6222,6 +6254,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-22-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Desearch SubnetRadar dashboard",
+      "netuid": 22,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/22"
+      ],
+      "subnet_name": "Desearch",
+      "subnet_slug": "sn-22",
+      "url": "https://subnetradar.com/subnet/22"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-22-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Desearch TaoMarketCap dashboard",
@@ -6328,38 +6392,6 @@
       "subnet_name": "Desearch",
       "subnet_slug": "sn-22",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_22/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-22-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Desearch Taostats metagraph",
-      "netuid": 22,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/22/metagraph"
-      ],
-      "subnet_name": "Desearch",
-      "subnet_slug": "sn-22",
-      "url": "https://taostats.io/subnets/22/metagraph"
     },
     {
       "auth_required": false,
@@ -6518,18 +6550,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-23-taomarketcap-dashboard",
+      "id": "sn-23-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Trishool TaoMarketCap dashboard",
+      "name": "Trishool SubnetRadar dashboard",
       "netuid": 23,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6541,11 +6573,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/23"
+        "https://subnetradar.com/subnet/23"
       ],
       "subnet_name": "Trishool",
       "subnet_slug": "sn-23",
-      "url": "https://taomarketcap.com/subnets/23"
+      "url": "https://subnetradar.com/subnet/23"
     },
     {
       "auth_required": false,
@@ -6746,6 +6778,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-23-website-link-trishool-ai-docs-1",
+      "kind": "docs",
+      "name": "Trishool docs",
+      "netuid": 23,
+      "notes": "Discovered from a public project website link. Requires verification before promotion.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://trishool.ai/"
+      ],
+      "subnet_name": "Trishool",
+      "subnet_slug": "sn-23",
+      "url": "https://docs.trishool.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-23-website-link-trishool-ai-docs-2",
       "kind": "docs",
       "name": "Trishool docs",
@@ -6774,38 +6838,6 @@
       "subnet_name": "Trishool",
       "subnet_slug": "sn-23",
       "url": "https://litepaper.trishool.ai/"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-23-website-subdomain-docs-docs-trishool-ai",
-      "kind": "docs",
-      "name": "Trishool docs subdomain",
-      "netuid": 23,
-      "notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://trishool.ai/"
-      ],
-      "subnet_name": "Trishool",
-      "subnet_slug": "sn-23",
-      "url": "https://docs.trishool.ai/"
     },
     {
       "auth_required": false,
@@ -6959,6 +6991,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-24-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Quasar SubnetRadar dashboard",
+      "netuid": 24,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/24"
+      ],
+      "subnet_name": "Quasar",
+      "subnet_slug": "sn-24",
+      "url": "https://subnetradar.com/subnet/24"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-24-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Quasar TaoMarketCap dashboard",
@@ -7001,38 +7065,6 @@
       "subnet_name": "Quasar",
       "subnet_slug": "sn-24",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_24/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-24-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Quasar Taostats metagraph",
-      "netuid": 24,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/24/metagraph"
-      ],
-      "subnet_name": "Quasar",
-      "subnet_slug": "sn-24",
-      "url": "https://taostats.io/subnets/24/metagraph"
     },
     {
       "auth_required": false,
@@ -7179,18 +7211,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-25-taomarketcap-dashboard",
+      "id": "sn-25-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Mainframe TaoMarketCap dashboard",
+      "name": "Mainframe SubnetRadar dashboard",
       "netuid": 25,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7202,11 +7234,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/25"
+        "https://subnetradar.com/subnet/25"
       ],
       "subnet_name": "Mainframe",
       "subnet_slug": "sn-25",
-      "url": "https://taomarketcap.com/subnets/25"
+      "url": "https://subnetradar.com/subnet/25"
     },
     {
       "auth_required": false,
@@ -7307,6 +7339,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-25-website-link-macrocosmos-ai-docs-3",
+      "kind": "docs",
+      "name": "Mainframe docs",
+      "netuid": 25,
+      "notes": "Discovered from a public project website link. Requires verification before promotion.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://macrocosmos.ai/sn25"
+      ],
+      "subnet_name": "Mainframe",
+      "subnet_slug": "sn-25",
+      "url": "https://docs.macrocosmos.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-25-website-link-macrocosmos-ai-docs-6",
       "kind": "docs",
       "name": "Mainframe docs",
@@ -7339,38 +7403,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-25-website-subdomain-docs-docs-macrocosmos-ai",
-      "kind": "docs",
-      "name": "Mainframe docs subdomain",
-      "netuid": 25,
-      "notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://macrocosmos.ai/sn25"
-      ],
-      "subnet_name": "Mainframe",
-      "subnet_slug": "sn-25",
-      "url": "https://docs.macrocosmos.ai/"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-26-backprop-dashboard",
       "kind": "dashboard",
       "name": "Perturb Backprop Finance dashboard",
@@ -7399,6 +7431,38 @@
       "subnet_name": "Perturb",
       "subnet_slug": "sn-26",
       "url": "https://backprop.finance/dtao/subnets/26-perturb"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-26-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Perturb SubnetRadar dashboard",
+      "netuid": 26,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/26"
+      ],
+      "subnet_name": "Perturb",
+      "subnet_slug": "sn-26",
+      "url": "https://subnetradar.com/subnet/26"
     },
     {
       "auth_required": false,
@@ -7530,38 +7594,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-26-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Perturb Taostats metagraph",
-      "netuid": 26,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/26/metagraph"
-      ],
-      "subnet_name": "Perturb",
-      "subnet_slug": "sn-26",
-      "url": "https://taostats.io/subnets/26/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-26-tensorplex-docs",
       "kind": "docs",
       "name": "Perturb Tensorplex subnet docs",
@@ -7652,8 +7684,97 @@
         "https://backprop.finance/dtao/subnets/27-nodexo"
       ],
       "subnet_name": "Nodexo",
-      "subnet_slug": "sn-27",
+      "subnet_slug": "nodexo",
       "url": "https://backprop.finance/dtao/subnets/27-nodexo"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-27-nodexo-console",
+      "kind": "dashboard",
+      "name": "Nodexo console",
+      "netuid": 27,
+      "notes": "Official Nodexo console surface. Authentication may be required for account-specific workflows.",
+      "provider": "nodexo",
+      "public_safe": true,
+      "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
+      "source_urls": [
+        "https://nodexo.ai/",
+        "https://docs.nodexo.ai/"
+      ],
+      "subnet_name": "Nodexo",
+      "subnet_slug": "nodexo",
+      "url": "https://console.nodexo.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-27-nodexo-docs",
+      "kind": "docs",
+      "name": "Nodexo docs",
+      "netuid": 27,
+      "notes": "Official Nodexo Compute documentation.",
+      "provider": "nodexo",
+      "public_safe": true,
+      "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
+      "source_urls": [
+        "https://nodexo.ai/",
+        "https://docs.nodexo.ai/"
+      ],
+      "subnet_name": "Nodexo",
+      "subnet_slug": "nodexo",
+      "url": "https://docs.nodexo.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-27-nodexo-website",
+      "kind": "website",
+      "name": "Nodexo website",
+      "netuid": 27,
+      "notes": "Official Nodexo Compute website.",
+      "provider": "nodexo",
+      "public_safe": true,
+      "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
+      "source_urls": [
+        "https://nodexo.ai/",
+        "https://docs.nodexo.ai/"
+      ],
+      "subnet_name": "Nodexo",
+      "subnet_slug": "nodexo",
+      "url": "https://nodexo.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-27-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Nodexo SubnetRadar dashboard",
+      "netuid": 27,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/27"
+      ],
+      "subnet_name": "Nodexo",
+      "subnet_slug": "nodexo",
+      "url": "https://subnetradar.com/subnet/27"
     },
     {
       "auth_required": false,
@@ -7684,7 +7805,7 @@
         "https://api.taomarketcap.com/public/v1/subnets/27"
       ],
       "subnet_name": "Nodexo",
-      "subnet_slug": "sn-27",
+      "subnet_slug": "nodexo",
       "url": "https://taomarketcap.com/subnets/27"
     },
     {
@@ -7716,40 +7837,8 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx"
       ],
       "subnet_name": "Nodexo",
-      "subnet_slug": "sn-27",
+      "subnet_slug": "nodexo",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_27/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-27-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Nodexo Taostats metagraph",
-      "netuid": 27,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/27/metagraph"
-      ],
-      "subnet_name": "Nodexo",
-      "subnet_slug": "sn-27",
-      "url": "https://taostats.io/subnets/27/metagraph"
     },
     {
       "auth_required": false,
@@ -7780,7 +7869,7 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/27/subnet.json"
       ],
       "subnet_name": "Nodexo",
-      "subnet_slug": "sn-27",
+      "subnet_slug": "nodexo",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/27"
     },
     {
@@ -7814,6 +7903,38 @@
       "subnet_name": "gm",
       "subnet_slug": "sn-28",
       "url": "https://backprop.finance/dtao/subnets/28-gm"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-28-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "gm SubnetRadar dashboard",
+      "netuid": 28,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/28"
+      ],
+      "subnet_name": "gm",
+      "subnet_slug": "sn-28",
+      "url": "https://subnetradar.com/subnet/28"
     },
     {
       "auth_required": false,
@@ -7878,38 +7999,6 @@
       "subnet_name": "gm",
       "subnet_slug": "sn-28",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_28/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-28-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "gm Taostats metagraph",
-      "netuid": 28,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/28/metagraph"
-      ],
-      "subnet_name": "gm",
-      "subnet_slug": "sn-28",
-      "url": "https://taostats.io/subnets/28/metagraph"
     },
     {
       "auth_required": false,
@@ -8120,6 +8209,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-29-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Coldint SubnetRadar dashboard",
+      "netuid": 29,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/29"
+      ],
+      "subnet_name": "Coldint",
+      "subnet_slug": "sn-29",
+      "url": "https://subnetradar.com/subnet/29"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-29-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Coldint TaoMarketCap dashboard",
@@ -8180,38 +8301,6 @@
       "subnet_name": "Coldint",
       "subnet_slug": "sn-29",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_29/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-29-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Coldint Taostats metagraph",
-      "netuid": 29,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/29/metagraph"
-      ],
-      "subnet_name": "Coldint",
-      "subnet_slug": "sn-29",
-      "url": "https://taostats.io/subnets/29/metagraph"
     },
     {
       "auth_required": false,
@@ -8326,6 +8415,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-30-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Endure Network SubnetRadar dashboard",
+      "netuid": 30,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/30"
+      ],
+      "subnet_name": "Endure Network",
+      "subnet_slug": "sn-30",
+      "url": "https://subnetradar.com/subnet/30"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-30-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Endure Network TaoMarketCap dashboard",
@@ -8386,38 +8507,6 @@
       "subnet_name": "Endure Network",
       "subnet_slug": "sn-30",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_30/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-30-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Endure Network Taostats metagraph",
-      "netuid": 30,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/30/metagraph"
-      ],
-      "subnet_name": "Endure Network",
-      "subnet_slug": "sn-30",
-      "url": "https://taostats.io/subnets/30/metagraph"
     },
     {
       "auth_required": false,
@@ -8486,6 +8575,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-31-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Recall SubnetRadar dashboard",
+      "netuid": 31,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/31"
+      ],
+      "subnet_name": "Recall",
+      "subnet_slug": "sn-31",
+      "url": "https://subnetradar.com/subnet/31"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-31-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Recall TaoMarketCap dashboard",
@@ -8546,38 +8667,6 @@
       "subnet_name": "Recall",
       "subnet_slug": "sn-31",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_31/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-31-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Recall Taostats metagraph",
-      "netuid": 31,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/31/metagraph"
-      ],
-      "subnet_name": "Recall",
-      "subnet_slug": "sn-31",
-      "url": "https://taostats.io/subnets/31/metagraph"
     },
     {
       "auth_required": false,
@@ -8692,6 +8781,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-32-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ItsAI SubnetRadar dashboard",
+      "netuid": 32,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/32"
+      ],
+      "subnet_name": "ItsAI",
+      "subnet_slug": "sn-32",
+      "url": "https://subnetradar.com/subnet/32"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-32-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ItsAI TaoMarketCap dashboard",
@@ -8756,38 +8877,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-32-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ItsAI Taostats metagraph",
-      "netuid": 32,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/32/metagraph"
-      ],
-      "subnet_name": "ItsAI",
-      "subnet_slug": "sn-32",
-      "url": "https://taostats.io/subnets/32/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-32-tensorplex-docs",
       "kind": "docs",
       "name": "ItsAI Tensorplex subnet docs",
@@ -8816,38 +8905,6 @@
       "subnet_name": "ItsAI",
       "subnet_slug": "sn-32",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/32"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-32-website-subdomain-docs-docs-its-ai-org",
-      "kind": "docs",
-      "name": "ItsAI docs subdomain",
-      "netuid": 32,
-      "notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://its-ai.org/en"
-      ],
-      "subnet_name": "ItsAI",
-      "subnet_slug": "sn-32",
-      "url": "https://docs.its-ai.org/"
     },
     {
       "auth_required": false,
@@ -9002,6 +9059,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-33-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ReadyAI SubnetRadar dashboard",
+      "netuid": 33,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/33"
+      ],
+      "subnet_name": "ReadyAI",
+      "subnet_slug": "sn-33",
+      "url": "https://subnetradar.com/subnet/33"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-33-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ReadyAI TaoMarketCap dashboard",
@@ -9062,38 +9151,6 @@
       "subnet_name": "ReadyAI",
       "subnet_slug": "sn-33",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_33/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-33-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ReadyAI Taostats metagraph",
-      "netuid": 33,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/33/metagraph"
-      ],
-      "subnet_name": "ReadyAI",
-      "subnet_slug": "sn-33",
-      "url": "https://taostats.io/subnets/33/metagraph"
     },
     {
       "auth_required": false,
@@ -9255,6 +9312,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-34-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "BitMind SubnetRadar dashboard",
+      "netuid": 34,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/34"
+      ],
+      "subnet_name": "BitMind",
+      "subnet_slug": "sn-34",
+      "url": "https://subnetradar.com/subnet/34"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-34-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "BitMind TaoMarketCap dashboard",
@@ -9315,38 +9404,6 @@
       "subnet_name": "BitMind",
       "subnet_slug": "sn-34",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_34/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-34-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "BitMind Taostats metagraph",
-      "netuid": 34,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/34/metagraph"
-      ],
-      "subnet_name": "BitMind",
-      "subnet_slug": "sn-34",
-      "url": "https://taostats.io/subnets/34/metagraph"
     },
     {
       "auth_required": false,
@@ -9415,6 +9472,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-35-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "OxMarkets SubnetRadar dashboard",
+      "netuid": 35,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/35"
+      ],
+      "subnet_name": "OxMarkets",
+      "subnet_slug": "sn-35",
+      "url": "https://subnetradar.com/subnet/35"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-35-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "OxMarkets TaoMarketCap dashboard",
@@ -9461,11 +9550,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -9542,38 +9632,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-35-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "OxMarkets Taostats metagraph",
-      "netuid": 35,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/35/metagraph"
-      ],
-      "subnet_name": "OxMarkets",
-      "subnet_slug": "sn-35",
-      "url": "https://taostats.io/subnets/35/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-35-tensorplex-docs",
       "kind": "docs",
       "name": "OxMarkets Tensorplex subnet docs",
@@ -9620,11 +9678,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -9633,6 +9692,38 @@
       "subnet_name": "OxMarkets",
       "subnet_slug": "sn-35",
       "url": "https://github.com/General-Tao-Ventures/cartha-cli"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-35-website-subdomain-docs-docs-0xmarkets-io",
+      "kind": "docs",
+      "name": "OxMarkets docs subdomain",
+      "netuid": 35,
+      "notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://www.0xmarkets.io/"
+      ],
+      "subnet_name": "OxMarkets",
+      "subnet_slug": "sn-35",
+      "url": "https://docs.0xmarkets.io/"
     },
     {
       "auth_required": false,
@@ -9665,6 +9756,38 @@
       "subnet_name": "Eirel",
       "subnet_slug": "sn-36",
       "url": "https://backprop.finance/dtao/subnets/36-eirel"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-36-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Eirel SubnetRadar dashboard",
+      "netuid": 36,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/36"
+      ],
+      "subnet_name": "Eirel",
+      "subnet_slug": "sn-36",
+      "url": "https://subnetradar.com/subnet/36"
     },
     {
       "auth_required": false,
@@ -9715,11 +9838,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -9792,38 +9916,6 @@
       "subnet_name": "Eirel",
       "subnet_slug": "sn-36",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_36/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-36-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Eirel Taostats metagraph",
-      "netuid": 36,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/36/metagraph"
-      ],
-      "subnet_name": "Eirel",
-      "subnet_slug": "sn-36",
-      "url": "https://taostats.io/subnets/36/metagraph"
     },
     {
       "auth_required": false,
@@ -9924,6 +10016,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-37-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Aurelius SubnetRadar dashboard",
+      "netuid": 37,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/37"
+      ],
+      "subnet_name": "Aurelius",
+      "subnet_slug": "sn-37",
+      "url": "https://subnetradar.com/subnet/37"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-37-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Aurelius TaoMarketCap dashboard",
@@ -9970,11 +10094,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -10047,38 +10172,6 @@
       "subnet_name": "Aurelius",
       "subnet_slug": "sn-37",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_37/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-37-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Aurelius Taostats metagraph",
-      "netuid": 37,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/37/metagraph"
-      ],
-      "subnet_name": "Aurelius",
-      "subnet_slug": "sn-37",
-      "url": "https://taostats.io/subnets/37/metagraph"
     },
     {
       "auth_required": false,
@@ -10179,6 +10272,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-38-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "colosseum SubnetRadar dashboard",
+      "netuid": 38,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/38"
+      ],
+      "subnet_name": "colosseum",
+      "subnet_slug": "sn-38",
+      "url": "https://subnetradar.com/subnet/38"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-38-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "colosseum TaoMarketCap dashboard",
@@ -10207,6 +10332,39 @@
       "subnet_name": "colosseum",
       "subnet_slug": "sn-38",
       "url": "https://taomarketcap.com/subnets/38"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-38-taomarketcap-source-repo",
+      "kind": "source-repo",
+      "name": "colosseum source repository",
+      "netuid": 38,
+      "notes": "Discovered from TaoMarketCap subnet identity metadata. Not probed or verified by Metagraphed.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/38",
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/38/subnet.json"
+      ],
+      "subnet_name": "colosseum",
+      "subnet_slug": "sn-38",
+      "url": "https://github.com/TAO-Colosseum/tao-colosseum-subnet"
     },
     {
       "auth_required": false,
@@ -10271,38 +10429,6 @@
       "subnet_name": "colosseum",
       "subnet_slug": "sn-38",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_38/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-38-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "colosseum Taostats metagraph",
-      "netuid": 38,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/38/metagraph"
-      ],
-      "subnet_name": "colosseum",
-      "subnet_slug": "sn-38",
-      "url": "https://taostats.io/subnets/38/metagraph"
     },
     {
       "auth_required": false,
@@ -10484,6 +10610,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-39-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "deprecated SubnetRadar dashboard",
+      "netuid": 39,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/39"
+      ],
+      "subnet_name": "Basilica",
+      "subnet_slug": "sn-39",
+      "url": "https://subnetradar.com/subnet/39"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-39-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "deprecated TaoMarketCap dashboard",
@@ -10548,38 +10706,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-39-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "deprecated Taostats metagraph",
-      "netuid": 39,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/39/metagraph"
-      ],
-      "subnet_name": "Basilica",
-      "subnet_slug": "sn-39",
-      "url": "https://taostats.io/subnets/39/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-39-tensorplex-docs",
       "kind": "docs",
       "name": "deprecated Tensorplex subnet docs",
@@ -10626,11 +10752,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -10671,6 +10798,38 @@
       "subnet_name": "Chunking",
       "subnet_slug": "sn-40",
       "url": "https://backprop.finance/dtao/subnets/40-chunking"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-40-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Chunking SubnetRadar dashboard",
+      "netuid": 40,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/40"
+      ],
+      "subnet_name": "Chunking",
+      "subnet_slug": "sn-40",
+      "url": "https://subnetradar.com/subnet/40"
     },
     {
       "auth_required": false,
@@ -10739,38 +10898,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-40-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Chunking Taostats metagraph",
-      "netuid": 40,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/40/metagraph"
-      ],
-      "subnet_name": "Chunking",
-      "subnet_slug": "sn-40",
-      "url": "https://taostats.io/subnets/40/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-40-tensorplex-docs",
       "kind": "docs",
       "name": "Chunking Tensorplex subnet docs",
@@ -10835,6 +10962,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-41-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Almanac SubnetRadar dashboard",
+      "netuid": 41,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/41"
+      ],
+      "subnet_name": "Almanac",
+      "subnet_slug": "sn-41",
+      "url": "https://subnetradar.com/subnet/41"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-41-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Almanac TaoMarketCap dashboard",
@@ -10881,11 +11040,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -10959,38 +11119,6 @@
       "subnet_name": "Almanac",
       "subnet_slug": "sn-41",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_41/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-41-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Almanac Taostats metagraph",
-      "netuid": 41,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/41/metagraph"
-      ],
-      "subnet_name": "Almanac",
-      "subnet_slug": "sn-41",
-      "url": "https://taostats.io/subnets/41/metagraph"
     },
     {
       "auth_required": false,
@@ -11173,6 +11301,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-42-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Gopher SubnetRadar dashboard",
+      "netuid": 42,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/42"
+      ],
+      "subnet_name": "Gopher",
+      "subnet_slug": "sn-42",
+      "url": "https://subnetradar.com/subnet/42"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-42-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Gopher TaoMarketCap dashboard",
@@ -11233,38 +11393,6 @@
       "subnet_name": "Gopher",
       "subnet_slug": "sn-42",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_42/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-42-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Gopher Taostats metagraph",
-      "netuid": 42,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/42/metagraph"
-      ],
-      "subnet_name": "Gopher",
-      "subnet_slug": "sn-42",
-      "url": "https://taostats.io/subnets/42/metagraph"
     },
     {
       "auth_required": false,
@@ -11381,6 +11509,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-43-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Graphite SubnetRadar dashboard",
+      "netuid": 43,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/43"
+      ],
+      "subnet_name": "Graphite",
+      "subnet_slug": "sn-43",
+      "url": "https://subnetradar.com/subnet/43"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-43-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Graphite TaoMarketCap dashboard",
@@ -11441,38 +11601,6 @@
       "subnet_name": "Graphite",
       "subnet_slug": "sn-43",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_43/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-43-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Graphite Taostats metagraph",
-      "netuid": 43,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/43/metagraph"
-      ],
-      "subnet_name": "Graphite",
-      "subnet_slug": "sn-43",
-      "url": "https://taostats.io/subnets/43/metagraph"
     },
     {
       "auth_required": false,
@@ -11541,6 +11669,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-44-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Score SubnetRadar dashboard",
+      "netuid": 44,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/44"
+      ],
+      "subnet_name": "Score",
+      "subnet_slug": "sn-44",
+      "url": "https://subnetradar.com/subnet/44"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-44-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Score TaoMarketCap dashboard",
@@ -11587,11 +11747,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -11668,38 +11829,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-44-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Score Taostats metagraph",
-      "netuid": 44,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/44/metagraph"
-      ],
-      "subnet_name": "Score",
-      "subnet_slug": "sn-44",
-      "url": "https://taostats.io/subnets/44/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-44-tensorplex-docs",
       "kind": "docs",
       "name": "Score Tensorplex subnet docs",
@@ -11746,11 +11875,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -11791,6 +11921,38 @@
       "subnet_name": "Talisman AI",
       "subnet_slug": "sn-45",
       "url": "https://backprop.finance/dtao/subnets/45-talisman-ai"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-45-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Talisman AI SubnetRadar dashboard",
+      "netuid": 45,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/45"
+      ],
+      "subnet_name": "Talisman AI",
+      "subnet_slug": "sn-45",
+      "url": "https://subnetradar.com/subnet/45"
     },
     {
       "auth_required": false,
@@ -11901,38 +12063,6 @@
       "subnet_name": "Talisman AI",
       "subnet_slug": "sn-45",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_45/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-45-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Talisman AI Taostats metagraph",
-      "netuid": 45,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/45/metagraph"
-      ],
-      "subnet_name": "Talisman AI",
-      "subnet_slug": "sn-45",
-      "url": "https://taostats.io/subnets/45/metagraph"
     },
     {
       "auth_required": false,
@@ -12097,18 +12227,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-46-taomarketcap-dashboard",
+      "id": "sn-46-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Zipcode TaoMarketCap dashboard",
+      "name": "Zipcode SubnetRadar dashboard",
       "netuid": 46,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12120,11 +12250,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/46"
+        "https://subnetradar.com/subnet/46"
       ],
       "subnet_name": "Zipcode",
       "subnet_slug": "sn-46",
-      "url": "https://taomarketcap.com/subnets/46"
+      "url": "https://subnetradar.com/subnet/46"
     },
     {
       "auth_required": false,
@@ -12143,11 +12273,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -12270,11 +12401,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -12301,11 +12433,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -12463,6 +12596,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-47-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "EvolAI SubnetRadar dashboard",
+      "netuid": 47,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/47"
+      ],
+      "subnet_name": "EvolAI",
+      "subnet_slug": "sn-47",
+      "url": "https://subnetradar.com/subnet/47"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-47-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "EvolAI TaoMarketCap dashboard",
@@ -12509,11 +12674,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -12554,38 +12720,6 @@
       "subnet_name": "EvolAI",
       "subnet_slug": "sn-47",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_47/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-47-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "EvolAI Taostats metagraph",
-      "netuid": 47,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/47/metagraph"
-      ],
-      "subnet_name": "EvolAI",
-      "subnet_slug": "sn-47",
-      "url": "https://taostats.io/subnets/47/metagraph"
     },
     {
       "auth_required": false,
@@ -12636,11 +12770,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -12731,6 +12866,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-48-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Quantum Compute SubnetRadar dashboard",
+      "netuid": 48,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/48"
+      ],
+      "subnet_name": "Quantum Compute",
+      "subnet_slug": "sn-48",
+      "url": "https://subnetradar.com/subnet/48"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-48-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Quantum Compute TaoMarketCap dashboard",
@@ -12791,38 +12958,6 @@
       "subnet_name": "Quantum Compute",
       "subnet_slug": "sn-48",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_48/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-48-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Quantum Compute Taostats metagraph",
-      "netuid": 48,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/48/metagraph"
-      ],
-      "subnet_name": "Quantum Compute",
-      "subnet_slug": "sn-48",
-      "url": "https://taostats.io/subnets/48/metagraph"
     },
     {
       "auth_required": false,
@@ -13031,6 +13166,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-49-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Nepher Robotics SubnetRadar dashboard",
+      "netuid": 49,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/49"
+      ],
+      "subnet_name": "Nepher Robotics",
+      "subnet_slug": "sn-49",
+      "url": "https://subnetradar.com/subnet/49"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-49-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Nepher Robotics TaoMarketCap dashboard",
@@ -13073,38 +13240,6 @@
       "subnet_name": "Nepher Robotics",
       "subnet_slug": "sn-49",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_49/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-49-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Nepher Robotics Taostats metagraph",
-      "netuid": 49,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/49/metagraph"
-      ],
-      "subnet_name": "Nepher Robotics",
-      "subnet_slug": "sn-49",
-      "url": "https://taostats.io/subnets/49/metagraph"
     },
     {
       "auth_required": false,
@@ -13164,6 +13299,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-50-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Synth SubnetRadar dashboard",
+      "netuid": 50,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/50"
+      ],
+      "subnet_name": "Synth",
+      "subnet_slug": "sn-50",
+      "url": "https://subnetradar.com/subnet/50"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-50-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Synth TaoMarketCap dashboard",
@@ -13210,11 +13377,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -13288,38 +13456,6 @@
       "subnet_name": "Synth",
       "subnet_slug": "sn-50",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_50/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-50-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Synth Taostats metagraph",
-      "netuid": 50,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/50/metagraph"
-      ],
-      "subnet_name": "Synth",
-      "subnet_slug": "sn-50",
-      "url": "https://taostats.io/subnets/50/metagraph"
     },
     {
       "auth_required": false,
@@ -13485,6 +13621,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-51-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "lium.io SubnetRadar dashboard",
+      "netuid": 51,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/51"
+      ],
+      "subnet_name": "lium.io",
+      "subnet_slug": "sn-51",
+      "url": "https://subnetradar.com/subnet/51"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-51-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "lium.io TaoMarketCap dashboard",
@@ -13531,11 +13699,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -13609,38 +13778,6 @@
       "subnet_name": "lium.io",
       "subnet_slug": "sn-51",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_51/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-51-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "lium.io Taostats metagraph",
-      "netuid": 51,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/51/metagraph"
-      ],
-      "subnet_name": "lium.io",
-      "subnet_slug": "sn-51",
-      "url": "https://taostats.io/subnets/51/metagraph"
     },
     {
       "auth_required": false,
@@ -13865,6 +14002,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-52-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Dojo SubnetRadar dashboard",
+      "netuid": 52,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/52"
+      ],
+      "subnet_name": "Dojo",
+      "subnet_slug": "sn-52",
+      "url": "https://subnetradar.com/subnet/52"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-52-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Dojo TaoMarketCap dashboard",
@@ -13925,38 +14094,6 @@
       "subnet_name": "Dojo",
       "subnet_slug": "sn-52",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_52/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-52-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Dojo Taostats metagraph",
-      "netuid": 52,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/52/metagraph"
-      ],
-      "subnet_name": "Dojo",
-      "subnet_slug": "sn-52",
-      "url": "https://taostats.io/subnets/52/metagraph"
     },
     {
       "auth_required": false,
@@ -14043,8 +14180,89 @@
         "https://backprop.finance/dtao/subnets/53-efficientfrontier"
       ],
       "subnet_name": "EfficientFrontier",
-      "subnet_slug": "sn-53",
+      "subnet_slug": "efficientfrontier",
       "url": "https://backprop.finance/dtao/subnets/53-efficientfrontier"
+    },
+    {
+      "auth_required": true,
+      "authority": "official",
+      "id": "sn-53-signalplus-mining",
+      "kind": "dashboard",
+      "name": "EfficientFrontier mining app",
+      "netuid": 53,
+      "notes": "SignalPlus mining/app surface linked by public SN53 references.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "signalplus",
+      "public_safe": true,
+      "rate_limit_notes": "Simple probes currently receive an auth/challenge-style response; endpoint health should be interpreted as access-state, not app correctness.",
+      "source_urls": [
+        "https://t.signalplus.com/mining",
+        "https://www.signalplus.com/"
+      ],
+      "subnet_name": "EfficientFrontier",
+      "subnet_slug": "efficientfrontier",
+      "url": "https://t.signalplus.com/mining"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-53-signalplus-website",
+      "kind": "website",
+      "name": "SignalPlus website",
+      "netuid": 53,
+      "notes": "SignalPlus team/company website for SN53 EfficientFrontier.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "signalplus",
+      "public_safe": true,
+      "source_urls": [
+        "https://www.signalplus.com/",
+        "https://t.signalplus.com/mining"
+      ],
+      "subnet_name": "EfficientFrontier",
+      "subnet_slug": "efficientfrontier",
+      "url": "https://www.signalplus.com/"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-53-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "EfficientFrontier SubnetRadar dashboard",
+      "netuid": 53,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/53"
+      ],
+      "subnet_name": "EfficientFrontier",
+      "subnet_slug": "efficientfrontier",
+      "url": "https://subnetradar.com/subnet/53"
     },
     {
       "auth_required": false,
@@ -14075,7 +14293,7 @@
         "https://api.taomarketcap.com/public/v1/subnets/53"
       ],
       "subnet_name": "EfficientFrontier",
-      "subnet_slug": "sn-53",
+      "subnet_slug": "efficientfrontier",
       "url": "https://taomarketcap.com/subnets/53"
     },
     {
@@ -14107,40 +14325,8 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx"
       ],
       "subnet_name": "EfficientFrontier",
-      "subnet_slug": "sn-53",
+      "subnet_slug": "efficientfrontier",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_53/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-53-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "EfficientFrontier Taostats metagraph",
-      "netuid": 53,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/53/metagraph"
-      ],
-      "subnet_name": "EfficientFrontier",
-      "subnet_slug": "sn-53",
-      "url": "https://taostats.io/subnets/53/metagraph"
     },
     {
       "auth_required": false,
@@ -14171,7 +14357,7 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json"
       ],
       "subnet_name": "EfficientFrontier",
-      "subnet_slug": "sn-53",
+      "subnet_slug": "efficientfrontier",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/53"
     },
     {
@@ -14241,18 +14427,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-54-taomarketcap-dashboard",
+      "id": "sn-54-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Yanez MIID TaoMarketCap dashboard",
+      "name": "Yanez MIID SubnetRadar dashboard",
       "netuid": 54,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14264,11 +14450,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/54"
+        "https://subnetradar.com/subnet/54"
       ],
       "subnet_name": "Yanez MIID",
       "subnet_slug": "sn-54",
-      "url": "https://taomarketcap.com/subnets/54"
+      "url": "https://subnetradar.com/subnet/54"
     },
     {
       "auth_required": false,
@@ -14287,11 +14473,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -14433,6 +14620,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-55-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "NIOME SubnetRadar dashboard",
+      "netuid": 55,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/55"
+      ],
+      "subnet_name": "NIOME",
+      "subnet_slug": "sn-55",
+      "url": "https://subnetradar.com/subnet/55"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-55-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "NIOME TaoMarketCap dashboard",
@@ -14562,38 +14781,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-55-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "NIOME Taostats metagraph",
-      "netuid": 55,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/55/metagraph"
-      ],
-      "subnet_name": "NIOME",
-      "subnet_slug": "sn-55",
-      "url": "https://taostats.io/subnets/55/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-55-tensorplex-docs",
       "kind": "docs",
       "name": "NIOME Tensorplex subnet docs",
@@ -14658,6 +14845,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-56-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Gradients SubnetRadar dashboard",
+      "netuid": 56,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/56"
+      ],
+      "subnet_name": "Gradients",
+      "subnet_slug": "sn-56",
+      "url": "https://subnetradar.com/subnet/56"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-56-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Gradients TaoMarketCap dashboard",
@@ -14704,11 +14923,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -14785,38 +15005,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-56-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Gradients Taostats metagraph",
-      "netuid": 56,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/56/metagraph"
-      ],
-      "subnet_name": "Gradients",
-      "subnet_slug": "sn-56",
-      "url": "https://taostats.io/subnets/56/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-56-tensorplex-docs",
       "kind": "docs",
       "name": "Gradients Tensorplex subnet docs",
@@ -14863,11 +15051,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -15056,6 +15245,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-57-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "gaia SubnetRadar dashboard",
+      "netuid": 57,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/57"
+      ],
+      "subnet_name": "Sparket",
+      "subnet_slug": "sn-57",
+      "url": "https://subnetradar.com/subnet/57"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-57-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "gaia TaoMarketCap dashboard",
@@ -15116,38 +15337,6 @@
       "subnet_name": "Sparket",
       "subnet_slug": "sn-57",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_57/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-57-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "gaia Taostats metagraph",
-      "netuid": 57,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/57/metagraph"
-      ],
-      "subnet_name": "Sparket",
-      "subnet_slug": "sn-57",
-      "url": "https://taostats.io/subnets/57/metagraph"
     },
     {
       "auth_required": false,
@@ -15417,6 +15606,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-58-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Pending SubnetRadar dashboard",
+      "netuid": 58,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/58"
+      ],
+      "subnet_name": "Handshake58",
+      "subnet_slug": "sn-58",
+      "url": "https://subnetradar.com/subnet/58"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-58-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Handshake58 TaoMarketCap dashboard",
@@ -15459,38 +15680,6 @@
       "subnet_name": "Handshake58",
       "subnet_slug": "sn-58",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_58/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-58-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Pending Taostats metagraph",
-      "netuid": 58,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/58/metagraph"
-      ],
-      "subnet_name": "Handshake58",
-      "subnet_slug": "sn-58",
-      "url": "https://taostats.io/subnets/58/metagraph"
     },
     {
       "auth_required": false,
@@ -15582,6 +15771,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-59-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Babelbit SubnetRadar dashboard",
+      "netuid": 59,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/59"
+      ],
+      "subnet_name": "Babelbit",
+      "subnet_slug": "sn-59",
+      "url": "https://subnetradar.com/subnet/59"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-59-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Babelbit TaoMarketCap dashboard",
@@ -15628,11 +15849,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -15706,38 +15928,6 @@
       "subnet_name": "Babelbit",
       "subnet_slug": "sn-59",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_59/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-59-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Babelbit Taostats metagraph",
-      "netuid": 59,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/59/metagraph"
-      ],
-      "subnet_name": "Babelbit",
-      "subnet_slug": "sn-59",
-      "url": "https://taostats.io/subnets/59/metagraph"
     },
     {
       "auth_required": false,
@@ -15838,6 +16028,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-60-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Bitsec.ai SubnetRadar dashboard",
+      "netuid": 60,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/60"
+      ],
+      "subnet_name": "Bitsec.ai",
+      "subnet_slug": "sn-60",
+      "url": "https://subnetradar.com/subnet/60"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-60-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Bitsec.ai TaoMarketCap dashboard",
@@ -15884,11 +16106,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -15961,38 +16184,6 @@
       "subnet_name": "Bitsec.ai",
       "subnet_slug": "sn-60",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-60-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Bitsec.ai Taostats metagraph",
-      "netuid": 60,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/60/metagraph"
-      ],
-      "subnet_name": "Bitsec.ai",
-      "subnet_slug": "sn-60",
-      "url": "https://taostats.io/subnets/60/metagraph"
     },
     {
       "auth_required": false,
@@ -16250,18 +16441,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-61-taomarketcap-dashboard",
+      "id": "sn-61-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "RedTeam TaoMarketCap dashboard",
+      "name": "RedTeam SubnetRadar dashboard",
       "netuid": 61,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16273,11 +16464,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/61"
+        "https://subnetradar.com/subnet/61"
       ],
       "subnet_name": "RedTeam",
       "subnet_slug": "sn-61",
-      "url": "https://taomarketcap.com/subnets/61"
+      "url": "https://subnetradar.com/subnet/61"
     },
     {
       "auth_required": false,
@@ -16401,6 +16592,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-62-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Ridges SubnetRadar dashboard",
+      "netuid": 62,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/62"
+      ],
+      "subnet_name": "Ridges",
+      "subnet_slug": "sn-62",
+      "url": "https://subnetradar.com/subnet/62"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-62-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Ridges TaoMarketCap dashboard",
@@ -16465,38 +16688,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-62-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Ridges Taostats metagraph",
-      "netuid": 62,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/62/metagraph"
-      ],
-      "subnet_name": "Ridges",
-      "subnet_slug": "sn-62",
-      "url": "https://taostats.io/subnets/62/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-62-tensorplex-docs",
       "kind": "docs",
       "name": "Ridges Tensorplex subnet docs",
@@ -16525,38 +16716,6 @@
       "subnet_name": "Ridges",
       "subnet_slug": "sn-62",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/62"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-62-website-subdomain-docs-docs-ridges-ai",
-      "kind": "docs",
-      "name": "Ridges docs subdomain",
-      "netuid": 62,
-      "notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://www.ridges.ai/"
-      ],
-      "subnet_name": "Ridges",
-      "subnet_slug": "sn-62",
-      "url": "https://docs.ridges.ai/"
     },
     {
       "auth_required": false,
@@ -16639,6 +16798,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-63-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Enigma SubnetRadar dashboard",
+      "netuid": 63,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/63"
+      ],
+      "subnet_name": "Enigma",
+      "subnet_slug": "sn-63",
+      "url": "https://subnetradar.com/subnet/63"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-63-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Enigma TaoMarketCap dashboard",
@@ -16699,38 +16890,6 @@
       "subnet_name": "Enigma",
       "subnet_slug": "sn-63",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_63/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-63-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Enigma Taostats metagraph",
-      "netuid": 63,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/63/metagraph"
-      ],
-      "subnet_name": "Enigma",
-      "subnet_slug": "sn-63",
-      "url": "https://taostats.io/subnets/63/metagraph"
     },
     {
       "auth_required": false,
@@ -16988,6 +17147,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-64-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Chutes SubnetRadar dashboard",
+      "netuid": 64,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/64"
+      ],
+      "subnet_name": "Chutes",
+      "subnet_slug": "sn-64",
+      "url": "https://subnetradar.com/subnet/64"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-64-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Chutes TaoMarketCap dashboard",
@@ -17034,38 +17225,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-64-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Chutes Taostats metagraph",
-      "netuid": 64,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/64/metagraph"
-      ],
-      "subnet_name": "Chutes",
-      "subnet_slug": "sn-64",
-      "url": "https://taostats.io/subnets/64/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-64-tensorplex-docs",
       "kind": "docs",
       "name": "Chutes Tensorplex subnet docs",
@@ -17103,11 +17262,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -17134,11 +17294,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -17247,6 +17408,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-65-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "TAO Private Network SubnetRadar dashboard",
+      "netuid": 65,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/65"
+      ],
+      "subnet_name": "TAO Private Network",
+      "subnet_slug": "sn-65",
+      "url": "https://subnetradar.com/subnet/65"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-65-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "TAO Private Network TaoMarketCap dashboard",
@@ -17293,11 +17486,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -17371,38 +17565,6 @@
       "subnet_name": "TAO Private Network",
       "subnet_slug": "sn-65",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_65/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-65-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "TAO Private Network Taostats metagraph",
-      "netuid": 65,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/65/metagraph"
-      ],
-      "subnet_name": "TAO Private Network",
-      "subnet_slug": "sn-65",
-      "url": "https://taostats.io/subnets/65/metagraph"
     },
     {
       "auth_required": false,
@@ -17710,6 +17872,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-66-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ninja SubnetRadar dashboard",
+      "netuid": 66,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/66"
+      ],
+      "subnet_name": "ninja",
+      "subnet_slug": "sn-66",
+      "url": "https://subnetradar.com/subnet/66"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-66-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ninja TaoMarketCap dashboard",
@@ -17752,38 +17946,6 @@
       "subnet_name": "ninja",
       "subnet_slug": "sn-66",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_66/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-66-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ninja Taostats metagraph",
-      "netuid": 66,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/66/metagraph"
-      ],
-      "subnet_name": "ninja",
-      "subnet_slug": "sn-66",
-      "url": "https://taostats.io/subnets/66/metagraph"
     },
     {
       "auth_required": false,
@@ -17940,18 +18102,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-67-taomarketcap-dashboard",
+      "id": "sn-67-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Harnyx TaoMarketCap dashboard",
+      "name": "Harnyx SubnetRadar dashboard",
       "netuid": 67,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17963,11 +18125,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/67"
+        "https://subnetradar.com/subnet/67"
       ],
       "subnet_name": "Harnyx",
       "subnet_slug": "sn-67",
-      "url": "https://taomarketcap.com/subnets/67"
+      "url": "https://subnetradar.com/subnet/67"
     },
     {
       "auth_required": false,
@@ -18082,11 +18244,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -18127,6 +18290,38 @@
       "subnet_name": "NOVA",
       "subnet_slug": "sn-68",
       "url": "https://backprop.finance/dtao/subnets/68-nova"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-68-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "NOVA SubnetRadar dashboard",
+      "netuid": 68,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/68"
+      ],
+      "subnet_name": "NOVA",
+      "subnet_slug": "sn-68",
+      "url": "https://subnetradar.com/subnet/68"
     },
     {
       "auth_required": false,
@@ -18177,11 +18372,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -18255,38 +18451,6 @@
       "subnet_name": "NOVA",
       "subnet_slug": "sn-68",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_68/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-68-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "NOVA Taostats metagraph",
-      "netuid": 68,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/68/metagraph"
-      ],
-      "subnet_name": "NOVA",
-      "subnet_slug": "sn-68",
-      "url": "https://taostats.io/subnets/68/metagraph"
     },
     {
       "auth_required": false,
@@ -18419,6 +18583,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-69-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ain SubnetRadar dashboard",
+      "netuid": 69,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/69"
+      ],
+      "subnet_name": "ain",
+      "subnet_slug": "sn-69",
+      "url": "https://subnetradar.com/subnet/69"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-69-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ain TaoMarketCap dashboard",
@@ -18479,38 +18675,6 @@
       "subnet_name": "ain",
       "subnet_slug": "sn-69",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_69/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-69-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ain Taostats metagraph",
-      "netuid": 69,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/69/metagraph"
-      ],
-      "subnet_name": "ain",
-      "subnet_slug": "sn-69",
-      "url": "https://taostats.io/subnets/69/metagraph"
     },
     {
       "auth_required": false,
@@ -18579,6 +18743,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-70-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "NexisGen SubnetRadar dashboard",
+      "netuid": 70,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/70"
+      ],
+      "subnet_name": "NexisGen",
+      "subnet_slug": "sn-70",
+      "url": "https://subnetradar.com/subnet/70"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-70-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "NexisGen TaoMarketCap dashboard",
@@ -18625,11 +18821,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -18702,38 +18899,6 @@
       "subnet_name": "NexisGen",
       "subnet_slug": "sn-70",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_70/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-70-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "NexisGen Taostats metagraph",
-      "netuid": 70,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/70/metagraph"
-      ],
-      "subnet_name": "NexisGen",
-      "subnet_slug": "sn-70",
-      "url": "https://taostats.io/subnets/70/metagraph"
     },
     {
       "auth_required": false,
@@ -18866,6 +19031,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-71-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Leadpoet SubnetRadar dashboard",
+      "netuid": 71,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/71"
+      ],
+      "subnet_name": "Leadpoet",
+      "subnet_slug": "sn-71",
+      "url": "https://subnetradar.com/subnet/71"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-71-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Leadpoet TaoMarketCap dashboard",
@@ -18912,11 +19109,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -18990,38 +19188,6 @@
       "subnet_name": "Leadpoet",
       "subnet_slug": "sn-71",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_71/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-71-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Leadpoet Taostats metagraph",
-      "netuid": 71,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/71/metagraph"
-      ],
-      "subnet_name": "Leadpoet",
-      "subnet_slug": "sn-71",
-      "url": "https://taostats.io/subnets/71/metagraph"
     },
     {
       "auth_required": false,
@@ -19297,6 +19463,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-72-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "StreetVision by NATIX SubnetRadar dashboard",
+      "netuid": 72,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/72"
+      ],
+      "subnet_name": "StreetVision by NATIX",
+      "subnet_slug": "sn-72",
+      "url": "https://subnetradar.com/subnet/72"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-72-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "StreetVision by NATIX TaoMarketCap dashboard",
@@ -19393,38 +19591,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-72-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "StreetVision by NATIX Taostats metagraph",
-      "netuid": 72,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/72/metagraph"
-      ],
-      "subnet_name": "StreetVision by NATIX",
-      "subnet_slug": "sn-72",
-      "url": "https://taostats.io/subnets/72/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-72-tensorplex-docs",
       "kind": "docs",
       "name": "StreetVision by NATIX Tensorplex subnet docs",
@@ -19482,9 +19648,41 @@
       "source_urls": [
         "https://backprop.finance/dtao/subnets/73-parked"
       ],
-      "subnet_name": "Parked",
-      "subnet_slug": "sn-73",
+      "subnet_name": "MetaHash",
+      "subnet_slug": "metahash",
       "url": "https://backprop.finance/dtao/subnets/73-parked"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-73-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Parked SubnetRadar dashboard",
+      "netuid": 73,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/73"
+      ],
+      "subnet_name": "MetaHash",
+      "subnet_slug": "metahash",
+      "url": "https://subnetradar.com/subnet/73"
     },
     {
       "auth_required": false,
@@ -19514,8 +19712,8 @@
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/73"
       ],
-      "subnet_name": "Parked",
-      "subnet_slug": "sn-73",
+      "subnet_name": "MetaHash",
+      "subnet_slug": "metahash",
       "url": "https://taomarketcap.com/subnets/73"
     },
     {
@@ -19546,41 +19744,9 @@
       "source_urls": [
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx"
       ],
-      "subnet_name": "Parked",
-      "subnet_slug": "sn-73",
+      "subnet_name": "MetaHash",
+      "subnet_slug": "metahash",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_73/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-73-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Parked Taostats metagraph",
-      "netuid": 73,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/73/metagraph"
-      ],
-      "subnet_name": "Parked",
-      "subnet_slug": "sn-73",
-      "url": "https://taostats.io/subnets/73/metagraph"
     },
     {
       "auth_required": false,
@@ -19610,8 +19776,8 @@
       "source_urls": [
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/73/subnet.json"
       ],
-      "subnet_name": "Parked",
-      "subnet_slug": "sn-73",
+      "subnet_name": "MetaHash",
+      "subnet_slug": "metahash",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/73"
     },
     {
@@ -19847,6 +20013,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-74-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Gittensor SubnetRadar dashboard",
+      "netuid": 74,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/74"
+      ],
+      "subnet_name": "Gittensor",
+      "subnet_slug": "gittensor",
+      "url": "https://subnetradar.com/subnet/74"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-74-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Gittensor TaoMarketCap dashboard",
@@ -19893,11 +20091,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -19938,38 +20137,6 @@
       "subnet_name": "Gittensor",
       "subnet_slug": "gittensor",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_74/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-74-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Gittensor Taostats metagraph",
-      "netuid": 74,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/74/metagraph"
-      ],
-      "subnet_name": "Gittensor",
-      "subnet_slug": "gittensor",
-      "url": "https://taostats.io/subnets/74/metagraph"
     },
     {
       "auth_required": false,
@@ -20218,6 +20385,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-75-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Hippius SubnetRadar dashboard",
+      "netuid": 75,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/75"
+      ],
+      "subnet_name": "Hippius",
+      "subnet_slug": "sn-75",
+      "url": "https://subnetradar.com/subnet/75"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-75-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Hippius TaoMarketCap dashboard",
@@ -20264,11 +20463,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -20310,38 +20510,6 @@
       "subnet_name": "Hippius",
       "subnet_slug": "sn-75",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_75/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-75-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Hippius Taostats metagraph",
-      "netuid": 75,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/75/metagraph"
-      ],
-      "subnet_name": "Hippius",
-      "subnet_slug": "sn-75",
-      "url": "https://taostats.io/subnets/75/metagraph"
     },
     {
       "auth_required": false,
@@ -20433,6 +20601,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-76-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Byzantium SubnetRadar dashboard",
+      "netuid": 76,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/76"
+      ],
+      "subnet_name": "Byzantium",
+      "subnet_slug": "sn-76",
+      "url": "https://subnetradar.com/subnet/76"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-76-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Byzantium TaoMarketCap dashboard",
@@ -20493,38 +20693,6 @@
       "subnet_name": "Byzantium",
       "subnet_slug": "sn-76",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_76/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-76-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Byzantium Taostats metagraph",
-      "netuid": 76,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/76/metagraph"
-      ],
-      "subnet_name": "Byzantium",
-      "subnet_slug": "sn-76",
-      "url": "https://taostats.io/subnets/76/metagraph"
     },
     {
       "auth_required": false,
@@ -20593,6 +20761,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-77-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Liquidity SubnetRadar dashboard",
+      "netuid": 77,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/77"
+      ],
+      "subnet_name": "Liquidity",
+      "subnet_slug": "sn-77",
+      "url": "https://subnetradar.com/subnet/77"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-77-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Liquidity TaoMarketCap dashboard",
@@ -20639,11 +20839,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -20717,38 +20918,6 @@
       "subnet_name": "Liquidity",
       "subnet_slug": "sn-77",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_77/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-77-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Liquidity Taostats metagraph",
-      "netuid": 77,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/77/metagraph"
-      ],
-      "subnet_name": "Liquidity",
-      "subnet_slug": "sn-77",
-      "url": "https://taostats.io/subnets/77/metagraph"
     },
     {
       "auth_required": false,
@@ -20882,6 +21051,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-78-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Vocence SubnetRadar dashboard",
+      "netuid": 78,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/78"
+      ],
+      "subnet_name": "Vocence",
+      "subnet_slug": "sn-78",
+      "url": "https://subnetradar.com/subnet/78"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-78-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Vocence TaoMarketCap dashboard",
@@ -20928,11 +21129,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -21005,38 +21207,6 @@
       "subnet_name": "Vocence",
       "subnet_slug": "sn-78",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_78/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-78-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Vocence Taostats metagraph",
-      "netuid": 78,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/78/metagraph"
-      ],
-      "subnet_name": "Vocence",
-      "subnet_slug": "sn-78",
-      "url": "https://taostats.io/subnets/78/metagraph"
     },
     {
       "auth_required": false,
@@ -21119,11 +21289,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -21334,6 +21505,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-79-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "MVTRX SubnetRadar dashboard",
+      "netuid": 79,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/79"
+      ],
+      "subnet_name": "MVTRX",
+      "subnet_slug": "sn-79",
+      "url": "https://subnetradar.com/subnet/79"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-79-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "MVTRX TaoMarketCap dashboard",
@@ -21394,38 +21597,6 @@
       "subnet_name": "MVTRX",
       "subnet_slug": "sn-79",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_79/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-79-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "MVTRX Taostats metagraph",
-      "netuid": 79,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/79/metagraph"
-      ],
-      "subnet_name": "MVTRX",
-      "subnet_slug": "sn-79",
-      "url": "https://taostats.io/subnets/79/metagraph"
     },
     {
       "auth_required": false,
@@ -21494,6 +21665,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-80-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "dogelayer SubnetRadar dashboard",
+      "netuid": 80,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/80"
+      ],
+      "subnet_name": "dogelayer",
+      "subnet_slug": "sn-80",
+      "url": "https://subnetradar.com/subnet/80"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-80-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "dogelayer TaoMarketCap dashboard",
@@ -21540,11 +21743,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -21617,38 +21821,6 @@
       "subnet_name": "dogelayer",
       "subnet_slug": "sn-80",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_80/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-80-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "dogelayer Taostats metagraph",
-      "netuid": 80,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/80/metagraph"
-      ],
-      "subnet_name": "dogelayer",
-      "subnet_slug": "sn-80",
-      "url": "https://taostats.io/subnets/80/metagraph"
     },
     {
       "auth_required": false,
@@ -21884,6 +22056,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-81-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "deprecated SubnetRadar dashboard",
+      "netuid": 81,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/81"
+      ],
+      "subnet_name": "Grail",
+      "subnet_slug": "sn-81",
+      "url": "https://subnetradar.com/subnet/81"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-81-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "deprecated TaoMarketCap dashboard",
@@ -21948,38 +22152,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-81-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "deprecated Taostats metagraph",
-      "netuid": 81,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/81/metagraph"
-      ],
-      "subnet_name": "Grail",
-      "subnet_slug": "sn-81",
-      "url": "https://taostats.io/subnets/81/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-81-tensorplex-docs",
       "kind": "docs",
       "name": "deprecated Tensorplex subnet docs",
@@ -22026,11 +22198,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -22121,6 +22294,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-82-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Compelle SubnetRadar dashboard",
+      "netuid": 82,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/82"
+      ],
+      "subnet_name": "Compelle",
+      "subnet_slug": "sn-82",
+      "url": "https://subnetradar.com/subnet/82"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-82-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Compelle TaoMarketCap dashboard",
@@ -22185,38 +22390,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-82-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Compelle Taostats metagraph",
-      "netuid": 82,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/82/metagraph"
-      ],
-      "subnet_name": "Compelle",
-      "subnet_slug": "sn-82",
-      "url": "https://taostats.io/subnets/82/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-82-tensorplex-docs",
       "kind": "docs",
       "name": "Compelle Tensorplex subnet docs",
@@ -22263,11 +22436,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -22308,6 +22482,38 @@
       "subnet_name": "CliqueAI",
       "subnet_slug": "sn-83",
       "url": "https://backprop.finance/dtao/subnets/83-cliqueai"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-83-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "CliqueAI SubnetRadar dashboard",
+      "netuid": 83,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/83"
+      ],
+      "subnet_name": "CliqueAI",
+      "subnet_slug": "sn-83",
+      "url": "https://subnetradar.com/subnet/83"
     },
     {
       "auth_required": false,
@@ -22358,11 +22564,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -22436,38 +22643,6 @@
       "subnet_name": "CliqueAI",
       "subnet_slug": "sn-83",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_83/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-83-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "CliqueAI Taostats metagraph",
-      "netuid": 83,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/83/metagraph"
-      ],
-      "subnet_name": "CliqueAI",
-      "subnet_slug": "sn-83",
-      "url": "https://taostats.io/subnets/83/metagraph"
     },
     {
       "auth_required": false,
@@ -22672,6 +22847,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-84-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ansuz SubnetRadar dashboard",
+      "netuid": 84,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/84"
+      ],
+      "subnet_name": "ansuz",
+      "subnet_slug": "sn-84",
+      "url": "https://subnetradar.com/subnet/84"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-84-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ansuz TaoMarketCap dashboard",
@@ -22736,38 +22943,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-84-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ansuz Taostats metagraph",
-      "netuid": 84,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/84/metagraph"
-      ],
-      "subnet_name": "ansuz",
-      "subnet_slug": "sn-84",
-      "url": "https://taostats.io/subnets/84/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-84-tensorplex-docs",
       "kind": "docs",
       "name": "ansuz Tensorplex subnet docs",
@@ -22814,11 +22989,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -22859,6 +23035,38 @@
       "subnet_name": "Vidaio",
       "subnet_slug": "sn-85",
       "url": "https://backprop.finance/dtao/subnets/85-vidaio"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-85-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Vidaio SubnetRadar dashboard",
+      "netuid": 85,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/85"
+      ],
+      "subnet_name": "Vidaio",
+      "subnet_slug": "sn-85",
+      "url": "https://subnetradar.com/subnet/85"
     },
     {
       "auth_required": false,
@@ -22923,38 +23131,6 @@
       "subnet_name": "Vidaio",
       "subnet_slug": "sn-85",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_85/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-85-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Vidaio Taostats metagraph",
-      "netuid": 85,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/85/metagraph"
-      ],
-      "subnet_name": "Vidaio",
-      "subnet_slug": "sn-85",
-      "url": "https://taostats.io/subnets/85/metagraph"
     },
     {
       "auth_required": false,
@@ -23071,6 +23247,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-86-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Subnet 86 SubnetRadar dashboard",
+      "netuid": 86,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/86"
+      ],
+      "subnet_name": "Subnet 86",
+      "subnet_slug": "sn-86",
+      "url": "https://subnetradar.com/subnet/86"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-86-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Subnet 86 TaoMarketCap dashboard",
@@ -23131,38 +23339,6 @@
       "subnet_name": "Subnet 86",
       "subnet_slug": "sn-86",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_86/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-86-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Subnet 86 Taostats metagraph",
-      "netuid": 86,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/86/metagraph"
-      ],
-      "subnet_name": "Subnet 86",
-      "subnet_slug": "sn-86",
-      "url": "https://taostats.io/subnets/86/metagraph"
     },
     {
       "auth_required": false,
@@ -23325,6 +23501,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-87-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Luminar Network SubnetRadar dashboard",
+      "netuid": 87,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/87"
+      ],
+      "subnet_name": "Luminar Network",
+      "subnet_slug": "sn-87",
+      "url": "https://subnetradar.com/subnet/87"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-87-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Luminar Network TaoMarketCap dashboard",
@@ -23385,38 +23593,6 @@
       "subnet_name": "Luminar Network",
       "subnet_slug": "sn-87",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_87/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-87-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Luminar Network Taostats metagraph",
-      "netuid": 87,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/87/metagraph"
-      ],
-      "subnet_name": "Luminar Network",
-      "subnet_slug": "sn-87",
-      "url": "https://taostats.io/subnets/87/metagraph"
     },
     {
       "auth_required": false,
@@ -23577,18 +23753,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-88-taomarketcap-dashboard",
+      "id": "sn-88-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Investing TaoMarketCap dashboard",
+      "name": "Investing SubnetRadar dashboard",
       "netuid": 88,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23600,11 +23776,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/88"
+        "https://subnetradar.com/subnet/88"
       ],
       "subnet_name": "Investing",
       "subnet_slug": "sn-88",
-      "url": "https://taomarketcap.com/subnets/88"
+      "url": "https://subnetradar.com/subnet/88"
     },
     {
       "auth_required": false,
@@ -23728,6 +23904,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-89-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "InfiniteHash SubnetRadar dashboard",
+      "netuid": 89,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/89"
+      ],
+      "subnet_name": "InfiniteHash",
+      "subnet_slug": "sn-89",
+      "url": "https://subnetradar.com/subnet/89"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-89-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "InfiniteHash TaoMarketCap dashboard",
@@ -23788,38 +23996,6 @@
       "subnet_name": "InfiniteHash",
       "subnet_slug": "sn-89",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_89/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-89-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "InfiniteHash Taostats metagraph",
-      "netuid": 89,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/89/metagraph"
-      ],
-      "subnet_name": "InfiniteHash",
-      "subnet_slug": "sn-89",
-      "url": "https://taostats.io/subnets/89/metagraph"
     },
     {
       "auth_required": false,
@@ -23935,6 +24111,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-90-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ogham SubnetRadar dashboard",
+      "netuid": 90,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/90"
+      ],
+      "subnet_name": "DegenBrain",
+      "subnet_slug": "sn-90",
+      "url": "https://subnetradar.com/subnet/90"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-90-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ogham TaoMarketCap dashboard",
@@ -23995,38 +24203,6 @@
       "subnet_name": "DegenBrain",
       "subnet_slug": "sn-90",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_90/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-90-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ogham Taostats metagraph",
-      "netuid": 90,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/90/metagraph"
-      ],
-      "subnet_name": "DegenBrain",
-      "subnet_slug": "sn-90",
-      "url": "https://taostats.io/subnets/90/metagraph"
     },
     {
       "auth_required": false,
@@ -24141,6 +24317,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-91-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Bitstarter #1 SubnetRadar dashboard",
+      "netuid": 91,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/91"
+      ],
+      "subnet_name": "Bitstarter #1",
+      "subnet_slug": "sn-91",
+      "url": "https://subnetradar.com/subnet/91"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-91-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Bitstarter #1 TaoMarketCap dashboard",
@@ -24201,38 +24409,6 @@
       "subnet_name": "Bitstarter #1",
       "subnet_slug": "sn-91",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_91/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-91-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Bitstarter #1 Taostats metagraph",
-      "netuid": 91,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/91/metagraph"
-      ],
-      "subnet_name": "Bitstarter #1",
-      "subnet_slug": "sn-91",
-      "url": "https://taostats.io/subnets/91/metagraph"
     },
     {
       "auth_required": false,
@@ -24301,6 +24477,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-92-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "luis SubnetRadar dashboard",
+      "netuid": 92,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/92"
+      ],
+      "subnet_name": "luis",
+      "subnet_slug": "sn-92",
+      "url": "https://subnetradar.com/subnet/92"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-92-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "SN92 TaoMarketCap dashboard",
@@ -24352,38 +24560,6 @@
       "subnet_name": "luis",
       "subnet_slug": "sn-92",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_92/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-92-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "luis Taostats metagraph",
-      "netuid": 92,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/92/metagraph"
-      ],
-      "subnet_name": "luis",
-      "subnet_slug": "sn-92",
-      "url": "https://taostats.io/subnets/92/metagraph"
     },
     {
       "auth_required": false,
@@ -24443,6 +24619,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-93-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Bitcast SubnetRadar dashboard",
+      "netuid": 93,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/93"
+      ],
+      "subnet_name": "Bitcast",
+      "subnet_slug": "sn-93",
+      "url": "https://subnetradar.com/subnet/93"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-93-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Bitcast TaoMarketCap dashboard",
@@ -24489,11 +24697,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -24567,38 +24776,6 @@
       "subnet_name": "Bitcast",
       "subnet_slug": "sn-93",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_93/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-93-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Bitcast Taostats metagraph",
-      "netuid": 93,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/93/metagraph"
-      ],
-      "subnet_name": "Bitcast",
-      "subnet_slug": "sn-93",
-      "url": "https://taostats.io/subnets/93/metagraph"
     },
     {
       "auth_required": false,
@@ -24732,6 +24909,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-94-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Bitsota SubnetRadar dashboard",
+      "netuid": 94,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/94"
+      ],
+      "subnet_name": "Bitsota",
+      "subnet_slug": "sn-94",
+      "url": "https://subnetradar.com/subnet/94"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-94-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Bitsota TaoMarketCap dashboard",
@@ -24778,11 +24987,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -24855,38 +25065,6 @@
       "subnet_name": "Bitsota",
       "subnet_slug": "sn-94",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_94/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-94-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Bitsota Taostats metagraph",
-      "netuid": 94,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/94/metagraph"
-      ],
-      "subnet_name": "Bitsota",
-      "subnet_slug": "sn-94",
-      "url": "https://taostats.io/subnets/94/metagraph"
     },
     {
       "auth_required": false,
@@ -24987,6 +25165,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-95-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Actual SubnetRadar dashboard",
+      "netuid": 95,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/95"
+      ],
+      "subnet_name": "Actual",
+      "subnet_slug": "sn-95",
+      "url": "https://subnetradar.com/subnet/95"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-95-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Actual TaoMarketCap dashboard",
@@ -25079,38 +25289,6 @@
       "subnet_name": "Actual",
       "subnet_slug": "sn-95",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_95/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-95-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Actual Taostats metagraph",
-      "netuid": 95,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/95/metagraph"
-      ],
-      "subnet_name": "Actual",
-      "subnet_slug": "sn-95",
-      "url": "https://taostats.io/subnets/95/metagraph"
     },
     {
       "auth_required": false,
@@ -25244,6 +25422,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-96-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Verathos SubnetRadar dashboard",
+      "netuid": 96,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/96"
+      ],
+      "subnet_name": "Verathos",
+      "subnet_slug": "sn-96",
+      "url": "https://subnetradar.com/subnet/96"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-96-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Verathos TaoMarketCap dashboard",
@@ -25290,38 +25500,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-96-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Verathos Taostats metagraph",
-      "netuid": 96,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/96/metagraph"
-      ],
-      "subnet_name": "Verathos",
-      "subnet_slug": "sn-96",
-      "url": "https://taostats.io/subnets/96/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-96-tensorplex-docs",
       "kind": "docs",
       "name": "Verathos Tensorplex subnet docs",
@@ -25359,11 +25537,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -25617,6 +25796,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-97-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Albedo SubnetRadar dashboard",
+      "netuid": 97,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/97"
+      ],
+      "subnet_name": "Albedo",
+      "subnet_slug": "sn-97",
+      "url": "https://subnetradar.com/subnet/97"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-97-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Albedo TaoMarketCap dashboard",
@@ -25663,11 +25874,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -25744,38 +25956,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-97-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Albedo Taostats metagraph",
-      "netuid": 97,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/97/metagraph"
-      ],
-      "subnet_name": "Albedo",
-      "subnet_slug": "sn-97",
-      "url": "https://taostats.io/subnets/97/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-97-tensorplex-docs",
       "kind": "docs",
       "name": "Albedo Tensorplex subnet docs",
@@ -25822,11 +26002,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -25983,6 +26164,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-98-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ForeverMoney SubnetRadar dashboard",
+      "netuid": 98,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/98"
+      ],
+      "subnet_name": "ForeverMoney",
+      "subnet_slug": "sn-98",
+      "url": "https://subnetradar.com/subnet/98"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-98-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ForeverMoney TaoMarketCap dashboard",
@@ -26043,38 +26256,6 @@
       "subnet_name": "ForeverMoney",
       "subnet_slug": "sn-98",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_98/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-98-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ForeverMoney Taostats metagraph",
-      "netuid": 98,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/98/metagraph"
-      ],
-      "subnet_name": "ForeverMoney",
-      "subnet_slug": "sn-98",
-      "url": "https://taostats.io/subnets/98/metagraph"
     },
     {
       "auth_required": false,
@@ -26143,11 +26324,11 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-98-website-subdomain-docs-docs-forevermoney-ai",
+      "id": "sn-98-website-link-forevermoney-ai-docs-2",
       "kind": "docs",
-      "name": "ForeverMoney docs subdomain",
+      "name": "ForeverMoney docs",
       "netuid": 98,
-      "notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "notes": "Discovered from a public project website link. Requires verification before promotion.",
       "probe": {
         "enabled": true,
         "expect": "any",
@@ -26239,6 +26420,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-99-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Leoma SubnetRadar dashboard",
+      "netuid": 99,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/99"
+      ],
+      "subnet_name": "Leoma",
+      "subnet_slug": "sn-99",
+      "url": "https://subnetradar.com/subnet/99"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-99-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Leoma TaoMarketCap dashboard",
@@ -26285,11 +26498,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -26366,38 +26580,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-99-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Leoma Taostats metagraph",
-      "netuid": 99,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/99/metagraph"
-      ],
-      "subnet_name": "Leoma",
-      "subnet_slug": "sn-99",
-      "url": "https://taostats.io/subnets/99/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-99-tensorplex-docs",
       "kind": "docs",
       "name": "Leoma Tensorplex subnet docs",
@@ -26444,11 +26626,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -26558,6 +26741,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-100-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Plaτform SubnetRadar dashboard",
+      "netuid": 100,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/100"
+      ],
+      "subnet_name": "Plaτform",
+      "subnet_slug": "sn-100",
+      "url": "https://subnetradar.com/subnet/100"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-100-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Plaτform TaoMarketCap dashboard",
@@ -26604,11 +26819,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -26685,38 +26901,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-100-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Plaτform Taostats metagraph",
-      "netuid": 100,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/100/metagraph"
-      ],
-      "subnet_name": "Plaτform",
-      "subnet_slug": "sn-100",
-      "url": "https://taostats.io/subnets/100/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-100-tensorplex-docs",
       "kind": "docs",
       "name": "Plaτform Tensorplex subnet docs",
@@ -26763,11 +26947,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -26876,6 +27061,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-101-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "eni SubnetRadar dashboard",
+      "netuid": 101,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/101"
+      ],
+      "subnet_name": "eni",
+      "subnet_slug": "sn-101",
+      "url": "https://subnetradar.com/subnet/101"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-101-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "eni TaoMarketCap dashboard",
@@ -26936,38 +27153,6 @@
       "subnet_name": "eni",
       "subnet_slug": "sn-101",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_101/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-101-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "eni Taostats metagraph",
-      "netuid": 101,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/101/metagraph"
-      ],
-      "subnet_name": "eni",
-      "subnet_slug": "sn-101",
-      "url": "https://taostats.io/subnets/101/metagraph"
     },
     {
       "auth_required": false,
@@ -27082,6 +27267,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-102-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ConnitoAI SubnetRadar dashboard",
+      "netuid": 102,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/102"
+      ],
+      "subnet_name": "ConnitoAI",
+      "subnet_slug": "sn-102",
+      "url": "https://subnetradar.com/subnet/102"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-102-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ConnitoAI TaoMarketCap dashboard",
@@ -27142,38 +27359,6 @@
       "subnet_name": "ConnitoAI",
       "subnet_slug": "sn-102",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_102/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-102-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ConnitoAI Taostats metagraph",
-      "netuid": 102,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/102/metagraph"
-      ],
-      "subnet_name": "ConnitoAI",
-      "subnet_slug": "sn-102",
-      "url": "https://taostats.io/subnets/102/metagraph"
     },
     {
       "auth_required": false,
@@ -27352,6 +27537,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-103-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Djinn SubnetRadar dashboard",
+      "netuid": 103,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/103"
+      ],
+      "subnet_name": "Djinn",
+      "subnet_slug": "sn-103",
+      "url": "https://subnetradar.com/subnet/103"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-103-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Djinn TaoMarketCap dashboard",
@@ -27444,38 +27661,6 @@
       "subnet_name": "Djinn",
       "subnet_slug": "sn-103",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_103/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-103-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Djinn Taostats metagraph",
-      "netuid": 103,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/103/metagraph"
-      ],
-      "subnet_name": "Djinn",
-      "subnet_slug": "sn-103",
-      "url": "https://taostats.io/subnets/103/metagraph"
     },
     {
       "auth_required": false,
@@ -27576,6 +27761,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-104-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "for sale (burn to uid1) SubnetRadar dashboard",
+      "netuid": 104,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/104"
+      ],
+      "subnet_name": "for sale (burn to uid1)",
+      "subnet_slug": "sn-104",
+      "url": "https://subnetradar.com/subnet/104"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-104-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "for sale (burn to uid1) TaoMarketCap dashboard",
@@ -27640,38 +27857,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-104-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "for sale (burn to uid1) Taostats metagraph",
-      "netuid": 104,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/104/metagraph"
-      ],
-      "subnet_name": "for sale (burn to uid1)",
-      "subnet_slug": "sn-104",
-      "url": "https://taostats.io/subnets/104/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-104-tensorplex-docs",
       "kind": "docs",
       "name": "for sale (burn to uid1) Tensorplex subnet docs",
@@ -27732,6 +27917,38 @@
       "subnet_name": "Beam",
       "subnet_slug": "sn-105",
       "url": "https://backprop.finance/dtao/subnets/105-beam"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-105-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Beam SubnetRadar dashboard",
+      "netuid": 105,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/105"
+      ],
+      "subnet_name": "Beam",
+      "subnet_slug": "sn-105",
+      "url": "https://subnetradar.com/subnet/105"
     },
     {
       "auth_required": false,
@@ -27860,38 +28077,6 @@
       "subnet_name": "Beam",
       "subnet_slug": "sn-105",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_105/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-105-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Beam Taostats metagraph",
-      "netuid": 105,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/105/metagraph"
-      ],
-      "subnet_name": "Beam",
-      "subnet_slug": "sn-105",
-      "url": "https://taostats.io/subnets/105/metagraph"
     },
     {
       "auth_required": false,
@@ -28025,6 +28210,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-106-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "VoidAI SubnetRadar dashboard",
+      "netuid": 106,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/106"
+      ],
+      "subnet_name": "VoidAI",
+      "subnet_slug": "sn-106",
+      "url": "https://subnetradar.com/subnet/106"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-106-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "VoidAI TaoMarketCap dashboard",
@@ -28071,11 +28288,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -28148,38 +28366,6 @@
       "subnet_name": "VoidAI",
       "subnet_slug": "sn-106",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_106/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-106-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "VoidAI Taostats metagraph",
-      "netuid": 106,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/106/metagraph"
-      ],
-      "subnet_name": "VoidAI",
-      "subnet_slug": "sn-106",
-      "url": "https://taostats.io/subnets/106/metagraph"
     },
     {
       "auth_required": false,
@@ -28312,6 +28498,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-107-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Minos SubnetRadar dashboard",
+      "netuid": 107,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/107"
+      ],
+      "subnet_name": "Minos",
+      "subnet_slug": "sn-107",
+      "url": "https://subnetradar.com/subnet/107"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-107-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Minos TaoMarketCap dashboard",
@@ -28358,11 +28576,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -28439,38 +28658,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-107-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Minos Taostats metagraph",
-      "netuid": 107,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/107/metagraph"
-      ],
-      "subnet_name": "Minos",
-      "subnet_slug": "sn-107",
-      "url": "https://taostats.io/subnets/107/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-107-tensorplex-docs",
       "kind": "docs",
       "name": "Minos Tensorplex subnet docs",
@@ -28517,11 +28704,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -28630,6 +28818,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-108-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "TalkHead SubnetRadar dashboard",
+      "netuid": 108,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/108"
+      ],
+      "subnet_name": "TalkHead",
+      "subnet_slug": "sn-108",
+      "url": "https://subnetradar.com/subnet/108"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-108-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "TalkHead TaoMarketCap dashboard",
@@ -28676,11 +28896,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -28754,38 +28975,6 @@
       "subnet_name": "TalkHead",
       "subnet_slug": "sn-108",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_108/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-108-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "TalkHead Taostats metagraph",
-      "netuid": 108,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/108/metagraph"
-      ],
-      "subnet_name": "TalkHead",
-      "subnet_slug": "sn-108",
-      "url": "https://taostats.io/subnets/108/metagraph"
     },
     {
       "auth_required": false,
@@ -28878,6 +29067,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-109-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Academia SubnetRadar dashboard",
+      "netuid": 109,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/109"
+      ],
+      "subnet_name": "Academia",
+      "subnet_slug": "sn-109",
+      "url": "https://subnetradar.com/subnet/109"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-109-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Academia TaoMarketCap dashboard",
@@ -28938,38 +29159,6 @@
       "subnet_name": "Academia",
       "subnet_slug": "sn-109",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_109/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-109-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Academia Taostats metagraph",
-      "netuid": 109,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/109/metagraph"
-      ],
-      "subnet_name": "Academia",
-      "subnet_slug": "sn-109",
-      "url": "https://taostats.io/subnets/109/metagraph"
     },
     {
       "auth_required": false,
@@ -29102,6 +29291,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-110-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Green Compute SubnetRadar dashboard",
+      "netuid": 110,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/110"
+      ],
+      "subnet_name": "Green Compute",
+      "subnet_slug": "sn-110",
+      "url": "https://subnetradar.com/subnet/110"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-110-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Green Compute TaoMarketCap dashboard",
@@ -29144,38 +29365,6 @@
       "subnet_name": "Green Compute",
       "subnet_slug": "sn-110",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_110/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-110-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Green Compute Taostats metagraph",
-      "netuid": 110,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/110/metagraph"
-      ],
-      "subnet_name": "Green Compute",
-      "subnet_slug": "sn-110",
-      "url": "https://taostats.io/subnets/110/metagraph"
     },
     {
       "auth_required": false,
@@ -29369,6 +29558,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-111-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "oneoneone SubnetRadar dashboard",
+      "netuid": 111,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/111"
+      ],
+      "subnet_name": "oneoneone",
+      "subnet_slug": "sn-111",
+      "url": "https://subnetradar.com/subnet/111"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-111-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "oneoneone TaoMarketCap dashboard",
@@ -29429,38 +29650,6 @@
       "subnet_name": "oneoneone",
       "subnet_slug": "sn-111",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_111/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-111-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "oneoneone Taostats metagraph",
-      "netuid": 111,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/111/metagraph"
-      ],
-      "subnet_name": "oneoneone",
-      "subnet_slug": "sn-111",
-      "url": "https://taostats.io/subnets/111/metagraph"
     },
     {
       "auth_required": false,
@@ -29529,6 +29718,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-112-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "minotaur SubnetRadar dashboard",
+      "netuid": 112,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/112"
+      ],
+      "subnet_name": "minotaur",
+      "subnet_slug": "sn-112",
+      "url": "https://subnetradar.com/subnet/112"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-112-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "minotaur TaoMarketCap dashboard",
@@ -29575,11 +29796,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -29657,38 +29879,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-112-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "minotaur Taostats metagraph",
-      "netuid": 112,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/112/metagraph"
-      ],
-      "subnet_name": "minotaur",
-      "subnet_slug": "sn-112",
-      "url": "https://taostats.io/subnets/112/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-112-tensorplex-docs",
       "kind": "docs",
       "name": "minotaur Tensorplex subnet docs",
@@ -29721,6 +29911,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-112-website-subdomain-docs-docs-minotaursubnet-com",
+      "kind": "docs",
+      "name": "minotaur docs subdomain",
+      "netuid": 112,
+      "notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://minotaursubnet.com/"
+      ],
+      "subnet_name": "minotaur",
+      "subnet_slug": "sn-112",
+      "url": "https://docs.minotaursubnet.com/"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-113-backprop-dashboard",
       "kind": "dashboard",
       "name": "TensorUSD Backprop Finance dashboard",
@@ -29749,6 +29971,38 @@
       "subnet_name": "TensorUSD",
       "subnet_slug": "sn-113",
       "url": "https://backprop.finance/dtao/subnets/113-tensorusd"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-113-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "TensorUSD SubnetRadar dashboard",
+      "netuid": 113,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/113"
+      ],
+      "subnet_name": "TensorUSD",
+      "subnet_slug": "sn-113",
+      "url": "https://subnetradar.com/subnet/113"
     },
     {
       "auth_required": false,
@@ -29813,38 +30067,6 @@
       "subnet_name": "TensorUSD",
       "subnet_slug": "sn-113",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_113/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-113-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "TensorUSD Taostats metagraph",
-      "netuid": 113,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/113/metagraph"
-      ],
-      "subnet_name": "TensorUSD",
-      "subnet_slug": "sn-113",
-      "url": "https://taostats.io/subnets/113/metagraph"
     },
     {
       "auth_required": false,
@@ -30014,6 +30236,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-114-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "SOMA SubnetRadar dashboard",
+      "netuid": 114,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/114"
+      ],
+      "subnet_name": "SOMA",
+      "subnet_slug": "sn-114",
+      "url": "https://subnetradar.com/subnet/114"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-114-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "SOMA TaoMarketCap dashboard",
@@ -30060,11 +30314,12 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -30141,38 +30396,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-114-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "SOMA Taostats metagraph",
-      "netuid": 114,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/114/metagraph"
-      ],
-      "subnet_name": "SOMA",
-      "subnet_slug": "sn-114",
-      "url": "https://taostats.io/subnets/114/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-114-tensorplex-docs",
       "kind": "docs",
       "name": "SOMA Tensorplex subnet docs",
@@ -30219,11 +30442,12 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -30324,6 +30548,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-115-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "HashiChain SubnetRadar dashboard",
+      "netuid": 115,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/115"
+      ],
+      "subnet_name": "HashiChain",
+      "subnet_slug": "sn-115",
+      "url": "https://subnetradar.com/subnet/115"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-115-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "HashiChain TaoMarketCap dashboard",
@@ -30388,38 +30644,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-115-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "HashiChain Taostats metagraph",
-      "netuid": 115,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/115/metagraph"
-      ],
-      "subnet_name": "HashiChain",
-      "subnet_slug": "sn-115",
-      "url": "https://taostats.io/subnets/115/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-115-tensorplex-docs",
       "kind": "docs",
       "name": "HashiChain Tensorplex subnet docs",
@@ -30477,9 +30701,64 @@
       "source_urls": [
         "https://backprop.finance/dtao/subnets/116-hard-sign"
       ],
-      "subnet_name": "hard_sign",
-      "subnet_slug": "sn-116",
+      "subnet_name": "TaoLend",
+      "subnet_slug": "taolend",
       "url": "https://backprop.finance/dtao/subnets/116-hard-sign"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-116-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "hard_sign SubnetRadar dashboard",
+      "netuid": 116,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/116"
+      ],
+      "subnet_name": "TaoLend",
+      "subnet_slug": "taolend",
+      "url": "https://subnetradar.com/subnet/116"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "id": "sn-116-taolend-website",
+      "kind": "website",
+      "name": "TaoLend website",
+      "netuid": 116,
+      "notes": "Official TaoLend website. Current probe state is expected to show degraded while the origin returns server errors.",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taolend",
+      "public_safe": true,
+      "source_urls": [
+        "https://taolend.io/"
+      ],
+      "subnet_name": "TaoLend",
+      "subnet_slug": "taolend",
+      "url": "https://taolend.io/"
     },
     {
       "auth_required": false,
@@ -30509,8 +30788,8 @@
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/116"
       ],
-      "subnet_name": "hard_sign",
-      "subnet_slug": "sn-116",
+      "subnet_name": "TaoLend",
+      "subnet_slug": "taolend",
       "url": "https://taomarketcap.com/subnets/116"
     },
     {
@@ -30541,41 +30820,9 @@
       "source_urls": [
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx"
       ],
-      "subnet_name": "hard_sign",
-      "subnet_slug": "sn-116",
+      "subnet_name": "TaoLend",
+      "subnet_slug": "taolend",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-116-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "hard_sign Taostats metagraph",
-      "netuid": 116,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/116/metagraph"
-      ],
-      "subnet_name": "hard_sign",
-      "subnet_slug": "sn-116",
-      "url": "https://taostats.io/subnets/116/metagraph"
     },
     {
       "auth_required": false,
@@ -30605,8 +30852,8 @@
       "source_urls": [
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/116/subnet.json"
       ],
-      "subnet_name": "hard_sign",
-      "subnet_slug": "sn-116",
+      "subnet_name": "TaoLend",
+      "subnet_slug": "taolend",
       "url": "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/116"
     },
     {
@@ -30688,6 +30935,38 @@
       "subnet_name": "BrainPlay",
       "subnet_slug": "sn-117",
       "url": "https://github.com/shiftlayer-llc/brainplay-subnet"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-117-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "BrainPlay SubnetRadar dashboard",
+      "netuid": 117,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/117"
+      ],
+      "subnet_name": "BrainPlay",
+      "subnet_slug": "sn-117",
+      "url": "https://subnetradar.com/subnet/117"
     },
     {
       "auth_required": false,
@@ -30787,38 +31066,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-117-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "BrainPlay Taostats metagraph",
-      "netuid": 117,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/117/metagraph"
-      ],
-      "subnet_name": "BrainPlay",
-      "subnet_slug": "sn-117",
-      "url": "https://taostats.io/subnets/117/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-117-tensorplex-docs",
       "kind": "docs",
       "name": "BrainPlay Tensorplex subnet docs",
@@ -30879,6 +31126,38 @@
       "subnet_name": "Ditto",
       "subnet_slug": "sn-118",
       "url": "https://backprop.finance/dtao/subnets/118-ditto"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-118-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Ditto SubnetRadar dashboard",
+      "netuid": 118,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/118"
+      ],
+      "subnet_name": "Ditto",
+      "subnet_slug": "sn-118",
+      "url": "https://subnetradar.com/subnet/118"
     },
     {
       "auth_required": false,
@@ -31007,38 +31286,6 @@
       "subnet_name": "Ditto",
       "subnet_slug": "sn-118",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_118/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-118-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Ditto Taostats metagraph",
-      "netuid": 118,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/118/metagraph"
-      ],
-      "subnet_name": "Ditto",
-      "subnet_slug": "sn-118",
-      "url": "https://taostats.io/subnets/118/metagraph"
     },
     {
       "auth_required": false,
@@ -31202,6 +31449,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-119-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Satori SubnetRadar dashboard",
+      "netuid": 119,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/119"
+      ],
+      "subnet_name": "Satori",
+      "subnet_slug": "sn-119",
+      "url": "https://subnetradar.com/subnet/119"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-119-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Satori TaoMarketCap dashboard",
@@ -31262,38 +31541,6 @@
       "subnet_name": "Satori",
       "subnet_slug": "sn-119",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_119/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-119-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Satori Taostats metagraph",
-      "netuid": 119,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/119/metagraph"
-      ],
-      "subnet_name": "Satori",
-      "subnet_slug": "sn-119",
-      "url": "https://taostats.io/subnets/119/metagraph"
     },
     {
       "auth_required": false,
@@ -31394,18 +31641,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-120-taomarketcap-dashboard",
+      "id": "sn-120-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Affine TaoMarketCap dashboard",
+      "name": "Affine SubnetRadar dashboard",
       "netuid": 120,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31417,11 +31664,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/120"
+        "https://subnetradar.com/subnet/120"
       ],
       "subnet_name": "Affine",
       "subnet_slug": "sn-120",
-      "url": "https://taomarketcap.com/subnets/120"
+      "url": "https://subnetradar.com/subnet/120"
     },
     {
       "auth_required": false,
@@ -31585,6 +31832,38 @@
     },
     {
       "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-121-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "sundae_bar SubnetRadar dashboard",
+      "netuid": 121,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/121"
+      ],
+      "subnet_name": "sundae_bar",
+      "subnet_slug": "sn-121",
+      "url": "https://subnetradar.com/subnet/121"
+    },
+    {
+      "auth_required": false,
       "authority": "official",
       "id": "sn-121-sundae-bar-source",
       "kind": "source-repo",
@@ -31692,38 +31971,6 @@
       "subnet_name": "sundae_bar",
       "subnet_slug": "sn-121",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_121/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-121-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "sundae_bar Taostats metagraph",
-      "netuid": 121,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/121/metagraph"
-      ],
-      "subnet_name": "sundae_bar",
-      "subnet_slug": "sn-121",
-      "url": "https://taostats.io/subnets/121/metagraph"
     },
     {
       "auth_required": false,
@@ -31862,6 +32109,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-122-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "gamma_small SubnetRadar dashboard",
+      "netuid": 122,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/122"
+      ],
+      "subnet_name": "Bitrecs",
+      "subnet_slug": "sn-122",
+      "url": "https://subnetradar.com/subnet/122"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-122-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "gamma_small TaoMarketCap dashboard",
@@ -31922,38 +32201,6 @@
       "subnet_name": "Bitrecs",
       "subnet_slug": "sn-122",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_122/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-122-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "gamma_small Taostats metagraph",
-      "netuid": 122,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/122/metagraph"
-      ],
-      "subnet_name": "Bitrecs",
-      "subnet_slug": "sn-122",
-      "url": "https://taostats.io/subnets/122/metagraph"
     },
     {
       "auth_required": false,
@@ -32046,6 +32293,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-123-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "MANTIS SubnetRadar dashboard",
+      "netuid": 123,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/123"
+      ],
+      "subnet_name": "MANTIS",
+      "subnet_slug": "sn-123",
+      "url": "https://subnetradar.com/subnet/123"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-123-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "MANTIS TaoMarketCap dashboard",
@@ -32106,38 +32385,6 @@
       "subnet_name": "MANTIS",
       "subnet_slug": "sn-123",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-123-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "MANTIS Taostats metagraph",
-      "netuid": 123,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/123/metagraph"
-      ],
-      "subnet_name": "MANTIS",
-      "subnet_slug": "sn-123",
-      "url": "https://taostats.io/subnets/123/metagraph"
     },
     {
       "auth_required": false,
@@ -32238,18 +32485,18 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-124-taomarketcap-dashboard",
+      "id": "sn-124-subnetradar-dashboard",
       "kind": "dashboard",
-      "name": "Swarm TaoMarketCap dashboard",
+      "name": "Swarm SubnetRadar dashboard",
       "netuid": 124,
-      "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority.",
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
       "probe": {
         "enabled": true,
         "expect": "any",
         "method": "HEAD",
         "timeout_ms": 10000
       },
-      "provider": "taomarketcap",
+      "provider": "subnetradar",
       "public_safe": true,
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32261,11 +32508,11 @@
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/124"
+        "https://subnetradar.com/subnet/124"
       ],
       "subnet_name": "Swarm",
       "subnet_slug": "sn-124",
-      "url": "https://taomarketcap.com/subnets/124"
+      "url": "https://subnetradar.com/subnet/124"
     },
     {
       "auth_required": false,
@@ -32495,6 +32742,38 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
+      "id": "sn-125-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "8 Ball SubnetRadar dashboard",
+      "netuid": 125,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/125"
+      ],
+      "subnet_name": "8 Ball",
+      "subnet_slug": "sn-125",
+      "url": "https://subnetradar.com/subnet/125"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
       "id": "sn-125-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "8 Ball TaoMarketCap dashboard",
@@ -32559,38 +32838,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-125-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "8 Ball Taostats metagraph",
-      "netuid": 125,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/125/metagraph"
-      ],
-      "subnet_name": "8 Ball",
-      "subnet_slug": "sn-125",
-      "url": "https://taostats.io/subnets/125/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-125-tensorplex-docs",
       "kind": "docs",
       "name": "8 Ball Tensorplex subnet docs",
@@ -32651,6 +32898,38 @@
       "subnet_name": "Poker44",
       "subnet_slug": "sn-126",
       "url": "https://backprop.finance/dtao/subnets/126-poker44"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-126-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Poker44 SubnetRadar dashboard",
+      "netuid": 126,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/126"
+      ],
+      "subnet_name": "Poker44",
+      "subnet_slug": "sn-126",
+      "url": "https://subnetradar.com/subnet/126"
     },
     {
       "auth_required": false,
@@ -32782,38 +33061,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-126-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Poker44 Taostats metagraph",
-      "netuid": 126,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/126/metagraph"
-      ],
-      "subnet_name": "Poker44",
-      "subnet_slug": "sn-126",
-      "url": "https://taostats.io/subnets/126/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-126-tensorplex-docs",
       "kind": "docs",
       "name": "Poker44 Tensorplex subnet docs",
@@ -32874,6 +33121,38 @@
       "subnet_name": "Astrid",
       "subnet_slug": "sn-127",
       "url": "https://backprop.finance/dtao/subnets/127-astrid"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-127-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Astrid SubnetRadar dashboard",
+      "netuid": 127,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/127"
+      ],
+      "subnet_name": "Astrid",
+      "subnet_slug": "sn-127",
+      "url": "https://subnetradar.com/subnet/127"
     },
     {
       "auth_required": false,
@@ -33005,38 +33284,6 @@
     {
       "auth_required": false,
       "authority": "registry-observed",
-      "id": "sn-127-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "Astrid Taostats metagraph",
-      "netuid": 127,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/127/metagraph"
-      ],
-      "subnet_name": "Astrid",
-      "subnet_slug": "sn-127",
-      "url": "https://taostats.io/subnets/127/metagraph"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
       "id": "sn-127-tensorplex-docs",
       "kind": "docs",
       "name": "Astrid Tensorplex subnet docs",
@@ -33097,6 +33344,38 @@
       "subnet_name": "ByteLeap",
       "subnet_slug": "sn-128",
       "url": "https://backprop.finance/dtao/subnets/128-byteleap"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "id": "sn-128-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ByteLeap SubnetRadar dashboard",
+      "netuid": 128,
+      "notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "subnetradar",
+      "public_safe": true,
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "source_urls": [
+        "https://subnetradar.com/subnet/128"
+      ],
+      "subnet_name": "ByteLeap",
+      "subnet_slug": "sn-128",
+      "url": "https://subnetradar.com/subnet/128"
     },
     {
       "auth_required": false,
@@ -33225,38 +33504,6 @@
       "subnet_name": "ByteLeap",
       "subnet_slug": "sn-128",
       "url": "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_128/index.mdx"
-    },
-    {
-      "auth_required": false,
-      "authority": "registry-observed",
-      "id": "sn-128-taostats-metagraph",
-      "kind": "dashboard",
-      "name": "ByteLeap Taostats metagraph",
-      "netuid": 128,
-      "notes": "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
-      "probe": {
-        "enabled": true,
-        "expect": "any",
-        "method": "HEAD",
-        "timeout_ms": 10000
-      },
-      "provider": "taostats",
-      "public_safe": true,
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
-      },
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "source_urls": [
-        "https://taostats.io/subnets/128/metagraph"
-      ],
-      "subnet_name": "ByteLeap",
-      "subnet_slug": "sn-128",
-      "url": "https://taostats.io/subnets/128/metagraph"
     },
     {
       "auth_required": false,

--- a/registry/candidates/generated/public-sources.json
+++ b/registry/candidates/generated/public-sources.json
@@ -24,6 +24,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-0-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "root SubnetRadar dashboard",
+      "netuid": 0,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/0",
+      "source_urls": [
+        "https://subnetradar.com/subnet/0"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/0"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-0-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "root TaoMarketCap dashboard",
@@ -104,6 +125,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/1-apex"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-1-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Apex SubnetRadar dashboard",
+      "netuid": 1,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/1",
+      "source_urls": [
+        "https://subnetradar.com/subnet/1"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/1"
     },
     {
       "auth_required": false,
@@ -572,6 +614,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-2-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "DSperse SubnetRadar dashboard",
+      "netuid": 2,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/2",
+      "source_urls": [
+        "https://subnetradar.com/subnet/2"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/2"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-2-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "DSperse TaoMarketCap dashboard",
@@ -867,6 +930,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-3-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "deprecated SubnetRadar dashboard",
+      "netuid": 3,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/3",
+      "source_urls": [
+        "https://subnetradar.com/subnet/3"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/3"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-3-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "deprecated TaoMarketCap dashboard",
@@ -989,6 +1073,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/4-targon"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-4-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Targon SubnetRadar dashboard",
+      "netuid": 4,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/4",
+      "source_urls": [
+        "https://subnetradar.com/subnet/4"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/4"
     },
     {
       "auth_required": false,
@@ -1140,6 +1245,27 @@
     {
       "auth_required": false,
       "confidence": "low",
+      "id": "sn-4-website-link-targon-com-docs-4",
+      "kind": "docs",
+      "name": "Targon docs",
+      "netuid": 4,
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Discovered from a public project website link. Requires verification before promotion.",
+      "schema_version": 1,
+      "source_tier": "provider-claimed",
+      "source_type": "project-website-link",
+      "source_url": "https://targon.com/",
+      "source_urls": [
+        "https://targon.com/"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.targon.com/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "low",
       "id": "sn-4-website-link-targon-com-docs-9",
       "kind": "docs",
       "name": "Targon docs",
@@ -1157,27 +1283,6 @@
       ],
       "state": "schema-valid",
       "url": "https://targon.com/releases/intel-whitepaper"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-4-website-subdomain-docs-docs-targon-com",
-      "kind": "docs",
-      "name": "Targon docs subdomain",
-      "netuid": 4,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://targon.com/",
-      "source_urls": [
-        "https://targon.com/"
-      ],
-      "state": "schema-valid",
-      "url": "https://docs.targon.com/"
     },
     {
       "auth_required": false,
@@ -1494,6 +1599,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/5-hone"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-5-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Hone SubnetRadar dashboard",
+      "netuid": 5,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/5",
+      "source_urls": [
+        "https://subnetradar.com/subnet/5"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/5"
     },
     {
       "auth_required": false,
@@ -1877,6 +2003,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-6-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Numinous SubnetRadar dashboard",
+      "netuid": 6,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/6",
+      "source_urls": [
+        "https://subnetradar.com/subnet/6"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/6"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-6-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Numinous TaoMarketCap dashboard",
@@ -2235,6 +2382,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-7-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Allways SubnetRadar dashboard",
+      "netuid": 7,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/7",
+      "source_urls": [
+        "https://subnetradar.com/subnet/7"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/7"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-7-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Allways TaoMarketCap dashboard",
@@ -2505,6 +2673,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/8-vanta"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-8-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Vanta SubnetRadar dashboard",
+      "netuid": 8,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/8",
+      "source_urls": [
+        "https://subnetradar.com/subnet/8"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/8"
     },
     {
       "auth_required": false,
@@ -2867,6 +3056,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-9-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "iota SubnetRadar dashboard",
+      "netuid": 9,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/9",
+      "source_urls": [
+        "https://subnetradar.com/subnet/9"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/9"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-9-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "iota TaoMarketCap dashboard",
@@ -3073,27 +3283,6 @@
       ],
       "state": "schema-valid",
       "url": "https://docs.macrocosmos.ai/product-and-services/tah"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-9-website-subdomain-docs-docs-iota-macrocosmos-ai",
-      "kind": "docs",
-      "name": "iota docs subdomain",
-      "netuid": 9,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://iota.macrocosmos.ai/",
-      "source_urls": [
-        "https://iota.macrocosmos.ai/"
-      ],
-      "state": "schema-valid",
-      "url": "https://docs.iota.macrocosmos.ai/"
     },
     {
       "auth_required": false,
@@ -3351,6 +3540,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-10-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Swap SubnetRadar dashboard",
+      "netuid": 10,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/10",
+      "source_urls": [
+        "https://subnetradar.com/subnet/10"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/10"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-10-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Swap TaoMarketCap dashboard",
@@ -3452,6 +3662,27 @@
       ],
       "state": "schema-valid",
       "url": "https://www.taofi.com/docs"
+    },
+    {
+      "auth_required": false,
+      "confidence": "low",
+      "id": "sn-10-website-subdomain-docs-docs-taofi-com",
+      "kind": "docs",
+      "name": "Swap docs subdomain",
+      "netuid": 10,
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "schema_version": 1,
+      "source_tier": "provider-claimed",
+      "source_type": "project-website-docs-subdomain",
+      "source_url": "https://www.taofi.com/pool",
+      "source_urls": [
+        "https://www.taofi.com/pool"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.taofi.com/"
     },
     {
       "auth_required": false,
@@ -3621,6 +3852,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/11-trajectoryrl"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-11-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "TrajectoryRL SubnetRadar dashboard",
+      "netuid": 11,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/11",
+      "source_urls": [
+        "https://subnetradar.com/subnet/11"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/11"
     },
     {
       "auth_required": false,
@@ -3983,6 +4235,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-12-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Compute Horde SubnetRadar dashboard",
+      "netuid": 12,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/12",
+      "source_urls": [
+        "https://subnetradar.com/subnet/12"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/12"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-12-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Compute Horde TaoMarketCap dashboard",
@@ -4148,6 +4421,27 @@
       ],
       "state": "schema-valid",
       "url": "https://sn13-dashboard.api.macrocosmos.ai/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-13-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Data Universe SubnetRadar dashboard",
+      "netuid": 13,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/13",
+      "source_urls": [
+        "https://subnetradar.com/subnet/13"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/13"
     },
     {
       "auth_required": false,
@@ -4615,6 +4909,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-14-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Cacheon SubnetRadar dashboard",
+      "netuid": 14,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/14",
+      "source_urls": [
+        "https://subnetradar.com/subnet/14"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/14"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-14-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Cacheon TaoMarketCap dashboard",
@@ -5011,6 +5326,27 @@
       ],
       "state": "schema-valid",
       "url": "https://oroagents.com/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-15-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ORO SubnetRadar dashboard",
+      "netuid": 15,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/15",
+      "source_urls": [
+        "https://subnetradar.com/subnet/15"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/15"
     },
     {
       "auth_required": false,
@@ -5436,6 +5772,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-16-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "BitAds SubnetRadar dashboard",
+      "netuid": 16,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/16",
+      "source_urls": [
+        "https://subnetradar.com/subnet/16"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/16"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-16-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "BitAds TaoMarketCap dashboard",
@@ -5726,6 +6083,27 @@
       ],
       "state": "schema-valid",
       "url": "https://dashboard.404.xyz/d/main/404-gen"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-17-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "404—GEN SubnetRadar dashboard",
+      "netuid": 17,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/17",
+      "source_urls": [
+        "https://subnetradar.com/subnet/17"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/17"
     },
     {
       "auth_required": false,
@@ -6108,6 +6486,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-18-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Zeus SubnetRadar dashboard",
+      "netuid": 18,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/18",
+      "source_urls": [
+        "https://subnetradar.com/subnet/18"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/18"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-18-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Zeus TaoMarketCap dashboard",
@@ -6483,6 +6882,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/19-blockmachine"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-19-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "blockmachine SubnetRadar dashboard",
+      "netuid": 19,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/19",
+      "source_urls": [
+        "https://subnetradar.com/subnet/19"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/19"
     },
     {
       "auth_required": false,
@@ -6972,6 +7392,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-20-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "GroundLayer SubnetRadar dashboard",
+      "netuid": 20,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/20",
+      "source_urls": [
+        "https://subnetradar.com/subnet/20"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/20"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-20-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "GroundLayer TaoMarketCap dashboard",
@@ -7283,6 +7724,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/21-adtao"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-21-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "AdTAO SubnetRadar dashboard",
+      "netuid": 21,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/21",
+      "source_urls": [
+        "https://subnetradar.com/subnet/21"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/21"
     },
     {
       "auth_required": false,
@@ -7770,6 +8232,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-22-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Desearch SubnetRadar dashboard",
+      "netuid": 22,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/22",
+      "source_urls": [
+        "https://subnetradar.com/subnet/22"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/22"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-22-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Desearch TaoMarketCap dashboard",
@@ -8066,6 +8549,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-23-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Trishool SubnetRadar dashboard",
+      "netuid": 23,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/23",
+      "source_urls": [
+        "https://subnetradar.com/subnet/23"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/23"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-23-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Trishool TaoMarketCap dashboard",
@@ -8171,6 +8675,27 @@
     {
       "auth_required": false,
       "confidence": "low",
+      "id": "sn-23-website-link-trishool-ai-docs-1",
+      "kind": "docs",
+      "name": "Trishool docs",
+      "netuid": 23,
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Discovered from a public project website link. Requires verification before promotion.",
+      "schema_version": 1,
+      "source_tier": "provider-claimed",
+      "source_type": "project-website-link",
+      "source_url": "https://trishool.ai/",
+      "source_urls": [
+        "https://trishool.ai/"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.trishool.ai/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "low",
       "id": "sn-23-website-link-trishool-ai-docs-2",
       "kind": "docs",
       "name": "Trishool docs",
@@ -8188,27 +8713,6 @@
       ],
       "state": "schema-valid",
       "url": "https://litepaper.trishool.ai/"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-23-website-subdomain-docs-docs-trishool-ai",
-      "kind": "docs",
-      "name": "Trishool docs subdomain",
-      "netuid": 23,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://trishool.ai/",
-      "source_urls": [
-        "https://trishool.ai/"
-      ],
-      "state": "schema-valid",
-      "url": "https://docs.trishool.ai/"
     },
     {
       "auth_required": false,
@@ -8420,6 +8924,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/24-quasar"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-24-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Quasar SubnetRadar dashboard",
+      "netuid": 24,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/24",
+      "source_urls": [
+        "https://subnetradar.com/subnet/24"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/24"
     },
     {
       "auth_required": false,
@@ -8803,6 +9328,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-25-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Mainframe SubnetRadar dashboard",
+      "netuid": 25,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/25",
+      "source_urls": [
+        "https://subnetradar.com/subnet/25"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/25"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-25-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Mainframe TaoMarketCap dashboard",
@@ -8929,6 +9475,27 @@
     {
       "auth_required": false,
       "confidence": "low",
+      "id": "sn-25-website-link-macrocosmos-ai-docs-3",
+      "kind": "docs",
+      "name": "Mainframe docs",
+      "netuid": 25,
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Discovered from a public project website link. Requires verification before promotion.",
+      "schema_version": 1,
+      "source_tier": "provider-claimed",
+      "source_type": "project-website-link",
+      "source_url": "https://macrocosmos.ai/sn25",
+      "source_urls": [
+        "https://macrocosmos.ai/sn25"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.macrocosmos.ai/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "low",
       "id": "sn-25-website-link-macrocosmos-ai-docs-6",
       "kind": "docs",
       "name": "Mainframe docs",
@@ -8946,27 +9513,6 @@
       ],
       "state": "schema-valid",
       "url": "https://macrocosmos.ai/delegation-guide"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-25-website-subdomain-docs-docs-macrocosmos-ai",
-      "kind": "docs",
-      "name": "Mainframe docs subdomain",
-      "netuid": 25,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://macrocosmos.ai/sn25",
-      "source_urls": [
-        "https://macrocosmos.ai/sn25"
-      ],
-      "state": "schema-valid",
-      "url": "https://docs.macrocosmos.ai/"
     },
     {
       "auth_required": false,
@@ -9262,6 +9808,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/26-perturb"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-26-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Perturb SubnetRadar dashboard",
+      "netuid": 26,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/26",
+      "source_urls": [
+        "https://subnetradar.com/subnet/26"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/26"
     },
     {
       "auth_required": false,
@@ -9623,6 +10190,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-27-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Nodexo SubnetRadar dashboard",
+      "netuid": 27,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/27",
+      "source_urls": [
+        "https://subnetradar.com/subnet/27"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/27"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-27-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Nodexo TaoMarketCap dashboard",
@@ -9724,27 +10312,6 @@
       ],
       "state": "schema-valid",
       "url": "https://nodexo.ai/docs"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-27-website-subdomain-docs-docs-nodexo-ai",
-      "kind": "docs",
-      "name": "Nodexo docs subdomain",
-      "netuid": 27,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://nodexo.ai/",
-      "source_urls": [
-        "https://nodexo.ai/"
-      ],
-      "state": "schema-valid",
-      "url": "https://docs.nodexo.ai/"
     },
     {
       "auth_required": false,
@@ -9918,6 +10485,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-28-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "gm SubnetRadar dashboard",
+      "netuid": 28,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/28",
+      "source_urls": [
+        "https://subnetradar.com/subnet/28"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/28"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-28-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "gm TaoMarketCap dashboard",
@@ -10019,6 +10607,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/29-coldint"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-29-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Coldint SubnetRadar dashboard",
+      "netuid": 29,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/29",
+      "source_urls": [
+        "https://subnetradar.com/subnet/29"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/29"
     },
     {
       "auth_required": false,
@@ -10167,6 +10776,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/30-endure-network"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-30-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Endure Network SubnetRadar dashboard",
+      "netuid": 30,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/30",
+      "source_urls": [
+        "https://subnetradar.com/subnet/30"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/30"
     },
     {
       "auth_required": false,
@@ -10465,6 +11095,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-31-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Recall SubnetRadar dashboard",
+      "netuid": 31,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/31",
+      "source_urls": [
+        "https://subnetradar.com/subnet/31"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/31"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-31-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Recall TaoMarketCap dashboard",
@@ -10570,6 +11221,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-32-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ItsAI SubnetRadar dashboard",
+      "netuid": 32,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/32",
+      "source_urls": [
+        "https://subnetradar.com/subnet/32"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/32"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-32-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ItsAI TaoMarketCap dashboard",
@@ -10671,27 +11343,6 @@
       ],
       "state": "schema-valid",
       "url": "https://its-ai.org/docs"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-32-website-subdomain-docs-docs-its-ai-org",
-      "kind": "docs",
-      "name": "ItsAI docs subdomain",
-      "netuid": 32,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://its-ai.org/en",
-      "source_urls": [
-        "https://its-ai.org/en"
-      ],
-      "state": "schema-valid",
-      "url": "https://docs.its-ai.org/"
     },
     {
       "auth_required": false,
@@ -11075,6 +11726,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-33-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ReadyAI SubnetRadar dashboard",
+      "netuid": 33,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/33",
+      "source_urls": [
+        "https://subnetradar.com/subnet/33"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/33"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-33-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ReadyAI TaoMarketCap dashboard",
@@ -11244,6 +11916,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-34-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "BitMind SubnetRadar dashboard",
+      "netuid": 34,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/34",
+      "source_urls": [
+        "https://subnetradar.com/subnet/34"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/34"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-34-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "BitMind TaoMarketCap dashboard",
@@ -11371,6 +12064,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-35-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "OxMarkets SubnetRadar dashboard",
+      "netuid": 35,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/35",
+      "source_urls": [
+        "https://subnetradar.com/subnet/35"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/35"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-35-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "OxMarkets TaoMarketCap dashboard",
@@ -11472,6 +12186,27 @@
       ],
       "state": "schema-valid",
       "url": "https://www.0xmarkets.io/docs"
+    },
+    {
+      "auth_required": false,
+      "confidence": "low",
+      "id": "sn-35-website-subdomain-docs-docs-0xmarkets-io",
+      "kind": "docs",
+      "name": "OxMarkets docs subdomain",
+      "netuid": 35,
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "schema_version": 1,
+      "source_tier": "provider-claimed",
+      "source_type": "project-website-docs-subdomain",
+      "source_url": "https://www.0xmarkets.io/",
+      "source_urls": [
+        "https://www.0xmarkets.io/"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.0xmarkets.io/"
     },
     {
       "auth_required": false,
@@ -11661,6 +12396,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/36-eirel"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-36-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Eirel SubnetRadar dashboard",
+      "netuid": 36,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/36",
+      "source_urls": [
+        "https://subnetradar.com/subnet/36"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/36"
     },
     {
       "auth_required": false,
@@ -12018,6 +12774,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/37-aurelius"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-37-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Aurelius SubnetRadar dashboard",
+      "netuid": 37,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/37",
+      "source_urls": [
+        "https://subnetradar.com/subnet/37"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/37"
     },
     {
       "auth_required": false,
@@ -12400,6 +13177,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-38-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "colosseum SubnetRadar dashboard",
+      "netuid": 38,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/38",
+      "source_urls": [
+        "https://subnetradar.com/subnet/38"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/38"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-38-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "colosseum TaoMarketCap dashboard",
@@ -12674,6 +13472,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-39-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "deprecated SubnetRadar dashboard",
+      "netuid": 39,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/39",
+      "source_urls": [
+        "https://subnetradar.com/subnet/39"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/39"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-39-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "deprecated TaoMarketCap dashboard",
@@ -12821,6 +13640,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-40-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Chunking SubnetRadar dashboard",
+      "netuid": 40,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/40",
+      "source_urls": [
+        "https://subnetradar.com/subnet/40"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/40"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-40-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Chunking TaoMarketCap dashboard",
@@ -12944,6 +13784,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/41-almanac"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-41-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Almanac SubnetRadar dashboard",
+      "netuid": 41,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/41",
+      "source_urls": [
+        "https://subnetradar.com/subnet/41"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/41"
     },
     {
       "auth_required": false,
@@ -13243,6 +14104,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-42-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Gopher SubnetRadar dashboard",
+      "netuid": 42,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/42",
+      "source_urls": [
+        "https://subnetradar.com/subnet/42"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/42"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-42-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Gopher TaoMarketCap dashboard",
@@ -13344,6 +14226,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/43-graphite"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-43-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Graphite SubnetRadar dashboard",
+      "netuid": 43,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/43",
+      "source_urls": [
+        "https://subnetradar.com/subnet/43"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/43"
     },
     {
       "auth_required": false,
@@ -13471,6 +14374,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/44-score"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-44-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Score SubnetRadar dashboard",
+      "netuid": 44,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/44",
+      "source_urls": [
+        "https://subnetradar.com/subnet/44"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/44"
     },
     {
       "auth_required": false,
@@ -13786,6 +14710,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/45-talisman-ai"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-45-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Talisman AI SubnetRadar dashboard",
+      "netuid": 45,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/45",
+      "source_urls": [
+        "https://subnetradar.com/subnet/45"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/45"
     },
     {
       "auth_required": false,
@@ -14315,6 +15260,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-46-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Zipcode SubnetRadar dashboard",
+      "netuid": 46,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/46",
+      "source_urls": [
+        "https://subnetradar.com/subnet/46"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/46"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-46-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Zipcode TaoMarketCap dashboard",
@@ -14756,6 +15722,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-47-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "EvolAI SubnetRadar dashboard",
+      "netuid": 47,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/47",
+      "source_urls": [
+        "https://subnetradar.com/subnet/47"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/47"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-47-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "EvolAI TaoMarketCap dashboard",
@@ -14920,6 +15907,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/48-quantum-compute"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-48-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Quantum Compute SubnetRadar dashboard",
+      "netuid": 48,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/48",
+      "source_urls": [
+        "https://subnetradar.com/subnet/48"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/48"
     },
     {
       "auth_required": false,
@@ -15407,6 +16415,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-49-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Nepher Robotics SubnetRadar dashboard",
+      "netuid": 49,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/49",
+      "source_urls": [
+        "https://subnetradar.com/subnet/49"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/49"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-49-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Nepher Robotics TaoMarketCap dashboard",
@@ -15722,6 +16751,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-50-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Synth SubnetRadar dashboard",
+      "netuid": 50,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/50",
+      "source_urls": [
+        "https://subnetradar.com/subnet/50"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/50"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-50-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Synth TaoMarketCap dashboard",
@@ -16013,6 +17063,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/51-lium-io"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-51-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "lium.io SubnetRadar dashboard",
+      "netuid": 51,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/51",
+      "source_urls": [
+        "https://subnetradar.com/subnet/51"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/51"
     },
     {
       "auth_required": false,
@@ -16522,6 +17593,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-52-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Dojo SubnetRadar dashboard",
+      "netuid": 52,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/52",
+      "source_urls": [
+        "https://subnetradar.com/subnet/52"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/52"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-52-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Dojo TaoMarketCap dashboard",
@@ -16733,6 +17825,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-53-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "EfficientFrontier SubnetRadar dashboard",
+      "netuid": 53,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/53",
+      "source_urls": [
+        "https://subnetradar.com/subnet/53"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/53"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-53-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "EfficientFrontier TaoMarketCap dashboard",
@@ -16877,6 +17990,27 @@
       ],
       "state": "schema-valid",
       "url": "https://tao-ui-dashboard.yanez.ai/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-54-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Yanez MIID SubnetRadar dashboard",
+      "netuid": 54,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/54",
+      "source_urls": [
+        "https://subnetradar.com/subnet/54"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/54"
     },
     {
       "auth_required": false,
@@ -17193,6 +18327,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/55-niome"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-55-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "NIOME SubnetRadar dashboard",
+      "netuid": 55,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/55",
+      "source_urls": [
+        "https://subnetradar.com/subnet/55"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/55"
     },
     {
       "auth_required": false,
@@ -17551,6 +18706,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/56-gradients"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-56-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Gradients SubnetRadar dashboard",
+      "netuid": 56,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/56",
+      "source_urls": [
+        "https://subnetradar.com/subnet/56"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/56"
     },
     {
       "auth_required": false,
@@ -18059,6 +19235,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-57-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "gaia SubnetRadar dashboard",
+      "netuid": 57,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/57",
+      "source_urls": [
+        "https://subnetradar.com/subnet/57"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/57"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-57-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "gaia TaoMarketCap dashboard",
@@ -18181,6 +19378,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/58-pending"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-58-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Pending SubnetRadar dashboard",
+      "netuid": 58,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/58",
+      "source_urls": [
+        "https://subnetradar.com/subnet/58"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/58"
     },
     {
       "auth_required": false,
@@ -18349,6 +19567,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/59-babelbit"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-59-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Babelbit SubnetRadar dashboard",
+      "netuid": 59,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/59",
+      "source_urls": [
+        "https://subnetradar.com/subnet/59"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/59"
     },
     {
       "auth_required": false,
@@ -18732,6 +19971,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-60-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Bitsec.ai SubnetRadar dashboard",
+      "netuid": 60,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/60",
+      "source_urls": [
+        "https://subnetradar.com/subnet/60"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/60"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-60-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Bitsec.ai TaoMarketCap dashboard",
@@ -19069,6 +20329,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-61-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "RedTeam SubnetRadar dashboard",
+      "netuid": 61,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/61",
+      "source_urls": [
+        "https://subnetradar.com/subnet/61"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/61"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-61-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "RedTeam TaoMarketCap dashboard",
@@ -19365,6 +20646,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-62-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Ridges SubnetRadar dashboard",
+      "netuid": 62,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/62",
+      "source_urls": [
+        "https://subnetradar.com/subnet/62"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/62"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-62-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Ridges TaoMarketCap dashboard",
@@ -19466,27 +20768,6 @@
       ],
       "state": "schema-valid",
       "url": "https://www.ridges.ai/docs"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-62-website-subdomain-docs-docs-ridges-ai",
-      "kind": "docs",
-      "name": "Ridges docs subdomain",
-      "netuid": 62,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://www.ridges.ai/",
-      "source_urls": [
-        "https://www.ridges.ai/"
-      ],
-      "state": "schema-valid",
-      "url": "https://docs.ridges.ai/"
     },
     {
       "auth_required": false,
@@ -19656,6 +20937,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/63-enigma"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-63-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Enigma SubnetRadar dashboard",
+      "netuid": 63,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/63",
+      "source_urls": [
+        "https://subnetradar.com/subnet/63"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/63"
     },
     {
       "auth_required": false,
@@ -20139,6 +21441,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/64-chutes"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-64-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Chutes SubnetRadar dashboard",
+      "netuid": 64,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/64",
+      "source_urls": [
+        "https://subnetradar.com/subnet/64"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/64"
     },
     {
       "auth_required": false,
@@ -20733,6 +22056,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-65-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "TAO Private Network SubnetRadar dashboard",
+      "netuid": 65,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/65",
+      "source_urls": [
+        "https://subnetradar.com/subnet/65"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/65"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-65-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "TAO Private Network TaoMarketCap dashboard",
@@ -21133,6 +22477,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-66-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ninja SubnetRadar dashboard",
+      "netuid": 66,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/66",
+      "source_urls": [
+        "https://subnetradar.com/subnet/66"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/66"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-66-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ninja TaoMarketCap dashboard",
@@ -21491,6 +22856,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-67-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Harnyx SubnetRadar dashboard",
+      "netuid": 67,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/67",
+      "source_urls": [
+        "https://subnetradar.com/subnet/67"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/67"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-67-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Harnyx TaoMarketCap dashboard",
@@ -21802,6 +23188,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/68-nova"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-68-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "NOVA SubnetRadar dashboard",
+      "netuid": 68,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/68",
+      "source_urls": [
+        "https://subnetradar.com/subnet/68"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/68"
     },
     {
       "auth_required": false,
@@ -22185,6 +23592,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-69-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ain SubnetRadar dashboard",
+      "netuid": 69,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/69",
+      "source_urls": [
+        "https://subnetradar.com/subnet/69"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/69"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-69-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ain TaoMarketCap dashboard",
@@ -22286,6 +23714,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/70-nexisgen"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-70-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "NexisGen SubnetRadar dashboard",
+      "netuid": 70,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/70",
+      "source_urls": [
+        "https://subnetradar.com/subnet/70"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/70"
     },
     {
       "auth_required": false,
@@ -22668,6 +24117,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-71-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Leadpoet SubnetRadar dashboard",
+      "netuid": 71,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/71",
+      "source_urls": [
+        "https://subnetradar.com/subnet/71"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/71"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-71-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Leadpoet TaoMarketCap dashboard",
@@ -22938,6 +24408,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/72-streetvision-by-natix"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-72-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "StreetVision by NATIX SubnetRadar dashboard",
+      "netuid": 72,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/72",
+      "source_urls": [
+        "https://subnetradar.com/subnet/72"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/72"
     },
     {
       "auth_required": false,
@@ -23447,6 +24938,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-73-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Parked SubnetRadar dashboard",
+      "netuid": 73,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/73",
+      "source_urls": [
+        "https://subnetradar.com/subnet/73"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/73"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-73-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Parked TaoMarketCap dashboard",
@@ -23569,6 +25081,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/74-gittensor"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-74-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Gittensor SubnetRadar dashboard",
+      "netuid": 74,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/74",
+      "source_urls": [
+        "https://subnetradar.com/subnet/74"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/74"
     },
     {
       "auth_required": false,
@@ -23884,6 +25417,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/75-hippius"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-75-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Hippius SubnetRadar dashboard",
+      "netuid": 75,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/75",
+      "source_urls": [
+        "https://subnetradar.com/subnet/75"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/75"
     },
     {
       "auth_required": false,
@@ -24414,6 +25968,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-76-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Byzantium SubnetRadar dashboard",
+      "netuid": 76,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/76",
+      "source_urls": [
+        "https://subnetradar.com/subnet/76"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/76"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-76-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Byzantium TaoMarketCap dashboard",
@@ -24683,6 +26258,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/77-liquidity"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-77-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Liquidity SubnetRadar dashboard",
+      "netuid": 77,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/77",
+      "source_urls": [
+        "https://subnetradar.com/subnet/77"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/77"
     },
     {
       "auth_required": false,
@@ -24957,6 +26553,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/78-vocence"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-78-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Vocence SubnetRadar dashboard",
+      "netuid": 78,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/78",
+      "source_urls": [
+        "https://subnetradar.com/subnet/78"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/78"
     },
     {
       "auth_required": false,
@@ -25272,6 +26889,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/79-mvtrx"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-79-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "MVTRX SubnetRadar dashboard",
+      "netuid": 79,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/79",
+      "source_urls": [
+        "https://subnetradar.com/subnet/79"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/79"
     },
     {
       "auth_required": false,
@@ -25801,6 +27439,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-80-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "dogelayer SubnetRadar dashboard",
+      "netuid": 80,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/80",
+      "source_urls": [
+        "https://subnetradar.com/subnet/80"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/80"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-80-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "dogelayer TaoMarketCap dashboard",
@@ -26116,6 +27775,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-81-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "deprecated SubnetRadar dashboard",
+      "netuid": 81,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/81",
+      "source_urls": [
+        "https://subnetradar.com/subnet/81"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/81"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-81-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "deprecated TaoMarketCap dashboard",
@@ -26259,6 +27939,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/82-compelle"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-82-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Compelle SubnetRadar dashboard",
+      "netuid": 82,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/82",
+      "source_urls": [
+        "https://subnetradar.com/subnet/82"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/82"
     },
     {
       "auth_required": false,
@@ -26788,6 +28489,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-83-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "CliqueAI SubnetRadar dashboard",
+      "netuid": 83,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/83",
+      "source_urls": [
+        "https://subnetradar.com/subnet/83"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/83"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-83-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "CliqueAI TaoMarketCap dashboard",
@@ -27062,6 +28784,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-84-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ansuz SubnetRadar dashboard",
+      "netuid": 84,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/84",
+      "source_urls": [
+        "https://subnetradar.com/subnet/84"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/84"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-84-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ansuz TaoMarketCap dashboard",
@@ -27205,6 +28948,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/85-vidaio"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-85-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Vidaio SubnetRadar dashboard",
+      "netuid": 85,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/85",
+      "source_urls": [
+        "https://subnetradar.com/subnet/85"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/85"
     },
     {
       "auth_required": false,
@@ -27651,6 +29415,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-86-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Subnet 86 SubnetRadar dashboard",
+      "netuid": 86,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/86",
+      "source_urls": [
+        "https://subnetradar.com/subnet/86"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/86"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-86-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Subnet 86 TaoMarketCap dashboard",
@@ -27752,6 +29537,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/87-luminar-network"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-87-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Luminar Network SubnetRadar dashboard",
+      "netuid": 87,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/87",
+      "source_urls": [
+        "https://subnetradar.com/subnet/87"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/87"
     },
     {
       "auth_required": false,
@@ -27879,6 +29685,27 @@
       ],
       "state": "schema-valid",
       "url": "https://db.investing88.ai/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-88-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Investing SubnetRadar dashboard",
+      "netuid": 88,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/88",
+      "source_urls": [
+        "https://subnetradar.com/subnet/88"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/88"
     },
     {
       "auth_required": false,
@@ -28241,6 +30068,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-89-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "InfiniteHash SubnetRadar dashboard",
+      "netuid": 89,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/89",
+      "source_urls": [
+        "https://subnetradar.com/subnet/89"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/89"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-89-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "InfiniteHash TaoMarketCap dashboard",
@@ -28515,6 +30363,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-90-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ogham SubnetRadar dashboard",
+      "netuid": 90,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/90",
+      "source_urls": [
+        "https://subnetradar.com/subnet/90"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/90"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-90-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ogham TaoMarketCap dashboard",
@@ -28616,6 +30485,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/91-bitstarter-1"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-91-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Bitstarter #1 SubnetRadar dashboard",
+      "netuid": 91,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/91",
+      "source_urls": [
+        "https://subnetradar.com/subnet/91"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/91"
     },
     {
       "auth_required": false,
@@ -28977,6 +30867,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-92-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "luis SubnetRadar dashboard",
+      "netuid": 92,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/92",
+      "source_urls": [
+        "https://subnetradar.com/subnet/92"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/92"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-92-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "luis TaoMarketCap dashboard",
@@ -29120,6 +31031,27 @@
       ],
       "state": "schema-valid",
       "url": "https://www.dashboard.bitcast.network/briefs"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-93-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Bitcast SubnetRadar dashboard",
+      "netuid": 93,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/93",
+      "source_urls": [
+        "https://subnetradar.com/subnet/93"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/93"
     },
     {
       "auth_required": false,
@@ -29503,6 +31435,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-94-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Bitsota SubnetRadar dashboard",
+      "netuid": 94,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/94",
+      "source_urls": [
+        "https://subnetradar.com/subnet/94"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/94"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-94-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Bitsota TaoMarketCap dashboard",
@@ -29839,6 +31792,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-95-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Actual SubnetRadar dashboard",
+      "netuid": 95,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/95",
+      "source_urls": [
+        "https://subnetradar.com/subnet/95"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/95"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-95-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Actual TaoMarketCap dashboard",
@@ -30150,6 +32124,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/96-verathos"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-96-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Verathos SubnetRadar dashboard",
+      "netuid": 96,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/96",
+      "source_urls": [
+        "https://subnetradar.com/subnet/96"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/96"
     },
     {
       "auth_required": false,
@@ -30466,6 +32461,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/97-albedo"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-97-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Albedo SubnetRadar dashboard",
+      "netuid": 97,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/97",
+      "source_urls": [
+        "https://subnetradar.com/subnet/97"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/97"
     },
     {
       "auth_required": false,
@@ -30827,6 +32843,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-98-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ForeverMoney SubnetRadar dashboard",
+      "netuid": 98,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/98",
+      "source_urls": [
+        "https://subnetradar.com/subnet/98"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/98"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-98-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ForeverMoney TaoMarketCap dashboard",
@@ -30953,17 +32990,17 @@
     {
       "auth_required": false,
       "confidence": "low",
-      "id": "sn-98-website-subdomain-docs-docs-forevermoney-ai",
+      "id": "sn-98-website-link-forevermoney-ai-docs-2",
       "kind": "docs",
-      "name": "ForeverMoney docs subdomain",
+      "name": "ForeverMoney docs",
       "netuid": 98,
       "provider": "taomarketcap",
       "public_safe": true,
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "review_notes": "Discovered from a public project website link. Requires verification before promotion.",
       "schema_version": 1,
       "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
+      "source_type": "project-website-link",
       "source_url": "https://forevermoney.ai/",
       "source_urls": [
         "https://forevermoney.ai/"
@@ -31264,6 +33301,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/99-leoma"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-99-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Leoma SubnetRadar dashboard",
+      "netuid": 99,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/99",
+      "source_urls": [
+        "https://subnetradar.com/subnet/99"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/99"
     },
     {
       "auth_required": false,
@@ -31600,6 +33658,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/100-pla-form"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-100-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Plaτform SubnetRadar dashboard",
+      "netuid": 100,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/100",
+      "source_urls": [
+        "https://subnetradar.com/subnet/100"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/100"
     },
     {
       "auth_required": false,
@@ -32003,6 +34082,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-101-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "eni SubnetRadar dashboard",
+      "netuid": 101,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/101",
+      "source_urls": [
+        "https://subnetradar.com/subnet/101"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/101"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-101-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "eni TaoMarketCap dashboard",
@@ -32104,6 +34204,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/102-connitoai"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-102-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ConnitoAI SubnetRadar dashboard",
+      "netuid": 102,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/102",
+      "source_urls": [
+        "https://subnetradar.com/subnet/102"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/102"
     },
     {
       "auth_required": false,
@@ -32486,6 +34607,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-103-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Djinn SubnetRadar dashboard",
+      "netuid": 103,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/103",
+      "source_urls": [
+        "https://subnetradar.com/subnet/103"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/103"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-103-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Djinn TaoMarketCap dashboard",
@@ -32608,27 +34750,6 @@
       ],
       "state": "schema-valid",
       "url": "https://djinn.gg/docs"
-    },
-    {
-      "auth_required": false,
-      "confidence": "low",
-      "id": "sn-103-website-subdomain-docs-docs-djinn-gg",
-      "kind": "docs",
-      "name": "Djinn docs subdomain",
-      "netuid": 103,
-      "provider": "taomarketcap",
-      "public_safe": true,
-      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
-      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
-      "schema_version": 1,
-      "source_tier": "provider-claimed",
-      "source_type": "project-website-docs-subdomain",
-      "source_url": "https://djinn.gg/",
-      "source_urls": [
-        "https://djinn.gg/"
-      ],
-      "state": "schema-valid",
-      "url": "https://docs.djinn.gg/"
     },
     {
       "auth_required": false,
@@ -32969,6 +35090,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-104-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "for sale (burn to uid1) SubnetRadar dashboard",
+      "netuid": 104,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/104",
+      "source_urls": [
+        "https://subnetradar.com/subnet/104"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/104"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-104-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "for sale (burn to uid1) TaoMarketCap dashboard",
@@ -33070,6 +35212,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/105-beam"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-105-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Beam SubnetRadar dashboard",
+      "netuid": 105,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/105",
+      "source_urls": [
+        "https://subnetradar.com/subnet/105"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/105"
     },
     {
       "auth_required": false,
@@ -33347,6 +35510,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-106-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "VoidAI SubnetRadar dashboard",
+      "netuid": 106,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/106",
+      "source_urls": [
+        "https://subnetradar.com/subnet/106"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/106"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-106-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "VoidAI TaoMarketCap dashboard",
@@ -33616,6 +35800,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/107-minos"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-107-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Minos SubnetRadar dashboard",
+      "netuid": 107,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/107",
+      "source_urls": [
+        "https://subnetradar.com/subnet/107"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/107"
     },
     {
       "auth_required": false,
@@ -34040,6 +36245,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-108-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "TalkHead SubnetRadar dashboard",
+      "netuid": 108,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/108",
+      "source_urls": [
+        "https://subnetradar.com/subnet/108"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/108"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-108-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "TalkHead TaoMarketCap dashboard",
@@ -34440,6 +36666,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-109-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Academia SubnetRadar dashboard",
+      "netuid": 109,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/109",
+      "source_urls": [
+        "https://subnetradar.com/subnet/109"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/109"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-109-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Academia TaoMarketCap dashboard",
@@ -34562,6 +36809,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/110-green-compute"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-110-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Green Compute SubnetRadar dashboard",
+      "netuid": 110,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/110",
+      "source_urls": [
+        "https://subnetradar.com/subnet/110"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/110"
     },
     {
       "auth_required": false,
@@ -35049,6 +37317,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-111-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "oneoneone SubnetRadar dashboard",
+      "netuid": 111,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/111",
+      "source_urls": [
+        "https://subnetradar.com/subnet/111"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/111"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-111-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "oneoneone TaoMarketCap dashboard",
@@ -35176,6 +37465,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-112-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "minotaur SubnetRadar dashboard",
+      "netuid": 112,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/112",
+      "source_urls": [
+        "https://subnetradar.com/subnet/112"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/112"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-112-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "minotaur TaoMarketCap dashboard",
@@ -35277,6 +37587,27 @@
       ],
       "state": "schema-valid",
       "url": "https://minotaursubnet.com/docs"
+    },
+    {
+      "auth_required": false,
+      "confidence": "low",
+      "id": "sn-112-website-subdomain-docs-docs-minotaursubnet-com",
+      "kind": "docs",
+      "name": "minotaur docs subdomain",
+      "netuid": 112,
+      "provider": "taomarketcap",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Docs subdomain candidate inferred from a public project website root for a subnet without project-level docs. Requires verification before promotion.",
+      "schema_version": 1,
+      "source_tier": "provider-claimed",
+      "source_type": "project-website-docs-subdomain",
+      "source_url": "https://minotaursubnet.com/",
+      "source_urls": [
+        "https://minotaursubnet.com/"
+      ],
+      "state": "schema-valid",
+      "url": "https://docs.minotaursubnet.com/"
     },
     {
       "auth_required": false,
@@ -35467,6 +37798,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/113-tensorusd"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-113-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "TensorUSD SubnetRadar dashboard",
+      "netuid": 113,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/113",
+      "source_urls": [
+        "https://subnetradar.com/subnet/113"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/113"
     },
     {
       "auth_required": false,
@@ -35866,6 +38218,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/114-soma"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-114-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "SOMA SubnetRadar dashboard",
+      "netuid": 114,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/114",
+      "source_urls": [
+        "https://subnetradar.com/subnet/114"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/114"
     },
     {
       "auth_required": false,
@@ -36311,6 +38684,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-115-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "HashiChain SubnetRadar dashboard",
+      "netuid": 115,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/115",
+      "source_urls": [
+        "https://subnetradar.com/subnet/115"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/115"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-115-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "HashiChain TaoMarketCap dashboard",
@@ -36437,6 +38831,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-116-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "hard_sign SubnetRadar dashboard",
+      "netuid": 116,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/116",
+      "source_urls": [
+        "https://subnetradar.com/subnet/116"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/116"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-116-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "hard_sign TaoMarketCap dashboard",
@@ -36559,6 +38974,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/117-brainplay"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-117-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "BrainPlay SubnetRadar dashboard",
+      "netuid": 117,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/117",
+      "source_urls": [
+        "https://subnetradar.com/subnet/117"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/117"
     },
     {
       "auth_required": false,
@@ -36727,6 +39163,27 @@
       ],
       "state": "schema-valid",
       "url": "https://subnet-118-dashboard.vercel.app/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-118-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Ditto SubnetRadar dashboard",
+      "netuid": 118,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/118",
+      "source_urls": [
+        "https://subnetradar.com/subnet/118"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/118"
     },
     {
       "auth_required": false,
@@ -37214,6 +39671,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-119-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Satori SubnetRadar dashboard",
+      "netuid": 119,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/119",
+      "source_urls": [
+        "https://subnetradar.com/subnet/119"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/119"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-119-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Satori TaoMarketCap dashboard",
@@ -37357,6 +39835,27 @@
       ],
       "state": "schema-valid",
       "url": "https://www.affine.io/"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-120-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Affine SubnetRadar dashboard",
+      "netuid": 120,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/120",
+      "source_urls": [
+        "https://subnetradar.com/subnet/120"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/120"
     },
     {
       "auth_required": false,
@@ -37631,6 +40130,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/121-sundae-bar"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-121-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "sundae_bar SubnetRadar dashboard",
+      "netuid": 121,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/121",
+      "source_urls": [
+        "https://subnetradar.com/subnet/121"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/121"
     },
     {
       "auth_required": false,
@@ -38118,6 +40638,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-122-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "gamma_small SubnetRadar dashboard",
+      "netuid": 122,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/122",
+      "source_urls": [
+        "https://subnetradar.com/subnet/122"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/122"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-122-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "gamma_small TaoMarketCap dashboard",
@@ -38240,6 +40781,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/123-mantis"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-123-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "MANTIS SubnetRadar dashboard",
+      "netuid": 123,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/123",
+      "source_urls": [
+        "https://subnetradar.com/subnet/123"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/123"
     },
     {
       "auth_required": false,
@@ -38388,6 +40950,27 @@
       ],
       "state": "schema-valid",
       "url": "https://swarm124.com/benchmark"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-124-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Swarm SubnetRadar dashboard",
+      "netuid": 124,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/124",
+      "source_urls": [
+        "https://subnetradar.com/subnet/124"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/124"
     },
     {
       "auth_required": false,
@@ -38666,6 +41249,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-125-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "8 Ball SubnetRadar dashboard",
+      "netuid": 125,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/125",
+      "source_urls": [
+        "https://subnetradar.com/subnet/125"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/125"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-125-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "8 Ball TaoMarketCap dashboard",
@@ -38767,6 +41371,27 @@
       ],
       "state": "schema-valid",
       "url": "https://backprop.finance/dtao/subnets/126-poker44"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "sn-126-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Poker44 SubnetRadar dashboard",
+      "netuid": 126,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/126",
+      "source_urls": [
+        "https://subnetradar.com/subnet/126"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/126"
     },
     {
       "auth_required": false,
@@ -39128,6 +41753,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-127-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "Astrid SubnetRadar dashboard",
+      "netuid": 127,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/127",
+      "source_urls": [
+        "https://subnetradar.com/subnet/127"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/127"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-127-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "Astrid TaoMarketCap dashboard",
@@ -39464,6 +42110,27 @@
     {
       "auth_required": false,
       "confidence": "medium",
+      "id": "sn-128-subnetradar-dashboard",
+      "kind": "dashboard",
+      "name": "ByteLeap SubnetRadar dashboard",
+      "netuid": 128,
+      "provider": "subnetradar",
+      "public_safe": true,
+      "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
+      "review_notes": "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
+      "schema_version": 1,
+      "source_tier": "third-party-index",
+      "source_type": "subnetradar-dashboard",
+      "source_url": "https://subnetradar.com/subnet/128",
+      "source_urls": [
+        "https://subnetradar.com/subnet/128"
+      ],
+      "state": "schema-valid",
+      "url": "https://subnetradar.com/subnet/128"
+    },
+    {
+      "auth_required": false,
+      "confidence": "medium",
       "id": "sn-128-taomarketcap-dashboard",
       "kind": "dashboard",
       "name": "ByteLeap TaoMarketCap dashboard",
@@ -39740,7 +42407,7 @@
   "generated_by": "metagraphed-discover-candidates",
   "native_snapshot_captured_at": "2026-06-07T21:51:54Z",
   "notes": "Generated candidate surfaces from public sources. These are not verified registry surfaces until maintainer review promotes them into registry/subnets.",
-  "observed_at": "2026-06-08T13:11:57.000Z",
+  "observed_at": "2026-06-08T14:11:05.342Z",
   "schema_version": 1,
   "sources": [
     {
@@ -39754,6 +42421,10 @@
     {
       "id": "taostats",
       "url": "https://taostats.io/subnets/"
+    },
+    {
+      "id": "subnetradar",
+      "url": "https://subnetradar.com/subnet/"
     },
     {
       "id": "tensorplex-subnet-docs",

--- a/registry/generated/subnet-overlays-summary.json
+++ b/registry/generated/subnet-overlays-summary.json
@@ -1,7 +1,7 @@
 {
-  "generated_overlay_count": 66,
+  "generated_overlay_count": 61,
   "generated_without_surfaces": [],
-  "manual_overlay_count": 63,
+  "manual_overlay_count": 68,
   "mode": "write",
   "native_subnet_count": 129,
   "overlays": [
@@ -12,398 +12,368 @@
       "surface_count": 10
     },
     {
-      "checksum": "22a5a79613fc3456bb6239a616bb2af778cab916fa2c9051d05fe3ab8c1fb720",
+      "checksum": "a4a8c46e974d94c69fd62a947ac761a3d1547ecf3ed0132656b81c047ea80ffd",
       "netuid": 5,
       "slug": "sn-5",
       "surface_count": 7
     },
     {
-      "checksum": "5392b9f4623eaf5843ee51a46d6211b448772602498f668180702214523c6732",
+      "checksum": "6a8bf74760a9d3f83f7dfab466fd24bb0f9398829526e10c6629c5ae8a05a142",
       "netuid": 6,
       "slug": "sn-6",
       "surface_count": 7
     },
     {
-      "checksum": "7e39430bb3dfbabce10b4a174c391e4b2decb0457c37c06ec8f6286d6a73a1ff",
+      "checksum": "04f903b48a9afdf144c64cae4a125a5ea21c7665abc57fe057b6d228767de401",
       "netuid": 8,
       "slug": "sn-8",
       "surface_count": 7
     },
     {
-      "checksum": "5d0156642ac0bad8aa30fccbcf7357c9a6fa42e218e33b5d5bc39305940847cd",
+      "checksum": "c98813442a07f40f8447243744695e099a310b252ffdf19a1ca1eb6408806b81",
       "netuid": 10,
       "slug": "sn-10",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "checksum": "5349a17577e4f9547460c7b531fdf8c3b64947f607c3d38e060b07c196a22de2",
+      "checksum": "c1619af2bd6a0378abd0873d601c5b148bcb6e99b1851fb5ab1db6de129db7d1",
       "netuid": 11,
       "slug": "sn-11",
       "surface_count": 8
     },
     {
-      "checksum": "5d387c525667b0d8d6fe8abc31bd0769216c9e4394b0b18b14a56779b48c46c6",
+      "checksum": "e03ca7159bb575af418f4c099f3e78e1af5fdbceb5e1574c8680bd24f81063c8",
       "netuid": 14,
       "slug": "sn-14",
       "surface_count": 10
     },
     {
-      "checksum": "11cc744e02ef2bd6a0548638c7784791485aa9fc205f0d3577b1ff654a685698",
+      "checksum": "b13aada63e16d4cbe1a2a4b56452177a8f271add626c73fd72c7c3863090ac27",
       "netuid": 16,
       "slug": "sn-16",
       "surface_count": 9
     },
     {
-      "checksum": "f18fc65ce8a98552e75407532f470fc5c424c8fec536a2f044a36e8617c9999d",
+      "checksum": "775663b340715cf621bdf3fc753b20fddf8e599a8ee036aa1b9c84e3a3d74d77",
       "netuid": 17,
       "slug": "sn-17",
       "surface_count": 8
     },
     {
-      "checksum": "77b31801051291fe2266ca2a0bb14f9f5abaac0a7c95a62bd21f3e0df27b3578",
+      "checksum": "4f14ed10003f319830969e25e422ab0a1b37eecb6855bf0ca9265bb8c6032f54",
       "netuid": 18,
       "slug": "sn-18",
       "surface_count": 8
     },
     {
-      "checksum": "e57d47410d94f0cc0e17ddd14eb4dd67e9dbc16f8a0e3d0a51c4fa85e84de83c",
+      "checksum": "5c02e0b22c6dffeeae167a5669e6d3205280046782782c2a05a4e42704995622",
       "netuid": 26,
       "slug": "sn-26",
       "surface_count": 8
     },
     {
-      "checksum": "47959eb46fceafe15b26a117472416a1c59e37915eefd9f6d22929e7cca3f539",
-      "netuid": 27,
-      "slug": "sn-27",
-      "surface_count": 5
-    },
-    {
-      "checksum": "9be99ac34b5de7ea6543a3fced3cebeb6d2f788fc386d2547f861845a5eb4a01",
+      "checksum": "ee9092de68a34200b8c5da515dfaf5f2389f8da437af7ca41c8bca14474d0dc3",
       "netuid": 28,
       "slug": "sn-28",
       "surface_count": 5
     },
     {
-      "checksum": "f347b0e6b94d43c570d781e652439b1343e34aef7f66df30653c5f10e2a51883",
+      "checksum": "d6d0b6c499a2773f289fbc72e10c56763d95cf9df65b591bd75ebb3b8d49bd38",
       "netuid": 31,
       "slug": "sn-31",
       "surface_count": 5
     },
     {
-      "checksum": "9928b72cbd52e02498fff1ab337a0a92f0d525002b969d1ed82065979d3dc8de",
+      "checksum": "7931631a1d5fefa0e5b9046580c92feb4ac42714a3babfe6e0f13cf61ff32577",
       "netuid": 35,
       "slug": "sn-35",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "checksum": "a6d397b712c9d4aa19c6c92ab5c867aa7064f11fe77de59f88698846cc8e90ac",
+      "checksum": "89a5f532b4eb008c96261bde5f9e43a65b61a34d921ed11dc085e22a76933eca",
       "netuid": 36,
       "slug": "sn-36",
       "surface_count": 8
     },
     {
-      "checksum": "add784ded2cb8300a0d07321c5734a052936916156f5cbae32f82cac383aab42",
+      "checksum": "7bff9f0b95b2df9a5c90334dd58c62555ee0aa4c8248159cecb5103838e73c28",
       "netuid": 37,
       "slug": "sn-37",
       "surface_count": 8
     },
     {
-      "checksum": "e50feb88867b321308d7a04b7797eb63eb57a63d483be90d5c486ef163c7a753",
+      "checksum": "f06282d62f12a10a49653900c2837d77f6dd05c42df1a89ec92493732ffdbf32",
       "netuid": 38,
       "slug": "sn-38",
-      "surface_count": 8
+      "surface_count": 9
     },
     {
-      "checksum": "da7e1ede26a46779bf942d6030066dc65ba2bc2b34cfac44f621f9e1fbaf3675",
+      "checksum": "1937645c2c42ba76561f17d11bdfb8b4a00a7d626917da8f6d8223967742e64a",
       "netuid": 40,
       "slug": "sn-40",
       "surface_count": 5
     },
     {
-      "checksum": "3fe09c914b5b1bf09255c0d2c344478eb89293c76a6167819ab9722a65b4e5c4",
+      "checksum": "40fb0a53777fc93d4bce3066d943bbc9af4247f91abe402d5a91e97ae596879e",
       "netuid": 41,
       "slug": "sn-41",
       "surface_count": 9
     },
     {
-      "checksum": "d0f5a50edee38dbc025e054ca8979390eb387694a1fef868b52433f8989396f9",
+      "checksum": "230c13ae29e29ee409b4f54a3472c3331b457035fccf1372b80ee94f4ccc2bcf",
       "netuid": 44,
       "slug": "sn-44",
       "surface_count": 8
     },
     {
-      "checksum": "9d0255bd91735f15b93db81ae0281824299432860dabe8c92cc9a00f3c6e50df",
+      "checksum": "bba361f4810ee4a94f40efb223fe072f828f50b10dde40710e870f280762bb58",
       "netuid": 46,
       "slug": "sn-46",
       "surface_count": 11
     },
     {
-      "checksum": "715d088a5998408f4592063ca7335f41396ef3fc10b56f2519fe783f76ca963a",
+      "checksum": "aee7168aa0d98eb48ea80bc1353e14e0a32b14f3847da4178882dd72a114f810",
       "netuid": 50,
       "slug": "sn-50",
       "surface_count": 9
     },
     {
-      "checksum": "85ebdcb8e71e624adcc8aba1e10a27aad347f2136c909d38bfbf219cc5014815",
+      "checksum": "89fa65098cc704b5dbaf13d783cf0d0db6e1ed6cf685e3f17372fb29ac2da84e",
       "netuid": 51,
       "slug": "sn-51",
       "surface_count": 10
     },
     {
-      "checksum": "ee3fa477b5ba232a6826caaf90441032bba7113cf4242725197aa0e176b2b8a8",
-      "netuid": 53,
-      "slug": "sn-53",
-      "surface_count": 5
-    },
-    {
-      "checksum": "bb5458d9bfe23eff83cbdbbcb72139c3f9599aa1c396b3452c433ec239180afa",
+      "checksum": "385b42cf693187bcb3f19c9f4298a5523df0dc43e7d8418e757ade75b7fb8030",
       "netuid": 54,
       "slug": "sn-54",
       "surface_count": 7
     },
     {
-      "checksum": "3784bfea39642ab3555560b1b12f8dc76d96c0183fe83aa76323344f1f421c9c",
+      "checksum": "3ed9725eff9d6516506dda19414d026474b8afdd35d14501d0f55dac77a7a9ec",
       "netuid": 55,
       "slug": "sn-55",
       "surface_count": 7
     },
     {
-      "checksum": "5bbb19648575cc4bd6ee21267f990f1193debdd25c7355415499e18c4d11b773",
+      "checksum": "558c64c7e2fea151bba4036b6e4314e7b747fe93d6c035a8b71096e8e4162cfd",
       "netuid": 56,
       "slug": "sn-56",
       "surface_count": 11
     },
     {
-      "checksum": "d628ee40f1b0e2c6e9c2957ae33b6ae434184c375d583851139b2197531f1dce",
+      "checksum": "9738c301d6b04e3291b232eb4845cfd7ab6f0faf860806fe0fe55e23771e7313",
       "netuid": 59,
       "slug": "sn-59",
       "surface_count": 8
     },
     {
-      "checksum": "9b06527345db0b2c034560cb62531638c1567e9fd704368b948220f7951a4d7e",
+      "checksum": "07a9ebad67740490733f5fb143817caf23290eb7309900bd70a7faa94330c38b",
       "netuid": 60,
       "slug": "sn-60",
       "surface_count": 11
     },
     {
-      "checksum": "a2d1c714921e549b0a91da9fa6b193d56ce4cb0e35a1fbb0366b9cbd771275cf",
+      "checksum": "b0191ea7949a6ab56f43741e0486a65e0507ee75ae6fb955a6c5bd05336ae9e1",
       "netuid": 65,
       "slug": "sn-65",
       "surface_count": 10
     },
     {
-      "checksum": "33f60f7f671671e01168e9751827d5130c474f8a8c0189fc4b6c7dcd970e82b2",
+      "checksum": "7cc4cfb63c1bf05437799f696462c7c1126b855bf134e5db831a902f0e532fae",
       "netuid": 67,
       "slug": "sn-67",
       "surface_count": 7
     },
     {
-      "checksum": "82168017963125f99b3fa1b913f8638f4a3b77fb9730adda10c2a820b2c5d7cf",
+      "checksum": "e3b1591e7dc2358923cc303e1a5a689476a7a479f82fb1eec1f41e76bee7c2e9",
       "netuid": 68,
       "slug": "sn-68",
       "surface_count": 9
     },
     {
-      "checksum": "ef1b1962e248ec13e53b9cf4d5cbabc285e537b94fbebaf353035af64038348d",
+      "checksum": "229947b752aee1392a7853c1b077742e5b511967092a865bbd50402838a9a78f",
       "netuid": 69,
       "slug": "sn-69",
       "surface_count": 5
     },
     {
-      "checksum": "a044e08e98def59f14b407837e3c92e46db4f8b78029995f90134e38bab1bd32",
+      "checksum": "1abbf05b3082091f746f9e58160cb875431b097f8b57c7ba192111a118d48499",
       "netuid": 70,
       "slug": "sn-70",
       "surface_count": 9
     },
     {
-      "checksum": "d89762d8da21bffe24675cec707299358b4278227bbe19e1318543e61388f093",
+      "checksum": "d0908efc513a5940cc73f8932712b5460c08860c862d1bf81fe288ecdafa2c2f",
       "netuid": 71,
       "slug": "sn-71",
       "surface_count": 9
     },
     {
-      "checksum": "644c97fe76b9cedf12932fd42602f546a2f78eb5765e22e5297c8b288ba453b7",
-      "netuid": 73,
-      "slug": "sn-73",
-      "surface_count": 5
-    },
-    {
-      "checksum": "1a663ced9dd65b0a369298677989515cb39239ef51270272049e2febafaa8b85",
+      "checksum": "cd41bf7f46295193dafec0ff3d63a32d1ae8aa350d2df4154fe5610e95357feb",
       "netuid": 77,
       "slug": "sn-77",
       "surface_count": 9
     },
     {
-      "checksum": "50c33629958df381a6dfc645191de04d1a9d53ea4d887b774b279d9c8ad8d4c4",
+      "checksum": "e01d94805bf6bd488f1b3a36101c98849c139d2c1dd69a821c81e2a4ef60c033",
       "netuid": 78,
       "slug": "sn-78",
       "surface_count": 11
     },
     {
-      "checksum": "eb8386433feacd9a95efb0f2457581de1d0d32dca17806267d52e76e2883c61d",
+      "checksum": "7dff4827ad0a93503e6871bd399454b070520c4f88f8d08e6a2fa0002a6b821c",
       "netuid": 80,
       "slug": "sn-80",
       "surface_count": 10
     },
     {
-      "checksum": "598a4adfcfc6f522647b8bf8b44daf02a55e9e034b4ec406e3ff17b0115ddbc0",
+      "checksum": "472c0232d3cf8bcb36201141d94e3524f7f9865f88cfee67ec9323463e6f43a2",
       "netuid": 83,
       "slug": "sn-83",
       "surface_count": 9
     },
     {
-      "checksum": "0e0e2d46cdc851a20f88ea425bccca4e86718c920b629c9f7daf3a0be70c586d",
+      "checksum": "ce017e9518cfb37b1a2dcf4e760804de9d80eb51f327c6f059fb94935e8371fc",
       "netuid": 86,
       "slug": "sn-86",
       "surface_count": 5
     },
     {
-      "checksum": "54765fdfef1e47e40c0bcce8a4964631bdd3b9a0c4f74673ac18645ae0297e8e",
-      "netuid": 90,
-      "slug": "sn-90",
-      "surface_count": 5
-    },
-    {
-      "checksum": "6d3a14f3aca9018ddb4a438980ba4412c36e84032694d032bf8833c1fe1d1296",
+      "checksum": "247ba88a6919acb918da12149a9d47d5e2cb54865fdcb49e412d3ff32361814c",
       "netuid": 93,
       "slug": "sn-93",
       "surface_count": 9
     },
     {
-      "checksum": "54bf6a6b0fe4c43c0e41426e609fcf23d038a5fd299d1e66a7bb34bd5d9e8ed2",
+      "checksum": "268d8bf74d5b069e595e77921316a3feca3999cd1205637048d91f97b09e540e",
       "netuid": 94,
       "slug": "sn-94",
       "surface_count": 8
     },
     {
-      "checksum": "b2a366ff3a81a4e75a00044f0b99766977c3b8988a2dbd8d16f8285ba536ddce",
+      "checksum": "f357dccfffc477cbc2b914e9fa12761c775257f0d3ff608972515accdcdd444d",
       "netuid": 95,
       "slug": "sn-95",
       "surface_count": 8
     },
     {
-      "checksum": "6a05d5447ddcaf511cdfd5ae9174e1bbc5c0d51702df25d0d9bc4eae28a8d966",
+      "checksum": "6f3273425c42250a62076e6e94e3f7e132c30f47b8dc177c9221c7192bdd7306",
       "netuid": 97,
       "slug": "sn-97",
       "surface_count": 11
     },
     {
-      "checksum": "1cb542a5e91031ab31191dc1965faaca63a86d057507c3f25f35978e035f44bc",
+      "checksum": "72486b6661101ae1eaf745e4ab697b5d83023ac434cba41a92927fb1b408f76c",
       "netuid": 99,
       "slug": "sn-99",
       "surface_count": 11
     },
     {
-      "checksum": "7628196216a215b43bbb069d7b3f6dac55f35bf5a76f6bb8321c571c869a6002",
+      "checksum": "1f5c36c1710f90f4c364c110d401216992e70cd78e97635b83e48d7abd7bc2bc",
       "netuid": 100,
       "slug": "sn-100",
       "surface_count": 10
     },
     {
-      "checksum": "edd14e7f79a08e79832880548d8e3161b9b587c1733516d0fdb787310b62b87f",
+      "checksum": "7a236c12036b4442d58a6e0566e7ce42ef5739cdf09f01a1ba833f562a6b2456",
       "netuid": 101,
       "slug": "sn-101",
       "surface_count": 5
     },
     {
-      "checksum": "7435523b13ae8883d70c9b1d5fbf0ff34c48c901c8f4d00ec885f46429ffa694",
+      "checksum": "e7aaf3c77c88ad2f380d62ed9666e18bb042b7e78c1519f2b2bc7793c397b974",
       "netuid": 104,
       "slug": "sn-104",
       "surface_count": 5
     },
     {
-      "checksum": "76527276269bff57b4ad909f210c17d93fd6f9cef3ecf62e666b5c0e4586fdd5",
+      "checksum": "852e35700eb77c199560477168ea7e506948053d280e1ffa83d9eae40f2c501e",
       "netuid": 105,
       "slug": "sn-105",
       "surface_count": 9
     },
     {
-      "checksum": "91256002e8f6c08f59518742e3ff50e5f083ac4506dc4ce20c285310a4e2ee53",
+      "checksum": "41baced03cee0907f54134e60e02cee813df259164ad383c58f04512fa3c706c",
       "netuid": 106,
       "slug": "sn-106",
       "surface_count": 8
     },
     {
-      "checksum": "d89659d03bf7cb892945d9a6d96997e58aff79f2055f1122a4904283845803c1",
+      "checksum": "ddbbb275c6cbc4e90c2882095eed8491774f9d5bd657d94375b7acd6dcf82255",
       "netuid": 107,
       "slug": "sn-107",
       "surface_count": 11
     },
     {
-      "checksum": "6aca082998173349b074993808705fbf754a76cd718284b11bdc056c5b802576",
+      "checksum": "460c2f378bd53c7cf290b126649df36c33f6bdcc27ece66f68e1048e6ac2025d",
       "netuid": 108,
       "slug": "sn-108",
       "surface_count": 7
     },
     {
-      "checksum": "5895ca77e1877951e01f095e226de153587f4a9efe2f787c504d14714e068e8a",
+      "checksum": "135bccfa5314fea391fb71f464ceb4fa7e348c9247f90262746e31a48a5374b7",
       "netuid": 112,
       "slug": "sn-112",
-      "surface_count": 7
+      "surface_count": 8
     },
     {
-      "checksum": "3472ab2a612a27a6f215a9adb95db766548a83c6e0771a8f5b72665719eb233d",
+      "checksum": "d4d625dc9174ed3cb6415ff24cf71dc276ee187d93a70b40d930cefa76b6e55f",
       "netuid": 114,
       "slug": "sn-114",
       "surface_count": 9
     },
     {
-      "checksum": "e350fd4d19a1b841cfe7d66c465bd8c6a44ed1c0e44558b3fedee8008f658bcf",
-      "netuid": 116,
-      "slug": "sn-116",
-      "surface_count": 5
-    },
-    {
-      "checksum": "8dfef40578ca8317e1b4867461107752d20d29f1c0c35e664d87fff0996e2388",
+      "checksum": "cfe0a57a337c37150e67cf6765e62ddd273f113c396fed425099524e6711d5f8",
       "netuid": 118,
       "slug": "sn-118",
       "surface_count": 10
     },
     {
-      "checksum": "7959fd972124dc1ea74f6c099bcbfb7fb1212f10ad5c6a1d9d2d8ec724a93ae0",
+      "checksum": "7de61c1418113b2e7091c07e4eb4e3674bd4f99dc3f02efa1155de4ec80417b1",
       "netuid": 119,
       "slug": "sn-119",
       "surface_count": 5
     },
     {
-      "checksum": "edd1dc03c883b74c56ae36ef1526e022d58759e823e5504537a207da04ef35bb",
+      "checksum": "1229c8cd7459db6c6e288c2641a7257f5fe4882640b9ed79c8522b9f375b54d2",
       "netuid": 120,
       "slug": "sn-120",
       "surface_count": 7
     },
     {
-      "checksum": "29eb58ccbcce2173091f16c5cc930f0d8d207b902dfc481f9b70d146a1e941d6",
+      "checksum": "16f3505388e56a12e7660359514c99ba5a4d5474d5a01928fd7774fd8be81906",
       "netuid": 124,
       "slug": "sn-124",
       "surface_count": 9
     },
     {
-      "checksum": "ebfd69cefb54590ba20fa91a9c57844ac7d7825449ac9224493cd6e9a3ca44d0",
+      "checksum": "d1f6c29b80c62828342fb4a1daf5eb4d64c65ea41588c5b07a8877841b1e7b33",
       "netuid": 125,
       "slug": "sn-125",
       "surface_count": 5
     },
     {
-      "checksum": "de16899216742721123ea59d5ee37a12951739783097f38dc5134be88bf48b48",
+      "checksum": "8efdd1f9c187af2038a682895e1e23e6c024b4cd3ed85581dddc364e6155d8fc",
       "netuid": 126,
       "slug": "sn-126",
       "surface_count": 7
     },
     {
-      "checksum": "4e55ee7b17f66f7f681dafc7ff5927acebce34c11435df299a5b7278d0446e95",
+      "checksum": "2fb03ae4df955a48338d7923b112f353e790ec4fe0c3ae8820766d5552a2ac3c",
       "netuid": 127,
       "slug": "sn-127",
       "surface_count": 7
     },
     {
-      "checksum": "c51f055cda177d13de1b9d920f730d7b53e84df9c53e3902d6165ebadceabbbb",
+      "checksum": "c7092cf40c5a132fd80c1c20e8eaf53d9fdef96790e57e23352bed950802d814",
       "netuid": 128,
       "slug": "sn-128",
       "surface_count": 10
     }
   ],
-  "promoted_surface_count": 523,
+  "promoted_surface_count": 502,
   "schema_version": 1,
   "total_overlay_count": 129,
-  "verification_result_count": 1891
+  "verification_result_count": 2018
 }

--- a/registry/providers/nodexo.json
+++ b/registry/providers/nodexo.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "nodexo",
+  "name": "Nodexo",
+  "kind": "subnet-team",
+  "website_url": "https://nodexo.ai/",
+  "docs_url": "https://docs.nodexo.ai/",
+  "authority": "provider-claimed",
+  "notes": "Provider entry for Nodexo Compute / SN27. Official browser-facing website, docs, and console surfaces are tracked, but simple Node/HEAD probes currently receive connection resets and are not treated as healthy monitored endpoints."
+}

--- a/registry/providers/signalplus.json
+++ b/registry/providers/signalplus.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "signalplus",
+  "name": "SignalPlus",
+  "kind": "subnet-team",
+  "website_url": "https://www.signalplus.com/",
+  "authority": "provider-claimed",
+  "notes": "Provider entry for SignalPlus and SN53 EfficientFrontier. The SignalPlus company website is live; the subnet mining surface currently returns an auth/challenge-style response to simple probes."
+}

--- a/registry/providers/subnetradar.json
+++ b/registry/providers/subnetradar.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "id": "subnetradar",
+  "name": "SubnetRadar",
+  "kind": "data-provider",
+  "website_url": "https://subnetradar.com/",
+  "docs_url": "https://subnetradar.com/about",
+  "authority": "provider-claimed",
+  "notes": "Third-party Bittensor subnet analytics and risk/health dashboard. Tracked as dashboard enrichment only; Metagraphed's endpoint health remains probe-derived from our own monitors."
+}

--- a/registry/providers/taolend.json
+++ b/registry/providers/taolend.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "taolend",
+  "name": "TaoLend",
+  "kind": "subnet-team",
+  "website_url": "https://taolend.io/",
+  "authority": "provider-claimed",
+  "notes": "Provider entry for TaoLend / SN116. The official website is tracked with probe-derived degraded status when it returns server errors."
+}

--- a/registry/subnets/efficientfrontier.json
+++ b/registry/subnets/efficientfrontier.json
@@ -1,0 +1,81 @@
+{
+  "schema_version": 1,
+  "netuid": 53,
+  "name": "EfficientFrontier",
+  "slug": "efficientfrontier",
+  "status": "active",
+  "categories": [
+    "baseline-curated",
+    "defi",
+    "financial-trading",
+    "identity-reviewed",
+    "official-website",
+    "trading-strategies"
+  ],
+  "website_url": "https://www.signalplus.com/",
+  "dashboard_url": "https://t.signalplus.com/mining",
+  "source_repo": null,
+  "notes": "Reviewed overlay for SN53 EfficientFrontier by SignalPlus. The SignalPlus company website is live; the mining app surface returns an auth/challenge-style response to simple probes. The previously discovered EfficientFrontier source repository currently returns 404 and is not promoted.",
+  "curation": {
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T14:15:00.000Z",
+    "verified_at": "2026-06-08T14:15:00.000Z",
+    "source_count": 6,
+    "gap_notes": [
+      "SignalPlus website is live and is tracked as the team/project website.",
+      "The subnet mining app currently returns a 403/auth-challenge response to simple probes and is expected to appear degraded rather than healthy.",
+      "Previously discovered GitHub source repository currently returns 404.",
+      "No verified live source repository yet.",
+      "No verified machine-readable OpenAPI/Swagger schema yet.",
+      "No verified safe public subnet API endpoint yet.",
+      "No verified SSE/event stream yet.",
+      "No verified standalone static data artifact yet."
+    ]
+  },
+  "surfaces": [
+    {
+      "id": "sn-53-signalplus-website",
+      "name": "SignalPlus website",
+      "kind": "website",
+      "url": "https://www.signalplus.com/",
+      "provider": "signalplus",
+      "auth_required": false,
+      "authority": "official",
+      "public_safe": true,
+      "source_urls": [
+        "https://www.signalplus.com/",
+        "https://t.signalplus.com/mining"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
+      "notes": "SignalPlus team/company website for SN53 EfficientFrontier."
+    },
+    {
+      "id": "sn-53-signalplus-mining",
+      "name": "EfficientFrontier mining app",
+      "kind": "dashboard",
+      "url": "https://t.signalplus.com/mining",
+      "provider": "signalplus",
+      "auth_required": true,
+      "authority": "official",
+      "public_safe": true,
+      "source_urls": [
+        "https://t.signalplus.com/mining",
+        "https://www.signalplus.com/"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
+      "rate_limit_notes": "Simple probes currently receive an auth/challenge-style response; endpoint health should be interpreted as access-state, not app correctness.",
+      "notes": "SignalPlus mining/app surface linked by public SN53 references."
+    }
+  ]
+}

--- a/registry/subnets/metahash.json
+++ b/registry/subnets/metahash.json
@@ -1,0 +1,38 @@
+{
+  "schema_version": 1,
+  "netuid": 73,
+  "name": "MetaHash",
+  "slug": "metahash",
+  "status": "active",
+  "categories": [
+    "baseline-curated",
+    "defi",
+    "identity-reviewed",
+    "otc",
+    "treasury"
+  ],
+  "source_repo": null,
+  "website_url": null,
+  "docs_url": null,
+  "dashboard_url": null,
+  "notes": "Reviewed identity overlay for SN73. Native chain identity currently reports Parked, while public subnet directories identify SN73 as MetaHash. Official-looking docs and source URLs discovered from public directories currently do not resolve or return 404, so they are not promoted.",
+  "curation": {
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T14:15:00.000Z",
+    "verified_at": "2026-06-08T14:15:00.000Z",
+    "source_count": 5,
+    "gap_notes": [
+      "Native chain name currently reports as Parked; multiple public directories identify SN73 as MetaHash.",
+      "Official-looking docs domain docs.metahash73.com currently does not resolve from simple probes.",
+      "Previously discovered GitHub source repository currently returns 404.",
+      "No verified official website yet.",
+      "No verified live source repository yet.",
+      "No verified machine-readable OpenAPI/Swagger schema yet.",
+      "No verified safe public subnet API endpoint yet.",
+      "No verified SSE/event stream yet.",
+      "No verified standalone static data artifact yet."
+    ]
+  },
+  "surfaces": []
+}

--- a/registry/subnets/nodexo.json
+++ b/registry/subnets/nodexo.json
@@ -1,0 +1,77 @@
+{
+  "schema_version": 1,
+  "netuid": 27,
+  "name": "Nodexo",
+  "slug": "nodexo",
+  "status": "active",
+  "categories": [
+    "baseline-curated",
+    "compute",
+    "gpu",
+    "identity-reviewed",
+    "official-docs",
+    "official-website"
+  ],
+  "website_url": "https://nodexo.ai/",
+  "docs_url": "https://docs.nodexo.ai/",
+  "dashboard_url": "https://console.nodexo.ai/",
+  "source_repo": null,
+  "notes": "Reviewed overlay for SN27 Nodexo Compute. Official browser-facing website, docs, and console surfaces are known, but simple Node/HEAD probes currently receive connection resets. The previously discovered source repository candidate currently returns 404 and is not promoted.",
+  "curation": {
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T14:15:00.000Z",
+    "verified_at": "2026-06-08T14:15:00.000Z",
+    "source_count": 5,
+    "gap_notes": [
+      "Official website/docs/console are browser-facing but currently reject simple machine probes with connection resets, so these surfaces are listed without recurring probe monitoring.",
+      "Previously discovered GitHub source repository candidates currently return 404.",
+      "No verified live source repository yet.",
+      "No verified machine-readable OpenAPI/Swagger schema yet.",
+      "No verified safe public subnet API endpoint yet.",
+      "No verified SSE/event stream yet.",
+      "No verified standalone static data artifact yet."
+    ]
+  },
+  "surfaces": [
+    {
+      "id": "sn-27-nodexo-website",
+      "name": "Nodexo website",
+      "kind": "website",
+      "url": "https://nodexo.ai/",
+      "provider": "nodexo",
+      "auth_required": false,
+      "authority": "official",
+      "public_safe": true,
+      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
+      "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
+      "notes": "Official Nodexo Compute website."
+    },
+    {
+      "id": "sn-27-nodexo-docs",
+      "name": "Nodexo docs",
+      "kind": "docs",
+      "url": "https://docs.nodexo.ai/",
+      "provider": "nodexo",
+      "auth_required": false,
+      "authority": "official",
+      "public_safe": true,
+      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
+      "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
+      "notes": "Official Nodexo Compute documentation."
+    },
+    {
+      "id": "sn-27-nodexo-console",
+      "name": "Nodexo console",
+      "kind": "dashboard",
+      "url": "https://console.nodexo.ai/",
+      "provider": "nodexo",
+      "auth_required": true,
+      "authority": "official",
+      "public_safe": true,
+      "source_urls": ["https://nodexo.ai/", "https://docs.nodexo.ai/"],
+      "rate_limit_notes": "Not probe-enabled because simple Node/HEAD probes currently receive connection resets from the origin.",
+      "notes": "Official Nodexo console surface. Authentication may be required for account-specific workflows."
+    }
+  ]
+}

--- a/registry/subnets/taolend.json
+++ b/registry/subnets/taolend.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": 1,
+  "netuid": 116,
+  "name": "TaoLend",
+  "slug": "taolend",
+  "status": "active",
+  "categories": [
+    "baseline-curated",
+    "defi",
+    "identity-reviewed",
+    "lending",
+    "official-website"
+  ],
+  "website_url": "https://taolend.io/",
+  "source_repo": null,
+  "notes": "Reviewed overlay for SN116 TaoLend. Native chain identity currently reports hard_sign, while public subnet directories identify SN116 as TaoLend. The official website is tracked but currently returns server errors to simple probes. The previously discovered source repository currently returns 404 and is not promoted.",
+  "curation": {
+    "level": "maintainer-reviewed",
+    "review_state": "maintainer-reviewed",
+    "reviewed_at": "2026-06-08T14:15:00.000Z",
+    "verified_at": "2026-06-08T14:15:00.000Z",
+    "source_count": 6,
+    "gap_notes": [
+      "Native chain name currently reports as hard_sign; public directories identify SN116 as TaoLend.",
+      "Official website currently returns 500/server-error responses to simple probes and should appear degraded until it recovers.",
+      "Previously discovered GitHub source repository currently returns 404.",
+      "No verified live source repository yet.",
+      "No verified machine-readable OpenAPI/Swagger schema yet.",
+      "No verified safe public subnet API endpoint yet.",
+      "No verified SSE/event stream yet.",
+      "No verified standalone static data artifact yet."
+    ]
+  },
+  "surfaces": [
+    {
+      "id": "sn-116-taolend-website",
+      "name": "TaoLend website",
+      "kind": "website",
+      "url": "https://taolend.io/",
+      "provider": "taolend",
+      "auth_required": false,
+      "authority": "official",
+      "public_safe": true,
+      "source_urls": ["https://taolend.io/"],
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "html",
+        "timeout_ms": 10000
+      },
+      "notes": "Official TaoLend website. Current probe state is expected to show degraded while the origin returns server errors."
+    }
+  ]
+}

--- a/registry/verification/promotions.json
+++ b/registry/verification/promotions.json
@@ -1,5 +1,5 @@
 {
-  "candidate_count": 1891,
+  "candidate_count": 2018,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "notes": "Compact promotion snapshot for deterministic Git review. Full latency, timestamp, and probe-detail rows are staged for R2 during refresh/publish runs.",
   "results": [
@@ -13,6 +13,27 @@
       "netuid": 0,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-0-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 0,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -127,6 +148,27 @@
         "transient_failure": false
       },
       "redirect_target": "https://docs.macrocosmos.ai/",
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-1-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 1,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -588,6 +630,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-2-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 2,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-2-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -857,6 +920,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-3-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 3,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-3-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -967,6 +1051,27 @@
       "netuid": 4,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-4-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 4,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -1269,6 +1374,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-4-website-link-targon-com-docs-4",
+      "classification": "live",
+      "confidence_score": 76,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "docs",
+      "netuid": 4,
+      "private_redirect_blocked": false,
+      "provider": "taomarketcap",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-4-website-link-targon-com-docs-9",
       "classification": "live",
       "confidence_score": 76,
@@ -1437,27 +1563,6 @@
       "status": "ok"
     },
     {
-      "candidate_id": "sn-4-website-subdomain-docs-docs-targon-com",
-      "classification": "live",
-      "confidence_score": 76,
-      "content_type": "text/html; charset=utf-8",
-      "error": null,
-      "kind": "docs",
-      "netuid": 4,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "redirect_target": null,
-      "status": "ok"
-    },
-    {
       "candidate_id": "sn-5-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -1467,6 +1572,27 @@
       "netuid": 5,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-5-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 5,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -1853,6 +1979,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-6-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 6,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-6-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -2227,6 +2374,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-7-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 7,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-7-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -2484,6 +2652,27 @@
       "netuid": 8,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-8-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 8,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -2868,6 +3057,27 @@
       },
       "redirect_target": null,
       "status": "failed"
+    },
+    {
+      "candidate_id": "sn-9-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 9,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
     },
     {
       "candidate_id": "sn-9-taomarketcap-dashboard",
@@ -3286,26 +3496,6 @@
       "status": "failed"
     },
     {
-      "candidate_id": "sn-9-website-subdomain-docs-docs-iota-macrocosmos-ai",
-      "classification": "unsupported",
-      "confidence_score": 23,
-      "content_type": null,
-      "error": "probe-failed",
-      "kind": "docs",
-      "netuid": 9,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "status": "failed"
-    },
-    {
       "candidate_id": "sn-10-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -3315,6 +3505,27 @@
       "netuid": 10,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-10-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 10,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -3575,6 +3786,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-10-website-subdomain-docs-docs-taofi-com",
+      "classification": "live",
+      "confidence_score": 76,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "docs",
+      "netuid": 10,
+      "private_redirect_blocked": false,
+      "provider": "taomarketcap",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-11-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -3584,6 +3816,27 @@
       "netuid": 11,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-11-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 11,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -3970,6 +4223,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-12-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 12,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-12-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -4152,6 +4426,27 @@
       },
       "redirect_target": null,
       "status": "failed"
+    },
+    {
+      "candidate_id": "sn-13-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 13,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
     },
     {
       "candidate_id": "sn-13-taomarketcap-dashboard",
@@ -4612,6 +4907,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-14-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 14,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-14-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -5003,6 +5319,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-15-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 15,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-15-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -5377,6 +5714,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-16-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 16,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-16-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -5661,6 +6019,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-17-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 17,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -6025,6 +6404,27 @@
       "netuid": 18,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-18-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 18,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -6426,6 +6826,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-19-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 19,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -6890,6 +7311,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-20-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 20,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-20-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -7192,6 +7634,27 @@
       "netuid": 21,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-21-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 21,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -7683,6 +8146,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-22-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 22,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-22-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -7994,6 +8478,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-23-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 23,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-23-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -8259,10 +8764,10 @@
       "status": "failed"
     },
     {
-      "candidate_id": "sn-23-website-link-trishool-ai-docs-2",
+      "candidate_id": "sn-23-website-link-trishool-ai-docs-1",
       "classification": "live",
-      "confidence_score": 68,
-      "content_type": "application/pdf",
+      "confidence_score": 76,
+      "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "docs",
       "netuid": 23,
@@ -8280,10 +8785,10 @@
       "status": "ok"
     },
     {
-      "candidate_id": "sn-23-website-subdomain-docs-docs-trishool-ai",
+      "candidate_id": "sn-23-website-link-trishool-ai-docs-2",
       "classification": "live",
-      "confidence_score": 76,
-      "content_type": "text/html; charset=utf-8",
+      "confidence_score": 68,
+      "content_type": "application/pdf",
       "error": null,
       "kind": "docs",
       "netuid": 23,
@@ -8337,6 +8842,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-24-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 24,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -8738,6 +9264,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-25-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 25,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-25-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -8986,6 +9533,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-25-website-link-macrocosmos-ai-docs-3",
+      "classification": "live",
+      "confidence_score": 76,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "docs",
+      "netuid": 25,
+      "private_redirect_blocked": false,
+      "provider": "taomarketcap",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-25-website-link-macrocosmos-ai-docs-6",
       "classification": "redirected",
       "confidence_score": 71,
@@ -9112,27 +9680,6 @@
       "status": "ok"
     },
     {
-      "candidate_id": "sn-25-website-subdomain-docs-docs-macrocosmos-ai",
-      "classification": "live",
-      "confidence_score": 76,
-      "content_type": "text/html; charset=utf-8",
-      "error": null,
-      "kind": "docs",
-      "netuid": 25,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "redirect_target": null,
-      "status": "ok"
-    },
-    {
       "candidate_id": "sn-26-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -9142,6 +9689,27 @@
       "netuid": 26,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-26-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 26,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -9506,6 +10074,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-27-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 27,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-27-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -9750,26 +10339,6 @@
       "status": "failed"
     },
     {
-      "candidate_id": "sn-27-website-subdomain-docs-docs-nodexo-ai",
-      "classification": "unsupported",
-      "confidence_score": 23,
-      "content_type": null,
-      "error": "probe-failed",
-      "kind": "docs",
-      "netuid": 27,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "status": "failed"
-    },
-    {
       "candidate_id": "sn-28-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -9779,6 +10348,27 @@
       "netuid": 28,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-28-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 28,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -9896,6 +10486,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-29-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 29,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-29-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -9919,18 +10530,21 @@
     {
       "candidate_id": "sn-29-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 29,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9999,18 +10613,21 @@
     {
       "candidate_id": "sn-29-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 29,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10023,6 +10640,27 @@
       "netuid": 30,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-30-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 30,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -10329,6 +10967,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-31-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 31,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-31-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -10434,6 +11093,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-32-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 32,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-32-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -10457,18 +11137,21 @@
     {
       "candidate_id": "sn-32-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 32,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10892,27 +11575,6 @@
       "status": "ok"
     },
     {
-      "candidate_id": "sn-32-website-subdomain-docs-docs-its-ai-org",
-      "classification": "live",
-      "confidence_score": 76,
-      "content_type": "text/html; charset=utf-8",
-      "error": null,
-      "kind": "docs",
-      "netuid": 32,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "redirect_target": null,
-      "status": "ok"
-    },
-    {
       "candidate_id": "sn-33-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -10976,6 +11638,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-33-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 33,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-33-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -10999,18 +11682,21 @@
     {
       "candidate_id": "sn-33-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 33,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11098,6 +11784,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-34-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 34,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-34-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -11121,18 +11828,21 @@
     {
       "candidate_id": "sn-34-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 34,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11220,6 +11930,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-35-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 35,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-35-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -11243,18 +11974,21 @@
     {
       "candidate_id": "sn-35-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 35,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11344,18 +12078,21 @@
     {
       "candidate_id": "sn-35-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 35,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11485,6 +12222,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-35-website-subdomain-docs-docs-0xmarkets-io",
+      "classification": "live",
+      "confidence_score": 76,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "docs",
+      "netuid": 35,
+      "private_redirect_blocked": false,
+      "provider": "taomarketcap",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-36-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -11494,6 +12252,27 @@
       "netuid": 36,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-36-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 36,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -11529,18 +12308,21 @@
     {
       "candidate_id": "sn-36-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 36,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11859,6 +12641,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-37-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 37,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-37-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -11882,18 +12685,21 @@
     {
       "candidate_id": "sn-37-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 37,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12233,6 +13039,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-38-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 38,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-38-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -12255,20 +13082,23 @@
     },
     {
       "candidate_id": "sn-38-taomarketcap-source-repo",
-      "classification": "unsupported",
-      "confidence_score": 20,
+      "classification": "live",
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 38,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": true,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
-      "status": "failed"
+      "redirect_target": null,
+      "status": "ok"
     },
     {
       "candidate_id": "sn-38-taomarketcap-website",
@@ -12502,6 +13332,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-39-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 39,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-39-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -12607,19 +13458,22 @@
     },
     {
       "candidate_id": "sn-39-tensorplex-source-repo-1",
-      "classification": "live",
-      "confidence_score": 80,
+      "classification": "redirected",
+      "confidence_score": 50,
       "error": null,
       "kind": "source-repo",
       "netuid": 39,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": "https://github.com/one-covenant/basilica",
       "status": "ok"
     },
     {
@@ -12632,6 +13486,27 @@
       "netuid": 40,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-40-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 40,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -12769,6 +13644,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-41-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 41,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-41-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -12792,18 +13688,21 @@
     {
       "candidate_id": "sn-41-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 41,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13059,6 +13958,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-42-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 42,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-42-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -13164,6 +14084,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-43-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 43,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-43-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -13187,18 +14128,21 @@
     {
       "candidate_id": "sn-43-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 43,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13286,6 +14230,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-44-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 44,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-44-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -13309,18 +14274,21 @@
     {
       "candidate_id": "sn-44-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 44,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13410,18 +14378,21 @@
     {
       "candidate_id": "sn-44-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 44,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13593,6 +14564,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-45-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 45,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-45-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -13616,18 +14608,21 @@
     {
       "candidate_id": "sn-45-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 45,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14111,6 +15106,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-46-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 46,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-46-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -14134,18 +15150,21 @@
     {
       "candidate_id": "sn-46-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 46,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14235,35 +15254,41 @@
     {
       "candidate_id": "sn-46-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 46,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-46-tensorplex-source-repo-2",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 46,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14451,7 +15476,7 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": "https://accounts.google.com/v3/signin/identifier?opparams=%253F&dsh=S942905491%3A1780924533297355&client_id=327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com&code_challenge=zGToScs4R1T7ex5LEZtaBt7RaKsGSyqmUbc5IdyNxG0&code_challenge_method=S256&nonce=yFuBi3ogykwGoak5JK62HvAjNBHYSicmkQvLSTc8KFM&o2v=2&prompt=select_account&redirect_uri=https%3A%2F%2Fzipcode.ai%2Fapi%2Fportal-auth%2Fgoogle%2Fcallback&response_type=code&scope=openid+email+profile&service=lso&state=JP2kw3EFPvZQevuGIACR8HiL8zNpA5MYYRYD9zW6Rqo&flowName=GeneralOAuthLite&continue=https%3A%2F%2Faccounts.google.com%2Fsignin%2Foauth%2Flegacy%2Fconsent%3Fauthuser%3Dunknown%26part%3DAJi8hAPdfsFH9Nlywlb0fjHozHFqxzNLkM9m7qlp0CjwXAb72cQy9892pE9rkdAHJdiPeByIb1GOJYEyzmnKb658GnqCYMUwBOaJTvNrhKkTqQoa10GdZS3Nd7RLCK1bL0k3F1_4M1N7GaY7Ooh80VshPalfj9y1Far6WXu176b5Qu4d2TmzPUpYljDn87ZN0mjchKHeDLy5M5ucat1InqD9qw2j8GpoB3jph9J1xWa1xmvom38jiSUUJLwjd3QyXxM4rfA-JTjPq3BBQgdr5ETRfYntW2gaBn-aQVoW4ICRI4P54mgyeNAc8UU6WDhhl1r_Ew2s84w4Wgwh5cqUSukWO5fIBr2DHvTMbn8IEHC-cW6y9gNORTrBQNiYOAQp8VgAUDdxfMs5LPZBls26wt1vgyFMyA3ZA8ijDWbaK4on3vVUoBTIickW6rJz2duHuaCsVTfuBQaFWR2lWu3ZRuUJiMPGdjKeGA%26flowName%3DGeneralOAuthFlow%26as%3DS942905491%253A1780924533297355%26client_id%3D327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com%23&app_domain=https%3A%2F%2Fzipcode.ai&rart=ANgoxcduLdkaO2R_2iIyReI-doSVEqpImmzvdCwdALFAGus5xQsL0-KHJXvVP9lX7DxuYF5trCqLr_DVLKUO1Tr95g5z5rPQ4b0oTriZJ9cmc41msprjAWA",
+      "redirect_target": "https://accounts.google.com/v3/signin/identifier?opparams=%253F&dsh=S-165979954%3A1780927900000092&client_id=327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com&code_challenge=NybiCUinNQrqWDW1gZ9EZVkh462QXgIwN361WZcT3dw&code_challenge_method=S256&nonce=yIqKJtnoIIA_K6PmFLkBkPyClHvMvgtOvEbfKUJjvP0&o2v=2&prompt=select_account&redirect_uri=https%3A%2F%2Fzipcode.ai%2Fapi%2Fportal-auth%2Fgoogle%2Fcallback&response_type=code&scope=openid+email+profile&service=lso&state=EKPG6nN-P5iQwZUu5ZSh5u7CjKkJWpuFpKjbmhU1PDk&flowName=GeneralOAuthLite&continue=https%3A%2F%2Faccounts.google.com%2Fsignin%2Foauth%2Flegacy%2Fconsent%3Fauthuser%3Dunknown%26part%3DAJi8hAObtNeYJIh6n3Oq3SHdSpeUyJrLF0SPsPXpmyzpmRXzQekQDnvYVfjbFVpCsov0QrC7Om89i137XrLVm7sgPZ0TlpDO7XyXaTH2OParYdaz8-Pk8MrYu_GxmI-Nyr4YGhhlu_IAvSufDJexn_SlNn_MsFBu65PPsi3XIKX7yixy0OHnGcahAmHOYPOOy_UHRFN5K5j8ojZtGCVIghzdBGNXLif9vXzb3SBVOHk2jRG6eGkIG_1QipLlDC218cSJFAsUCNCqW7d_zRewGNgHrRGou1U2eSXckgBJ1CEP8nVwzLCV9vIdxG6ZBp8lAmX9XtyJ_bDL7KjqpsBaA2qjL94hQZ2la5B7R3hMgVHQLqI0X_r5qDYXVvDM0zX0O-oDw8yo1tHhrN6SErQLu4BLse5rFeRzbosD1nSlPqjBw-X6NM5wThBMz1lUwQlUHCS2JuDNNBt-1GyXJk1FYPL5kmlR6npY5w%26flowName%3DGeneralOAuthFlow%26as%3DS-165979954%253A1780927900000092%26client_id%3D327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com%23&app_domain=https%3A%2F%2Fzipcode.ai&rart=ANgoxcf7fuzMQPI8VQoQO2dEnBZf7vw_H4-yhj6JxR07hrhMALLtYZKl_bTN4zHTlZFc3bdz3UPnxlBpUCToHgdzxmURcJoknbtOw6l0RaenlvZdUxlUx9A",
       "status": "ok"
     },
     {
@@ -14539,6 +15564,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-47-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 47,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-47-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -14561,19 +15607,22 @@
     },
     {
       "candidate_id": "sn-47-taomarketcap-source-repo",
-      "classification": "live",
-      "confidence_score": 80,
+      "classification": "redirected",
+      "confidence_score": 54,
       "error": null,
       "kind": "source-repo",
       "netuid": 47,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": "https://github.com/openevolai/evolai",
       "status": "ok"
     },
     {
@@ -14642,18 +15691,21 @@
     {
       "candidate_id": "sn-47-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 47,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14666,6 +15718,27 @@
       "netuid": 48,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-48-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 48,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -14701,18 +15774,21 @@
     {
       "candidate_id": "sn-48-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 48,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15198,6 +16274,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-49-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 49,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-49-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -15221,18 +16318,21 @@
     {
       "candidate_id": "sn-49-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 49,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15481,6 +16581,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-50-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 50,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-50-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -15503,19 +16624,22 @@
     },
     {
       "candidate_id": "sn-50-taomarketcap-source-repo",
-      "classification": "live",
-      "confidence_score": 80,
+      "classification": "redirected",
+      "confidence_score": 54,
       "error": null,
       "kind": "source-repo",
       "netuid": 50,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": "https://github.com/synthdataco/synth-subnet",
       "status": "ok"
     },
     {
@@ -15771,6 +16895,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-51-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 51,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-51-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -15794,18 +16939,21 @@
     {
       "candidate_id": "sn-51-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 51,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16271,6 +17419,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-52-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 52,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-52-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -16294,18 +17463,21 @@
     {
       "candidate_id": "sn-52-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 52,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16394,35 +17566,41 @@
     {
       "candidate_id": "sn-52-tensorplex-source-repo-3",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 52,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-52-tensorplex-source-repo-4",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 52,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16435,6 +17613,27 @@
       "netuid": 53,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-53-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 53,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -16593,6 +17792,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-54-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 54,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-54-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -16616,18 +17836,21 @@
     {
       "candidate_id": "sn-54-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 54,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16892,6 +18115,27 @@
       "netuid": 55,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-55-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 55,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -17260,6 +18504,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-56-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 56,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-56-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -17283,18 +18548,21 @@
     {
       "candidate_id": "sn-56-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 56,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17383,19 +18651,22 @@
     },
     {
       "candidate_id": "sn-56-tensorplex-source-repo-1",
-      "classification": "live",
-      "confidence_score": 80,
+      "classification": "redirected",
+      "confidence_score": 50,
       "error": null,
       "kind": "source-repo",
       "netuid": 56,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": "https://github.com/gradients-ai/G.O.D",
       "status": "ok"
     },
     {
@@ -17756,6 +19027,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-57-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 57,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-57-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -17842,18 +19134,21 @@
     {
       "candidate_id": "sn-57-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 57,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17914,6 +19209,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-58-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 58,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -18006,18 +19322,21 @@
     {
       "candidate_id": "sn-58-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 58,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18063,6 +19382,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-59-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 59,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-59-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -18086,18 +19426,21 @@
     {
       "candidate_id": "sn-59-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 59,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18437,6 +19780,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-60-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 60,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-60-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -18460,18 +19824,21 @@
     {
       "candidate_id": "sn-60-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 60,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18768,6 +20135,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-61-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 61,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-61-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -18791,18 +20179,21 @@
     {
       "candidate_id": "sn-61-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 61,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19037,6 +20428,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-62-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 62,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-62-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -19060,18 +20472,21 @@
     {
       "candidate_id": "sn-62-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 62,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19285,27 +20700,6 @@
       "status": "failed"
     },
     {
-      "candidate_id": "sn-62-website-subdomain-docs-docs-ridges-ai",
-      "classification": "live",
-      "confidence_score": 76,
-      "content_type": "text/html; charset=utf-8",
-      "error": null,
-      "kind": "docs",
-      "netuid": 62,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "redirect_target": null,
-      "status": "ok"
-    },
-    {
       "candidate_id": "sn-63-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -19315,6 +20709,27 @@
       "netuid": 63,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-63-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 63,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -19350,18 +20765,21 @@
     {
       "candidate_id": "sn-63-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 63,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19867,6 +21285,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-64-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 64,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-64-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -19890,18 +21329,21 @@
     {
       "candidate_id": "sn-64-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 64,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19990,36 +21432,42 @@
     },
     {
       "candidate_id": "sn-64-tensorplex-source-repo-1",
-      "classification": "live",
-      "confidence_score": 80,
+      "classification": "redirected",
+      "confidence_score": 50,
       "error": null,
       "kind": "source-repo",
       "netuid": 64,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": "https://github.com/chutesai/chutes-miner",
       "status": "ok"
     },
     {
       "candidate_id": "sn-64-tensorplex-source-repo-2",
-      "classification": "live",
-      "confidence_score": 80,
+      "classification": "redirected",
+      "confidence_score": 50,
       "error": null,
       "kind": "source-repo",
       "netuid": 64,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": "https://github.com/chutesai/chutes",
       "status": "ok"
     },
     {
@@ -20380,6 +21828,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-65-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 65,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-65-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -20403,18 +21872,21 @@
     {
       "candidate_id": "sn-65-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 65,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20775,6 +22247,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-66-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 66,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-66-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -20798,18 +22291,21 @@
     {
       "candidate_id": "sn-66-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 66,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21128,6 +22624,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-67-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 67,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-67-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -21235,18 +22752,21 @@
     {
       "candidate_id": "sn-67-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 67,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21439,6 +22959,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-68-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 68,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-68-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -21462,18 +23003,21 @@
     {
       "candidate_id": "sn-68-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 68,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21813,6 +23357,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-69-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 69,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-69-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -21918,6 +23483,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-70-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 70,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-70-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -21941,18 +23527,21 @@
     {
       "candidate_id": "sn-70-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 70,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22292,6 +23881,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-71-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 71,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-71-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -22315,18 +23925,21 @@
     {
       "candidate_id": "sn-71-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 71,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22582,6 +24195,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-72-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 72,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-72-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -22605,18 +24239,21 @@
     {
       "candidate_id": "sn-72-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 72,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23061,6 +24698,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-73-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 73,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-73-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -23228,6 +24886,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-74-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 74,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-74-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -23251,18 +24930,21 @@
     {
       "candidate_id": "sn-74-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 74,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23352,18 +25034,21 @@
     {
       "candidate_id": "sn-74-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 74,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23514,6 +25199,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-75-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 75,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-75-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -23537,18 +25243,21 @@
     {
       "candidate_id": "sn-75-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 75,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23638,35 +25347,41 @@
     {
       "candidate_id": "sn-75-tensorplex-source-repo-2",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 75,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-75-tensorplex-source-repo-3",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 75,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24027,6 +25742,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-76-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 76,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-76-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -24300,6 +26036,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-77-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 77,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-77-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -24323,18 +26080,21 @@
     {
       "candidate_id": "sn-77-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 77,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24569,6 +26329,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-78-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 78,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-78-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -24592,18 +26373,21 @@
     {
       "candidate_id": "sn-78-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 78,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24714,18 +26498,21 @@
     {
       "candidate_id": "sn-78-tensorplex-source-repo-2",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 78,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24897,6 +26684,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-79-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 79,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-79-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -25004,18 +26812,21 @@
     {
       "candidate_id": "sn-79-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 79,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25396,6 +27207,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-80-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 80,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-80-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -25419,18 +27251,21 @@
     {
       "candidate_id": "sn-80-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 80,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25707,6 +27542,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-81-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 81,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-81-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -25812,19 +27668,22 @@
     },
     {
       "candidate_id": "sn-81-tensorplex-source-repo-1",
-      "classification": "live",
-      "confidence_score": 80,
+      "classification": "redirected",
+      "confidence_score": 50,
       "error": null,
       "kind": "source-repo",
       "netuid": 81,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": "https://github.com/one-covenant/grail",
       "status": "ok"
     },
     {
@@ -25837,6 +27696,27 @@
       "netuid": 82,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-82-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 82,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -25872,18 +27752,21 @@
     {
       "candidate_id": "sn-82-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 82,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25973,18 +27856,21 @@
     {
       "candidate_id": "sn-82-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 82,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26366,6 +28252,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-83-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 83,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-83-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -26389,18 +28296,21 @@
     {
       "candidate_id": "sn-83-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 83,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26635,6 +28545,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-84-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 84,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-84-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -26721,35 +28652,41 @@
     {
       "candidate_id": "sn-84-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 84,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-84-tensorplex-source-repo-2",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 84,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26762,6 +28699,27 @@
       "netuid": 85,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-85-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 85,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -26797,18 +28755,21 @@
     {
       "candidate_id": "sn-85-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 85,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27211,6 +29172,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-86-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 86,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-86-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -27304,6 +29286,27 @@
       "netuid": 87,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-87-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 87,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -27463,6 +29466,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-88-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 88,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-88-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -27486,18 +29510,21 @@
     {
       "candidate_id": "sn-88-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 88,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27795,6 +29822,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-89-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 89,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-89-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -27818,18 +29866,21 @@
     {
       "candidate_id": "sn-89-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 89,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28064,6 +30115,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-90-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 90,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-90-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -28157,6 +30229,27 @@
       "netuid": 91,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-91-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 91,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -28526,6 +30619,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-92-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 92,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-92-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -28671,6 +30785,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-93-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 93,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-93-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -28694,18 +30829,21 @@
     {
       "candidate_id": "sn-93-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 93,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29045,6 +31183,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-94-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 94,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-94-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -29068,18 +31227,21 @@
     {
       "candidate_id": "sn-94-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 94,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29365,6 +31527,27 @@
       "netuid": 95,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-95-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 95,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -29733,6 +31916,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-96-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 96,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-96-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -29756,18 +31960,21 @@
     {
       "candidate_id": "sn-96-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 96,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29857,18 +32064,21 @@
     {
       "candidate_id": "sn-96-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 96,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30040,6 +32250,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-97-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 97,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-97-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -30063,18 +32294,21 @@
     {
       "candidate_id": "sn-97-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 97,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30164,18 +32398,21 @@
     {
       "candidate_id": "sn-97-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 97,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30347,6 +32584,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-98-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 98,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-98-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -30370,18 +32628,21 @@
     {
       "candidate_id": "sn-98-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 98,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30636,6 +32897,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-98-website-link-forevermoney-ai-docs-2",
+      "classification": "live",
+      "confidence_score": 76,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "docs",
+      "netuid": 98,
+      "private_redirect_blocked": false,
+      "provider": "taomarketcap",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-98-website-link-forevermoney-ai-website-3",
       "classification": "live",
       "confidence_score": 76,
@@ -30741,27 +33023,6 @@
       "status": "ok"
     },
     {
-      "candidate_id": "sn-98-website-subdomain-docs-docs-forevermoney-ai",
-      "classification": "live",
-      "confidence_score": 76,
-      "content_type": "text/html; charset=utf-8",
-      "error": null,
-      "kind": "docs",
-      "netuid": 98,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "redirect_target": null,
-      "status": "ok"
-    },
-    {
       "candidate_id": "sn-99-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -30825,6 +33086,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-99-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 99,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-99-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -30848,18 +33130,21 @@
     {
       "candidate_id": "sn-99-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 99,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30949,18 +33234,21 @@
     {
       "candidate_id": "sn-99-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 99,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31111,6 +33399,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-100-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 100,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-100-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -31134,18 +33443,21 @@
     {
       "candidate_id": "sn-100-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 100,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31234,19 +33546,22 @@
     },
     {
       "candidate_id": "sn-100-tensorplex-source-repo-1",
-      "classification": "live",
-      "confidence_score": 80,
+      "classification": "redirected",
+      "confidence_score": 50,
       "error": null,
       "kind": "source-repo",
       "netuid": 100,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": true,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": "https://github.com/PlatformNetwork/platform",
       "status": "ok"
     },
     {
@@ -31502,6 +33817,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-101-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 101,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-101-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -31628,6 +33964,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-102-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 102,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-102-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -31651,18 +34008,21 @@
     {
       "candidate_id": "sn-102-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 102,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31981,6 +34341,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-103-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 103,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-103-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -32004,18 +34385,21 @@
     {
       "candidate_id": "sn-103-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 103,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32418,27 +34802,6 @@
       "status": "ok"
     },
     {
-      "candidate_id": "sn-103-website-subdomain-docs-docs-djinn-gg",
-      "classification": "dead",
-      "confidence_score": 0,
-      "content_type": "text/html",
-      "error": null,
-      "kind": "docs",
-      "netuid": 103,
-      "private_redirect_blocked": false,
-      "provider": "taomarketcap",
-      "quality_signals": {
-        "content_type_matches_kind": true,
-        "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "provider-claimed",
-        "transient_failure": false
-      },
-      "redirect_target": null,
-      "status": "failed"
-    },
-    {
       "candidate_id": "sn-104-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -32448,6 +34811,27 @@
       "netuid": 104,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-104-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 104,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -32553,6 +34937,27 @@
       "netuid": 105,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-105-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 105,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -32837,6 +35242,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-106-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 106,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-106-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -32860,18 +35286,21 @@
     {
       "candidate_id": "sn-106-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 106,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33147,6 +35576,27 @@
       "status": "failed"
     },
     {
+      "candidate_id": "sn-107-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 107,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-107-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -33170,18 +35620,21 @@
     {
       "candidate_id": "sn-107-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 107,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33271,18 +35724,21 @@
     {
       "candidate_id": "sn-107-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 107,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33517,6 +35973,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-108-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 108,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-108-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -33540,18 +36017,21 @@
     {
       "candidate_id": "sn-108-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 108,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33912,6 +36392,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-109-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 109,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-109-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -33935,18 +36436,21 @@
     {
       "candidate_id": "sn-109-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 109,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34022,6 +36526,27 @@
       "netuid": 110,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-110-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 110,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -34141,18 +36666,21 @@
     {
       "candidate_id": "sn-110-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 110,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34513,6 +37041,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-111-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 111,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-111-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -34536,18 +37085,21 @@
     {
       "candidate_id": "sn-111-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 111,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34635,6 +37187,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-112-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 112,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-112-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -34658,18 +37231,21 @@
     {
       "candidate_id": "sn-112-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 112,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34904,6 +37480,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-112-website-subdomain-docs-docs-minotaursubnet-com",
+      "classification": "live",
+      "confidence_score": 76,
+      "content_type": "text/html",
+      "error": null,
+      "kind": "docs",
+      "netuid": 112,
+      "private_redirect_blocked": false,
+      "provider": "taomarketcap",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "provider-claimed",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-113-backprop-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -34946,6 +37543,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-113-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 113,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-113-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -34969,18 +37587,21 @@
     {
       "candidate_id": "sn-113-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 113,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35320,6 +37941,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-114-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 114,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-114-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -35343,18 +37985,21 @@
     {
       "candidate_id": "sn-114-taomarketcap-source-repo",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 59,
       "error": null,
       "kind": "source-repo",
       "netuid": 114,
+      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "third-party-index"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35444,18 +38089,21 @@
     {
       "candidate_id": "sn-114-tensorplex-source-repo-1",
       "classification": "live",
-      "confidence_score": 80,
+      "confidence_score": 55,
       "error": null,
       "kind": "source-repo",
       "netuid": 114,
+      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "archived": false,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
+        "content_type_matches_kind": true,
         "public_safe": true,
-        "source_tier": "community-docs"
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "community-docs",
+        "transient_failure": false
       },
+      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35753,6 +38401,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-115-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 115,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-115-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -35863,6 +38532,27 @@
       "netuid": 116,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-116-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 116,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -35988,6 +38678,27 @@
       "netuid": 117,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-117-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 117,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -36158,6 +38869,27 @@
       },
       "redirect_target": null,
       "status": "failed"
+    },
+    {
+      "candidate_id": "sn-118-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 118,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
     },
     {
       "candidate_id": "sn-118-taomarketcap-dashboard",
@@ -36638,6 +39370,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-119-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 119,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-119-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -36778,6 +39531,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-120-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 120,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -37041,6 +39815,27 @@
       "netuid": 121,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-121-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 121,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -37532,6 +40327,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-122-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 122,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-122-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -37642,6 +40458,27 @@
       "netuid": 123,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-123-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 123,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -37791,6 +40628,27 @@
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-124-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 124,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
         "transient_failure": false
       },
       "redirect_target": null,
@@ -38066,6 +40924,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-125-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 125,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-125-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -38159,6 +41038,27 @@
       "netuid": 126,
       "private_redirect_blocked": false,
       "provider": "backprop-finance",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
+      "candidate_id": "sn-126-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 126,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
         "public_safe": true,
@@ -38524,6 +41424,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-127-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 127,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-127-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -38856,6 +41777,27 @@
       "status": "ok"
     },
     {
+      "candidate_id": "sn-128-subnetradar-dashboard",
+      "classification": "live",
+      "confidence_score": 77,
+      "content_type": "text/html; charset=utf-8",
+      "error": null,
+      "kind": "dashboard",
+      "netuid": 128,
+      "private_redirect_blocked": false,
+      "provider": "subnetradar",
+      "quality_signals": {
+        "content_type_matches_kind": true,
+        "public_safe": true,
+        "rate_limited": false,
+        "redirected": false,
+        "source_tier": "third-party-index",
+        "transient_failure": false
+      },
+      "redirect_target": null,
+      "status": "ok"
+    },
+    {
       "candidate_id": "sn-128-taomarketcap-dashboard",
       "classification": "live",
       "confidence_score": 77,
@@ -39126,18 +42068,18 @@
     "by_classification": {
       "auth-required": 9,
       "content-mismatch": 46,
-      "dead": 400,
-      "live": 1233,
+      "dead": 399,
+      "live": 1356,
       "rate-limited": 7,
-      "redirected": 159,
+      "redirected": 167,
       "transient": 4,
       "unsafe": 2,
-      "unsupported": 31
+      "unsupported": 28
     },
     "by_kind": {
-      "dashboard": 435,
+      "dashboard": 564,
       "data-artifact": 14,
-      "docs": 426,
+      "docs": 424,
       "openapi": 280,
       "source-repo": 156,
       "subnet-api": 215,
@@ -39147,12 +42089,13 @@
       "allways": 1,
       "backprop-finance": 129,
       "gittensor": 1,
-      "taomarketcap": 1307,
+      "subnetradar": 129,
+      "taomarketcap": 1305,
       "taopedia-articles": 128,
       "taostats": 129,
       "tensorplex-subnet-docs": 196
     },
-    "promotable_count": 1392
+    "promotable_count": 1523
   },
   "verification_finished_at": null,
   "verification_started_at": null

--- a/scripts/artifact-budgets.mjs
+++ b/scripts/artifact-budgets.mjs
@@ -1,6 +1,6 @@
 export const ARTIFACT_SIZE_BUDGETS = [
-  budget("candidates.json", 4_000_000, 8_000_000),
-  budget("review-queue.json", 4_000_000, 8_000_000),
+  budget("candidates.json", 4_500_000, 8_000_000),
+  budget("review-queue.json", 4_500_000, 8_000_000),
   budget("verification/latest.json", 3_000_000, 5_000_000),
   budget("surfaces.json", 1_500_000, 4_000_000),
   budget("endpoints.json", 2_500_000, 5_000_000),

--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -54,6 +54,7 @@ await discoverFromTaopediaArticles();
 await discoverUniversalTaoMarketCapDashboards();
 await discoverUniversalBackpropFinanceDashboards();
 await discoverUniversalTaostatsMetagraphDashboards();
+await discoverUniversalSubnetRadarDashboards();
 if (restoredProviders.size === 0) {
   await discoverFromGithubReadmes();
   await discoverFromProjectWebsites();
@@ -113,6 +114,10 @@ if (!dryRun) {
         {
           id: "taostats",
           url: "https://taostats.io/subnets/",
+        },
+        {
+          id: "subnetradar",
+          url: "https://subnetradar.com/subnet/",
         },
         {
           id: "tensorplex-subnet-docs",
@@ -423,6 +428,27 @@ async function discoverUniversalTaostatsMetagraphDashboards() {
       provider: "taostats",
       review_notes:
         "Universal Taostats subnet metagraph dashboard candidate. Third-party explorer enrichment, not protocol authority.",
+    });
+  }
+}
+
+async function discoverUniversalSubnetRadarDashboards() {
+  for (const subnet of nativeSnapshot.subnets) {
+    const displayName = displayNameForNetuid(subnet.netuid);
+    const url = `https://subnetradar.com/subnet/${subnet.netuid}`;
+    addCandidate({
+      id: `sn-${subnet.netuid}-subnetradar-dashboard`,
+      netuid: subnet.netuid,
+      name: `${displayName} SubnetRadar dashboard`,
+      kind: "dashboard",
+      url,
+      source_url: url,
+      source_type: "subnetradar-dashboard",
+      source_tier: "third-party-index",
+      confidence: "medium",
+      provider: "subnetradar",
+      review_notes:
+        "Universal SubnetRadar subnet dashboard candidate. Third-party risk/market analytics enrichment, not Metagraphed endpoint health authority.",
     });
   }
 }
@@ -1071,7 +1097,9 @@ function isGenericHost(hostname) {
     "gitlab.com",
     "bitbucket.org",
     "readthedocs.io",
+    "subnetradar.com",
     "taomarketcap.com",
+    "taostats.io",
     "docs.google.com",
   ].some(
     (genericHost) => host === genericHost || host.endsWith(`.${genericHost}`),

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -560,6 +560,7 @@ const GENERIC_README_REFERENCE_HOSTS = [
   "openai.com",
   "pm2.io",
   "python.org",
+  "subnetradar.com",
   "taomarketcap.com",
   "taostats.io",
 ];


### PR DESCRIPTION
## Summary
- add reviewed enrichment overlays for Nodexo, EfficientFrontier, MetaHash, and TaoLend
- add SubnetRadar as a third-party dashboard discovery source
- refresh generated compact registry artifacts from verified candidate and probe data

## What changed
- Added provider profiles for Nodexo, SignalPlus, SubnetRadar, and TaoLend.
- Added maintainer-reviewed subnet overlays for SN27, SN53, SN73, and SN116.
- Added universal SubnetRadar dashboard candidate discovery for active Finney netuids.
- Regenerated candidate, promotion, coverage, profile, surface, search, evidence, and R2 manifest artifacts.
- Raised expanded R2 candidate/review-queue warning budgets to the current 2k-candidate scale while keeping fail thresholds unchanged.

## Why
- Several low-completeness subnets had real identity/project evidence but were still represented mostly by directory-derived surfaces.
- Some public sources are stale or degraded; the registry should record that explicitly instead of silently leaving those subnets as untouched machine-generated gaps.
- SubnetRadar provides probeable third-party subnet dashboards that are useful as enrichment, while Metagraphed endpoint health remains probe-derived from our own monitors.

## Validation
- `npm run discover:candidates:dry-run`
- `npm run verify:candidates`
- `npm run curate:baseline`
- `npm run build`
- `METAGRAPH_WRITE_PROBE_RESULTS=1 npm run probes:smoke`
- `npm run validate`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:artifact-budgets`
- `npm run scan:public-safety`
- `npm run check`
- `npm run test:coverage`
- `git diff --check`

## Notes
- Current registry output: 129 subnets, 1122 surfaces, 72 providers, 2018 candidates, and 1115 probed surfaces.
- Smoke probes reported 1106 ok, 9 degraded, and 0 failed monitored surfaces. Degraded states are retained as operational signal.
- Candidate/review detail remains R2-backed; Git still stores reviewed inputs and compact public projections.
