### PR TITLE
fix(api): expose schema snapshot artifacts

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -62,6 +62,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/endpoint-incidents.json`: probe-derived endpoint incident summary and active endpoint failures.
 - `/metagraph/schema-drift.json`: OpenAPI snapshot/drift status.
 - `/metagraph/schemas/index.json`: captured machine-readable schema index.
+- `/metagraph/schemas/{surface_id}.json`: captured machine-readable OpenAPI/Swagger schema snapshot detail. R2-backed.
 - `/metagraph/adapters/{slug}.json`: adapter-backed public metrics snapshot. R2-backed.
 - `/metagraph/r2-manifest.json`: compact committed Cloudflare R2 upload manifest. The full upload manifest is generated under `dist/metagraph-r2/metagraph/r2-manifest.json`.
 - `/metagraph/review/curation.json`: maintainer review and adapter candidate report.

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -289,6 +289,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "schema-snapshot",
+      "path": "/metagraph/schemas/{surface_id}.json",
+      "schema_ref": "#/components/schemas/JsonObject",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",
       "schema_ref": "#/components/schemas/AdapterArtifact",

--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,24 +7,24 @@
   },
   "artifact_budgets": [],
   "artifact_count": 23,
-  "artifact_size_bytes": 5513741,
+  "artifact_size_bytes": 5514179,
   "artifacts": [
     {
       "path": "api-index.json",
-      "sha256": "25180464764d42f7b37b35add626cc4721bed8da62325dd8668b1745af45a44e",
-      "size_bytes": 86083,
+      "sha256": "2c20d8282759dd3da4e5f85978d1bbbd745ddb4a4e7fdfff7af7f4bf62f6530a",
+      "size_bytes": 86305,
       "storage_tier": "dual"
     },
     {
       "path": "changelog.json",
-      "sha256": "07342a0258a055001d33b58b0269105baed6dcb59066d8b434830eaf8e3c0e32",
-      "size_bytes": 1349,
+      "sha256": "8b988b12ffb8ac473c7c396e3e44af7351532c7caff27e62b7f10a3dfb52843e",
+      "size_bytes": 1211,
       "storage_tier": "dual"
     },
     {
       "path": "contracts.json",
-      "sha256": "0f62ba4372e8b56085b8cb87928da44ad6421937cbd034dad63495655741cb30",
-      "size_bytes": 18666,
+      "sha256": "f1ee86995f7953a878322af4e72fce6d448c9ebfc1d04e03f6bcaa0a0b97eaea",
+      "size_bytes": 19020,
       "storage_tier": "dual"
     },
     {
@@ -47,7 +47,7 @@
     },
     {
       "path": "freshness.json",
-      "sha256": "e46cc964fb68ed9eb41a503d5082ceced79657449c4044766f9393eba9eba9d7",
+      "sha256": "7830a1e22360002c3a512ff0f27bbe0ed88bdcaddf29feda0b2413af8d7f08b1",
       "size_bytes": 7081,
       "storage_tier": "dual"
     },
@@ -119,13 +119,13 @@
     },
     {
       "path": "schema-drift.json",
-      "sha256": "8a568403fcf8c5d6835886b3230f372e6b7e7443b5f06de26f19c4a167451970",
+      "sha256": "f4699ee1e5cde1089573898b9331cc1a2c9db27a02499cb52890caa9fb8904e6",
       "size_bytes": 6264,
       "storage_tier": "dual"
     },
     {
       "path": "schemas/index.json",
-      "sha256": "098b5c4e0bcf86782586e59de4065120cbeb5e3004eb77a74a9ceda806e54f1c",
+      "sha256": "aa3ad3dc2b93bddb96701b921b0387c8f069ecf5e31e65d82bd1d7180339d80d",
       "size_bytes": 18221,
       "storage_tier": "dual"
     },
@@ -187,7 +187,7 @@
   },
   "endpoint_count": 1111,
   "full_artifact_count": 1239,
-  "full_artifact_size_bytes": 48833977,
+  "full_artifact_size_bytes": 48834415,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 80,
@@ -202,7 +202,7 @@
     "r2": 1216
   },
   "storage_tier_size_bytes": {
-    "dual": 4609323,
+    "dual": 4609761,
     "git": 904418,
     "r2": 43320236
   },

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,12 +1,7 @@
 {
   "artifacts": {
     "added": [],
-    "modified": [
-      {
-        "hash": "e46cc964fb68ed9eb41a503d5082ceced79657449c4044766f9393eba9eba9d7",
-        "path": "freshness.json"
-      }
-    ],
+    "modified": [],
     "removed": []
   },
   "contract_version": "2026-06-06.1",
@@ -24,7 +19,7 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 1,
+    "artifact_modified_count": 0,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -372,6 +372,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Captured machine-readable OpenAPI/Swagger schema snapshot detail.",
+      "id": "schema-snapshot",
+      "path": "/metagraph/schemas/{surface_id}.json",
+      "schema_ref": "#/components/schemas/JsonObject",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Adapter-backed public metrics by subnet slug.",
       "id": "adapter",
       "path": "/metagraph/adapters/{slug}.json",

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,14 +1,14 @@
 {
   "artifact_count": 24,
-  "artifact_size_bytes": 5713866,
+  "artifact_size_bytes": 5714304,
   "artifacts": [
     {
       "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/api-index.json",
       "latest_key": "latest/api-index.json",
       "path": "/metagraph/api-index.json",
-      "sha256": "25180464764d42f7b37b35add626cc4721bed8da62325dd8668b1745af45a44e",
-      "size_bytes": 86083,
+      "sha256": "2c20d8282759dd3da4e5f85978d1bbbd745ddb4a4e7fdfff7af7f4bf62f6530a",
+      "size_bytes": 86305,
       "storage_tier": "dual"
     },
     {
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "07342a0258a055001d33b58b0269105baed6dcb59066d8b434830eaf8e3c0e32",
-      "size_bytes": 1349,
+      "sha256": "8b988b12ffb8ac473c7c396e3e44af7351532c7caff27e62b7f10a3dfb52843e",
+      "size_bytes": 1211,
       "storage_tier": "dual"
     },
     {
@@ -25,8 +25,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/contracts.json",
       "latest_key": "latest/contracts.json",
       "path": "/metagraph/contracts.json",
-      "sha256": "0f62ba4372e8b56085b8cb87928da44ad6421937cbd034dad63495655741cb30",
-      "size_bytes": 18666,
+      "sha256": "f1ee86995f7953a878322af4e72fce6d448c9ebfc1d04e03f6bcaa0a0b97eaea",
+      "size_bytes": 19020,
       "storage_tier": "dual"
     },
     {
@@ -223,7 +223,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1252,
-  "full_artifact_size_bytes": 49043116,
+  "full_artifact_size_bytes": 49043624,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -246,8 +246,8 @@
     "r2": 1228
   },
   "storage_tier_size_bytes": {
-    "dual": 4809448,
+    "dual": 4809886,
     "git": 904418,
-    "r2": 43329250
+    "r2": 43329320
   }
 }

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -112,7 +112,8 @@ async function artifactValidationTargets() {
     if (
       artifact.path.includes("{netuid}") ||
       artifact.path.includes("{slug}") ||
-      artifact.path.includes("{date}")
+      artifact.path.includes("{date}") ||
+      artifact.path.includes("{surface_id}")
     ) {
       const filePaths =
         artifact.id === "provider-endpoints"
@@ -156,6 +157,7 @@ function templatedArtifactDirectory(artifactId) {
     ...netuidArtifactDirectories(),
     ...slugArtifactDirectories(),
     "health-history": "health/history",
+    "schema-snapshot": "schemas",
   };
   const relativeDir = directories[artifactId];
   const template = PUBLIC_ARTIFACTS.find(

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -770,6 +770,12 @@ export const PUBLIC_ARTIFACTS = [
     "SchemaIndexArtifact",
   ),
   artifact(
+    "schema-snapshot",
+    "/metagraph/schemas/{surface_id}.json",
+    "Captured machine-readable OpenAPI/Swagger schema snapshot detail.",
+    "JsonObject",
+  ),
+  artifact(
     "adapter",
     "/metagraph/adapters/{slug}.json",
     "Adapter-backed public metrics by subnet slug.",
@@ -1465,19 +1471,22 @@ export function artifactPathFromTemplate(template, params = {}) {
   return template
     .replace("{netuid}", String(params.netuid ?? ""))
     .replace("{slug}", String(params.slug ?? ""))
-    .replace("{date}", String(params.date ?? ""));
+    .replace("{date}", String(params.date ?? ""))
+    .replace("{surface_id}", String(params.surface_id ?? ""));
 }
 
 export function compileRoutePattern(pathTemplate) {
   const tokenized = pathTemplate
     .replace(/\{netuid\}/g, "__METAGRAPH_NETUID__")
     .replace(/\{slug\}/g, "__METAGRAPH_SLUG__")
-    .replace(/\{date\}/g, "__METAGRAPH_DATE__");
+    .replace(/\{date\}/g, "__METAGRAPH_DATE__")
+    .replace(/\{surface_id\}/g, "__METAGRAPH_SURFACE_ID__");
   const pattern = tokenized
     .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
     .replace(/__METAGRAPH_NETUID__/g, "(?<netuid>\\d+)")
     .replace(/__METAGRAPH_SLUG__/g, "(?<slug>[a-z0-9-]+)")
-    .replace(/__METAGRAPH_DATE__/g, "(?<date>\\d{4}-\\d{2}-\\d{2})");
+    .replace(/__METAGRAPH_DATE__/g, "(?<date>\\d{4}-\\d{2}-\\d{2})")
+    .replace(/__METAGRAPH_SURFACE_ID__/g, "(?<surface_id>[a-z0-9-]+)");
   return new RegExp(`^${pattern}\\/?$`);
 }
 
@@ -1612,11 +1621,13 @@ function pathTemplatesMatch(contractPath, artifactPath) {
   const contractPattern = contractPath
     .replace("{netuid}", ":netuid")
     .replace("{slug}", ":slug")
-    .replace("{date}", ":date");
+    .replace("{date}", ":date")
+    .replace("{surface_id}", ":surface_id");
   const artifactPattern = artifactPath
     .replace("{netuid}", ":netuid")
     .replace("{slug}", ":slug")
-    .replace("{date}", ":date");
+    .replace("{date}", ":date")
+    .replace("{surface_id}", ":surface_id");
   return contractPattern === artifactPattern;
 }
 

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -78,6 +78,24 @@ describe("public contract registry", () => {
       }),
       "/metagraph/health/history/2026-06-06.json",
     );
+
+    const schemaPattern = compileRoutePattern(
+      "/metagraph/schemas/{surface_id}.json",
+    );
+    const schemaMatch = schemaPattern.exec(
+      "/metagraph/schemas/sn-56-gradients-openapi.json",
+    );
+    assert.equal(schemaMatch.groups.surface_id, "sn-56-gradients-openapi");
+    assert.equal(
+      schemaPattern.test("/metagraph/schemas/SN-56-gradients-openapi.json"),
+      false,
+    );
+    assert.equal(
+      artifactPathFromTemplate("/metagraph/schemas/{surface_id}.json", {
+        surface_id: "sn-56-gradients-openapi",
+      }),
+      "/metagraph/schemas/sn-56-gradients-openapi.json",
+    );
   });
 
   test("builds contracts, API index, and OpenAPI from one route table", async () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -165,6 +165,47 @@ describe("Worker runtime", () => {
     assert.equal((await response.json()).network, "finney");
   });
 
+  test("serves raw R2-backed schema snapshot artifacts", async () => {
+    const r2KeysRequested = [];
+    const schemaSnapshot = {
+      schema_version: 1,
+      contract_version: "2026-06-06.1",
+      generated_at: "1970-01-01T00:00:00.000Z",
+      observed_at: "2999-01-01T00:00:00.000Z",
+      surface_id: "example-openapi",
+      schema_url: "https://example.com/openapi.json",
+      hash: "abc123",
+      openapi_version: "3.1.0",
+      title: "Example API",
+    };
+    const response = await handleRequest(
+      new Request(
+        "https://metagraph.sh/metagraph/schemas/example-openapi.json",
+      ),
+      {
+        ASSETS: env.ASSETS,
+        METAGRAPH_ARCHIVE: {
+          async get(key) {
+            r2KeysRequested.push(key);
+            assert.equal(key, "latest/schemas/example-openapi.json");
+            return {
+              async json() {
+                return schemaSnapshot;
+              },
+            };
+          },
+        },
+      },
+      {},
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("x-metagraph-artifact-source"), "r2");
+    assert.equal(response.headers.get("x-metagraph-storage-tier"), "r2");
+    assert.deepEqual(r2KeysRequested, ["latest/schemas/example-openapi.json"]);
+    assert.equal((await response.json()).title, "Example API");
+  });
+
   test("rejects raw artifact paths outside public contracts before storage lookup", async () => {
     const assetRequests = [];
     const r2KeysRequested = [];


### PR DESCRIPTION
## Summary
- Add `/metagraph/schemas/{surface_id}.json` to the public raw artifact contract.
- Teach path helpers/schema validation about `{surface_id}` templates.
- Add Worker regression coverage for R2-backed schema snapshot detail artifacts.

## Why
- `/metagraph/schemas/index.json` exposes per-surface schema snapshot paths, but the Worker rejected those raw paths because they were not declared in `PUBLIC_ARTIFACTS`.
- This keeps schema details R2-backed while making the indexed raw artifact paths usable.

## Validation
- npm run check
- npm run validate
- npm run validate:schemas
- npm run validate:api
- npm run validate:openapi
- npm run validate:types
- npm run validate:contract-drift
- npm run validate:openapi-examples
- npm run validate:artifact-budgets
- npm run worker:test
- npm run test:coverage
- npm run scan:public-safety
- git diff --check

## Notes
- The R2 manifest still reports 1252 full artifacts, including the 12 schema detail snapshots staged for upload.
- This does not enable RPC proxying or add new UI behavior.