### PR TITLE
feat(adapters): add generic openapi enrichment snapshots

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -1,13 +1,13 @@
 {
-  "adapter_count": 2,
+  "adapter_count": 9,
   "artifact_budget_summary": {
     "fail_count": 0,
-    "ok_count": 1225,
+    "ok_count": 1232,
     "warn_count": 0
   },
   "artifact_budgets": [],
   "artifact_count": 22,
-  "artifact_size_bytes": 4443184,
+  "artifact_size_bytes": 4445963,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -17,7 +17,7 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "b13297ddf6b56496372190bb582692c4fc6baf5dd9fafeba4139ebf1b6378ec1",
+      "sha256": "6be120d66265bedf2c12b54e995a34277bbad88c4f1d736f395b8baab9c3e39d",
       "size_bytes": 1349,
       "storage_tier": "dual"
     },
@@ -47,8 +47,8 @@
     },
     {
       "path": "freshness.json",
-      "sha256": "45dc70badc1745ef7e0f0c8159e7ea136c9aa182d8ea7b7355746976e7768cd5",
-      "size_bytes": 4324,
+      "sha256": "df6abe7e1c2ab9778ab2b0b4cb70c2d7239501d9be2b686920c74be8a1d57da4",
+      "size_bytes": 7103,
       "storage_tier": "dual"
     },
     {
@@ -180,8 +180,8 @@
     "surface_count": 1107
   },
   "endpoint_count": 1107,
-  "full_artifact_count": 1225,
-  "full_artifact_size_bytes": 47613356,
+  "full_artifact_count": 1232,
+  "full_artifact_size_bytes": 47646051,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 77,
@@ -193,12 +193,12 @@
   "storage_tier_counts": {
     "dual": 21,
     "git": 1,
-    "r2": 1203
+    "r2": 1210
   },
   "storage_tier_size_bytes": {
-    "dual": 4313033,
+    "dual": 4315812,
     "git": 130151,
-    "r2": 43170172
+    "r2": 43200088
   },
   "subnet_count": 129,
   "surface_count": 1107

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -3,7 +3,7 @@
     "added": [],
     "modified": [
       {
-        "hash": "45dc70badc1745ef7e0f0c8159e7ea136c9aa182d8ea7b7355746976e7768cd5",
+        "hash": "df6abe7e1c2ab9778ab2b0b4cb70c2d7239501d9be2b686920c74be8a1d57da4",
         "path": "freshness.json"
       }
     ],

--- a/public/metagraph/freshness.json
+++ b/public/metagraph/freshness.json
@@ -4,7 +4,7 @@
   "schema_version": 1,
   "sources": [
     {
-      "as_of": "2026-06-07T21:52:49.513Z",
+      "as_of": "2026-06-08T16:07:27.131Z",
       "id": "adapter-snapshots",
       "lane": "adapter-snapshot",
       "notes": "",
@@ -13,11 +13,11 @@
       "stale_after_hours": 12,
       "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-07T21:52:49.513Z",
+      "timestamp": "2026-06-08T16:07:27.131Z",
       "timestamp_field": "adapter_snapshot_as_of"
     },
     {
-      "as_of": "2026-06-07T21:52:48.909Z",
+      "as_of": "2026-06-08T16:07:24.922Z",
       "id": "adapter:allways",
       "lane": "adapter-snapshot",
       "notes": "",
@@ -26,11 +26,11 @@
       "stale_after_hours": 12,
       "stale_behavior": "warn",
       "status": "captured",
-      "timestamp": "2026-06-07T21:52:48.909Z",
+      "timestamp": "2026-06-08T16:07:24.922Z",
       "timestamp_field": null
     },
     {
-      "as_of": "2026-06-07T21:52:49.513Z",
+      "as_of": "2026-06-08T16:07:25.053Z",
       "id": "adapter:gittensor",
       "lane": "adapter-snapshot",
       "notes": "",
@@ -39,7 +39,98 @@
       "stale_after_hours": 12,
       "stale_behavior": "warn",
       "status": "captured",
-      "timestamp": "2026-06-07T21:52:49.513Z",
+      "timestamp": "2026-06-08T16:07:25.053Z",
+      "timestamp_field": null
+    },
+    {
+      "as_of": "2026-06-08T16:07:26.153Z",
+      "id": "adapter:numinous",
+      "lane": "adapter-snapshot",
+      "notes": "",
+      "path": "registry/adapters/latest/numinous.json",
+      "required_for_publish": false,
+      "stale_after_hours": 12,
+      "stale_behavior": "warn",
+      "status": "captured",
+      "timestamp": "2026-06-08T16:07:26.153Z",
+      "timestamp_field": null
+    },
+    {
+      "as_of": "2026-06-08T16:07:25.992Z",
+      "id": "adapter:sn-22",
+      "lane": "adapter-snapshot",
+      "notes": "",
+      "path": "registry/adapters/latest/sn-22.json",
+      "required_for_publish": false,
+      "stale_after_hours": 12,
+      "stale_behavior": "warn",
+      "status": "captured",
+      "timestamp": "2026-06-08T16:07:25.992Z",
+      "timestamp_field": null
+    },
+    {
+      "as_of": "2026-06-08T16:07:25.886Z",
+      "id": "adapter:sn-46",
+      "lane": "adapter-snapshot",
+      "notes": "",
+      "path": "registry/adapters/latest/sn-46.json",
+      "required_for_publish": false,
+      "stale_after_hours": 12,
+      "stale_behavior": "warn",
+      "status": "captured",
+      "timestamp": "2026-06-08T16:07:25.886Z",
+      "timestamp_field": null
+    },
+    {
+      "as_of": "2026-06-08T16:07:27.131Z",
+      "id": "adapter:sn-49",
+      "lane": "adapter-snapshot",
+      "notes": "",
+      "path": "registry/adapters/latest/sn-49.json",
+      "required_for_publish": false,
+      "stale_after_hours": 12,
+      "stale_behavior": "warn",
+      "status": "captured",
+      "timestamp": "2026-06-08T16:07:27.131Z",
+      "timestamp_field": null
+    },
+    {
+      "as_of": "2026-06-08T16:07:26.062Z",
+      "id": "adapter:sn-58",
+      "lane": "adapter-snapshot",
+      "notes": "",
+      "path": "registry/adapters/latest/sn-58.json",
+      "required_for_publish": false,
+      "stale_after_hours": 12,
+      "stale_behavior": "warn",
+      "status": "captured",
+      "timestamp": "2026-06-08T16:07:26.062Z",
+      "timestamp_field": null
+    },
+    {
+      "as_of": "2026-06-08T16:07:26.746Z",
+      "id": "adapter:sn-96",
+      "lane": "adapter-snapshot",
+      "notes": "",
+      "path": "registry/adapters/latest/sn-96.json",
+      "required_for_publish": false,
+      "stale_after_hours": 12,
+      "stale_behavior": "warn",
+      "status": "captured",
+      "timestamp": "2026-06-08T16:07:26.746Z",
+      "timestamp_field": null
+    },
+    {
+      "as_of": "2026-06-08T16:07:26.740Z",
+      "id": "adapter:sn-97",
+      "lane": "adapter-snapshot",
+      "notes": "",
+      "path": "registry/adapters/latest/sn-97.json",
+      "required_for_publish": false,
+      "stale_after_hours": 12,
+      "stale_behavior": "warn",
+      "status": "captured",
+      "timestamp": "2026-06-08T16:07:26.740Z",
       "timestamp_field": null
     },
     {
@@ -109,8 +200,8 @@
     }
   ],
   "summary": {
-    "adapter_count": 2,
-    "adapter_snapshot_as_of": "2026-06-07T21:52:49.513Z",
+    "adapter_count": 9,
+    "adapter_snapshot_as_of": "2026-06-08T16:07:27.131Z",
     "blocking_source_count": 5,
     "candidate_discovery_as_of": "2026-06-08T14:11:05.342Z",
     "health_probe_as_of": "2026-06-08T15:43:17.492Z",
@@ -126,6 +217,6 @@
     ],
     "verification_as_of": "2026-06-08T15:38:22.213Z",
     "verification_generated_at": "1970-01-01T00:00:00.000Z",
-    "warning_source_count": 3
+    "warning_source_count": 10
   }
 }

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 4630261,
+  "artifact_size_bytes": 4633040,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,7 +16,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "b13297ddf6b56496372190bb582692c4fc6baf5dd9fafeba4139ebf1b6378ec1",
+      "sha256": "6be120d66265bedf2c12b54e995a34277bbad88c4f1d736f395b8baab9c3e39d",
       "size_bytes": 1349,
       "storage_tier": "dual"
     },
@@ -61,8 +61,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "45dc70badc1745ef7e0f0c8159e7ea136c9aa182d8ea7b7355746976e7768cd5",
-      "size_bytes": 4324,
+      "sha256": "df6abe7e1c2ab9778ab2b0b4cb70c2d7239501d9be2b686920c74be8a1d57da4",
+      "size_bytes": 7103,
       "storage_tier": "dual"
     },
     {
@@ -213,8 +213,8 @@
   "bucket_binding": "METAGRAPH_ARCHIVE",
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
-  "full_artifact_count": 1226,
-  "full_artifact_size_bytes": 47800433,
+  "full_artifact_count": 1233,
+  "full_artifact_size_bytes": 47833128,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -234,11 +234,11 @@
   "storage_tier_counts": {
     "dual": 22,
     "git": 1,
-    "r2": 1203
+    "r2": 1210
   },
   "storage_tier_size_bytes": {
-    "dual": 4500110,
+    "dual": 4502889,
     "git": 130151,
-    "r2": 43170172
+    "r2": 43200088
   }
 }

--- a/registry/adapters/latest/allways.json
+++ b/registry/adapters/latest/allways.json
@@ -2,10 +2,10 @@
   "contract_version": "2026-06-06.1",
   "dimensions": {
     "crown": {
-      "captured_at": "2026-06-07T21:52:48.570Z",
+      "captured_at": "2026-06-08T16:07:24.411Z",
       "content_type": "application/json; charset=utf-8",
-      "hash": "bc43bcaf3fadcfc654890b1ba4d5c7317c07eb5c68bc5abae72b6d43df24cb43",
-      "latency_ms": 112,
+      "hash": "d13d42a3ebe7300940ad29154d6c918087f155e9294b8fc389152524157f27f6",
+      "latency_ms": 110,
       "shape": {
         "array_fields": [],
         "object_fields": [
@@ -31,10 +31,10 @@
       "url": "https://api.all-ways.io/crown"
     },
     "events_latest": {
-      "captured_at": "2026-06-07T21:52:48.567Z",
+      "captured_at": "2026-06-08T16:07:24.411Z",
       "content_type": "application/json; charset=utf-8",
-      "hash": "4414dde6187f120fd72e4041f1bf58132343f9b6c0394fcd76a11eb372a763ed",
-      "latency_ms": 110,
+      "hash": "2a97c6fb31eea7b6f190a4efe97f58ec38fa4dd1029c824aba8681f239b6a66a",
+      "latency_ms": 114,
       "shape": {
         "first_item_keys": [
           "amountRaw",
@@ -66,10 +66,10 @@
       "url": "https://api.all-ways.io/events/latest"
     },
     "health": {
-      "captured_at": "2026-06-07T21:52:48.456Z",
+      "captured_at": "2026-06-08T16:07:24.289Z",
       "content_type": "application/json; charset=utf-8",
       "hash": "61ac5857feb130a1dc475db36bbe21604fddf30024110bb2bea9d8b23e8b1b44",
-      "latency_ms": 186,
+      "latency_ms": 131,
       "shape": {
         "array_fields": [],
         "object_fields": [],
@@ -85,10 +85,10 @@
       "url": "https://api.all-ways.io/health"
     },
     "leaderboard": {
-      "captured_at": "2026-06-07T21:52:48.856Z",
+      "captured_at": "2026-06-08T16:07:24.863Z",
       "content_type": "application/json; charset=utf-8",
-      "hash": "95022f9eca4ed04372528a2a838c1a7a1bed23eef59f38ef30a830c22ce3f59a",
-      "latency_ms": 584,
+      "hash": "333c6227d0fced9e246558b7a0d8e0b2d48defa5f1f17e18679d068916872970",
+      "latency_ms": 703,
       "shape": {
         "first_item_keys": [
           "collateralRao",
@@ -101,7 +101,7 @@
           "uid",
           "volumeTao"
         ],
-        "item_count": 54,
+        "item_count": 58,
         "redacted_key_count": 1,
         "type": "array"
       },
@@ -110,10 +110,10 @@
       "url": "https://api.all-ways.io/miners/leaderboard"
     },
     "miners": {
-      "captured_at": "2026-06-07T21:52:48.446Z",
+      "captured_at": "2026-06-08T16:07:24.299Z",
       "content_type": "application/json; charset=utf-8",
-      "hash": "c680fdd30bcac6cd8ae2a7e60abf36e7e69ed91619fdcd6dfa321740b0809c36",
-      "latency_ms": 174,
+      "hash": "c821d27d6fbb8ab0190d86f1405c96bb0e456835f0781ed145757783f7b1a6ad",
+      "latency_ms": 139,
       "shape": {
         "first_item_keys": [
           "collateralRao",
@@ -129,7 +129,7 @@
           "uid",
           "updatedAt"
         ],
-        "item_count": 54,
+        "item_count": 58,
         "redacted_key_count": 3,
         "type": "array"
       },
@@ -138,10 +138,10 @@
       "url": "https://api.all-ways.io/miners"
     },
     "network_overview": {
-      "captured_at": "2026-06-07T21:52:48.458Z",
+      "captured_at": "2026-06-08T16:07:24.324Z",
       "content_type": "application/json; charset=utf-8",
-      "hash": "c52c02889b41959aff99c825b80d209f12bc934fd85d2d6f8af9af76eb8e18c6",
-      "latency_ms": 186,
+      "hash": "91cca2e7cb65d5bfbe109812e30171829179d7b05bb81486f1c107c1c42e4522",
+      "latency_ms": 165,
       "shape": {
         "array_fields": [
           {
@@ -168,10 +168,10 @@
       "url": "https://api.all-ways.io/network/overview"
     },
     "protocol_chain_state": {
-      "captured_at": "2026-06-07T21:52:48.482Z",
+      "captured_at": "2026-06-08T16:07:24.313Z",
       "content_type": "application/json; charset=utf-8",
-      "hash": "e923828bb1b40e592f19024d9544b8f38e0a177a5fa3ede4cbe1929ba94a1ed9",
-      "latency_ms": 211,
+      "hash": "084906349e8d614a7e112692f435b701be87d8ff101adadcb7de7486d2a11cf3",
+      "latency_ms": 154,
       "shape": {
         "array_fields": [],
         "object_fields": [],
@@ -187,10 +187,10 @@
       "url": "https://api.all-ways.io/protocol/chain-state"
     },
     "protocol_constants": {
-      "captured_at": "2026-06-07T21:52:48.458Z",
+      "captured_at": "2026-06-08T16:07:24.290Z",
       "content_type": "application/json; charset=utf-8",
       "hash": "7a49de612a186c2614a967e6b4705402d512f0a3a1bed2159e91547032b00583",
-      "latency_ms": 216,
+      "latency_ms": 159,
       "shape": {
         "array_fields": [],
         "object_fields": [],
@@ -209,10 +209,10 @@
       "url": "https://api.all-ways.io/protocol/constants"
     },
     "reliability": {
-      "captured_at": "2026-06-07T21:52:48.541Z",
+      "captured_at": "2026-06-08T16:07:24.447Z",
       "content_type": "application/json; charset=utf-8",
-      "hash": "c77c6f1f5a567de5788dd89de1f0e35f1b604dbff395223f64f615a918070b86",
-      "latency_ms": 83,
+      "hash": "c63a1ab25cbddb3210c56d2b9e512e7f61c373cf681380f9213c318ac714733b",
+      "latency_ms": 151,
       "shape": {
         "first_item_keys": [
           "completed",
@@ -220,7 +220,7 @@
           "sourceChain",
           "total"
         ],
-        "item_count": 93,
+        "item_count": 97,
         "redacted_key_count": 1,
         "type": "array"
       },
@@ -229,16 +229,16 @@
       "url": "https://api.all-ways.io/miners/reliability"
     },
     "sse": {
-      "captured_at": "2026-06-07T21:52:48.909Z",
+      "captured_at": "2026-06-08T16:07:24.922Z",
       "content_type": "text/event-stream",
       "first_chunk_bytes": 25,
-      "latency_ms": 50,
+      "latency_ms": 57,
       "status": "captured",
       "status_code": 200,
       "url": "https://api.all-ways.io/sse"
     }
   },
-  "generated_at": "2026-06-07T21:51:31.426Z",
+  "generated_at": "1970-01-01T00:00:00.000Z",
   "netuid": 7,
   "notes": [
     "Allways adapter publishes response-shape, count, hash, and freshness metadata only.",

--- a/registry/adapters/latest/gittensor.json
+++ b/registry/adapters/latest/gittensor.json
@@ -12,11 +12,11 @@
       "status": "docs-only"
     },
     "master_repositories": {
-      "captured_at": "2026-06-07T21:52:48.668Z",
+      "captured_at": "2026-06-08T16:07:24.324Z",
       "config_hash": "d61ad080861bcb00f3418313cf146fdee6faefa821df2f4adbcae2684ee4ebf7",
       "content_type": "text/plain; charset=utf-8",
       "issue_discovery_enabled_count": 3,
-      "latency_ms": 396,
+      "latency_ms": 164,
       "maintainer_cut_repo_count": 9,
       "max_maintainer_cut": 0.5,
       "repository_count": 18,
@@ -90,24 +90,24 @@
     },
     "mirror_freshness": {
       "archived": false,
-      "captured_at": "2026-06-07T21:52:49.513Z",
+      "captured_at": "2026-06-08T16:07:25.053Z",
       "default_branch": "test",
       "disabled": false,
       "full_name": "entrius/das-github-mirror",
       "html_url": "https://github.com/entrius/das-github-mirror",
-      "latency_ms": 423,
-      "open_issues_count": 14,
-      "pushed_at": "2026-06-06T03:23:52Z",
+      "latency_ms": 274,
+      "open_issues_count": 6,
+      "pushed_at": "2026-06-08T15:25:30Z",
       "status": "captured",
       "topics": [],
-      "updated_at": "2026-06-06T03:23:56Z"
+      "updated_at": "2026-06-08T15:27:17Z"
     },
     "repository_metadata": {
       "archived_count": 0,
       "captured_count": 18,
       "disabled_count": 0,
       "html_fallback_count": 0,
-      "latest_push_at": "2026-06-07T21:52:22Z",
+      "latest_push_at": "2026-06-08T15:54:42Z",
       "rate_limited_or_forbidden_count": 0,
       "repositories": [
         {
@@ -116,8 +116,8 @@
           "full_name": "cogniax/tao-pulse-app",
           "html_url": "https://github.com/cogniax/tao-pulse-app",
           "metadata_level": "github-api",
-          "open_issues_count": 53,
-          "pushed_at": "2026-06-07T20:05:57Z",
+          "open_issues_count": 52,
+          "pushed_at": "2026-06-08T10:20:02Z",
           "topic_count": 0
         },
         {
@@ -146,8 +146,8 @@
           "full_name": "entrius/allways",
           "html_url": "https://github.com/entrius/allways",
           "metadata_level": "github-api",
-          "open_issues_count": 24,
-          "pushed_at": "2026-06-04T20:41:16Z",
+          "open_issues_count": 20,
+          "pushed_at": "2026-06-08T15:52:19Z",
           "topic_count": 0
         },
         {
@@ -156,8 +156,8 @@
           "full_name": "entrius/das-github-mirror",
           "html_url": "https://github.com/entrius/das-github-mirror",
           "metadata_level": "github-api",
-          "open_issues_count": 14,
-          "pushed_at": "2026-06-06T03:23:52Z",
+          "open_issues_count": 6,
+          "pushed_at": "2026-06-08T15:25:30Z",
           "topic_count": 0
         },
         {
@@ -176,8 +176,8 @@
           "full_name": "entrius/gittensor-ui",
           "html_url": "https://github.com/entrius/gittensor-ui",
           "metadata_level": "github-api",
-          "open_issues_count": 44,
-          "pushed_at": "2026-05-29T22:30:21Z",
+          "open_issues_count": 24,
+          "pushed_at": "2026-06-08T15:31:28Z",
           "topic_count": 0
         },
         {
@@ -206,8 +206,8 @@
           "full_name": "infiniflow/ragflow",
           "html_url": "https://github.com/infiniflow/ragflow",
           "metadata_level": "github-api",
-          "open_issues_count": 3314,
-          "pushed_at": "2026-06-05T13:59:26Z",
+          "open_issues_count": 3323,
+          "pushed_at": "2026-06-08T15:01:36Z",
           "topic_count": 10
         },
         {
@@ -216,8 +216,8 @@
           "full_name": "JSONbored/awesome-claude",
           "html_url": "https://github.com/JSONbored/awesome-claude",
           "metadata_level": "github-api",
-          "open_issues_count": 252,
-          "pushed_at": "2026-06-07T09:20:42Z",
+          "open_issues_count": 254,
+          "pushed_at": "2026-06-08T09:50:17Z",
           "topic_count": 20
         },
         {
@@ -226,8 +226,8 @@
           "full_name": "JSONbored/gittensory",
           "html_url": "https://github.com/JSONbored/gittensory",
           "metadata_level": "github-api",
-          "open_issues_count": 61,
-          "pushed_at": "2026-06-07T08:52:14Z",
+          "open_issues_count": 57,
+          "pushed_at": "2026-06-08T09:10:48Z",
           "topic_count": 0
         },
         {
@@ -236,7 +236,7 @@
           "full_name": "MkDev11/gittensor-hub",
           "html_url": "https://github.com/MkDev11/gittensor-hub",
           "metadata_level": "github-api",
-          "open_issues_count": 11,
+          "open_issues_count": 5,
           "pushed_at": "2026-06-07T07:40:18Z",
           "topic_count": 6
         },
@@ -246,8 +246,8 @@
           "full_name": "phase-rs/phase",
           "html_url": "https://github.com/phase-rs/phase",
           "metadata_level": "github-api",
-          "open_issues_count": 594,
-          "pushed_at": "2026-06-07T21:52:22Z",
+          "open_issues_count": 574,
+          "pushed_at": "2026-06-08T15:54:42Z",
           "topic_count": 8
         },
         {
@@ -286,8 +286,8 @@
           "full_name": "we-promise/sure",
           "html_url": "https://github.com/we-promise/sure",
           "metadata_level": "github-api",
-          "open_issues_count": 383,
-          "pushed_at": "2026-06-07T10:02:16Z",
+          "open_issues_count": 391,
+          "pushed_at": "2026-06-08T14:19:22Z",
           "topic_count": 0
         }
       ],
@@ -301,7 +301,7 @@
     "private_dashboards",
     "wallet_data"
   ],
-  "generated_at": "2026-06-07T21:51:31.426Z",
+  "generated_at": "1970-01-01T00:00:00.000Z",
   "netuid": 74,
   "notes": [
     "Gittensor adapter publishes public repository/config aggregates only.",

--- a/registry/adapters/latest/numinous.json
+++ b/registry/adapters/latest/numinous.json
@@ -1,0 +1,99 @@
+{
+  "adapter_kind": "generic-openapi",
+  "contract_version": "2026-06-06.1",
+  "dimensions": {
+    "openapi_schemas": {
+      "captured_at": "2026-06-08T16:07:26.153Z",
+      "captured_count": 1,
+      "schema_count": 1,
+      "schemas": [
+        {
+          "auth_required": false,
+          "captured_at": "2026-06-08T16:07:26.153Z",
+          "content_type": "application/json",
+          "hash": "adbe238958cc0ff5c5b690ac008240c04fa0bd8e67f2864ca872d4dc93a8e8a9",
+          "latency_ms": 460,
+          "name": "Numinous OpenAPI schema",
+          "provider": "numinous",
+          "schema_url": "https://api.numinouslabs.io/api/openapi.json",
+          "shape": {
+            "component_schema_count": 42,
+            "has_global_security": false,
+            "method_counts": {
+              "get": 18,
+              "post": 2
+            },
+            "openapi_version": "3.1.0",
+            "operation_count": 20,
+            "path_count": 20,
+            "sample_paths": [
+              "/api/health",
+              "/api/v1/agents/{version_id}/code",
+              "/api/v1/aggregated-scores",
+              "/api/v1/benchmarks/baseline",
+              "/api/v1/causal-drivers/",
+              "/api/v1/deep-research/",
+              "/api/v1/forecasters/prediction-jobs",
+              "/api/v1/forecasters/prediction-jobs/{prediction_id}",
+              "/api/v1/forecasters/predictions",
+              "/api/v1/internal/forecasters/prediction-jobs",
+              "/api/v1/internal/liveuamap/events",
+              "/api/v1/internal/liveuamap/regions",
+              "/api/v1/leaderboard",
+              "/api/v1/miner-reasonings"
+            ],
+            "security_scheme_count": 1,
+            "server_count": 0,
+            "tag_count": 0,
+            "title": "Numinous API",
+            "version": "0.1.0"
+          },
+          "status": "captured",
+          "status_code": 200,
+          "surface_id": "sn-6-numinous-openapi-schema",
+          "url": "https://api.numinouslabs.io/api/openapi.json"
+        }
+      ],
+      "status": "captured",
+      "total_operation_count": 20,
+      "total_path_count": 20
+    },
+    "public_api_surfaces": {
+      "captured_at": "2026-06-08T16:07:26.153Z",
+      "status": "captured",
+      "surface_count": 2,
+      "surfaces": [
+        {
+          "auth_required": false,
+          "id": "sn-6-numinous-api-health",
+          "kind": "subnet-api",
+          "name": "Numinous API health",
+          "probe_enabled": true,
+          "provider": "numinous",
+          "schema_url": null,
+          "url": "https://api.numinouslabs.io/api/health"
+        },
+        {
+          "auth_required": false,
+          "id": "sn-6-numinous-leaderboard",
+          "kind": "subnet-api",
+          "name": "Numinous leaderboard API",
+          "probe_enabled": true,
+          "provider": "numinous",
+          "schema_url": null,
+          "url": "https://api.numinouslabs.io/api/v1/leaderboard"
+        }
+      ]
+    }
+  },
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "netuid": 6,
+  "notes": [
+    "Generic OpenAPI adapter publishes schema-shape, operation-count, hash, and freshness metadata only.",
+    "Raw schemas, protected method calls, credentialed data, and API response payloads are not persisted."
+  ],
+  "schema_version": 1,
+  "slug": "numinous",
+  "source": "adapter-snapshot",
+  "status": "captured"
+}

--- a/registry/adapters/latest/sn-22.json
+++ b/registry/adapters/latest/sn-22.json
@@ -1,0 +1,147 @@
+{
+  "adapter_kind": "generic-openapi",
+  "contract_version": "2026-06-06.1",
+  "dimensions": {
+    "openapi_schemas": {
+      "captured_at": "2026-06-08T16:07:25.992Z",
+      "captured_count": 2,
+      "schema_count": 2,
+      "schemas": [
+        {
+          "auth_required": false,
+          "captured_at": "2026-06-08T16:07:25.848Z",
+          "content_type": "application/json; charset=utf-8",
+          "hash": "fe1a03bb8e620faafb286f53d185dc2e562454f27cd1b707b75d085af223b3d1",
+          "latency_ms": 152,
+          "name": "Desearch OpenAPI schema",
+          "provider": "desearch",
+          "schema_url": "https://www.desearch.ai/openapi.json",
+          "shape": {
+            "component_schema_count": 76,
+            "has_global_security": true,
+            "method_counts": {
+              "get": 28,
+              "post": 7
+            },
+            "openapi_version": "3.1.0",
+            "operation_count": 35,
+            "path_count": 35,
+            "sample_paths": [
+              "/desearch/ai/search",
+              "/desearch/ai/search/links/twitter",
+              "/desearch/ai/search/links/web",
+              "/desearch/facebook/comments/{post_id}",
+              "/desearch/facebook/hashtag/{tag}",
+              "/desearch/facebook/post/{id}",
+              "/desearch/facebook/profile/{profile_id}",
+              "/desearch/facebook/profile/{profile_id}/posts",
+              "/desearch/facebook/search",
+              "/desearch/instagram/comments/{media_id}",
+              "/desearch/instagram/hashtag/{tag}",
+              "/desearch/instagram/media/{id}",
+              "/desearch/instagram/profile/{username}",
+              "/desearch/instagram/profile/{username}/posts",
+              "/desearch/instagram/search",
+              "/desearch/tiktok/comments/{video_id}",
+              "/desearch/tiktok/hashtag/{tag}",
+              "/desearch/tiktok/post/{id}",
+              "/desearch/tiktok/profile/{username}",
+              "/desearch/tiktok/profile/{username}/posts"
+            ],
+            "security_scheme_count": 1,
+            "server_count": 1,
+            "tag_count": 0,
+            "title": "Desearch API",
+            "version": "1.0.0"
+          },
+          "status": "captured",
+          "status_code": 200,
+          "surface_id": "sn-22-desearch-openapi",
+          "url": "https://www.desearch.ai/openapi.json"
+        },
+        {
+          "auth_required": false,
+          "captured_at": "2026-06-08T16:07:25.992Z",
+          "content_type": "application/json; charset=utf-8",
+          "hash": "fe1a03bb8e620faafb286f53d185dc2e562454f27cd1b707b75d085af223b3d1",
+          "latency_ms": 299,
+          "name": "Desearch OpenAPI JSON",
+          "provider": "taomarketcap",
+          "schema_url": "https://desearch.ai/openapi.json",
+          "shape": {
+            "component_schema_count": 76,
+            "has_global_security": true,
+            "method_counts": {
+              "get": 28,
+              "post": 7
+            },
+            "openapi_version": "3.1.0",
+            "operation_count": 35,
+            "path_count": 35,
+            "sample_paths": [
+              "/desearch/ai/search",
+              "/desearch/ai/search/links/twitter",
+              "/desearch/ai/search/links/web",
+              "/desearch/facebook/comments/{post_id}",
+              "/desearch/facebook/hashtag/{tag}",
+              "/desearch/facebook/post/{id}",
+              "/desearch/facebook/profile/{profile_id}",
+              "/desearch/facebook/profile/{profile_id}/posts",
+              "/desearch/facebook/search",
+              "/desearch/instagram/comments/{media_id}",
+              "/desearch/instagram/hashtag/{tag}",
+              "/desearch/instagram/media/{id}",
+              "/desearch/instagram/profile/{username}",
+              "/desearch/instagram/profile/{username}/posts",
+              "/desearch/instagram/search",
+              "/desearch/tiktok/comments/{video_id}",
+              "/desearch/tiktok/hashtag/{tag}",
+              "/desearch/tiktok/post/{id}",
+              "/desearch/tiktok/profile/{username}",
+              "/desearch/tiktok/profile/{username}/posts"
+            ],
+            "security_scheme_count": 1,
+            "server_count": 1,
+            "tag_count": 0,
+            "title": "Desearch API",
+            "version": "1.0.0"
+          },
+          "status": "captured",
+          "status_code": 200,
+          "surface_id": "sn-22-website-common-openapi-json",
+          "url": "https://desearch.ai/openapi.json"
+        }
+      ],
+      "status": "captured",
+      "total_operation_count": 70,
+      "total_path_count": 70
+    },
+    "public_api_surfaces": {
+      "captured_at": "2026-06-08T16:07:25.992Z",
+      "status": "captured",
+      "surface_count": 1,
+      "surfaces": [
+        {
+          "auth_required": true,
+          "id": "sn-22-desearch-api",
+          "kind": "subnet-api",
+          "name": "Desearch API",
+          "probe_enabled": false,
+          "provider": "desearch",
+          "schema_url": "https://www.desearch.ai/openapi.json",
+          "url": "https://api.desearch.ai"
+        }
+      ]
+    }
+  },
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "netuid": 22,
+  "notes": [
+    "Generic OpenAPI adapter publishes schema-shape, operation-count, hash, and freshness metadata only.",
+    "Raw schemas, protected method calls, credentialed data, and API response payloads are not persisted."
+  ],
+  "schema_version": 1,
+  "slug": "sn-22",
+  "source": "adapter-snapshot",
+  "status": "captured"
+}

--- a/registry/adapters/latest/sn-46.json
+++ b/registry/adapters/latest/sn-46.json
@@ -1,0 +1,87 @@
+{
+  "adapter_kind": "generic-openapi",
+  "contract_version": "2026-06-06.1",
+  "dimensions": {
+    "openapi_schemas": {
+      "captured_at": "2026-06-08T16:07:25.886Z",
+      "captured_count": 1,
+      "schema_count": 1,
+      "schemas": [
+        {
+          "auth_required": false,
+          "captured_at": "2026-06-08T16:07:25.886Z",
+          "content_type": "application/json; charset=utf-8",
+          "hash": "d8a18908415e864944add3f5d950e788045e56c7a4adca2c168f0b14e8b33ebc",
+          "latency_ms": 191,
+          "name": "Zipcode OpenAPI JSON",
+          "provider": "taomarketcap",
+          "schema_url": "https://zipcode.ai/openapi.json",
+          "shape": {
+            "component_schema_count": 3,
+            "has_global_security": false,
+            "method_counts": {
+              "delete": 8,
+              "get": 24,
+              "patch": 2,
+              "post": 18,
+              "put": 5
+            },
+            "openapi_version": "3.0.0",
+            "operation_count": 57,
+            "path_count": 41,
+            "sample_paths": [
+              "/api/billing/checkout",
+              "/api/billing/portal",
+              "/api/billing/summary",
+              "/api/dashboard/auth/validation-set",
+              "/api/dashboard/docs",
+              "/api/dashboard/models",
+              "/api/dashboard/models/{uid}",
+              "/api/dashboard/models/{uid}/validations",
+              "/api/dashboard/models/{uid}/validations/{date}",
+              "/api/dashboard/stats",
+              "/api/dashboard/stats/emissions",
+              "/api/dashboard/validation-set/real_estate/download",
+              "/api/docs",
+              "/api/geocode",
+              "/api/portal/acs/{zipCode}",
+              "/api/portal/projects",
+              "/api/portal/projects/{projectId}",
+              "/api/portal/projects/{projectId}/api-keys/{keyId}/reveal",
+              "/api/portal/projects/{projectId}/api-keys/{keyId}/revoke",
+              "/api/portal/projects/{projectId}/chats"
+            ],
+            "security_scheme_count": 3,
+            "server_count": 1,
+            "tag_count": 5,
+            "title": "Zip Code Portal API",
+            "version": "1.0.0"
+          },
+          "status": "captured",
+          "status_code": 200,
+          "surface_id": "sn-46-website-common-openapi-json",
+          "url": "https://zipcode.ai/openapi.json"
+        }
+      ],
+      "status": "captured",
+      "total_operation_count": 57,
+      "total_path_count": 41
+    },
+    "public_api_surfaces": {
+      "captured_at": "2026-06-08T16:07:25.886Z",
+      "status": "captured",
+      "surface_count": 0,
+      "surfaces": []
+    }
+  },
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "netuid": 46,
+  "notes": [
+    "Generic OpenAPI adapter publishes schema-shape, operation-count, hash, and freshness metadata only.",
+    "Raw schemas, protected method calls, credentialed data, and API response payloads are not persisted."
+  ],
+  "schema_version": 1,
+  "slug": "sn-46",
+  "source": "adapter-snapshot",
+  "status": "captured"
+}

--- a/registry/adapters/latest/sn-49.json
+++ b/registry/adapters/latest/sn-49.json
@@ -1,0 +1,98 @@
+{
+  "adapter_kind": "generic-openapi",
+  "contract_version": "2026-06-06.1",
+  "dimensions": {
+    "openapi_schemas": {
+      "captured_at": "2026-06-08T16:07:27.131Z",
+      "captured_count": 1,
+      "schema_count": 1,
+      "schemas": [
+        {
+          "auth_required": false,
+          "captured_at": "2026-06-08T16:07:27.131Z",
+          "content_type": "application/json",
+          "hash": "f66e82d9985b4f782619b9537d925d3f0c281d5f743ca90e6c9bf146618570da",
+          "latency_ms": 1434,
+          "name": "Nepher tournament OpenAPI schema",
+          "provider": "nepher-robotics",
+          "schema_url": "https://tournament-api.nepher.ai/openapi.json",
+          "shape": {
+            "component_schema_count": 116,
+            "has_global_security": false,
+            "method_counts": {
+              "delete": 12,
+              "get": 90,
+              "patch": 11,
+              "post": 50,
+              "put": 2
+            },
+            "openapi_version": "3.1.0",
+            "operation_count": 165,
+            "path_count": 137,
+            "sample_paths": [
+              "/api/v1/admin/agents/{agent_id}/disqualify",
+              "/api/v1/admin/audit/logs",
+              "/api/v1/admin/cleanup/agents/superseded/{tournament_id}",
+              "/api/v1/admin/cleanup/agents/superseded/{tournament_id}/list",
+              "/api/v1/admin/cleanup/agents/unevaluated/{tournament_id}",
+              "/api/v1/admin/cleanup/agents/unevaluated/{tournament_id}/list",
+              "/api/v1/admin/cleanup/eligible-miners",
+              "/api/v1/admin/cleanup/evaluations/failed/{tournament_id}",
+              "/api/v1/admin/cleanup/evaluations/stale/{tournament_id}",
+              "/api/v1/admin/clone/{tournament_id}",
+              "/api/v1/admin/config",
+              "/api/v1/admin/emergency/deactivate/{tournament_id}",
+              "/api/v1/admin/emergency/pause/{tournament_id}",
+              "/api/v1/admin/emergency/unpause/{tournament_id}",
+              "/api/v1/admin/evaluations/{evaluation_id}/exclude",
+              "/api/v1/admin/export/audit-logs",
+              "/api/v1/admin/export/evaluations/{tournament_id}",
+              "/api/v1/admin/export/leaderboard/{tournament_id}",
+              "/api/v1/admin/export/summary/{tournament_id}",
+              "/api/v1/admin/gallery"
+            ],
+            "security_scheme_count": 1,
+            "server_count": 0,
+            "tag_count": 0,
+            "title": "Tournament Backend API",
+            "version": "1.0.0"
+          },
+          "status": "captured",
+          "status_code": 200,
+          "surface_id": "sn-49-nepher-tournament-openapi",
+          "url": "https://tournament-api.nepher.ai/openapi.json"
+        }
+      ],
+      "status": "captured",
+      "total_operation_count": 165,
+      "total_path_count": 137
+    },
+    "public_api_surfaces": {
+      "captured_at": "2026-06-08T16:07:27.131Z",
+      "status": "captured",
+      "surface_count": 1,
+      "surfaces": [
+        {
+          "auth_required": true,
+          "id": "sn-49-nepher-tournament-api",
+          "kind": "subnet-api",
+          "name": "Nepher tournament API",
+          "probe_enabled": false,
+          "provider": "nepher-robotics",
+          "schema_url": "https://tournament-api.nepher.ai/openapi.json",
+          "url": "https://tournament-api.nepher.ai"
+        }
+      ]
+    }
+  },
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "netuid": 49,
+  "notes": [
+    "Generic OpenAPI adapter publishes schema-shape, operation-count, hash, and freshness metadata only.",
+    "Raw schemas, protected method calls, credentialed data, and API response payloads are not persisted."
+  ],
+  "schema_version": 1,
+  "slug": "sn-49",
+  "source": "adapter-snapshot",
+  "status": "captured"
+}

--- a/registry/adapters/latest/sn-58.json
+++ b/registry/adapters/latest/sn-58.json
@@ -1,0 +1,98 @@
+{
+  "adapter_kind": "generic-openapi",
+  "contract_version": "2026-06-06.1",
+  "dimensions": {
+    "openapi_schemas": {
+      "captured_at": "2026-06-08T16:07:26.062Z",
+      "captured_count": 1,
+      "schema_count": 1,
+      "schemas": [
+        {
+          "auth_required": false,
+          "captured_at": "2026-06-08T16:07:26.062Z",
+          "content_type": "application/json; charset=UTF-8",
+          "hash": "fe0b7027c64483c36518429c5e56d5fc219e2b75780696b1d3d0ea141992e7ca",
+          "latency_ms": 124,
+          "name": "Handshake58 OpenAPI schema",
+          "provider": "handshake58",
+          "schema_url": "https://handshake58.com/openapi.json",
+          "shape": {
+            "component_schema_count": 5,
+            "has_global_security": false,
+            "method_counts": {
+              "get": 4
+            },
+            "openapi_version": "3.0.3",
+            "operation_count": 4,
+            "path_count": 4,
+            "sample_paths": [
+              "/api/agent",
+              "/api/directory/providers",
+              "/api/mcp/providers",
+              "/api/validator/registry"
+            ],
+            "security_scheme_count": 0,
+            "server_count": 1,
+            "tag_count": 0,
+            "title": "Handshake58 DRAIN Protocol API",
+            "version": "1.0.0"
+          },
+          "status": "captured",
+          "status_code": 200,
+          "surface_id": "sn-58-handshake58-openapi",
+          "url": "https://handshake58.com/openapi.json"
+        }
+      ],
+      "status": "captured",
+      "total_operation_count": 4,
+      "total_path_count": 4
+    },
+    "public_api_surfaces": {
+      "captured_at": "2026-06-08T16:07:26.062Z",
+      "status": "captured",
+      "surface_count": 3,
+      "surfaces": [
+        {
+          "auth_required": false,
+          "id": "sn-58-github-readme-handshake58-hs58-subnet-api-2",
+          "kind": "subnet-api",
+          "name": "Pending API surface",
+          "probe_enabled": true,
+          "provider": "tensorplex-subnet-docs",
+          "schema_url": null,
+          "url": "https://handshake58.com/api/drain/signing"
+        },
+        {
+          "auth_required": false,
+          "id": "sn-58-handshake58-provider-directory-api",
+          "kind": "subnet-api",
+          "name": "Handshake58 provider directory API",
+          "probe_enabled": true,
+          "provider": "handshake58",
+          "schema_url": "https://handshake58.com/openapi.json",
+          "url": "https://handshake58.com/api/mcp/providers"
+        },
+        {
+          "auth_required": false,
+          "id": "sn-58-handshake58-skills-api",
+          "kind": "subnet-api",
+          "name": "Handshake58 skills API",
+          "probe_enabled": true,
+          "provider": "handshake58",
+          "schema_url": null,
+          "url": "https://handshake58.com/api/skills?status=published"
+        }
+      ]
+    }
+  },
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "netuid": 58,
+  "notes": [
+    "Generic OpenAPI adapter publishes schema-shape, operation-count, hash, and freshness metadata only.",
+    "Raw schemas, protected method calls, credentialed data, and API response payloads are not persisted."
+  ],
+  "schema_version": 1,
+  "slug": "sn-58",
+  "source": "adapter-snapshot",
+  "status": "captured"
+}

--- a/registry/adapters/latest/sn-96.json
+++ b/registry/adapters/latest/sn-96.json
@@ -1,0 +1,97 @@
+{
+  "adapter_kind": "generic-openapi",
+  "contract_version": "2026-06-06.1",
+  "dimensions": {
+    "openapi_schemas": {
+      "captured_at": "2026-06-08T16:07:26.746Z",
+      "captured_count": 1,
+      "schema_count": 1,
+      "schemas": [
+        {
+          "auth_required": false,
+          "captured_at": "2026-06-08T16:07:26.746Z",
+          "content_type": "application/json",
+          "hash": "8a520fd1ee1037929b75f68f4a627610e58eede285d044bfaae20ea7a0860ae0",
+          "latency_ms": 750,
+          "name": "Verathos OpenAPI schema",
+          "provider": "verathos",
+          "schema_url": "https://verathos.ai/openapi.json",
+          "shape": {
+            "component_schema_count": 20,
+            "has_global_security": false,
+            "method_counts": {
+              "delete": 1,
+              "get": 15,
+              "patch": 1,
+              "post": 10
+            },
+            "openapi_version": "3.1.0",
+            "operation_count": 27,
+            "path_count": 24,
+            "sample_paths": [
+              "/api/auth/create-key",
+              "/api/auth/login",
+              "/api/auth/me",
+              "/api/auth/register",
+              "/api/chat/{conversation_id}",
+              "/api/conversations/",
+              "/api/conversations/claim",
+              "/api/conversations/{conversation_id}",
+              "/api/dashboard",
+              "/api/dashboard/timeseries",
+              "/api/deposits/balance",
+              "/api/deposits/withdraw",
+              "/api/docs/list",
+              "/api/docs/{slug}",
+              "/api/health",
+              "/api/models/chain-info",
+              "/api/models/load",
+              "/api/models/presets",
+              "/api/models/refresh",
+              "/api/models/status"
+            ],
+            "security_scheme_count": 0,
+            "server_count": 0,
+            "tag_count": 0,
+            "title": "Verathos",
+            "version": "0.1.0"
+          },
+          "status": "captured",
+          "status_code": 200,
+          "surface_id": "sn-96-verathos-openapi",
+          "url": "https://verathos.ai/openapi.json"
+        }
+      ],
+      "status": "captured",
+      "total_operation_count": 27,
+      "total_path_count": 24
+    },
+    "public_api_surfaces": {
+      "captured_at": "2026-06-08T16:07:26.746Z",
+      "status": "captured",
+      "surface_count": 1,
+      "surfaces": [
+        {
+          "auth_required": false,
+          "id": "sn-96-verathos-models-api",
+          "kind": "subnet-api",
+          "name": "Verathos models API",
+          "probe_enabled": true,
+          "provider": "verathos",
+          "schema_url": "https://verathos.ai/openapi.json",
+          "url": "https://api.verathos.ai/v1/models"
+        }
+      ]
+    }
+  },
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "netuid": 96,
+  "notes": [
+    "Generic OpenAPI adapter publishes schema-shape, operation-count, hash, and freshness metadata only.",
+    "Raw schemas, protected method calls, credentialed data, and API response payloads are not persisted."
+  ],
+  "schema_version": 1,
+  "slug": "sn-96",
+  "source": "adapter-snapshot",
+  "status": "captured"
+}

--- a/registry/adapters/latest/sn-97.json
+++ b/registry/adapters/latest/sn-97.json
@@ -1,0 +1,78 @@
+{
+  "adapter_kind": "generic-openapi",
+  "contract_version": "2026-06-06.1",
+  "dimensions": {
+    "openapi_schemas": {
+      "captured_at": "2026-06-08T16:07:26.740Z",
+      "captured_count": 1,
+      "schema_count": 1,
+      "schemas": [
+        {
+          "auth_required": false,
+          "captured_at": "2026-06-08T16:07:26.740Z",
+          "content_type": "application/json",
+          "hash": "61b026a793721514ba0a4a018c746c575858b0058cc671ecd9aaeca638dc10ba",
+          "latency_ms": 676,
+          "name": "Albedo OpenAPI JSON",
+          "provider": "taomarketcap",
+          "schema_url": "https://us-east-1.hippius.com/openapi.json",
+          "shape": {
+            "component_schema_count": 7,
+            "has_global_security": true,
+            "method_counts": {
+              "delete": 3,
+              "get": 10,
+              "head": 3,
+              "post": 4,
+              "put": 3
+            },
+            "openapi_version": "3.1.0",
+            "operation_count": 23,
+            "path_count": 12,
+            "sample_paths": [
+              "/",
+              "/public/{bucket_name}/{object_key}",
+              "/user/credits",
+              "/user/get_bucket_location",
+              "/user/list_buckets",
+              "/user/list_objects",
+              "/user/recent_uploads",
+              "/user/unban",
+              "/{bucket_name}",
+              "/{bucket_name}/{object_key}",
+              "/{bucket_name}/{object_key}/"
+            ],
+            "security_scheme_count": 1,
+            "server_count": 0,
+            "tag_count": 0,
+            "title": "Hippius S3",
+            "version": "1.0.0"
+          },
+          "status": "captured",
+          "status_code": 200,
+          "surface_id": "sn-97-website-common-openapi-json",
+          "url": "https://us-east-1.hippius.com/openapi.json"
+        }
+      ],
+      "status": "captured",
+      "total_operation_count": 23,
+      "total_path_count": 12
+    },
+    "public_api_surfaces": {
+      "captured_at": "2026-06-08T16:07:26.740Z",
+      "status": "captured",
+      "surface_count": 0,
+      "surfaces": []
+    }
+  },
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "netuid": 97,
+  "notes": [
+    "Generic OpenAPI adapter publishes schema-shape, operation-count, hash, and freshness metadata only.",
+    "Raw schemas, protected method calls, credentialed data, and API response payloads are not persisted."
+  ],
+  "schema_version": 1,
+  "slug": "sn-97",
+  "source": "adapter-snapshot",
+  "status": "captured"
+}

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -185,21 +185,47 @@ const schemaDriftPlaceholder = buildSchemaDriftPlaceholder(surfaces);
 const contracts = buildContractsArtifact(generatedAt);
 const openApi = await buildCanonicalOpenApiArtifact(generatedAt);
 
-const adapterArtifacts = Object.fromEntries(
-  activeOverlays
+const overlayBySlug = new Map(
+  activeOverlays.map((subnet) => [subnet.slug, subnet]),
+);
+const adapterSlugs = new Set([
+  ...activeOverlays
     .filter((subnet) => subnet.extensions)
-    .map((subnet) => [
-      subnet.slug,
-      {
-        schema_version: 1,
-        generated_at: generatedAt,
-        netuid: subnet.netuid,
-        subnet: subnet.name,
-        slug: subnet.slug,
-        extensions: subnet.extensions,
-        snapshot: adapterSnapshots.get(subnet.slug) || null,
-      },
-    ]),
+    .map((subnet) => subnet.slug),
+  ...adapterSnapshots.keys(),
+]);
+const adapterArtifacts = Object.fromEntries(
+  [...adapterSlugs]
+    .sort()
+    .map((slug) => {
+      const subnet = overlayBySlug.get(slug);
+      if (!subnet) {
+        return null;
+      }
+      const snapshot = adapterSnapshots.get(slug) || null;
+      return [
+        slug,
+        {
+          schema_version: 1,
+          generated_at: generatedAt,
+          netuid: subnet.netuid,
+          subnet: subnet.name,
+          slug: subnet.slug,
+          extensions:
+            subnet.extensions ||
+            (snapshot?.adapter_kind
+              ? {
+                  generic_adapter: {
+                    enabled: true,
+                    kind: snapshot.adapter_kind,
+                  },
+                }
+              : {}),
+          snapshot,
+        },
+      ];
+    })
+    .filter(Boolean),
 );
 
 const coverage = {

--- a/scripts/snapshot-adapters.mjs
+++ b/scripts/snapshot-adapters.mjs
@@ -4,6 +4,7 @@ import {
   hashJson,
   isJsonContentType,
   isUnsafeResolvedUrl,
+  loadSubnets,
   repoRoot,
   stableStringify,
   writeJson,
@@ -15,12 +16,27 @@ const dryRun = args.has("--dry-run") || !shouldWrite;
 const generatedAt = buildTimestamp();
 const contractVersion = "2026-06-06.1";
 const outputRoot = path.join(repoRoot, "registry/adapters/latest");
+const OPENAPI_METHODS = new Set([
+  "delete",
+  "get",
+  "head",
+  "options",
+  "patch",
+  "post",
+  "put",
+  "trace",
+]);
 
 const [allways, gittensor] = await Promise.all([
   snapshotAllways(),
   snapshotGittensor(),
 ]);
-const snapshots = [allways, gittensor];
+const genericSnapshots = await snapshotGenericOpenApiAdapters(
+  new Set([allways.slug, gittensor.slug]),
+);
+const snapshots = [allways, gittensor, ...genericSnapshots].sort(
+  (a, b) => a.netuid - b.netuid || a.slug.localeCompare(b.slug),
+);
 
 if (!dryRun) {
   for (const snapshot of snapshots) {
@@ -131,6 +147,238 @@ async function snapshotGittensor() {
       "No PATs, wallet paths, local validator state, private scoring inputs, or credentialed GitHub data are collected.",
     ],
   };
+}
+
+async function snapshotGenericOpenApiAdapters(excludedSlugs) {
+  const overlays = await loadSubnets();
+  const snapshots = [];
+  await mapLimit(
+    overlays.filter((overlay) => !excludedSlugs.has(overlay.slug)),
+    4,
+    async (overlay) => {
+      const schemaSurfaces = machineReadableOpenApiSurfaces(overlay);
+      if (schemaSurfaces.length === 0) {
+        return;
+      }
+      snapshots.push(
+        await snapshotGenericOpenApiAdapter(overlay, schemaSurfaces),
+      );
+    },
+  );
+  return snapshots;
+}
+
+function machineReadableOpenApiSurfaces(overlay) {
+  const surfaces = overlay.surfaces || [];
+  const seen = new Set();
+  return surfaces
+    .filter(
+      (surface) =>
+        surface.kind === "openapi" &&
+        surface.public_safe !== false &&
+        surface.schema_status === "machine-readable",
+    )
+    .map((surface) => ({
+      ...surface,
+      schema_url: surface.schema_url || surface.url,
+    }))
+    .filter((surface) => {
+      if (!surface.schema_url) {
+        return false;
+      }
+      const key = surface.schema_url;
+      if (seen.has(key)) {
+        return false;
+      }
+      seen.add(key);
+      return true;
+    })
+    .sort((a, b) => a.schema_url.localeCompare(b.schema_url));
+}
+
+async function snapshotGenericOpenApiAdapter(overlay, schemaSurfaces) {
+  const schemas = [];
+  await mapLimit(schemaSurfaces, 4, async (surface) => {
+    schemas.push(await fetchOpenApiSchemaSummary(surface));
+  });
+  schemas.sort((a, b) => a.surface_id.localeCompare(b.surface_id));
+
+  const apiSurfaces = (overlay.surfaces || [])
+    .filter((surface) =>
+      ["subnet-api", "data-artifact", "sse"].includes(surface.kind),
+    )
+    .map(publicSurfaceSummary)
+    .sort((a, b) => a.id.localeCompare(b.id));
+
+  const dimensions = {
+    openapi_schemas: summarizeOpenApiSchemas(schemas),
+    public_api_surfaces: {
+      status: "captured",
+      captured_at: latestTimestamp(schemas.map((schema) => schema.captured_at)),
+      surface_count: apiSurfaces.length,
+      surfaces: apiSurfaces,
+    },
+  };
+
+  return {
+    schema_version: 1,
+    contract_version: contractVersion,
+    generated_at: generatedAt,
+    source: "adapter-snapshot",
+    adapter_kind: "generic-openapi",
+    netuid: overlay.netuid,
+    slug: overlay.slug,
+    status: adapterStatus(Object.values(dimensions)),
+    dimensions,
+    notes: [
+      "Generic OpenAPI adapter publishes schema-shape, operation-count, hash, and freshness metadata only.",
+      "Raw schemas, protected method calls, credentialed data, and API response payloads are not persisted.",
+    ],
+  };
+}
+
+async function fetchOpenApiSchemaSummary(surface) {
+  const schemaUrl = surface.schema_url || surface.url;
+  const fetched = await fetchJson(schemaUrl);
+  const base = {
+    surface_id: surface.id,
+    name: surface.name,
+    schema_url: schemaUrl,
+    url: surface.url,
+    provider: surface.provider || null,
+    auth_required: Boolean(surface.auth_required),
+    captured_at: fetched.captured_at,
+  };
+  if (!fetched.ok || !fetched.body || typeof fetched.body !== "object") {
+    return {
+      ...base,
+      status: fetched.status || "failed",
+      error: fetched.error || null,
+      status_code: fetched.status_code || null,
+      content_type: fetched.content_type || null,
+      latency_ms: fetched.latency_ms ?? null,
+    };
+  }
+
+  return {
+    ...base,
+    status: "captured",
+    status_code: fetched.status_code,
+    content_type: fetched.content_type,
+    latency_ms: fetched.latency_ms,
+    hash: hashJson(fetched.body),
+    shape: summarizeOpenApiShape(fetched.body),
+  };
+}
+
+function summarizeOpenApiSchemas(schemas) {
+  const captured = schemas.filter((schema) => schema.status === "captured");
+  return {
+    status:
+      captured.length === schemas.length
+        ? "captured"
+        : captured.length > 0
+          ? "degraded"
+          : "failed",
+    schema_count: schemas.length,
+    captured_count: captured.length,
+    captured_at: latestTimestamp(schemas.map((schema) => schema.captured_at)),
+    total_path_count: captured.reduce(
+      (sum, schema) => sum + (schema.shape?.path_count || 0),
+      0,
+    ),
+    total_operation_count: captured.reduce(
+      (sum, schema) => sum + (schema.shape?.operation_count || 0),
+      0,
+    ),
+    schemas,
+  };
+}
+
+function summarizeOpenApiShape(schema) {
+  const paths =
+    schema.paths && typeof schema.paths === "object" ? schema.paths : {};
+  const pathEntries = Object.entries(paths);
+  const methodCounts = {};
+  let operationCount = 0;
+  for (const [, pathDefinition] of pathEntries) {
+    if (!pathDefinition || typeof pathDefinition !== "object") {
+      continue;
+    }
+    for (const method of Object.keys(pathDefinition)) {
+      const normalized = method.toLowerCase();
+      if (!OPENAPI_METHODS.has(normalized)) {
+        continue;
+      }
+      methodCounts[normalized] = (methodCounts[normalized] || 0) + 1;
+      operationCount += 1;
+    }
+  }
+  const components =
+    schema.components && typeof schema.components === "object"
+      ? schema.components
+      : {};
+  const securitySchemes =
+    components.securitySchemes && typeof components.securitySchemes === "object"
+      ? components.securitySchemes
+      : {};
+  const componentSchemas =
+    components.schemas && typeof components.schemas === "object"
+      ? components.schemas
+      : {};
+
+  return {
+    title: schema.info?.title || null,
+    version: schema.info?.version || null,
+    openapi_version: schema.openapi || schema.swagger || null,
+    path_count: pathEntries.length,
+    operation_count: operationCount,
+    method_counts: Object.fromEntries(
+      Object.entries(methodCounts).sort(([a], [b]) => a.localeCompare(b)),
+    ),
+    server_count: Array.isArray(schema.servers) ? schema.servers.length : 0,
+    tag_count: Array.isArray(schema.tags) ? schema.tags.length : 0,
+    component_schema_count: Object.keys(componentSchemas).length,
+    security_scheme_count: Object.keys(securitySchemes).length,
+    has_global_security:
+      Array.isArray(schema.security) && schema.security.length > 0,
+    sample_paths: pathEntries
+      .map(([apiPath]) => apiPath)
+      .filter(isPublicSafeOpenApiPath)
+      .sort()
+      .slice(0, 20),
+  };
+}
+
+function publicSurfaceSummary(surface) {
+  return {
+    id: surface.id,
+    kind: surface.kind,
+    name: surface.name,
+    url: surface.url,
+    provider: surface.provider || null,
+    auth_required: Boolean(surface.auth_required),
+    schema_url: surface.schema_url || null,
+    probe_enabled: Boolean(surface.probe?.enabled),
+  };
+}
+
+function latestTimestamp(values) {
+  return (
+    values
+      .filter(Boolean)
+      .map((value) => new Date(value))
+      .filter((value) => !Number.isNaN(value.getTime()))
+      .sort((a, b) => a.getTime() - b.getTime())
+      .at(-1)
+      ?.toISOString() || null
+  );
+}
+
+function isPublicSafeOpenApiPath(apiPath) {
+  return !/(address|coldkey|hotkey|keypair|private|secret|seed|token|wallet)/i.test(
+    String(apiPath),
+  );
 }
 
 async function fetchJsonSummary(url) {

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -369,6 +369,8 @@ test("public artifacts are internally consistent", () => {
   const gapPriorities = readArtifact("review/gap-priorities.json");
   const profileCompleteness = readArtifact("review/profile-completeness.json");
   const adapterCandidates = readArtifact("review/adapter-candidates.json");
+  const genericAdapter = readArtifact("adapters/numinous.json");
+  const schemaOnlyGenericAdapter = readArtifact("adapters/sn-46.json");
   const enrichmentQueue = readArtifact("review/enrichment-queue.json");
   const enrichmentEvidence = readArtifact("review/enrichment-evidence.json");
   const reviewDecisions = readArtifact("review/maintainer-decisions.json");
@@ -713,6 +715,26 @@ test("public artifacts are internally consistent", () => {
   assert.equal(
     profileCompleteness.summary.by_profile_level["adapter-backed"] >= 2,
     true,
+  );
+  assert.equal(genericAdapter.snapshot.adapter_kind, "generic-openapi");
+  assert.equal(
+    genericAdapter.extensions.generic_adapter.kind,
+    "generic-openapi",
+  );
+  assert.equal(
+    genericAdapter.snapshot.dimensions.openapi_schemas.captured_count > 0,
+    true,
+  );
+  assert.equal(
+    genericAdapter.snapshot.dimensions.openapi_schemas.total_operation_count >
+      0,
+    true,
+  );
+  assert.equal(schemaOnlyGenericAdapter.snapshot.status, "captured");
+  assert.equal(
+    schemaOnlyGenericAdapter.snapshot.dimensions.public_api_surfaces
+      .surface_count,
+    0,
   );
   assert.equal(
     profileCompleteness.summary.by_profile_level["directory-only"] > 0,


### PR DESCRIPTION
## Summary
- add generic OpenAPI adapter snapshots for schema-backed subnets beyond Allways and Gittensor
- publish adapter artifacts for snapshot-backed subnets even when they do not have bespoke extension blocks

## What changed
- `adapters:snapshot` now discovers curated machine-readable OpenAPI surfaces and captures public-safe schema shape metadata.
- Added generic adapter snapshots for Numinous, Desearch, Zipcode, Nepher Robotics, Handshake58, Verathos, and Albedo.
- Generic snapshots summarize schema hash, OpenAPI version, path count, operation count, method counts, component/security counts, sample public-safe paths, and related public API surfaces.
- `build-artifacts` now emits adapter artifacts for valid adapter snapshots by slug, while preserving bespoke Allways/Gittensor adapters.
- Added artifact regression coverage for generic OpenAPI adapters and schema-only adapters.

## Why
This deepens subnet enrichment in a scalable way. Instead of writing a bespoke adapter for every subnet immediately, Metagraphed can now turn verified OpenAPI schemas into normalized, public-safe operational metadata that the API/UI can consume.

## Validation
- `npm run check`
- `npm run test:coverage`
- `git diff --check`

## Notes
- Adapter snapshots now cover 9 subnets total: Allways, Gittensor, Numinous, Desearch, Zipcode, Nepher Robotics, Handshake58, Verathos, and Albedo.
- The generic pass does not persist raw schema bodies, protected API responses, credentialed flows, wallet data, or private validator data.
