### PR TITLE
fix(artifacts): detect stale R2 manifests

### DIFF
--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -61,7 +61,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "0d8285b702ba20390cbb3f43b1c10f936f3bc9eb28721e2172a204e31d1e4082",
+      "sha256": "d6aab1867ab01487bae994dd738e20ac4a749aeb93c375eb639dfc8bf65d1209",
       "size_bytes": 7081,
       "storage_tier": "dual"
     },
@@ -169,7 +169,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/schema-drift.json",
       "latest_key": "latest/schema-drift.json",
       "path": "/metagraph/schema-drift.json",
-      "sha256": "e17212ca0a4634c7492aa1addd31e890cb19a1950d6a07428192d751a72d459e",
+      "sha256": "6a840d32f692854a3baa0555eff0e2c5b8e696123b8a371114f46a2e83aaa1a2",
       "size_bytes": 6298,
       "storage_tier": "dual"
     },
@@ -178,7 +178,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/schemas/index.json",
       "latest_key": "latest/schemas/index.json",
       "path": "/metagraph/schemas/index.json",
-      "sha256": "f651923769017ea7e3abeb3e9a98b63ae615910ea18531fdafff6b2b6dc38df7",
+      "sha256": "49f646216354ce73c884d60c20f42967b6ad7281a7f996d88bb43d2edcdb1875",
       "size_bytes": 18325,
       "storage_tier": "dual"
     },

--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { existsSync } from "node:fs";
 import { mkdir, readFile, readdir, stat } from "node:fs/promises";
 import {
   buildTimestamp,
@@ -21,13 +22,32 @@ const fullManifestPath = path.join(
   R2_STAGING_RELATIVE_ROOT,
   "r2-manifest.json",
 );
+const r2StagingRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 const fullManifest = write
   ? await buildManifest()
-  : await readJson(fullManifestPath).catch(() => null);
+  : existsSync(r2StagingRoot)
+    ? await buildManifest()
+    : await readJson(fullManifestPath).catch(() => null);
 const manifest = write
   ? buildCompactManifest(fullManifest)
   : await readJson(manifestPath);
 const validationManifest = fullManifest || manifest;
+
+if (!write && fullManifest) {
+  const expectedManifest = buildCompactManifest(fullManifest);
+  if (stableStringify(manifest) !== stableStringify(expectedManifest)) {
+    console.error(
+      stableStringify({
+        error: "r2 compact manifest is stale",
+        expected_artifact_count: expectedManifest.artifact_count,
+        actual_artifact_count: manifest.artifact_count,
+        expected_full_artifact_count: expectedManifest.full_artifact_count,
+        actual_full_artifact_count: manifest.full_artifact_count,
+      }),
+    );
+    process.exit(1);
+  }
+}
 
 const summary = {
   artifact_count: manifest.artifact_count,


### PR DESCRIPTION
## Summary
- fix stale compact R2 manifest hashes for schema/freshness artifacts
- make `r2:manifest:dry-run` recompute from local R2 staging when staging exists
- fail dry-run if the tracked compact manifest does not match the staged full manifest

## What changed
- updated `public/metagraph/r2-manifest.json` hashes for post-schema-snapshot artifacts
- added stale compact-manifest detection to `scripts/r2-manifest.mjs`

## Why
- R2 upload correctly rejected a stale local manifest after the enrichment merge
- this makes the validation path catch stale compact manifests before publish instead of discovering them during upload

## Validation
- `npm run r2:manifest:dry-run`
- `npm run validate:artifact-budgets`
- `npm run check`
- `npm run test:coverage`
- `git diff --check`
