### PR TITLE
feat(api): filter adapter candidates by enrichment signals

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -3718,9 +3718,13 @@ export interface operations {
             query?: {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                candidate_api_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                reason_codes?: string;
+                recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 limit?: number;
                 cursor?: number;
-                sort?: "candidate_api_count" | "curation_level" | "name" | "netuid" | "operational_surface_count" | "priority_score";
+                sort?: "candidate_api_count" | "candidate_api_kinds" | "curation_level" | "name" | "netuid" | "operational_kinds" | "operational_surface_count" | "priority_score" | "recommended_adapter_kind";
                 order?: "asc" | "desc";
             };
             header?: never;

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -1894,7 +1894,11 @@
       "query_collection": "adapter-candidates",
       "query_filter_names": [
         "netuid",
-        "curation_level"
+        "curation_level",
+        "candidate_api_kinds",
+        "operational_kinds",
+        "reason_codes",
+        "recommended_adapter_kind"
       ],
       "query_parameters": [
         {
@@ -1913,6 +1917,68 @@
               "machine-verified",
               "maintainer-reviewed",
               "adapter-backed"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "candidate_api_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "operational_kinds",
+          "schema": {
+            "enum": [
+              "archive",
+              "dashboard",
+              "data-artifact",
+              "docs",
+              "example",
+              "openapi",
+              "repo-registry",
+              "sdk",
+              "source-repo",
+              "sse",
+              "subnet-api",
+              "subtensor-rpc",
+              "subtensor-wss",
+              "website"
+            ],
+            "type": "string"
+          }
+        },
+        {
+          "name": "reason_codes",
+          "schema": {
+            "type": "string"
+          }
+        },
+        {
+          "name": "recommended_adapter_kind",
+          "schema": {
+            "enum": [
+              "custom-adapter",
+              "data-artifact-adapter",
+              "generic-openapi-or-custom",
+              "stream-adapter"
             ],
             "type": "string"
           }
@@ -1937,11 +2003,14 @@
           "schema": {
             "enum": [
               "candidate_api_count",
+              "candidate_api_kinds",
               "curation_level",
               "name",
               "netuid",
+              "operational_kinds",
               "operational_surface_count",
-              "priority_score"
+              "priority_score",
+              "recommended_adapter_kind"
             ],
             "type": "string"
           }

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,18 +7,18 @@
   },
   "artifact_budgets": [],
   "artifact_count": 22,
-  "artifact_size_bytes": 4641858,
+  "artifact_size_bytes": 4645826,
   "artifacts": [
     {
       "path": "api-index.json",
-      "sha256": "05d06b56a2084e498c7f2ae450278e87fed697093adbd4675e53f60c276be188",
-      "size_bytes": 73942,
+      "sha256": "4f5b64f88a1728791fffe1acc03efcefeccbf2f58f16930a4376925e0fa0275a",
+      "size_bytes": 75670,
       "storage_tier": "dual"
     },
     {
       "path": "changelog.json",
-      "sha256": "ef7be06bdad818eb7b8becc299cedc175c8004e71495f29b19c82b27314dfaf4",
-      "size_bytes": 1211,
+      "sha256": "5bb7063e63892c836200f6e6e77078d9a60eccb45d8d5db2bcf705a5b413b1e8",
+      "size_bytes": 1481,
       "storage_tier": "dual"
     },
     {
@@ -59,8 +59,8 @@
     },
     {
       "path": "openapi.json",
-      "sha256": "aad400ddcc94a97f3e8753794740b8f251124664779ae2fe94a83c2a8b82b3d1",
-      "size_bytes": 326554,
+      "sha256": "58cbd2f1bacb35879f88cbf76b8f99ce4d4b7fe306b1e6aa0b3eb21c085530e4",
+      "size_bytes": 328524,
       "storage_tier": "dual"
     },
     {
@@ -181,7 +181,7 @@
   },
   "endpoint_count": 1107,
   "full_artifact_count": 1232,
-  "full_artifact_size_bytes": 47887052,
+  "full_artifact_size_bytes": 47891020,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 77,
@@ -196,7 +196,7 @@
     "r2": 1210
   },
   "storage_tier_size_bytes": {
-    "dual": 4511911,
+    "dual": 4515879,
     "git": 129947,
     "r2": 43245194
   },

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,7 +1,16 @@
 {
   "artifacts": {
     "added": [],
-    "modified": [],
+    "modified": [
+      {
+        "hash": "4f5b64f88a1728791fffe1acc03efcefeccbf2f58f16930a4376925e0fa0275a",
+        "path": "api-index.json"
+      },
+      {
+        "hash": "58cbd2f1bacb35879f88cbf76b8f99ce4d4b7fe306b1e6aa0b3eb21c085530e4",
+        "path": "openapi.json"
+      }
+    ],
     "removed": []
   },
   "contract_version": "2026-06-06.1",
@@ -19,7 +28,7 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 0,
+    "artifact_modified_count": 2,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9342,6 +9342,76 @@
           },
           {
             "in": "query",
+            "name": "candidate_api_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "operational_kinds",
+            "required": false,
+            "schema": {
+              "enum": [
+                "archive",
+                "dashboard",
+                "data-artifact",
+                "docs",
+                "example",
+                "openapi",
+                "repo-registry",
+                "sdk",
+                "source-repo",
+                "sse",
+                "subnet-api",
+                "subtensor-rpc",
+                "subtensor-wss",
+                "website"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "reason_codes",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "recommended_adapter_kind",
+            "required": false,
+            "schema": {
+              "enum": [
+                "custom-adapter",
+                "data-artifact-adapter",
+                "generic-openapi-or-custom",
+                "stream-adapter"
+              ],
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "limit",
             "required": false,
             "schema": {
@@ -9366,11 +9436,14 @@
             "schema": {
               "enum": [
                 "candidate_api_count",
+                "candidate_api_kinds",
                 "curation_level",
                 "name",
                 "netuid",
+                "operational_kinds",
                 "operational_surface_count",
-                "priority_score"
+                "priority_score",
+                "recommended_adapter_kind"
               ],
               "type": "string"
             }

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 4830168,
+  "artifact_size_bytes": 4834838,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "05d06b56a2084e498c7f2ae450278e87fed697093adbd4675e53f60c276be188",
-      "size_bytes": 73942,
+      "sha256": "4f5b64f88a1728791fffe1acc03efcefeccbf2f58f16930a4376925e0fa0275a",
+      "size_bytes": 75670,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "ef7be06bdad818eb7b8becc299cedc175c8004e71495f29b19c82b27314dfaf4",
-      "size_bytes": 1211,
+      "sha256": "5bb7063e63892c836200f6e6e77078d9a60eccb45d8d5db2bcf705a5b413b1e8",
+      "size_bytes": 1481,
       "storage_tier": "dual"
     },
     {
@@ -79,8 +79,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
-      "sha256": "aad400ddcc94a97f3e8753794740b8f251124664779ae2fe94a83c2a8b82b3d1",
-      "size_bytes": 326554,
+      "sha256": "58cbd2f1bacb35879f88cbf76b8f99ce4d4b7fe306b1e6aa0b3eb21c085530e4",
+      "size_bytes": 328524,
       "storage_tier": "dual"
     },
     {
@@ -205,8 +205,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/types.d.ts",
       "latest_key": "latest/types.d.ts",
       "path": "/metagraph/types.d.ts",
-      "sha256": "6814b34c9d4a63458af3a71325bccedb8dc52632ed080cde620901395c65d2de",
-      "size_bytes": 188310,
+      "sha256": "dbeeed42e90fc152701d908cefb63d6a37daec8acf8a335b7fabe1c8b83156df",
+      "size_bytes": 189012,
       "storage_tier": "dual"
     }
   ],
@@ -214,7 +214,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1233,
-  "full_artifact_size_bytes": 48075362,
+  "full_artifact_size_bytes": 48080032,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -237,7 +237,7 @@
     "r2": 1210
   },
   "storage_tier_size_bytes": {
-    "dual": 4700221,
+    "dual": 4704891,
     "git": 129947,
     "r2": 43245194
   }

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -3718,9 +3718,13 @@ export interface operations {
             query?: {
                 netuid?: number;
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
+                candidate_api_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                operational_kinds?: "archive" | "dashboard" | "data-artifact" | "docs" | "example" | "openapi" | "repo-registry" | "sdk" | "source-repo" | "sse" | "subnet-api" | "subtensor-rpc" | "subtensor-wss" | "website";
+                reason_codes?: string;
+                recommended_adapter_kind?: "custom-adapter" | "data-artifact-adapter" | "generic-openapi-or-custom" | "stream-adapter";
                 limit?: number;
                 cursor?: number;
-                sort?: "candidate_api_count" | "curation_level" | "name" | "netuid" | "operational_surface_count" | "priority_score";
+                sort?: "candidate_api_count" | "candidate_api_kinds" | "curation_level" | "name" | "netuid" | "operational_kinds" | "operational_surface_count" | "priority_score" | "recommended_adapter_kind";
                 order?: "asc" | "desc";
             };
             header?: never;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -74,6 +74,12 @@ export const QUERY_ENUMS = {
   ],
   endpointIncidentSeverity: ["critical", "warning", "info"],
   endpointIncidentState: ["active", "resolved"],
+  recommendedAdapterKind: [
+    "custom-adapter",
+    "data-artifact-adapter",
+    "generic-openapi-or-custom",
+    "stream-adapter",
+  ],
   surfaceKind: [
     "archive",
     "dashboard",
@@ -257,14 +263,21 @@ export const API_QUERY_COLLECTIONS = {
     filters: {
       netuid: integerSchema,
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
+      candidate_api_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
+      operational_kinds: enumSchema(QUERY_ENUMS.surfaceKind),
+      reason_codes: textSchema,
+      recommended_adapter_kind: enumSchema(QUERY_ENUMS.recommendedAdapterKind),
     },
     sort: [
       "candidate_api_count",
+      "candidate_api_kinds",
       "curation_level",
       "name",
       "netuid",
+      "operational_kinds",
       "operational_surface_count",
       "priority_score",
+      "recommended_adapter_kind",
     ],
   }),
   "enrichment-queue": queryCollection("queue", {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -945,6 +945,32 @@ describe("Worker runtime", () => {
           body.data.candidates.every((candidate) => candidate.netuid === 7),
       ],
       [
+        "https://metagraph.sh/api/v1/review/adapter-candidates?recommended_adapter_kind=generic-openapi-or-custom",
+        (body) =>
+          body.data.candidates.length > 0 &&
+          body.data.candidates.every(
+            (candidate) =>
+              candidate.recommended_adapter_kind ===
+              "generic-openapi-or-custom",
+          ),
+      ],
+      [
+        "https://metagraph.sh/api/v1/review/adapter-candidates?operational_kinds=openapi",
+        (body) =>
+          body.data.candidates.length > 0 &&
+          body.data.candidates.every((candidate) =>
+            candidate.operational_kinds.includes("openapi"),
+          ),
+      ],
+      [
+        "https://metagraph.sh/api/v1/review/adapter-candidates?reason_codes=existing-adapter",
+        (body) =>
+          body.data.candidates.length > 0 &&
+          body.data.candidates.every((candidate) =>
+            candidate.reason_codes.includes("existing-adapter"),
+          ),
+      ],
+      [
         "https://metagraph.sh/api/v1/subnets/7/health?status=ok",
         (body) =>
           body.data.surfaces.every(
@@ -980,6 +1006,7 @@ describe("Worker runtime", () => {
       "https://metagraph.sh/api/v1/subnets?netuid=not-a-number",
       "https://metagraph.sh/api/v1/subnets?coverage_level=fake",
       "https://metagraph.sh/api/v1/candidates?state=approved",
+      "https://metagraph.sh/api/v1/review/adapter-candidates?recommended_adapter_kind=generic",
       "https://metagraph.sh/api/v1/subnets/7/health?status=alive",
     ];
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -466,7 +466,12 @@ function filterRows(rows, params, keys) {
       if (!params.has(key)) {
         return true;
       }
-      return String(row[key]) === params.get(key);
+      const expected = params.get(key);
+      const value = row[key];
+      if (Array.isArray(value)) {
+        return value.map(String).includes(expected);
+      }
+      return String(value) === expected;
     }),
   );
 }


### PR DESCRIPTION
## Summary
- add adapter-candidate query filters for recommended adapter kind, operational kinds, API candidate kinds, and reason codes
- make Worker list filtering array-aware so filters match values inside array fields
- regenerate OpenAPI, API index, and TypeScript definitions for the new query contract

## Why
- lets API consumers and the future frontend target adapter work by actual enrichment signal instead of downloading and filtering the full artifact manually
- keeps the route-specific OpenAPI contract aligned with the richer adapter candidate report

## Validation
- npm run check
- npm run test:coverage
- git diff --check

## Notes
- This keeps all health and uptime data probe-derived; the change only affects review/enrichment query ergonomics.