### PR TITLE
feat(enrichment): add mantis builder sdk resource

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 22,
-  "artifact_size_bytes": 5155119,
+  "artifact_size_bytes": 5157314,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -17,8 +17,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "a2bf37747503bcdeabbb165c5c656a5367b9c3a72b38cff026c110ad6bc88e26",
-      "size_bytes": 3150,
+      "sha256": "98c10e1b0ee2ab2f690c6fa520ad82be4541a162e7e6ca3158be9a6b8d2d2e93",
+      "size_bytes": 3000,
       "storage_tier": "dual"
     },
     {
@@ -29,32 +29,32 @@
     },
     {
       "path": "coverage.json",
-      "sha256": "afa46e451f4a76e5ccd210cb41b4c23baac33daa83ab03936e532d53b9c9247a",
+      "sha256": "df67ec41708977a3ff5fc541deebda5b53a031f19a01e07a77ed5acd30ac8464",
       "size_bytes": 1048,
       "storage_tier": "dual"
     },
     {
       "path": "curation.json",
-      "sha256": "df63fb2fe0865454c7f48de082e3d7efe6da1735a6e74895e1bb9e7210a8b33b",
-      "size_bytes": 178453,
+      "sha256": "884e43fe1aa5c668564d22d5e1420f6b67705f727bcfe4bd3bd1255fd256a629",
+      "size_bytes": 178624,
       "storage_tier": "dual"
     },
     {
       "path": "evidence-ledger.json",
-      "sha256": "1dc5fb36a4759fcc4699568ca6cfc443a4d70ceaa1e861bc5eae85f032a5109b",
-      "size_bytes": 857301,
+      "sha256": "f2577b64487067bf258d627b47bb4c4fab4b718f697ccc1b26bf2de67d7a2e45",
+      "size_bytes": 857834,
       "storage_tier": "dual"
     },
     {
       "path": "freshness.json",
-      "sha256": "4e86e36d20a018d7c025988cecbc9342420c449ba933495638e4427a32adb094",
+      "sha256": "ab606a4a2ca298bcca4f9f579618a915e427da650c7422fb57f94cdb2af485ab",
       "size_bytes": 7549,
       "storage_tier": "dual"
     },
     {
       "path": "gaps.json",
-      "sha256": "273b6205550b017cd434346c874db748238a4d3664cb72e70dd40ba5fd2d655a",
-      "size_bytes": 100869,
+      "sha256": "27b1043541e21b7edc7afa47f2f6d6cb5abe7e5f9aef2046f62c51cf82e0b895",
+      "size_bytes": 100963,
       "storage_tier": "dual"
     },
     {
@@ -65,8 +65,8 @@
     },
     {
       "path": "profiles.json",
-      "sha256": "d1ef555c85baf57fcbfc8f558a7b74de0b959e78d8a8eafb5c6c9af6724540d2",
-      "size_bytes": 605496,
+      "sha256": "25912bd55d52503c03a1bfb47ba693b241b619af52be4ad04504052412ce5665",
+      "size_bytes": 605599,
       "storage_tier": "dual"
     },
     {
@@ -83,19 +83,19 @@
     },
     {
       "path": "review/curation.json",
-      "sha256": "1edc8cd1e338affc98a0fd1c257b5d74d22e61f059f993fed93e6f9c1e7d97a8",
+      "sha256": "fd7b929793befb8a454afa00cde5b56dafb0378fbbe927932fac06810b11e559",
       "size_bytes": 156448,
       "storage_tier": "dual"
     },
     {
       "path": "review/enrichment-queue.json",
-      "sha256": "033a0a752348fe5ec2200d35e16248a9026487c58a8eba0629de4d88f33b109e",
-      "size_bytes": 366973,
+      "sha256": "be0f44a3c2dd64ac8ebec92695b0091af3e8fd4f0512e43f183392d2b2bf943b",
+      "size_bytes": 367044,
       "storage_tier": "dual"
     },
     {
       "path": "review/gap-priorities.json",
-      "sha256": "f5281ff5de774e9f2aa2bc260dc342745972154f03f499eb60248acfe51f4e5e",
+      "sha256": "104a042e0957766f0c33781efa683122b2ebaf2fcc7c6ad9fd042fb871590e24",
       "size_bytes": 65500,
       "storage_tier": "dual"
     },
@@ -107,8 +107,8 @@
     },
     {
       "path": "review/profile-completeness.json",
-      "sha256": "d207e89b36e20d30085013bca6eeba58e42a3057e142377d2cfa8bc334e8ba42",
-      "size_bytes": 258984,
+      "sha256": "1f9d3493cbdad42d74976dc854b56c16a4eaf02bed35b879b68cc20adca1710c",
+      "size_bytes": 258999,
       "storage_tier": "git"
     },
     {
@@ -125,20 +125,20 @@
     },
     {
       "path": "search.json",
-      "sha256": "87814dbe7ac687ae0222bb4dd55386a7acc334360d73dbe6f644cade09b8a585",
-      "size_bytes": 658105,
+      "sha256": "65e110d20750869de2f2da2b70db302d5506f23cce66933d20038cde8a9489da",
+      "size_bytes": 658609,
       "storage_tier": "dual"
     },
     {
       "path": "subnets.json",
-      "sha256": "be6596f3e2f19f5c8eb9fdd394828602313f0c7284fd67f5ffe5d4dc6f16a017",
-      "size_bytes": 128939,
+      "sha256": "0219efbe20cc69e037ce4c4ea5b687682db74c657ace16f0a08336bb755529c0",
+      "size_bytes": 128954,
       "storage_tier": "dual"
     },
     {
       "path": "surfaces.json",
-      "sha256": "d6a3772b2ce0fec8d53d60ba7c7376070034103fa33284a9a3e12d8f850534ba",
-      "size_bytes": 1138143,
+      "sha256": "d734fb0efde2221b0bb03aa16bd550c58fe52fd8292835e6f9372ef16a5d1349",
+      "size_bytes": 1138982,
       "storage_tier": "dual"
     }
   ],
@@ -163,7 +163,7 @@
     "native_snapshot_captured_at": "2026-06-08T22:53:27Z",
     "network": "finney",
     "probed_count": 129,
-    "probed_surface_count": 1131,
+    "probed_surface_count": 1132,
     "root_subnet_count": 1,
     "schema_version": 1,
     "source": {
@@ -178,11 +178,11 @@
       },
       "overlays": "registry/subnets"
     },
-    "surface_count": 1138
+    "surface_count": 1139
   },
-  "endpoint_count": 1138,
+  "endpoint_count": 1139,
   "full_artifact_count": 1260,
-  "full_artifact_size_bytes": 48881476,
+  "full_artifact_size_bytes": 48897266,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 90,
@@ -197,10 +197,10 @@
     "r2": 1238
   },
   "storage_tier_size_bytes": {
-    "dual": 4896135,
-    "git": 258984,
-    "r2": 43726357
+    "dual": 4898315,
+    "git": 258999,
+    "r2": 43739952
   },
   "subnet_count": 129,
-  "surface_count": 1138
+  "surface_count": 1139
 }

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -3,59 +3,55 @@
     "added": [],
     "modified": [
       {
-        "hash": "afa46e451f4a76e5ccd210cb41b4c23baac33daa83ab03936e532d53b9c9247a",
+        "hash": "df67ec41708977a3ff5fc541deebda5b53a031f19a01e07a77ed5acd30ac8464",
         "path": "coverage.json"
       },
       {
-        "hash": "df63fb2fe0865454c7f48de082e3d7efe6da1735a6e74895e1bb9e7210a8b33b",
+        "hash": "884e43fe1aa5c668564d22d5e1420f6b67705f727bcfe4bd3bd1255fd256a629",
         "path": "curation.json"
       },
       {
-        "hash": "1dc5fb36a4759fcc4699568ca6cfc443a4d70ceaa1e861bc5eae85f032a5109b",
+        "hash": "f2577b64487067bf258d627b47bb4c4fab4b718f697ccc1b26bf2de67d7a2e45",
         "path": "evidence-ledger.json"
       },
       {
-        "hash": "4e86e36d20a018d7c025988cecbc9342420c449ba933495638e4427a32adb094",
+        "hash": "ab606a4a2ca298bcca4f9f579618a915e427da650c7422fb57f94cdb2af485ab",
         "path": "freshness.json"
       },
       {
-        "hash": "273b6205550b017cd434346c874db748238a4d3664cb72e70dd40ba5fd2d655a",
+        "hash": "27b1043541e21b7edc7afa47f2f6d6cb5abe7e5f9aef2046f62c51cf82e0b895",
         "path": "gaps.json"
       },
       {
-        "hash": "d1ef555c85baf57fcbfc8f558a7b74de0b959e78d8a8eafb5c6c9af6724540d2",
+        "hash": "25912bd55d52503c03a1bfb47ba693b241b619af52be4ad04504052412ce5665",
         "path": "profiles.json"
       },
       {
-        "hash": "ee10f348c282b206d31a61798d1f5644a2c4be1718fbe763765487f44642c311",
-        "path": "review/adapter-candidates.json"
-      },
-      {
-        "hash": "1edc8cd1e338affc98a0fd1c257b5d74d22e61f059f993fed93e6f9c1e7d97a8",
+        "hash": "fd7b929793befb8a454afa00cde5b56dafb0378fbbe927932fac06810b11e559",
         "path": "review/curation.json"
       },
       {
-        "hash": "033a0a752348fe5ec2200d35e16248a9026487c58a8eba0629de4d88f33b109e",
+        "hash": "be0f44a3c2dd64ac8ebec92695b0091af3e8fd4f0512e43f183392d2b2bf943b",
         "path": "review/enrichment-queue.json"
       },
       {
-        "hash": "f5281ff5de774e9f2aa2bc260dc342745972154f03f499eb60248acfe51f4e5e",
+        "hash": "104a042e0957766f0c33781efa683122b2ebaf2fcc7c6ad9fd042fb871590e24",
         "path": "review/gap-priorities.json"
       },
       {
-        "hash": "d207e89b36e20d30085013bca6eeba58e42a3057e142377d2cfa8bc334e8ba42",
+        "hash": "1f9d3493cbdad42d74976dc854b56c16a4eaf02bed35b879b68cc20adca1710c",
         "path": "review/profile-completeness.json"
       },
       {
-        "hash": "87814dbe7ac687ae0222bb4dd55386a7acc334360d73dbe6f644cade09b8a585",
+        "hash": "65e110d20750869de2f2da2b70db302d5506f23cce66933d20038cde8a9489da",
         "path": "search.json"
       },
       {
-        "hash": "be6596f3e2f19f5c8eb9fdd394828602313f0c7284fd67f5ffe5d4dc6f16a017",
+        "hash": "0219efbe20cc69e037ce4c4ea5b687682db74c657ace16f0a08336bb755529c0",
         "path": "subnets.json"
       },
       {
-        "hash": "d6a3772b2ce0fec8d53d60ba7c7376070034103fa33284a9a3e12d8f850534ba",
+        "hash": "d734fb0efde2221b0bb03aa16bd550c58fe52fd8292835e6f9372ef16a5d1349",
         "path": "surfaces.json"
       }
     ],
@@ -76,7 +72,7 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 14,
+    "artifact_modified_count": 13,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {
@@ -96,9 +92,9 @@
       },
       "provider_count": null,
       "surface_count": {
-        "after": 1138,
-        "before": 1136,
-        "delta": 2
+        "after": 1139,
+        "before": 1138,
+        "delta": 1
       }
     },
     "netuid_added_count": 0,

--- a/public/metagraph/coverage.json
+++ b/public/metagraph/coverage.json
@@ -17,7 +17,7 @@
   "native_snapshot_captured_at": "2026-06-08T22:53:27Z",
   "network": "finney",
   "probed_count": 129,
-  "probed_surface_count": 1131,
+  "probed_surface_count": 1132,
   "root_subnet_count": 1,
   "schema_version": 1,
   "source": {
@@ -32,5 +32,5 @@
     },
     "overlays": "registry/subnets"
   },
-  "surface_count": 1138
+  "surface_count": 1139
 }

--- a/public/metagraph/curation.json
+++ b/public/metagraph/curation.json
@@ -5415,7 +5415,7 @@
       "curation": {
         "gap_notes": [
           "No verified standalone website yet.",
-          "No verified docs site yet.",
+          "The linked model iteration tool repository includes SDK and API guide references for builder workflows.",
           "No verified machine-readable OpenAPI/Swagger schema yet.",
           "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
@@ -5424,14 +5424,14 @@
         "level": "maintainer-reviewed",
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T10:50:00.000Z",
-        "source_count": 6,
+        "source_count": 7,
         "verified_at": "2026-06-08T10:50:00.000Z"
       },
       "gap_count": 5,
       "gaps": {
         "gap_notes": [
           "No verified standalone website yet.",
-          "No verified docs site yet.",
+          "The linked model iteration tool repository includes SDK and API guide references for builder workflows.",
           "No verified machine-readable OpenAPI/Swagger schema yet.",
           "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
@@ -5447,13 +5447,14 @@
         "supported_kinds": [
           "dashboard",
           "docs",
+          "sdk",
           "source-repo"
         ]
       },
       "name": "MANTIS",
       "netuid": 123,
       "slug": "sn-123",
-      "surface_count": 6
+      "surface_count": 7
     },
     {
       "candidate_count": 15,

--- a/public/metagraph/evidence-ledger.json
+++ b/public/metagraph/evidence-ledger.json
@@ -7019,6 +7019,17 @@
       "verified_at": "1970-01-01T00:00:00.000Z"
     },
     {
+      "claim": "MANTIS model iteration tool is a public sdk surface for SN123.",
+      "confidence": "high",
+      "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
+      "source_tier": "provider-claimed",
+      "source_type": "official",
+      "source_url": "https://github.com/Barbariandev/MANTIS",
+      "subject": "surface:sn-123-mantis-model-iteration-tool",
+      "support_summary": "Listed in curated overlay for sn-123.",
+      "verified_at": "1970-01-01T00:00:00.000Z"
+    },
+    {
       "claim": "MANTIS source repository is a public source-repo surface for SN123.",
       "confidence": "high",
       "limits": "Surface was recorded as public-safe; availability is tracked by health probes.",
@@ -16694,8 +16705,8 @@
   "schema_version": 1,
   "summary": {
     "candidate_claim_count": 250,
-    "claim_count": 1517,
+    "claim_count": 1518,
     "subnet_claim_count": 129,
-    "surface_claim_count": 1138
+    "surface_claim_count": 1139
   }
 }

--- a/public/metagraph/freshness.json
+++ b/public/metagraph/freshness.json
@@ -218,7 +218,7 @@
     "blocking_source_count": 5,
     "candidate_discovery_as_of": "2026-06-08T22:52:53.437Z",
     "health_probe_as_of": null,
-    "health_surface_count": 1131,
+    "health_surface_count": 1132,
     "missing_blocking_source_count": 1,
     "native_data_as_of": "2026-06-08T22:53:27Z",
     "native_snapshot_captured_at": "2026-06-08T22:53:27Z",

--- a/public/metagraph/gaps.json
+++ b/public/metagraph/gaps.json
@@ -3451,7 +3451,7 @@
       "gaps": {
         "gap_notes": [
           "No verified standalone website yet.",
-          "No verified docs site yet.",
+          "The linked model iteration tool repository includes SDK and API guide references for builder workflows.",
           "No verified machine-readable OpenAPI/Swagger schema yet.",
           "No verified safe public subnet API endpoint yet.",
           "No verified SSE/event stream yet.",
@@ -3467,6 +3467,7 @@
         "supported_kinds": [
           "dashboard",
           "docs",
+          "sdk",
           "source-repo"
         ]
       },

--- a/public/metagraph/profiles.json
+++ b/public/metagraph/profiles.json
@@ -18005,7 +18005,8 @@
         "baseline-augmented",
         "baseline-curated",
         "identity-reviewed",
-        "official-source-repo"
+        "official-source-repo",
+        "sdk"
       ],
       "completeness": {
         "confidence": "high",
@@ -18037,7 +18038,7 @@
       "completeness_score": 40,
       "confidence": "high",
       "curation_level": "maintainer-reviewed",
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "gap_reasons": [
         "missing-website",
         "missing-openapi",
@@ -18068,7 +18069,7 @@
       },
       "identity_level": "partial",
       "identity_surface_count": 2,
-      "interface_count": 3,
+      "interface_count": 4,
       "missing_critical_count": 5,
       "missing_identity": [
         "website"
@@ -18082,7 +18083,7 @@
       "missing_required": [
         "website"
       ],
-      "monitored_endpoint_count": 6,
+      "monitored_endpoint_count": 7,
       "name": "MANTIS",
       "native_identity": {
         "additional": null,
@@ -18118,13 +18119,14 @@
       "provenance": {
         "curation_level": "maintainer-reviewed",
         "identity_source": "curated-overlay",
-        "interface_source_count": 7,
+        "interface_source_count": 8,
         "review_state": "maintainer-reviewed",
         "reviewed_at": "2026-06-08T10:50:00.000Z",
         "source_urls": [
           "https://api.taomarketcap.com/public/v1/subnets/123",
           "https://backprop.finance/dtao/subnets/123-mantis",
           "https://github.com/Barbariandev/MANTIS",
+          "https://github.com/Barbariandev/mantis_model_iteration_tool",
           "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx",
           "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/123/subnet.json",
           "https://subnetradar.com/subnet/123",
@@ -18141,9 +18143,10 @@
       "supported_interface_kinds": [
         "dashboard",
         "docs",
+        "sdk",
         "source-repo"
       ],
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "𑀀",
       "team": null
     },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 5359113,
+  "artifact_size_bytes": 5361308,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "a2bf37747503bcdeabbb165c5c656a5367b9c3a72b38cff026c110ad6bc88e26",
-      "size_bytes": 3150,
+      "sha256": "98c10e1b0ee2ab2f690c6fa520ad82be4541a162e7e6ca3158be9a6b8d2d2e93",
+      "size_bytes": 3000,
       "storage_tier": "dual"
     },
     {
@@ -34,7 +34,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/coverage.json",
       "latest_key": "latest/coverage.json",
       "path": "/metagraph/coverage.json",
-      "sha256": "afa46e451f4a76e5ccd210cb41b4c23baac33daa83ab03936e532d53b9c9247a",
+      "sha256": "df67ec41708977a3ff5fc541deebda5b53a031f19a01e07a77ed5acd30ac8464",
       "size_bytes": 1048,
       "storage_tier": "dual"
     },
@@ -43,8 +43,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/curation.json",
       "latest_key": "latest/curation.json",
       "path": "/metagraph/curation.json",
-      "sha256": "df63fb2fe0865454c7f48de082e3d7efe6da1735a6e74895e1bb9e7210a8b33b",
-      "size_bytes": 178453,
+      "sha256": "884e43fe1aa5c668564d22d5e1420f6b67705f727bcfe4bd3bd1255fd256a629",
+      "size_bytes": 178624,
       "storage_tier": "dual"
     },
     {
@@ -52,8 +52,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/evidence-ledger.json",
       "latest_key": "latest/evidence-ledger.json",
       "path": "/metagraph/evidence-ledger.json",
-      "sha256": "1dc5fb36a4759fcc4699568ca6cfc443a4d70ceaa1e861bc5eae85f032a5109b",
-      "size_bytes": 857301,
+      "sha256": "f2577b64487067bf258d627b47bb4c4fab4b718f697ccc1b26bf2de67d7a2e45",
+      "size_bytes": 857834,
       "storage_tier": "dual"
     },
     {
@@ -61,7 +61,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "4e86e36d20a018d7c025988cecbc9342420c449ba933495638e4427a32adb094",
+      "sha256": "ab606a4a2ca298bcca4f9f579618a915e427da650c7422fb57f94cdb2af485ab",
       "size_bytes": 7549,
       "storage_tier": "dual"
     },
@@ -70,8 +70,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/gaps.json",
       "latest_key": "latest/gaps.json",
       "path": "/metagraph/gaps.json",
-      "sha256": "273b6205550b017cd434346c874db748238a4d3664cb72e70dd40ba5fd2d655a",
-      "size_bytes": 100869,
+      "sha256": "27b1043541e21b7edc7afa47f2f6d6cb5abe7e5f9aef2046f62c51cf82e0b895",
+      "size_bytes": 100963,
       "storage_tier": "dual"
     },
     {
@@ -88,8 +88,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/profiles.json",
       "latest_key": "latest/profiles.json",
       "path": "/metagraph/profiles.json",
-      "sha256": "d1ef555c85baf57fcbfc8f558a7b74de0b959e78d8a8eafb5c6c9af6724540d2",
-      "size_bytes": 605496,
+      "sha256": "25912bd55d52503c03a1bfb47ba693b241b619af52be4ad04504052412ce5665",
+      "size_bytes": 605599,
       "storage_tier": "dual"
     },
     {
@@ -115,7 +115,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/curation.json",
       "latest_key": "latest/review/curation.json",
       "path": "/metagraph/review/curation.json",
-      "sha256": "1edc8cd1e338affc98a0fd1c257b5d74d22e61f059f993fed93e6f9c1e7d97a8",
+      "sha256": "fd7b929793befb8a454afa00cde5b56dafb0378fbbe927932fac06810b11e559",
       "size_bytes": 156448,
       "storage_tier": "dual"
     },
@@ -124,8 +124,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
       "latest_key": "latest/review/enrichment-queue.json",
       "path": "/metagraph/review/enrichment-queue.json",
-      "sha256": "033a0a752348fe5ec2200d35e16248a9026487c58a8eba0629de4d88f33b109e",
-      "size_bytes": 366973,
+      "sha256": "be0f44a3c2dd64ac8ebec92695b0091af3e8fd4f0512e43f183392d2b2bf943b",
+      "size_bytes": 367044,
       "storage_tier": "dual"
     },
     {
@@ -133,7 +133,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/gap-priorities.json",
       "latest_key": "latest/review/gap-priorities.json",
       "path": "/metagraph/review/gap-priorities.json",
-      "sha256": "f5281ff5de774e9f2aa2bc260dc342745972154f03f499eb60248acfe51f4e5e",
+      "sha256": "104a042e0957766f0c33781efa683122b2ebaf2fcc7c6ad9fd042fb871590e24",
       "size_bytes": 65500,
       "storage_tier": "dual"
     },
@@ -151,8 +151,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/profile-completeness.json",
       "latest_key": "latest/review/profile-completeness.json",
       "path": "/metagraph/review/profile-completeness.json",
-      "sha256": "d207e89b36e20d30085013bca6eeba58e42a3057e142377d2cfa8bc334e8ba42",
-      "size_bytes": 258984,
+      "sha256": "1f9d3493cbdad42d74976dc854b56c16a4eaf02bed35b879b68cc20adca1710c",
+      "size_bytes": 258999,
       "storage_tier": "git"
     },
     {
@@ -178,8 +178,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/search.json",
       "latest_key": "latest/search.json",
       "path": "/metagraph/search.json",
-      "sha256": "87814dbe7ac687ae0222bb4dd55386a7acc334360d73dbe6f644cade09b8a585",
-      "size_bytes": 658105,
+      "sha256": "65e110d20750869de2f2da2b70db302d5506f23cce66933d20038cde8a9489da",
+      "size_bytes": 658609,
       "storage_tier": "dual"
     },
     {
@@ -187,8 +187,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/subnets.json",
       "latest_key": "latest/subnets.json",
       "path": "/metagraph/subnets.json",
-      "sha256": "be6596f3e2f19f5c8eb9fdd394828602313f0c7284fd67f5ffe5d4dc6f16a017",
-      "size_bytes": 128939,
+      "sha256": "0219efbe20cc69e037ce4c4ea5b687682db74c657ace16f0a08336bb755529c0",
+      "size_bytes": 128954,
       "storage_tier": "dual"
     },
     {
@@ -196,8 +196,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/surfaces.json",
       "latest_key": "latest/surfaces.json",
       "path": "/metagraph/surfaces.json",
-      "sha256": "d6a3772b2ce0fec8d53d60ba7c7376070034103fa33284a9a3e12d8f850534ba",
-      "size_bytes": 1138143,
+      "sha256": "d734fb0efde2221b0bb03aa16bd550c58fe52fd8292835e6f9372ef16a5d1349",
+      "size_bytes": 1138982,
       "storage_tier": "dual"
     },
     {
@@ -214,7 +214,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1273,
-  "full_artifact_size_bytes": 49094554,
+  "full_artifact_size_bytes": 49110344,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -238,8 +238,8 @@
     "r2": 1250
   },
   "storage_tier_size_bytes": {
-    "dual": 5100129,
-    "git": 258984,
-    "r2": 43735441
+    "dual": 5102309,
+    "git": 258999,
+    "r2": 43749036
   }
 }

--- a/public/metagraph/review/curation.json
+++ b/public/metagraph/review/curation.json
@@ -4660,7 +4660,7 @@
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 6,
+      "surface_count": 7,
       "verified_candidate_count": 7
     },
     {

--- a/public/metagraph/review/enrichment-queue.json
+++ b/public/metagraph/review/enrichment-queue.json
@@ -7312,7 +7312,7 @@
       "direct_submission_kinds": [
         "website"
       ],
-      "endpoint_count": 6,
+      "endpoint_count": 7,
       "evidence_action": "submit-new-evidence",
       "identity_level": "partial",
       "identity_surface_count": 2,
@@ -7353,13 +7353,14 @@
         "https://api.taomarketcap.com/public/v1/subnets/123",
         "https://backprop.finance/dtao/subnets/123-mantis",
         "https://github.com/Barbariandev/MANTIS",
+        "https://github.com/Barbariandev/mantis_model_iteration_tool",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_123/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/123/subnet.json",
         "https://subnetradar.com/subnet/123",
         "https://taomarketcap.com/subnets/123"
       ],
       "stale_candidate_count": 0,
-      "surface_count": 6,
+      "surface_count": 7,
       "verified_candidate_count": 7
     },
     {

--- a/public/metagraph/review/gap-priorities.json
+++ b/public/metagraph/review/gap-priorities.json
@@ -1784,7 +1784,7 @@
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
-      "surface_count": 6,
+      "surface_count": 7,
       "verified_candidate_count": 7
     },
     {

--- a/public/metagraph/review/profile-completeness.json
+++ b/public/metagraph/review/profile-completeness.json
@@ -1525,12 +1525,13 @@
       "profile_level": "identity-partial",
       "review_state": "maintainer-reviewed",
       "slug": "sn-123",
-      "source_count": 7,
+      "source_count": 8,
       "stale_identity_candidate_kind_count": 0,
       "suggested_next_action": "submit official docs, website, or source repository evidence",
       "supported_interface_kinds": [
         "dashboard",
         "docs",
+        "sdk",
         "source-repo"
       ]
     },

--- a/public/metagraph/search.json
+++ b/public/metagraph/search.json
@@ -1,6 +1,6 @@
 {
   "contract_version": "2026-06-06.1",
-  "document_count": 1357,
+  "document_count": 1358,
   "documents": [
     {
       "artifact_path": "/metagraph/providers.json",
@@ -4181,6 +4181,7 @@
         "official",
         "repo",
         "reviewed",
+        "sdk",
         "sn",
         "source"
       ],
@@ -18735,6 +18736,25 @@
       ],
       "type": "surface",
       "url": "https://backprop.finance/dtao/subnets/123-mantis"
+    },
+    {
+      "artifact_path": "/metagraph/surfaces.json",
+      "id": "surface:sn-123-mantis-model-iteration-tool",
+      "netuid": 123,
+      "slug": "sn-123",
+      "subtitle": "sdk / mantis",
+      "title": "MANTIS model iteration tool",
+      "tokens": [
+        "123",
+        "iteration",
+        "mantis",
+        "model",
+        "sdk",
+        "sn",
+        "tool"
+      ],
+      "type": "surface",
+      "url": "https://github.com/Barbariandev/mantis_model_iteration_tool"
     },
     {
       "artifact_path": "/metagraph/surfaces.json",

--- a/public/metagraph/subnets.json
+++ b/public/metagraph/subnets.json
@@ -3933,7 +3933,8 @@
         "baseline-augmented",
         "baseline-curated",
         "identity-reviewed",
-        "official-source-repo"
+        "official-source-repo",
+        "sdk"
       ],
       "coverage_level": "probed",
       "curation_level": "maintainer-reviewed",
@@ -3946,13 +3947,13 @@
       "native_name_quality": "chain",
       "netuid": 123,
       "participant_count": 256,
-      "probed_surface_count": 6,
+      "probed_surface_count": 7,
       "registered_at_block": 5794330,
       "slug": "sn-123",
       "source_repo": "https://github.com/Barbariandev/MANTIS",
       "status": "active",
       "subnet_type": "application",
-      "surface_count": 6,
+      "surface_count": 7,
       "symbol": "𑀀",
       "tempo": 360,
       "website_url": null

--- a/public/metagraph/surfaces.json
+++ b/public/metagraph/surfaces.json
@@ -32136,6 +32136,30 @@
     {
       "auth_required": false,
       "authority": "official",
+      "id": "sn-123-mantis-model-iteration-tool",
+      "kind": "sdk",
+      "name": "MANTIS model iteration tool",
+      "netuid": 123,
+      "notes": "Public SDK/tooling repository linked from the MANTIS source README for strategy iteration, GUI workflows, and local evaluation helpers.",
+      "probe": {
+        "enabled": true,
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "mantis",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/Barbariandev/MANTIS",
+        "https://github.com/Barbariandev/mantis_model_iteration_tool"
+      ],
+      "subnet_name": "MANTIS",
+      "subnet_slug": "sn-123",
+      "url": "https://github.com/Barbariandev/mantis_model_iteration_tool"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
       "id": "sn-123-mantis-source",
       "kind": "source-repo",
       "name": "MANTIS source repository",

--- a/registry/subnets/mantis.json
+++ b/registry/subnets/mantis.json
@@ -7,21 +7,22 @@
   "categories": [
     "baseline-curated",
     "identity-reviewed",
+    "sdk",
     "official-source-repo"
   ],
   "source_repo": "https://github.com/Barbariandev/MANTIS",
   "dashboard_url": "https://taomarketcap.com/subnets/123",
   "website_url": null,
-  "notes": "Reviewed overlay for SN123 using the live MANTIS source repository. No standalone website, docs site, API, OpenAPI, SSE, or data artifact has been verified yet.",
+  "notes": "Reviewed overlay for SN123 using the live MANTIS source repository and linked model-iteration SDK/tooling repository. No standalone website, docs site, public API, OpenAPI, SSE, or data artifact has been verified yet.",
   "curation": {
     "level": "maintainer-reviewed",
     "review_state": "maintainer-reviewed",
     "reviewed_at": "2026-06-08T10:50:00.000Z",
     "verified_at": "2026-06-08T10:50:00.000Z",
-    "source_count": 4,
+    "source_count": 5,
     "gap_notes": [
       "No verified standalone website yet.",
-      "No verified docs site yet.",
+      "The linked model iteration tool repository includes SDK and API guide references for builder workflows.",
       "No verified machine-readable OpenAPI/Swagger schema yet.",
       "No verified safe public subnet API endpoint yet.",
       "No verified SSE/event stream yet.",
@@ -49,6 +50,27 @@
         "timeout_ms": 10000
       },
       "notes": "Public MANTIS source repository for SN123."
+    },
+    {
+      "id": "sn-123-mantis-model-iteration-tool",
+      "name": "MANTIS model iteration tool",
+      "kind": "sdk",
+      "url": "https://github.com/Barbariandev/mantis_model_iteration_tool",
+      "provider": "mantis",
+      "auth_required": false,
+      "authority": "official",
+      "public_safe": true,
+      "source_urls": [
+        "https://github.com/Barbariandev/MANTIS",
+        "https://github.com/Barbariandev/mantis_model_iteration_tool"
+      ],
+      "probe": {
+        "enabled": true,
+        "method": "HEAD",
+        "expect": "any",
+        "timeout_ms": 10000
+      },
+      "notes": "Public SDK/tooling repository linked from the MANTIS source README for strategy iteration, GUI workflows, and local evaluation helpers."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add the MANTIS model iteration tool as a builder SDK surface
- regenerate compact Metagraphed public artifacts and R2 manifest

## What changed
- Added an `sdk` surface for `Barbariandev/mantis_model_iteration_tool` under SN123 MANTIS.
- Updated SN123 notes/gap context to distinguish builder SDK tooling from public APIs or data artifacts.
- Regenerated compact public registry artifacts.

## Why
The MANTIS source README links the model iteration tool as a public developer resource for strategy iteration, GUI workflows, and local evaluation helpers. This is a useful builder resource, but it is intentionally not classified as a public API, OpenAPI schema, SSE surface, or data artifact.

## Validation
- `npm run validate`
- `npm run validate:schemas`
- `npm run validate:api`
- `npm run validate:openapi`
- `npm run validate:types`
- `npm run validate:artifact-budgets`
- `npm run worker:test`
- `npm test`
- `npm run scan:public-safety`
- `git diff --check`
- `npm run check`
- `npm run test:coverage`

## Notes
- Coverage remains above target: 97.03% statement coverage.
- Surface count increases from 1,138 to 1,139.
- No high-churn R2 detail artifacts are tracked in Git.