### PR TITLE
fix(enrichment): hide maintainer-excluded candidates from targets

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 1270,
-  "artifact_size_bytes": 50271935,
+  "artifact_size_bytes": 50253457,
   "artifacts": [
     {
       "path": "adapters/allways.json",
@@ -716,8 +716,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "9bd8dfb3dd4e281ed5b2f63fa96c862d517d23c0d4c002fc973aa0327569627e",
-      "size_bytes": 2067
+      "sha256": "5e3bafb17bcc701ba9aab645b8ae40ca10518969fda7d86bbc85cf21d27ba9a0",
+      "size_bytes": 1513
     },
     {
       "path": "contracts.json",
@@ -1300,7 +1300,7 @@
   },
   "endpoint_count": 1135,
   "full_artifact_count": 1258,
-  "full_artifact_size_bytes": 50262851,
+  "full_artifact_size_bytes": 50244373,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 89,
@@ -1315,9 +1315,9 @@
     "r2": 1235
   },
   "storage_tier_size_bytes": {
-    "dual": 4888205,
-    "git": 1020954,
-    "r2": 44353692
+    "dual": 4883775,
+    "git": 1011697,
+    "r2": 44348901
   },
   "subnet_count": 129,
   "surface_count": 1135

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -3,28 +3,12 @@
     "added": [],
     "modified": [
       {
-        "hash": "c186c3dd1cd1dda45d0f5bfc018b19ba8b8b8f38693e7861060d22565dc971fc",
-        "path": "profiles.json"
-      },
-      {
-        "hash": "c301e681525773558497a2c880e8ad5b0c9068240528cb223fb9c3bc0a5db639",
-        "path": "review/curation.json"
-      },
-      {
-        "hash": "0a9712c54d52e4bbb063a60f0ebea4feff18b92212e06d991263e0b123e035c6",
+        "hash": "5c5a20e0644297c71b9f497d040a3fa53b633cccd941195268f56261ae0613ca",
         "path": "review/enrichment-queue.json"
       },
       {
-        "hash": "7386c2c45c8126ee0b56b91b0c0f855b1525dda2758bfd69065be4ce2b6f678c",
-        "path": "review/gap-priorities.json"
-      },
-      {
-        "hash": "1b214dbb72502fade87c83a62e7eb8b6ca72b7195b20ceae0a674218b3fc402e",
-        "path": "review/profile-completeness.json"
-      },
-      {
-        "hash": "d27a30f3ec152624e1beda62d1d6cb32b09d3278cbe6beb128c18edfd74cc01b",
-        "path": "surfaces.json"
+        "hash": "ae53d8889f6f7e6549b36507e6f94a421f065b47d348f762864255e263126bc4",
+        "path": "review/enrichment-targets.json"
       }
     ],
     "removed": []
@@ -44,7 +28,7 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 6,
+    "artifact_modified_count": 2,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 24,
-  "artifact_size_bytes": 6112188,
+  "artifact_size_bytes": 6098501,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "9bd8dfb3dd4e281ed5b2f63fa96c862d517d23c0d4c002fc973aa0327569627e",
-      "size_bytes": 2067,
+      "sha256": "5e3bafb17bcc701ba9aab645b8ae40ca10518969fda7d86bbc85cf21d27ba9a0",
+      "size_bytes": 1513,
       "storage_tier": "dual"
     },
     {
@@ -124,8 +124,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
       "latest_key": "latest/review/enrichment-queue.json",
       "path": "/metagraph/review/enrichment-queue.json",
-      "sha256": "0a9712c54d52e4bbb063a60f0ebea4feff18b92212e06d991263e0b123e035c6",
-      "size_bytes": 370592,
+      "sha256": "5c5a20e0644297c71b9f497d040a3fa53b633cccd941195268f56261ae0613ca",
+      "size_bytes": 366716,
       "storage_tier": "dual"
     },
     {
@@ -133,8 +133,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-targets.json",
       "latest_key": "latest/review/enrichment-targets.json",
       "path": "/metagraph/review/enrichment-targets.json",
-      "sha256": "40b5a64699a4a29578df392652775194fffa28ab40467ff2c31fb1e44487ad6b",
-      "size_bytes": 761955,
+      "sha256": "ae53d8889f6f7e6549b36507e6f94a421f065b47d348f762864255e263126bc4",
+      "size_bytes": 752698,
       "storage_tier": "git"
     },
     {
@@ -223,7 +223,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1271,
-  "full_artifact_size_bytes": 50474964,
+  "full_artifact_size_bytes": 50456486,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -246,8 +246,8 @@
     "r2": 1247
   },
   "storage_tier_size_bytes": {
-    "dual": 5091234,
-    "git": 1020954,
-    "r2": 44362776
+    "dual": 5086804,
+    "git": 1011697,
+    "r2": 44357985
   }
 }

--- a/public/metagraph/review/enrichment-queue.json
+++ b/public/metagraph/review/enrichment-queue.json
@@ -70,17 +70,14 @@
       "adapter_score": 12,
       "candidate_count": 26,
       "candidate_evidence_summary": {
-        "candidate_count": 7,
+        "candidate_count": 5,
         "kinds_with_candidates": [
           "openapi",
-          "source-repo",
           "subnet-api"
         ],
-        "live_kinds": [
-          "source-repo"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 7,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
         "stale_kinds": [
           "openapi",
           "subnet-api"
@@ -96,7 +93,7 @@
         "source-repo"
       ],
       "endpoint_count": 12,
-      "evidence_action": "review-existing-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "partial",
       "identity_surface_count": 2,
       "lane": "direct-submission",
@@ -128,15 +125,9 @@
         "sn-118-native-chain-website",
         "sn-118-subnetradar-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-118-taomarketcap-source-repo",
-        "sn-118-tensorplex-source-repo-1"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-118-taomarketcap-source-repo",
-        "sn-118-tensorplex-source-repo-1"
-      ],
+      "sample_target_candidate_ids": [],
       "slug": "sn-118",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/118",
@@ -2528,19 +2519,13 @@
       "adapter_score": 9,
       "candidate_count": 18,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -2597,7 +2582,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_91/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/91/subnet.json"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 0,
       "surface_count": 9,
       "verified_candidate_count": 11
     },
@@ -3326,21 +3311,17 @@
       "adapter_score": 9,
       "candidate_count": 16,
       "candidate_evidence_summary": {
-        "candidate_count": 6,
+        "candidate_count": 1,
         "kinds_with_candidates": [
-          "openapi",
-          "source-repo",
-          "subnet-api"
+          "source-repo"
         ],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 6,
+        "reviewable_count": 1,
         "stale_kinds": [
-          "openapi",
-          "source-repo",
-          "subnet-api"
+          "source-repo"
         ],
-        "stale_or_failed_count": 6,
+        "stale_or_failed_count": 1,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3401,7 +3382,7 @@
         "https://taomarketcap.com/subnets/20",
         "https://www.groundlayer.xyz/"
       ],
-      "stale_candidate_count": 6,
+      "stale_candidate_count": 1,
       "surface_count": 9,
       "verified_candidate_count": 9
     },
@@ -3596,22 +3577,17 @@
       "adapter_score": 27,
       "candidate_count": 16,
       "candidate_evidence_summary": {
-        "candidate_count": 6,
+        "candidate_count": 1,
         "kinds_with_candidates": [
-          "openapi",
-          "source-repo",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 6,
-        "stale_kinds": [
-          "openapi",
           "source-repo"
         ],
-        "stale_or_failed_count": 4,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
+          "source-repo"
+        ],
+        "stale_or_failed_count": 1,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3671,7 +3647,7 @@
         "https://models.actual.inc/",
         "https://subnetradar.com/subnet/95"
       ],
-      "stale_candidate_count": 4,
+      "stale_candidate_count": 1,
       "surface_count": 7,
       "verified_candidate_count": 12
     },
@@ -4419,19 +4395,13 @@
       "adapter_score": 7,
       "candidate_count": 15,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -4488,7 +4458,7 @@
         "https://subnetradar.com/subnet/30",
         "https://taomarketcap.com/subnets/30"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 8
     },
@@ -4650,21 +4620,17 @@
       "adapter_score": 8,
       "candidate_count": 14,
       "candidate_evidence_summary": {
-        "candidate_count": 6,
+        "candidate_count": 1,
         "kinds_with_candidates": [
-          "openapi",
-          "source-repo",
-          "subnet-api"
+          "source-repo"
         ],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 6,
+        "reviewable_count": 1,
         "stale_kinds": [
-          "openapi",
-          "source-repo",
-          "subnet-api"
+          "source-repo"
         ],
-        "stale_or_failed_count": 6,
+        "stale_or_failed_count": 1,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -4725,7 +4691,7 @@
         "https://nodexo.ai/",
         "https://subnetradar.com/subnet/27"
       ],
-      "stale_candidate_count": 6,
+      "stale_candidate_count": 1,
       "surface_count": 8,
       "verified_candidate_count": 6
     },
@@ -7030,17 +6996,13 @@
       "adapter_score": 0,
       "candidate_count": 7,
       "candidate_evidence_summary": {
-        "candidate_count": 1,
-        "kinds_with_candidates": [
-          "source-repo"
-        ],
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 1,
-        "stale_kinds": [
-          "source-repo"
-        ],
-        "stale_or_failed_count": 1,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -7051,7 +7013,7 @@
         "source-repo"
       ],
       "endpoint_count": 7,
-      "evidence_action": "replace-stale-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "partial",
       "identity_surface_count": 2,
       "lane": "direct-submission",
@@ -7084,12 +7046,8 @@
         "sn-92-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-92-tensorplex-source-repo-1"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-92-tensorplex-source-repo-1"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-92",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/92",
@@ -7100,7 +7058,7 @@
         "https://www.tensorclaw.ai/",
         "https://www.tensorclaw.ai/dashboard"
       ],
-      "stale_candidate_count": 1,
+      "stale_candidate_count": 0,
       "surface_count": 7,
       "verified_candidate_count": 6
     },
@@ -7338,17 +7296,13 @@
       "adapter_score": 0,
       "candidate_count": 7,
       "candidate_evidence_summary": {
-        "candidate_count": 1,
-        "kinds_with_candidates": [
-          "source-repo"
-        ],
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 1,
-        "stale_kinds": [
-          "source-repo"
-        ],
-        "stale_or_failed_count": 1,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -7359,7 +7313,7 @@
         "source-repo"
       ],
       "endpoint_count": 6,
-      "evidence_action": "replace-stale-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "partial",
       "identity_surface_count": 2,
       "lane": "direct-submission",
@@ -7392,12 +7346,8 @@
         "sn-116-taostats-metagraph"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-116-tensorplex-source-repo-1"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-116-tensorplex-source-repo-1"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "taolend",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/116",
@@ -7407,7 +7357,7 @@
         "https://subnetradar.com/subnet/116",
         "https://taolend.io/"
       ],
-      "stale_candidate_count": 1,
+      "stale_candidate_count": 0,
       "surface_count": 6,
       "verified_candidate_count": 6
     },
@@ -7575,7 +7525,7 @@
       "adapter_score": 7,
       "candidate_count": 22,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
+        "candidate_count": 4,
         "kinds_with_candidates": [
           "openapi",
           "subnet-api"
@@ -7584,11 +7534,11 @@
           "subnet-api"
         ],
         "live_or_redirected_count": 2,
-        "reviewable_count": 5,
+        "reviewable_count": 4,
         "stale_kinds": [
           "openapi"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 2,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -7638,14 +7588,12 @@
       ],
       "sample_stale_candidate_ids": [
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger",
         "sn-85-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
         "sn-85-website-common-api",
         "sn-85-website-common-health",
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger",
         "sn-85-website-common-swagger-json"
       ],
       "slug": "sn-85",
@@ -7659,7 +7607,7 @@
         "https://taomarketcap.com/subnets/85",
         "https://vidaio.io/"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 2,
       "surface_count": 7,
       "verified_candidate_count": 18
     },
@@ -8398,19 +8346,13 @@
       "adapter_score": 12,
       "candidate_count": 18,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -8423,7 +8365,7 @@
         "data-artifact"
       ],
       "endpoint_count": 12,
-      "evidence_action": "replace-stale-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "identity_surface_count": 3,
       "lane": "direct-submission",
@@ -8455,20 +8397,8 @@
         "sn-11-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-11",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/11",
@@ -8480,7 +8410,7 @@
         "https://trajrl.com/",
         "https://trajrl.com/docs"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 0,
       "surface_count": 12,
       "verified_candidate_count": 13
     },
@@ -8651,19 +8581,13 @@
       "adapter_score": 10,
       "candidate_count": 18,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -8676,7 +8600,7 @@
         "data-artifact"
       ],
       "endpoint_count": 10,
-      "evidence_action": "replace-stale-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "identity_surface_count": 3,
       "lane": "direct-submission",
@@ -8708,20 +8632,8 @@
         "sn-5-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-5-website-common-openapi-json",
-        "sn-5-website-common-swagger",
-        "sn-5-website-common-swagger-json",
-        "sn-5-website-common-api",
-        "sn-5-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-5-website-common-openapi-json",
-        "sn-5-website-common-swagger",
-        "sn-5-website-common-swagger-json",
-        "sn-5-website-common-api",
-        "sn-5-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-5",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/5",
@@ -8733,7 +8645,7 @@
         "https://taomarketcap.com/subnets/5",
         "https://www.hone.training/"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 0,
       "surface_count": 10,
       "verified_candidate_count": 11
     },
@@ -8741,19 +8653,13 @@
       "adapter_score": 10,
       "candidate_count": 17,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -8766,7 +8672,7 @@
         "data-artifact"
       ],
       "endpoint_count": 10,
-      "evidence_action": "replace-stale-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "identity_surface_count": 3,
       "lane": "direct-submission",
@@ -8798,20 +8704,8 @@
         "sn-8-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-8-website-common-openapi-json",
-        "sn-8-website-common-swagger",
-        "sn-8-website-common-swagger-json",
-        "sn-8-website-common-api",
-        "sn-8-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-8-website-common-openapi-json",
-        "sn-8-website-common-swagger",
-        "sn-8-website-common-swagger-json",
-        "sn-8-website-common-api",
-        "sn-8-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-8",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/8",
@@ -8823,7 +8717,7 @@
         "https://www.vantanetwork.io/",
         "https://www.vantanetwork.io/dashboard"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 0,
       "surface_count": 10,
       "verified_candidate_count": 11
     },
@@ -8831,7 +8725,7 @@
       "adapter_score": 8,
       "candidate_count": 17,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
+        "candidate_count": 4,
         "kinds_with_candidates": [
           "openapi",
           "subnet-api"
@@ -8840,11 +8734,11 @@
           "subnet-api"
         ],
         "live_or_redirected_count": 2,
-        "reviewable_count": 5,
+        "reviewable_count": 4,
         "stale_kinds": [
           "openapi"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 2,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -8894,14 +8788,12 @@
       ],
       "sample_stale_candidate_ids": [
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger",
         "sn-2-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
         "sn-2-website-common-api",
         "sn-2-website-common-health",
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger",
         "sn-2-website-common-swagger-json"
       ],
       "slug": "dsperse",
@@ -8914,7 +8806,7 @@
         "https://sn2-docs.inferencelabs.com/",
         "https://subnet2.inferencelabs.com/"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 2,
       "surface_count": 8,
       "verified_candidate_count": 14
     },
@@ -9185,19 +9077,13 @@
       "adapter_score": 8,
       "candidate_count": 14,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
         "live_kinds": [],
         "live_or_redirected_count": 0,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi",
-          "subnet-api"
-        ],
-        "stale_or_failed_count": 5,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -9210,7 +9096,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "identity_surface_count": 3,
       "lane": "direct-submission",
@@ -9242,20 +9128,8 @@
         "sn-10-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-10",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/10",
@@ -9267,7 +9141,7 @@
         "https://subnetradar.com/subnet/10",
         "https://taomarketcap.com/subnets/10"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 0,
       "surface_count": 8,
       "verified_candidate_count": 8
     },
@@ -9275,20 +9149,13 @@
       "adapter_score": 8,
       "candidate_count": 14,
       "candidate_evidence_summary": {
-        "candidate_count": 5,
-        "kinds_with_candidates": [
-          "openapi",
-          "subnet-api"
-        ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 5,
-        "stale_kinds": [
-          "openapi"
-        ],
-        "stale_or_failed_count": 3,
+        "candidate_count": 0,
+        "kinds_with_candidates": [],
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "stale_kinds": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -9301,7 +9168,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
-      "evidence_action": "replace-stale-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "identity_surface_count": 3,
       "lane": "direct-submission",
@@ -9332,22 +9199,9 @@
         "sn-16-subnetradar-dashboard",
         "sn-16-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-16-website-common-openapi-json",
-        "sn-16-website-common-swagger",
-        "sn-16-website-common-swagger-json"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health",
-        "sn-16-website-common-openapi-json",
-        "sn-16-website-common-swagger",
-        "sn-16-website-common-swagger-json"
-      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-16",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/16",
@@ -9359,7 +9213,7 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/16/subnet.json",
         "https://subnetradar.com/subnet/16"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 0,
       "surface_count": 8,
       "verified_candidate_count": 11
     },
@@ -10718,9 +10572,9 @@
     "evidence_action_counts": {
       "maintainer-review-existing-evidence": 17,
       "monitor": 1,
-      "replace-stale-evidence": 79,
-      "review-existing-evidence": 2,
-      "submit-new-evidence": 29,
+      "replace-stale-evidence": 72,
+      "review-existing-evidence": 1,
+      "submit-new-evidence": 37,
       "verify-existing-evidence": 1
     },
     "identity_level_counts": {

--- a/public/metagraph/review/enrichment-targets.json
+++ b/public/metagraph/review/enrichment-targets.json
@@ -276,9 +276,9 @@
     "by_evidence_action": {
       "maintainer-review-existing-evidence": 17,
       "monitor": 1,
-      "replace-stale-evidence": 123,
-      "review-existing-evidence": 26,
-      "submit-new-evidence": 127,
+      "replace-stale-evidence": 112,
+      "review-existing-evidence": 24,
+      "submit-new-evidence": 140,
       "verify-existing-evidence": 2
     },
     "by_kind": {
@@ -301,8 +301,8 @@
       "surface-candidate": 278
     },
     "manual_review_required_count": 18,
-    "new_evidence_count": 127,
-    "stale_replacement_count": 123,
+    "new_evidence_count": 140,
+    "stale_replacement_count": 112,
     "subnet_count": 129,
     "target_count": 296
   },
@@ -350,21 +350,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 118 --kind source-repo --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 2,
-        "classifications": {
-          "live": 2
-        },
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "sample_candidate_ids": [
-          "sn-118-taomarketcap-source-repo",
-          "sn-118-tensorplex-source-repo-1"
-        ],
+        "candidate_count": 0,
+        "classifications": {},
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
         "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Confirm and submit official public source-repo evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "review-existing-evidence",
+      "contribution_prompt": "Submit official public source-repo evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "partial",
       "kind": "source-repo",
       "lane": "direct-submission",
@@ -384,15 +379,9 @@
         "missing-source-repo"
       ],
       "recommended_action": "submit official docs, website, or source repository evidence",
-      "sample_live_candidate_ids": [
-        "sn-118-taomarketcap-source-repo",
-        "sn-118-tensorplex-source-repo-1"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-118-taomarketcap-source-repo",
-        "sn-118-tensorplex-source-repo-1"
-      ],
+      "sample_target_candidate_ids": [],
       "slug": "sn-118",
       "source_requirements": [
         "Prefer an official project/team source.",
@@ -405,7 +394,7 @@
         "https://backprop.finance/dtao/subnets/118-ditto"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "review-existing-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-118-surface-candidate-source-repo",
       "target_type": "surface-candidate"
     },
@@ -12907,20 +12896,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 92 --kind source-repo --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 1,
-        "classifications": {
-          "dead": 1
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 1,
-        "sample_candidate_ids": [
-          "sn-92-tensorplex-source-repo-1"
-        ],
-        "stale_or_failed_count": 1,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public source-repo evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public source-repo evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "partial",
       "kind": "source-repo",
       "lane": "direct-submission",
@@ -12941,12 +12926,8 @@
       ],
       "recommended_action": "submit official docs, website, or source repository evidence",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-92-tensorplex-source-repo-1"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-92-tensorplex-source-repo-1"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-92",
       "source_requirements": [
         "Prefer an official project/team source.",
@@ -12959,7 +12940,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_92/index.mdx"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-92-surface-candidate-source-repo",
       "target_type": "surface-candidate"
     },
@@ -12967,20 +12948,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 116 --kind source-repo --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 1,
-        "classifications": {
-          "dead": 1
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 1,
-        "sample_candidate_ids": [
-          "sn-116-tensorplex-source-repo-1"
-        ],
-        "stale_or_failed_count": 1,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public source-repo evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public source-repo evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "partial",
       "kind": "source-repo",
       "lane": "direct-submission",
@@ -13001,12 +12978,8 @@
       ],
       "recommended_action": "submit official docs, website, or source repository evidence",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-116-tensorplex-source-repo-1"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-116-tensorplex-source-repo-1"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "taolend",
       "source_requirements": [
         "Prefer an official project/team source.",
@@ -13019,7 +12992,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_116/index.mdx"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-116-surface-candidate-source-repo",
       "target_type": "surface-candidate"
     },
@@ -13425,14 +13398,12 @@
       ],
       "sample_stale_candidate_ids": [
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger",
         "sn-85-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
         "sn-85-website-common-api",
         "sn-85-website-common-health",
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger",
         "sn-85-website-common-swagger-json"
       ],
       "slug": "sn-85",
@@ -13526,18 +13497,17 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 85 --kind openapi --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 3,
+        "candidate_count": 2,
         "classifications": {
-          "content-mismatch": 3
+          "content-mismatch": 2
         },
         "live_or_redirected_count": 0,
-        "reviewable_count": 3,
+        "reviewable_count": 2,
         "sample_candidate_ids": [
           "sn-85-website-common-openapi-json",
-          "sn-85-website-common-swagger",
           "sn-85-website-common-swagger-json"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 2,
         "unverified_count": 0
       },
       "contribution_prompt": "Replace stale or failed official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
@@ -13568,14 +13538,12 @@
       ],
       "sample_stale_candidate_ids": [
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger",
         "sn-85-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
         "sn-85-website-common-api",
         "sn-85-website-common-health",
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger",
         "sn-85-website-common-swagger-json"
       ],
       "slug": "sn-85",
@@ -13709,14 +13677,12 @@
       ],
       "sample_stale_candidate_ids": [
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger",
         "sn-85-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
         "sn-85-website-common-api",
         "sn-85-website-common-health",
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger",
         "sn-85-website-common-swagger-json"
       ],
       "slug": "sn-85",
@@ -14977,20 +14943,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-11",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -15184,22 +15138,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 11 --kind openapi --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 3,
-        "classifications": {
-          "dead": 3
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "sample_candidate_ids": [
-          "sn-11-website-common-openapi-json",
-          "sn-11-website-common-swagger",
-          "sn-11-website-common-swagger-json"
-        ],
-        "stale_or_failed_count": 3,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "openapi",
       "lane": "direct-submission",
@@ -15221,20 +15169,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-11",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -15247,7 +15183,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-11-surface-candidate-openapi",
       "target_type": "surface-candidate"
     },
@@ -15434,21 +15370,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 11 --kind subnet-api --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 2,
-        "classifications": {
-          "dead": 2
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 2,
-        "sample_candidate_ids": [
-          "sn-11-website-common-api",
-          "sn-11-website-common-health"
-        ],
-        "stale_or_failed_count": 2,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "subnet-api",
       "lane": "direct-submission",
@@ -15470,20 +15401,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-11-website-common-openapi-json",
-        "sn-11-website-common-swagger",
-        "sn-11-website-common-swagger-json",
-        "sn-11-website-common-api",
-        "sn-11-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-11",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -15496,7 +15415,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_11/index.mdx"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-11-surface-candidate-subnet-api",
       "target_type": "surface-candidate"
     },
@@ -15659,20 +15578,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-5-website-common-openapi-json",
-        "sn-5-website-common-swagger",
-        "sn-5-website-common-swagger-json",
-        "sn-5-website-common-api",
-        "sn-5-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-5-website-common-openapi-json",
-        "sn-5-website-common-swagger",
-        "sn-5-website-common-swagger-json",
-        "sn-5-website-common-api",
-        "sn-5-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-5",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -15693,22 +15600,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 5 --kind openapi --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 3,
-        "classifications": {
-          "dead": 3
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "sample_candidate_ids": [
-          "sn-5-website-common-openapi-json",
-          "sn-5-website-common-swagger",
-          "sn-5-website-common-swagger-json"
-        ],
-        "stale_or_failed_count": 3,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "openapi",
       "lane": "direct-submission",
@@ -15730,20 +15631,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-5-website-common-openapi-json",
-        "sn-5-website-common-swagger",
-        "sn-5-website-common-swagger-json",
-        "sn-5-website-common-api",
-        "sn-5-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-5-website-common-openapi-json",
-        "sn-5-website-common-swagger",
-        "sn-5-website-common-swagger-json",
-        "sn-5-website-common-api",
-        "sn-5-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-5",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -15756,7 +15645,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-5-surface-candidate-openapi",
       "target_type": "surface-candidate"
     },
@@ -15764,21 +15653,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 5 --kind subnet-api --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 2,
-        "classifications": {
-          "dead": 2
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 2,
-        "sample_candidate_ids": [
-          "sn-5-website-common-api",
-          "sn-5-website-common-health"
-        ],
-        "stale_or_failed_count": 2,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "subnet-api",
       "lane": "direct-submission",
@@ -15800,20 +15684,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-5-website-common-openapi-json",
-        "sn-5-website-common-swagger",
-        "sn-5-website-common-swagger-json",
-        "sn-5-website-common-api",
-        "sn-5-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-5-website-common-openapi-json",
-        "sn-5-website-common-swagger",
-        "sn-5-website-common-swagger-json",
-        "sn-5-website-common-api",
-        "sn-5-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-5",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -15826,7 +15698,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_5/index.mdx"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-5-surface-candidate-subnet-api",
       "target_type": "surface-candidate"
     },
@@ -15865,20 +15737,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-8-website-common-openapi-json",
-        "sn-8-website-common-swagger",
-        "sn-8-website-common-swagger-json",
-        "sn-8-website-common-api",
-        "sn-8-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-8-website-common-openapi-json",
-        "sn-8-website-common-swagger",
-        "sn-8-website-common-swagger-json",
-        "sn-8-website-common-api",
-        "sn-8-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-8",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -15899,22 +15759,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 8 --kind openapi --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 3,
-        "classifications": {
-          "dead": 3
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "sample_candidate_ids": [
-          "sn-8-website-common-openapi-json",
-          "sn-8-website-common-swagger",
-          "sn-8-website-common-swagger-json"
-        ],
-        "stale_or_failed_count": 3,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "openapi",
       "lane": "direct-submission",
@@ -15936,20 +15790,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-8-website-common-openapi-json",
-        "sn-8-website-common-swagger",
-        "sn-8-website-common-swagger-json",
-        "sn-8-website-common-api",
-        "sn-8-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-8-website-common-openapi-json",
-        "sn-8-website-common-swagger",
-        "sn-8-website-common-swagger-json",
-        "sn-8-website-common-api",
-        "sn-8-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-8",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -15962,7 +15804,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-8-surface-candidate-openapi",
       "target_type": "surface-candidate"
     },
@@ -15970,21 +15812,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 8 --kind subnet-api --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 2,
-        "classifications": {
-          "dead": 2
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 2,
-        "sample_candidate_ids": [
-          "sn-8-website-common-api",
-          "sn-8-website-common-health"
-        ],
-        "stale_or_failed_count": 2,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "subnet-api",
       "lane": "direct-submission",
@@ -16006,20 +15843,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-8-website-common-openapi-json",
-        "sn-8-website-common-swagger",
-        "sn-8-website-common-swagger-json",
-        "sn-8-website-common-api",
-        "sn-8-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-8-website-common-openapi-json",
-        "sn-8-website-common-swagger",
-        "sn-8-website-common-swagger-json",
-        "sn-8-website-common-api",
-        "sn-8-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-8",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -16032,7 +15857,7 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_8/index.mdx"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-8-surface-candidate-subnet-api",
       "target_type": "surface-candidate"
     },
@@ -16076,14 +15901,12 @@
       ],
       "sample_stale_candidate_ids": [
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger",
         "sn-2-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
         "sn-2-website-common-api",
         "sn-2-website-common-health",
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger",
         "sn-2-website-common-swagger-json"
       ],
       "slug": "dsperse",
@@ -16106,18 +15929,17 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 2 --kind openapi --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 3,
+        "candidate_count": 2,
         "classifications": {
-          "content-mismatch": 3
+          "content-mismatch": 2
         },
         "live_or_redirected_count": 0,
-        "reviewable_count": 3,
+        "reviewable_count": 2,
         "sample_candidate_ids": [
           "sn-2-website-common-openapi-json",
-          "sn-2-website-common-swagger",
           "sn-2-website-common-swagger-json"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 2,
         "unverified_count": 0
       },
       "contribution_prompt": "Replace stale or failed official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
@@ -16148,14 +15970,12 @@
       ],
       "sample_stale_candidate_ids": [
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger",
         "sn-2-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
         "sn-2-website-common-api",
         "sn-2-website-common-health",
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger",
         "sn-2-website-common-swagger-json"
       ],
       "slug": "dsperse",
@@ -16219,14 +16039,12 @@
       ],
       "sample_stale_candidate_ids": [
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger",
         "sn-2-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
         "sn-2-website-common-api",
         "sn-2-website-common-health",
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger",
         "sn-2-website-common-swagger-json"
       ],
       "slug": "dsperse",
@@ -16883,20 +16701,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-10",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -16947,22 +16753,9 @@
         "missing-subnet-api"
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "sample_live_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-16-website-common-openapi-json",
-        "sn-16-website-common-swagger",
-        "sn-16-website-common-swagger-json"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health",
-        "sn-16-website-common-openapi-json",
-        "sn-16-website-common-swagger",
-        "sn-16-website-common-swagger-json"
-      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-16",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -16983,22 +16776,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 10 --kind openapi --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 3,
-        "classifications": {
-          "dead": 3
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "sample_candidate_ids": [
-          "sn-10-website-common-openapi-json",
-          "sn-10-website-common-swagger",
-          "sn-10-website-common-swagger-json"
-        ],
-        "stale_or_failed_count": 3,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "openapi",
       "lane": "direct-submission",
@@ -17020,20 +16807,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-10",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -17046,7 +16821,7 @@
         "https://docs.taofi.com/"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-10-surface-candidate-openapi",
       "target_type": "surface-candidate"
     },
@@ -17054,22 +16829,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 16 --kind openapi --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 3,
-        "classifications": {
-          "content-mismatch": 3
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 3,
-        "sample_candidate_ids": [
-          "sn-16-website-common-openapi-json",
-          "sn-16-website-common-swagger",
-          "sn-16-website-common-swagger-json"
-        ],
-        "stale_or_failed_count": 3,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public openapi evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "openapi",
       "lane": "direct-submission",
@@ -17090,22 +16859,9 @@
         "missing-subnet-api"
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "sample_live_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-16-website-common-openapi-json",
-        "sn-16-website-common-swagger",
-        "sn-16-website-common-swagger-json"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health",
-        "sn-16-website-common-openapi-json",
-        "sn-16-website-common-swagger",
-        "sn-16-website-common-swagger-json"
-      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-16",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -17118,7 +16874,7 @@
         "https://bitads.ai/"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-16-surface-candidate-openapi",
       "target_type": "surface-candidate"
     },
@@ -17126,21 +16882,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 10 --kind subnet-api --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 2,
-        "classifications": {
-          "dead": 2
-        },
+        "candidate_count": 0,
+        "classifications": {},
         "live_or_redirected_count": 0,
-        "reviewable_count": 2,
-        "sample_candidate_ids": [
-          "sn-10-website-common-api",
-          "sn-10-website-common-health"
-        ],
-        "stale_or_failed_count": 2,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
+        "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Replace stale or failed official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "replace-stale-evidence",
+      "contribution_prompt": "Submit official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "subnet-api",
       "lane": "direct-submission",
@@ -17162,20 +16913,8 @@
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "sample_live_candidate_ids": [],
-      "sample_stale_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-10-website-common-openapi-json",
-        "sn-10-website-common-swagger",
-        "sn-10-website-common-swagger-json",
-        "sn-10-website-common-api",
-        "sn-10-website-common-health"
-      ],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-10",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -17188,7 +16927,7 @@
         "https://docs.taofi.com/"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "replace-stale-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-10-surface-candidate-subnet-api",
       "target_type": "surface-candidate"
     },
@@ -17196,21 +16935,16 @@
       "auto_review_candidate": true,
       "candidate_command": "npm run candidate:new -- --netuid 16 --kind subnet-api --url <public-url> --source-url <public-source-url> --provider <provider-slug> --submitted-by <github-login> --write",
       "candidate_evidence": {
-        "candidate_count": 2,
-        "classifications": {
-          "live": 2
-        },
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "sample_candidate_ids": [
-          "sn-16-website-common-api",
-          "sn-16-website-common-health"
-        ],
+        "candidate_count": 0,
+        "classifications": {},
+        "live_or_redirected_count": 0,
+        "reviewable_count": 0,
+        "sample_candidate_ids": [],
         "stale_or_failed_count": 0,
         "unverified_count": 0
       },
-      "contribution_prompt": "Confirm and submit official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
-      "evidence_action": "review-existing-evidence",
+      "contribution_prompt": "Submit official public subnet-api evidence for this subnet. Use one candidate per PR and include a public source URL that proves provenance.",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "complete",
       "kind": "subnet-api",
       "lane": "direct-submission",
@@ -17231,22 +16965,9 @@
         "missing-subnet-api"
       ],
       "recommended_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "sample_live_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health"
-      ],
-      "sample_stale_candidate_ids": [
-        "sn-16-website-common-openapi-json",
-        "sn-16-website-common-swagger",
-        "sn-16-website-common-swagger-json"
-      ],
-      "sample_target_candidate_ids": [
-        "sn-16-website-common-api",
-        "sn-16-website-common-health",
-        "sn-16-website-common-openapi-json",
-        "sn-16-website-common-swagger",
-        "sn-16-website-common-swagger-json"
-      ],
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [],
+      "sample_target_candidate_ids": [],
       "slug": "sn-16",
       "source_requirements": [
         "The URL must be public-safe and read-only.",
@@ -17259,7 +16980,7 @@
         "https://bitads.ai/"
       ],
       "submission_route": "direct-candidate-pr",
-      "target_action": "review-existing-candidate",
+      "target_action": "submit-new-candidate",
       "target_id": "sn-16-surface-candidate-subnet-api",
       "target_type": "surface-candidate"
     },

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -328,6 +328,7 @@ const enrichmentArtifacts = buildEnrichmentQueueArtifacts({
   curationReview,
   profiles: profileArtifacts.profiles,
   reviewProfiles: profileArtifacts.reviewProfiles,
+  subnets: activeOverlays,
   verification,
 });
 const enrichmentQueue = enrichmentArtifacts.queueArtifact;
@@ -1070,6 +1071,7 @@ function buildEnrichmentQueueArtifacts({
   curationReview,
   profiles,
   reviewProfiles,
+  subnets,
   verification,
 }) {
   const verificationByCandidate = new Map(
@@ -1090,6 +1092,12 @@ function buildEnrichmentQueueArtifacts({
       candidate,
     ]),
   );
+  const excludedCandidateIdsByNetuid = new Map(
+    subnets.map((subnet) => [
+      subnet.netuid,
+      new Set(subnet.baseline_excluded_surface_ids || []),
+    ]),
+  );
   const candidatesByNetuid = groupByNetuid(candidates);
 
   const fullQueue = profiles
@@ -1099,7 +1107,10 @@ function buildEnrichmentQueueArtifacts({
         gapPriority: gapPriorityByNetuid.get(profile.netuid),
         profile,
         reviewProfile: reviewProfileByNetuid.get(profile.netuid),
-        subnetCandidates: candidatesByNetuid.get(profile.netuid) || [],
+        subnetCandidates: enrichmentCandidatesForSubnet({
+          excludedIds: excludedCandidateIdsByNetuid.get(profile.netuid),
+          subnetCandidates: candidatesByNetuid.get(profile.netuid) || [],
+        }),
         verificationByCandidate,
       }),
     )
@@ -1173,6 +1184,13 @@ function buildEnrichmentQueueArtifacts({
     queue,
   });
   return { evidenceArtifact, queueArtifact, targetArtifact };
+}
+
+function enrichmentCandidatesForSubnet({ excludedIds, subnetCandidates }) {
+  if (!excludedIds || excludedIds.size === 0) {
+    return subnetCandidates;
+  }
+  return subnetCandidates.filter((candidate) => !excludedIds.has(candidate.id));
 }
 
 function buildEnrichmentTargetsArtifact({ evidenceEntries, queue }) {

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1044,6 +1044,20 @@ test("limited R2 upload dry run skips control manifests", () => {
   assert.equal(summary.planned_object_count, 5);
 });
 
+test("enrichment guidance ignores maintainer-excluded candidate IDs", () => {
+  const queue = readArtifact("review/enrichment-queue.json");
+  const ditto = queue.queue.find((entry) => entry.netuid === 118);
+
+  assert(ditto, "expected SN118 Ditto enrichment queue entry");
+  assert.equal(ditto.evidence_action, "submit-new-evidence");
+  assert.deepEqual(ditto.sample_target_candidate_ids, []);
+  assert.deepEqual(ditto.sample_live_candidate_ids, []);
+  assert.equal(
+    ditto.candidate_evidence_summary.live_kinds.includes("source-repo"),
+    false,
+  );
+});
+
 test("Worker API serves public artifact envelopes", async () => {
   const env = createLocalArtifactEnv();
 


### PR DESCRIPTION
## Summary
- filter `baseline_excluded_surface_ids` out of generated enrichment queue evidence and contributor targets
- prevent maintainer-rejected or intentionally excluded candidates from being shown as live actionable evidence
- update compact review artifacts so SN118 Ditto now asks for new source-repo evidence instead of pointing at excluded source-repo candidates

## What changed
- enrichment queue generation now derives a per-netuid excluded-candidate set from active curated overlays
- candidate evidence, live sample IDs, stale sample IDs, and target sample IDs ignore excluded candidates
- added a regression test for the SN118 Ditto exclusion path

## Why
- reviewed overlays can deliberately reject generated candidates as non-canonical, stale, or unrelated
- contributor guidance should respect those maintainer decisions instead of re-surfacing excluded candidates as useful next actions

## Validation
- `npm test -- --run tests/artifacts.test.mjs`
- `npm run validate:api`
- `npm run validate:schemas`
- `npm run validate:openapi`
- `npm run validate:artifact-budgets`
- `npm run scan:public-safety`
- `npm run test:coverage`
- `npm run check`
- `git diff --check`

Coverage summary: 97.03% statements, 87.8% branches, 98.92% functions.

## Notes
- health, uptime, and endpoint status remain probe-derived only
- this changes contributor guidance only; it does not publish or remove curated surfaces