### PR TITLE
fix(enrichment): harden api candidate verification

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -2,12 +2,12 @@
   "adapter_count": 10,
   "artifact_budget_summary": {
     "fail_count": 0,
-    "ok_count": 1260,
+    "ok_count": 1272,
     "warn_count": 0
   },
   "artifact_budgets": [],
   "artifact_count": 22,
-  "artifact_size_bytes": 5157314,
+  "artifact_size_bytes": 5154138,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -17,8 +17,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "98c10e1b0ee2ab2f690c6fa520ad82be4541a162e7e6ca3158be9a6b8d2d2e93",
-      "size_bytes": 3000,
+      "sha256": "484da6be28397abd82b5d1b7950fa85bae30dd638facb06bfc6bd3e9c15b2724",
+      "size_bytes": 1211,
       "storage_tier": "dual"
     },
     {
@@ -47,7 +47,7 @@
     },
     {
       "path": "freshness.json",
-      "sha256": "ab606a4a2ca298bcca4f9f579618a915e427da650c7422fb57f94cdb2af485ab",
+      "sha256": "878283e46aaa648971d9e68d0e9fb34d365c7f13db31cf535fef53ecc9f66627",
       "size_bytes": 7549,
       "storage_tier": "dual"
     },
@@ -65,7 +65,7 @@
     },
     {
       "path": "profiles.json",
-      "sha256": "25912bd55d52503c03a1bfb47ba693b241b619af52be4ad04504052412ce5665",
+      "sha256": "3644fa1d8679a38932a72b70c2e23f93ec8d39efdaa76225ec927ba613e18298",
       "size_bytes": 605599,
       "storage_tier": "dual"
     },
@@ -83,20 +83,20 @@
     },
     {
       "path": "review/curation.json",
-      "sha256": "fd7b929793befb8a454afa00cde5b56dafb0378fbbe927932fac06810b11e559",
-      "size_bytes": 156448,
+      "sha256": "cfdfd5631d474b0e663a9fc2665d7833bfa667d103ee693cca77921dd08308b2",
+      "size_bytes": 156442,
       "storage_tier": "dual"
     },
     {
       "path": "review/enrichment-queue.json",
-      "sha256": "be0f44a3c2dd64ac8ebec92695b0091af3e8fd4f0512e43f183392d2b2bf943b",
-      "size_bytes": 367044,
+      "sha256": "8ccf0ea6854be7ba753e1e0f69ef69ff02895e9d0a1fdd00b9716cb1e7f9e5ec",
+      "size_bytes": 366225,
       "storage_tier": "dual"
     },
     {
       "path": "review/gap-priorities.json",
-      "sha256": "104a042e0957766f0c33781efa683122b2ebaf2fcc7c6ad9fd042fb871590e24",
-      "size_bytes": 65500,
+      "sha256": "91a854130af2ad376e93fecf650947b7e3883e27a126ec1c83c10d67799a582d",
+      "size_bytes": 65494,
       "storage_tier": "dual"
     },
     {
@@ -107,7 +107,7 @@
     },
     {
       "path": "review/profile-completeness.json",
-      "sha256": "1f9d3493cbdad42d74976dc854b56c16a4eaf02bed35b879b68cc20adca1710c",
+      "sha256": "551a9c57aa0b2d2b76b49acc1314aa6aa7929b3d4864fcfb51e5c1634315a566",
       "size_bytes": 258999,
       "storage_tier": "git"
     },
@@ -137,8 +137,8 @@
     },
     {
       "path": "surfaces.json",
-      "sha256": "d734fb0efde2221b0bb03aa16bd550c58fe52fd8292835e6f9372ef16a5d1349",
-      "size_bytes": 1138982,
+      "sha256": "d74aca31b200c8bc20afec19986526528b0f35197194746295d7a146fcd99989",
+      "size_bytes": 1138426,
       "storage_tier": "dual"
     }
   ],
@@ -181,8 +181,8 @@
     "surface_count": 1139
   },
   "endpoint_count": 1139,
-  "full_artifact_count": 1260,
-  "full_artifact_size_bytes": 48897266,
+  "full_artifact_count": 1272,
+  "full_artifact_size_bytes": 48937294,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 90,
@@ -194,12 +194,12 @@
   "storage_tier_counts": {
     "dual": 21,
     "git": 1,
-    "r2": 1238
+    "r2": 1250
   },
   "storage_tier_size_bytes": {
-    "dual": 4898315,
+    "dual": 4895139,
     "git": 258999,
-    "r2": 43739952
+    "r2": 43783156
   },
   "subnet_count": 129,
   "surface_count": 1139

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,60 +1,7 @@
 {
   "artifacts": {
     "added": [],
-    "modified": [
-      {
-        "hash": "df67ec41708977a3ff5fc541deebda5b53a031f19a01e07a77ed5acd30ac8464",
-        "path": "coverage.json"
-      },
-      {
-        "hash": "884e43fe1aa5c668564d22d5e1420f6b67705f727bcfe4bd3bd1255fd256a629",
-        "path": "curation.json"
-      },
-      {
-        "hash": "f2577b64487067bf258d627b47bb4c4fab4b718f697ccc1b26bf2de67d7a2e45",
-        "path": "evidence-ledger.json"
-      },
-      {
-        "hash": "ab606a4a2ca298bcca4f9f579618a915e427da650c7422fb57f94cdb2af485ab",
-        "path": "freshness.json"
-      },
-      {
-        "hash": "27b1043541e21b7edc7afa47f2f6d6cb5abe7e5f9aef2046f62c51cf82e0b895",
-        "path": "gaps.json"
-      },
-      {
-        "hash": "25912bd55d52503c03a1bfb47ba693b241b619af52be4ad04504052412ce5665",
-        "path": "profiles.json"
-      },
-      {
-        "hash": "fd7b929793befb8a454afa00cde5b56dafb0378fbbe927932fac06810b11e559",
-        "path": "review/curation.json"
-      },
-      {
-        "hash": "be0f44a3c2dd64ac8ebec92695b0091af3e8fd4f0512e43f183392d2b2bf943b",
-        "path": "review/enrichment-queue.json"
-      },
-      {
-        "hash": "104a042e0957766f0c33781efa683122b2ebaf2fcc7c6ad9fd042fb871590e24",
-        "path": "review/gap-priorities.json"
-      },
-      {
-        "hash": "1f9d3493cbdad42d74976dc854b56c16a4eaf02bed35b879b68cc20adca1710c",
-        "path": "review/profile-completeness.json"
-      },
-      {
-        "hash": "65e110d20750869de2f2da2b70db302d5506f23cce66933d20038cde8a9489da",
-        "path": "search.json"
-      },
-      {
-        "hash": "0219efbe20cc69e037ce4c4ea5b687682db74c657ace16f0a08336bb755529c0",
-        "path": "subnets.json"
-      },
-      {
-        "hash": "d734fb0efde2221b0bb03aa16bd550c58fe52fd8292835e6f9372ef16a5d1349",
-        "path": "surfaces.json"
-      }
-    ],
+    "modified": [],
     "removed": []
   },
   "contract_version": "2026-06-06.1",
@@ -72,7 +19,7 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 13,
+    "artifact_modified_count": 0,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {
@@ -93,8 +40,8 @@
       "provider_count": null,
       "surface_count": {
         "after": 1139,
-        "before": 1138,
-        "delta": 1
+        "before": 1139,
+        "delta": 0
       }
     },
     "netuid_added_count": 0,

--- a/public/metagraph/freshness.json
+++ b/public/metagraph/freshness.json
@@ -160,7 +160,7 @@
       "timestamp_field": "candidate_discovery_as_of"
     },
     {
-      "as_of": "2026-06-08T22:52:53.437Z",
+      "as_of": "2026-06-09T05:36:53.950Z",
       "id": "candidate-verification",
       "lane": "candidate-verification",
       "notes": "",
@@ -169,7 +169,7 @@
       "stale_after_hours": 24,
       "stale_behavior": "block",
       "status": "captured",
-      "timestamp": "2026-06-08T22:52:53.437Z",
+      "timestamp": "2026-06-09T05:36:53.950Z",
       "timestamp_field": "verification_as_of"
     },
     {
@@ -228,7 +228,7 @@
     "stale_window_warnings": [
       "surface-health has no observed timestamp; production publish should block."
     ],
-    "verification_as_of": "2026-06-08T22:52:53.437Z",
+    "verification_as_of": "2026-06-09T05:36:53.950Z",
     "verification_generated_at": "1970-01-01T00:00:00.000Z",
     "warning_source_count": 11
   }

--- a/public/metagraph/profiles.json
+++ b/public/metagraph/profiles.json
@@ -5660,6 +5660,7 @@
         ],
         "live_candidate_identity_kinds": [
           "docs",
+          "source-repo",
           "website"
         ],
         "native_contact_present": true,
@@ -5671,8 +5672,7 @@
         ],
         "needs_promotion_kinds": [],
         "stale_candidate_identity_kinds": [
-          "docs",
-          "source-repo"
+          "docs"
         ],
         "unverified_candidate_identity_kinds": []
       },

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 5361308,
+  "artifact_size_bytes": 5358132,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "98c10e1b0ee2ab2f690c6fa520ad82be4541a162e7e6ca3158be9a6b8d2d2e93",
-      "size_bytes": 3000,
+      "sha256": "484da6be28397abd82b5d1b7950fa85bae30dd638facb06bfc6bd3e9c15b2724",
+      "size_bytes": 1211,
       "storage_tier": "dual"
     },
     {
@@ -61,7 +61,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
       "latest_key": "latest/freshness.json",
       "path": "/metagraph/freshness.json",
-      "sha256": "ab606a4a2ca298bcca4f9f579618a915e427da650c7422fb57f94cdb2af485ab",
+      "sha256": "878283e46aaa648971d9e68d0e9fb34d365c7f13db31cf535fef53ecc9f66627",
       "size_bytes": 7549,
       "storage_tier": "dual"
     },
@@ -88,7 +88,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/profiles.json",
       "latest_key": "latest/profiles.json",
       "path": "/metagraph/profiles.json",
-      "sha256": "25912bd55d52503c03a1bfb47ba693b241b619af52be4ad04504052412ce5665",
+      "sha256": "3644fa1d8679a38932a72b70c2e23f93ec8d39efdaa76225ec927ba613e18298",
       "size_bytes": 605599,
       "storage_tier": "dual"
     },
@@ -115,8 +115,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/curation.json",
       "latest_key": "latest/review/curation.json",
       "path": "/metagraph/review/curation.json",
-      "sha256": "fd7b929793befb8a454afa00cde5b56dafb0378fbbe927932fac06810b11e559",
-      "size_bytes": 156448,
+      "sha256": "cfdfd5631d474b0e663a9fc2665d7833bfa667d103ee693cca77921dd08308b2",
+      "size_bytes": 156442,
       "storage_tier": "dual"
     },
     {
@@ -124,8 +124,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
       "latest_key": "latest/review/enrichment-queue.json",
       "path": "/metagraph/review/enrichment-queue.json",
-      "sha256": "be0f44a3c2dd64ac8ebec92695b0091af3e8fd4f0512e43f183392d2b2bf943b",
-      "size_bytes": 367044,
+      "sha256": "8ccf0ea6854be7ba753e1e0f69ef69ff02895e9d0a1fdd00b9716cb1e7f9e5ec",
+      "size_bytes": 366225,
       "storage_tier": "dual"
     },
     {
@@ -133,8 +133,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/gap-priorities.json",
       "latest_key": "latest/review/gap-priorities.json",
       "path": "/metagraph/review/gap-priorities.json",
-      "sha256": "104a042e0957766f0c33781efa683122b2ebaf2fcc7c6ad9fd042fb871590e24",
-      "size_bytes": 65500,
+      "sha256": "91a854130af2ad376e93fecf650947b7e3883e27a126ec1c83c10d67799a582d",
+      "size_bytes": 65494,
       "storage_tier": "dual"
     },
     {
@@ -151,7 +151,7 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/profile-completeness.json",
       "latest_key": "latest/review/profile-completeness.json",
       "path": "/metagraph/review/profile-completeness.json",
-      "sha256": "1f9d3493cbdad42d74976dc854b56c16a4eaf02bed35b879b68cc20adca1710c",
+      "sha256": "551a9c57aa0b2d2b76b49acc1314aa6aa7929b3d4864fcfb51e5c1634315a566",
       "size_bytes": 258999,
       "storage_tier": "git"
     },
@@ -196,8 +196,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/surfaces.json",
       "latest_key": "latest/surfaces.json",
       "path": "/metagraph/surfaces.json",
-      "sha256": "d734fb0efde2221b0bb03aa16bd550c58fe52fd8292835e6f9372ef16a5d1349",
-      "size_bytes": 1138982,
+      "sha256": "d74aca31b200c8bc20afec19986526528b0f35197194746295d7a146fcd99989",
+      "size_bytes": 1138426,
       "storage_tier": "dual"
     },
     {
@@ -214,7 +214,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1273,
-  "full_artifact_size_bytes": 49110344,
+  "full_artifact_size_bytes": 49141288,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -238,8 +238,8 @@
     "r2": 1250
   },
   "storage_tier_size_bytes": {
-    "dual": 5102309,
+    "dual": 5099133,
     "git": 258999,
-    "r2": 43749036
+    "r2": 43783156
   }
 }

--- a/public/metagraph/review/curation.json
+++ b/public/metagraph/review/curation.json
@@ -2891,7 +2891,7 @@
       "slug": "allways",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 22,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 19,
@@ -2942,7 +2942,7 @@
       "slug": "sn-51",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 19
     },
     {
       "candidate_count": 24,
@@ -2959,7 +2959,7 @@
       "slug": "sn-46",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 16
     },
     {
       "candidate_count": 20,
@@ -2995,7 +2995,7 @@
       "slug": "sn-65",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 20,
@@ -3013,7 +3013,7 @@
       "slug": "sn-93",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 14
     },
     {
       "candidate_count": 20,
@@ -3049,7 +3049,7 @@
       "slug": "sn-18",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 19,
@@ -3265,7 +3265,7 @@
       "slug": "sn-99",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 17,
@@ -3337,7 +3337,7 @@
       "slug": "sn-60",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 16,
@@ -3355,7 +3355,7 @@
       "slug": "sn-78",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 16,
@@ -3373,7 +3373,7 @@
       "slug": "sn-80",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 19,
@@ -3408,7 +3408,7 @@
       "slug": "sn-41",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 15,
@@ -3426,7 +3426,7 @@
       "slug": "sn-50",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 15,
@@ -3444,7 +3444,7 @@
       "slug": "sn-105",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 15,
@@ -3480,7 +3480,7 @@
       "slug": "sn-124",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 15,
@@ -3498,7 +3498,7 @@
       "slug": "sn-128",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 18,
@@ -3515,7 +3515,7 @@
       "slug": "sn-97",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 14,
@@ -3533,7 +3533,7 @@
       "slug": "sn-71",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 14,
@@ -3551,7 +3551,7 @@
       "slug": "sn-77",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 14,
@@ -3569,7 +3569,7 @@
       "slug": "sn-83",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 14,
@@ -3690,7 +3690,7 @@
       "slug": "sn-64",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 17,
-      "verified_candidate_count": 22
+      "verified_candidate_count": 21
     },
     {
       "candidate_count": 25,
@@ -3705,7 +3705,7 @@
       "slug": "gradients",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 14,
-      "verified_candidate_count": 22
+      "verified_candidate_count": 20
     },
     {
       "candidate_count": 26,
@@ -3742,7 +3742,7 @@
       "slug": "actual",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 7,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 25,
@@ -3833,7 +3833,7 @@
       "slug": "sn-114",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 16
     },
     {
       "candidate_count": 6,
@@ -4006,7 +4006,7 @@
       "slug": "numinous",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 19,
@@ -4023,7 +4023,7 @@
       "slug": "sn-88",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 12
     },
     {
       "candidate_count": 15,
@@ -4060,7 +4060,7 @@
       "slug": "sn-75",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 19
     },
     {
       "candidate_count": 26,
@@ -4171,7 +4171,7 @@
       "slug": "sn-32",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 19
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 9,
@@ -4404,7 +4404,7 @@
       "slug": "sn-85",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 16
     },
     {
       "candidate_count": 22,
@@ -4456,7 +4456,7 @@
       "slug": "gittensor",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 16,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 12
     },
     {
       "candidate_count": 20,
@@ -4474,7 +4474,7 @@
       "slug": "cacheon",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 14
     },
     {
       "candidate_count": 20,
@@ -4771,7 +4771,7 @@
       "slug": "dsperse",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 12
     },
     {
       "candidate_count": 17,
@@ -4875,7 +4875,7 @@
       "slug": "colosseum",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 15,
@@ -4929,7 +4929,7 @@
       "slug": "sn-16",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 14,
@@ -4945,7 +4945,7 @@
       "slug": "sn-22",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 15,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 17,
@@ -4962,7 +4962,7 @@
       "slug": "sn-66",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 12,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 11,
@@ -5012,7 +5012,7 @@
       "slug": "sn-96",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 12,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 8,
@@ -5030,7 +5030,7 @@
       "slug": "sn-12",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 7
     },
     {
       "candidate_count": 8,

--- a/public/metagraph/review/enrichment-queue.json
+++ b/public/metagraph/review/enrichment-queue.json
@@ -64,7 +64,7 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 22,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 12,
@@ -403,15 +403,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -456,21 +455,20 @@
         "sn-65-subnetradar-dashboard",
         "sn-65-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-65-website-common-api",
-        "sn-65-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-65-website-common-openapi-json",
         "sn-65-website-common-swagger",
-        "sn-65-website-common-swagger-json"
+        "sn-65-website-common-swagger-json",
+        "sn-65-website-common-api",
+        "sn-65-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-65-website-common-api",
-        "sn-65-website-common-health",
         "sn-65-website-common-openapi-json",
         "sn-65-website-common-swagger",
-        "sn-65-website-common-swagger-json"
+        "sn-65-website-common-swagger-json",
+        "sn-65-website-common-api",
+        "sn-65-website-common-health"
       ],
       "slug": "sn-65",
       "source_urls": [
@@ -483,9 +481,9 @@
         "https://subnetradar.com/subnet/65",
         "https://tpn.taofu.xyz/"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 15
     },
     {
       "adapter_score": 8,
@@ -496,15 +494,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -549,21 +546,20 @@
         "sn-93-native-chain-website",
         "sn-93-subnetradar-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-93-website-common-api",
-        "sn-93-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-93-website-common-openapi-json",
         "sn-93-website-common-swagger",
-        "sn-93-website-common-swagger-json"
+        "sn-93-website-common-swagger-json",
+        "sn-93-website-common-api",
+        "sn-93-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-93-website-common-api",
-        "sn-93-website-common-health",
         "sn-93-website-common-openapi-json",
         "sn-93-website-common-swagger",
-        "sn-93-website-common-swagger-json"
+        "sn-93-website-common-swagger-json",
+        "sn-93-website-common-api",
+        "sn-93-website-common-health"
       ],
       "slug": "sn-93",
       "source_urls": [
@@ -576,9 +572,9 @@
         "https://stats.bitcast.network/",
         "https://subnetradar.com/subnet/93"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 71,
@@ -1378,16 +1374,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 4,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -1432,10 +1426,9 @@
         "sn-18-subnetradar-dashboard",
         "sn-18-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-18-website-common-api"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
+        "sn-18-website-common-api",
         "sn-18-website-common-openapi-json",
         "sn-18-website-common-swagger",
         "sn-18-website-common-swagger-json",
@@ -1459,9 +1452,9 @@
         "https://subnetradar.com/subnet/18",
         "https://www.zeussubnet.com/"
       ],
-      "stale_candidate_count": 4,
+      "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 8,
@@ -2075,15 +2068,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 3,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 6,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 6,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -2128,22 +2120,20 @@
         "sn-99-native-chain-github",
         "sn-99-native-chain-website"
       ],
-      "sample_live_candidate_ids": [
-        "sn-99-github-readme-rendixnetwork-leoma-subnet-api-1",
-        "sn-99-website-common-api",
-        "sn-99-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-99-website-common-openapi-json",
         "sn-99-website-common-swagger",
-        "sn-99-website-common-swagger-json"
+        "sn-99-website-common-swagger-json",
+        "sn-99-github-readme-rendixnetwork-leoma-subnet-api-1",
+        "sn-99-website-common-api"
       ],
       "sample_target_candidate_ids": [
-        "sn-99-github-readme-rendixnetwork-leoma-subnet-api-1",
-        "sn-99-website-common-api",
-        "sn-99-website-common-health",
         "sn-99-website-common-openapi-json",
-        "sn-99-website-common-swagger"
+        "sn-99-website-common-swagger",
+        "sn-99-website-common-swagger-json",
+        "sn-99-github-readme-rendixnetwork-leoma-subnet-api-1",
+        "sn-99-website-common-api"
       ],
       "slug": "sn-99",
       "source_urls": [
@@ -2156,9 +2146,9 @@
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_99/index.mdx",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/99/subnet.json"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 6,
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 7,
@@ -2327,7 +2317,7 @@
       ],
       "stale_candidate_count": 3,
       "surface_count": 10,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 19
     },
     {
       "adapter_score": 10,
@@ -2338,16 +2328,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 4,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -2392,20 +2380,19 @@
         "sn-60-native-chain-website",
         "sn-60-subnetradar-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-60-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-60-website-common-openapi-json",
         "sn-60-website-common-swagger",
         "sn-60-website-common-swagger-json",
+        "sn-60-website-common-health",
         "sn-60-website-common-api"
       ],
       "sample_target_candidate_ids": [
-        "sn-60-website-common-health",
         "sn-60-website-common-openapi-json",
         "sn-60-website-common-swagger",
         "sn-60-website-common-swagger-json",
+        "sn-60-website-common-health",
         "sn-60-website-common-api"
       ],
       "slug": "sn-60",
@@ -2419,9 +2406,9 @@
         "https://github.com/Bitsec-AI/sandbox/blob/main/README.md",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_60/index.mdx"
       ],
-      "stale_candidate_count": 4,
+      "stale_candidate_count": 5,
       "surface_count": 10,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 10,
@@ -2432,15 +2419,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -2485,21 +2471,20 @@
         "sn-78-subnetradar-dashboard",
         "sn-78-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-78-website-common-api",
-        "sn-78-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-78-website-common-openapi-json",
         "sn-78-website-common-swagger",
-        "sn-78-website-common-swagger-json"
+        "sn-78-website-common-swagger-json",
+        "sn-78-website-common-api",
+        "sn-78-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-78-website-common-api",
-        "sn-78-website-common-health",
         "sn-78-website-common-openapi-json",
         "sn-78-website-common-swagger",
-        "sn-78-website-common-swagger-json"
+        "sn-78-website-common-swagger-json",
+        "sn-78-website-common-api",
+        "sn-78-website-common-health"
       ],
       "slug": "sn-78",
       "source_urls": [
@@ -2512,9 +2497,9 @@
         "https://subnetradar.com/subnet/78",
         "https://www.vocence.ai/"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 8,
@@ -2615,15 +2600,13 @@
         "kinds_with_candidates": [
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 4,
         "stale_kinds": [
           "subnet-api"
         ],
-        "stale_or_failed_count": 1,
+        "stale_or_failed_count": 2,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -2661,10 +2644,9 @@
         "sn-46-github-readme-resi-labs-ai-resi-models-dashboard-1",
         "sn-46-native-chain-github"
       ],
-      "sample_live_candidate_ids": [
-        "sn-46-website-link-zipcode-ai-subnet-api-3"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
+        "sn-46-website-link-zipcode-ai-subnet-api-3",
         "sn-46-github-readme-resi-labs-ai-resi-labs-api-subnet-api-1"
       ],
       "sample_target_candidate_ids": [
@@ -2684,9 +2666,9 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/46/subnet.json",
         "https://subnetradar.com/subnet/46"
       ],
-      "stale_candidate_count": 1,
+      "stale_candidate_count": 2,
       "surface_count": 11,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 9,
@@ -3061,16 +3043,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 4,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3115,20 +3095,19 @@
         "sn-80-subnetradar-dashboard",
         "sn-80-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-80-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-80-website-common-openapi-json",
         "sn-80-website-common-swagger",
         "sn-80-website-common-swagger-json",
+        "sn-80-website-common-health",
         "sn-80-website-common-api"
       ],
       "sample_target_candidate_ids": [
-        "sn-80-website-common-health",
         "sn-80-website-common-openapi-json",
         "sn-80-website-common-swagger",
         "sn-80-website-common-swagger-json",
+        "sn-80-website-common-health",
         "sn-80-website-common-api"
       ],
       "slug": "sn-80",
@@ -3142,9 +3121,9 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/80/subnet.json",
         "https://subnetradar.com/subnet/80"
       ],
-      "stale_candidate_count": 4,
+      "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 7,
@@ -3325,15 +3304,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3378,21 +3356,20 @@
         "sn-41-subnetradar-dashboard",
         "sn-41-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-41-website-common-api",
-        "sn-41-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-41-website-common-openapi-json",
         "sn-41-website-common-swagger",
-        "sn-41-website-common-swagger-json"
+        "sn-41-website-common-swagger-json",
+        "sn-41-website-common-api",
+        "sn-41-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-41-website-common-api",
-        "sn-41-website-common-health",
         "sn-41-website-common-openapi-json",
         "sn-41-website-common-swagger",
-        "sn-41-website-common-swagger-json"
+        "sn-41-website-common-swagger-json",
+        "sn-41-website-common-api",
+        "sn-41-website-common-health"
       ],
       "slug": "sn-41",
       "source_urls": [
@@ -3405,9 +3382,9 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/41/subnet.json",
         "https://subnetradar.com/subnet/41"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 8,
@@ -3418,15 +3395,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 3,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 6,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 6,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3471,22 +3447,20 @@
         "sn-50-native-chain-website",
         "sn-50-subnetradar-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-50-github-readme-mode-network-synth-subnet-subnet-api-1",
-        "sn-50-website-common-api",
-        "sn-50-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-50-website-common-openapi-json",
         "sn-50-website-common-swagger",
-        "sn-50-website-common-swagger-json"
+        "sn-50-website-common-swagger-json",
+        "sn-50-github-readme-mode-network-synth-subnet-subnet-api-1",
+        "sn-50-website-common-api"
       ],
       "sample_target_candidate_ids": [
-        "sn-50-github-readme-mode-network-synth-subnet-subnet-api-1",
-        "sn-50-website-common-api",
-        "sn-50-website-common-health",
         "sn-50-website-common-openapi-json",
-        "sn-50-website-common-swagger"
+        "sn-50-website-common-swagger",
+        "sn-50-website-common-swagger-json",
+        "sn-50-github-readme-mode-network-synth-subnet-subnet-api-1",
+        "sn-50-website-common-api"
       ],
       "slug": "sn-50",
       "source_urls": [
@@ -3499,9 +3473,9 @@
         "https://subnetradar.com/subnet/50",
         "https://synthdata.co/"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 6,
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 27,
@@ -3579,7 +3553,7 @@
       ],
       "stale_candidate_count": 1,
       "surface_count": 7,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 9,
@@ -3590,15 +3564,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3643,19 +3616,18 @@
         "sn-105-subnetradar-dashboard",
         "sn-105-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-105-website-common-api",
-        "sn-105-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-105-website-common-swagger",
+        "sn-105-website-common-api",
+        "sn-105-website-common-health",
         "sn-105-website-common-openapi-json",
         "sn-105-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
+        "sn-105-website-common-swagger",
         "sn-105-website-common-api",
         "sn-105-website-common-health",
-        "sn-105-website-common-swagger",
         "sn-105-website-common-openapi-json",
         "sn-105-website-common-swagger-json"
       ],
@@ -3670,9 +3642,9 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/105/subnet.json",
         "https://subnetradar.com/subnet/105"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 8,
@@ -3683,15 +3655,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3736,21 +3707,20 @@
         "sn-124-native-chain-website",
         "sn-124-subnetradar-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-124-website-common-api",
-        "sn-124-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-124-website-common-openapi-json",
         "sn-124-website-common-swagger",
-        "sn-124-website-common-swagger-json"
+        "sn-124-website-common-swagger-json",
+        "sn-124-website-common-api",
+        "sn-124-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-124-website-common-api",
-        "sn-124-website-common-health",
         "sn-124-website-common-openapi-json",
         "sn-124-website-common-swagger",
-        "sn-124-website-common-swagger-json"
+        "sn-124-website-common-swagger-json",
+        "sn-124-website-common-api",
+        "sn-124-website-common-health"
       ],
       "slug": "sn-124",
       "source_urls": [
@@ -3763,9 +3733,9 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/124/subnet.json",
         "https://subnetradar.com/subnet/124"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 9,
@@ -3776,15 +3746,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3829,21 +3798,20 @@
         "sn-128-subnetradar-dashboard",
         "sn-128-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-128-website-common-api",
-        "sn-128-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-128-website-common-openapi-json",
         "sn-128-website-common-swagger",
-        "sn-128-website-common-swagger-json"
+        "sn-128-website-common-swagger-json",
+        "sn-128-website-common-api",
+        "sn-128-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-128-website-common-api",
-        "sn-128-website-common-health",
         "sn-128-website-common-openapi-json",
         "sn-128-website-common-swagger",
-        "sn-128-website-common-swagger-json"
+        "sn-128-website-common-swagger-json",
+        "sn-128-website-common-api",
+        "sn-128-website-common-health"
       ],
       "slug": "sn-128",
       "source_urls": [
@@ -3856,9 +3824,9 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/128/subnet.json",
         "https://subnetradar.com/subnet/128"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 8,
@@ -3869,15 +3837,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -3922,21 +3889,20 @@
         "sn-71-subnetradar-dashboard",
         "sn-71-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-71-website-common-api",
-        "sn-71-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-71-website-common-openapi-json",
         "sn-71-website-common-swagger",
-        "sn-71-website-common-swagger-json"
+        "sn-71-website-common-swagger-json",
+        "sn-71-website-common-api",
+        "sn-71-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-71-website-common-api",
-        "sn-71-website-common-health",
         "sn-71-website-common-openapi-json",
         "sn-71-website-common-swagger",
-        "sn-71-website-common-swagger-json"
+        "sn-71-website-common-swagger-json",
+        "sn-71-website-common-api",
+        "sn-71-website-common-health"
       ],
       "slug": "sn-71",
       "source_urls": [
@@ -3949,9 +3915,9 @@
         "https://leadpoet.com/",
         "https://subnetradar.com/subnet/71"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 8,
@@ -3962,15 +3928,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -4015,19 +3980,18 @@
         "sn-77-subnetradar-dashboard",
         "sn-77-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-77-website-common-api",
-        "sn-77-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-77-website-common-swagger",
+        "sn-77-website-common-api",
+        "sn-77-website-common-health",
         "sn-77-website-common-openapi-json",
         "sn-77-website-common-swagger-json"
       ],
       "sample_target_candidate_ids": [
+        "sn-77-website-common-swagger",
         "sn-77-website-common-api",
         "sn-77-website-common-health",
-        "sn-77-website-common-swagger",
         "sn-77-website-common-openapi-json",
         "sn-77-website-common-swagger-json"
       ],
@@ -4042,9 +4006,9 @@
         "https://sn77.xyz/",
         "https://subnetradar.com/subnet/77"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 8,
@@ -4055,15 +4019,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -4108,21 +4071,20 @@
         "sn-83-subnetradar-dashboard",
         "sn-83-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-83-website-common-api",
-        "sn-83-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-83-website-common-openapi-json",
         "sn-83-website-common-swagger",
-        "sn-83-website-common-swagger-json"
+        "sn-83-website-common-swagger-json",
+        "sn-83-website-common-api",
+        "sn-83-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-83-website-common-api",
-        "sn-83-website-common-health",
         "sn-83-website-common-openapi-json",
         "sn-83-website-common-swagger",
-        "sn-83-website-common-swagger-json"
+        "sn-83-website-common-swagger-json",
+        "sn-83-website-common-api",
+        "sn-83-website-common-health"
       ],
       "slug": "sn-83",
       "source_urls": [
@@ -4135,9 +4097,9 @@
         "https://github.com/toptensor/CliqueAI",
         "https://subnetradar.com/subnet/83"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 8,
@@ -4544,7 +4506,7 @@
       ],
       "stale_candidate_count": 3,
       "surface_count": 17,
-      "verified_candidate_count": 22
+      "verified_candidate_count": 21
     },
     {
       "adapter_score": 8,
@@ -4686,7 +4648,7 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 14,
-      "verified_candidate_count": 22
+      "verified_candidate_count": 20
     },
     {
       "adapter_score": 6,
@@ -4933,15 +4895,13 @@
         "kinds_with_candidates": [
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 3,
         "stale_kinds": [
           "subnet-api"
         ],
-        "stale_or_failed_count": 1,
+        "stale_or_failed_count": 3,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -4979,16 +4939,15 @@
         "sn-97-native-chain-github",
         "sn-97-native-chain-website"
       ],
-      "sample_live_candidate_ids": [
-        "sn-97-website-common-health",
-        "sn-97-github-readme-unitone-labs-flamewire-subnet-api-2"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
+        "sn-97-github-readme-unitone-labs-flamewire-subnet-api-2",
+        "sn-97-website-common-health",
         "sn-97-website-common-api"
       ],
       "sample_target_candidate_ids": [
-        "sn-97-website-common-health",
         "sn-97-github-readme-unitone-labs-flamewire-subnet-api-2",
+        "sn-97-website-common-health",
         "sn-97-website-common-api"
       ],
       "slug": "sn-97",
@@ -5002,9 +4961,9 @@
         "https://github.com/unarbos/albedo",
         "https://github.com/unitone-labs/FlameWire/blob/main/README.md"
       ],
-      "stale_candidate_count": 1,
+      "stale_candidate_count": 3,
       "surface_count": 11,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 29,
@@ -5264,16 +5223,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 6,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 5,
+        "stale_or_failed_count": 6,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -5317,15 +5274,13 @@
         "sn-75-subnetradar-dashboard",
         "sn-75-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-75-website-link-hippius-com-subnet-api-10"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
+        "sn-75-website-link-hippius-com-subnet-api-10",
         "sn-75-website-common-openapi-json",
         "sn-75-website-common-swagger",
         "sn-75-website-common-swagger-json",
-        "sn-75-website-common-api",
-        "sn-75-website-common-health"
+        "sn-75-website-common-api"
       ],
       "sample_target_candidate_ids": [
         "sn-75-website-link-hippius-com-subnet-api-10",
@@ -5345,9 +5300,9 @@
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/75/subnet.json",
         "https://github.com/thenervelab/hippius-storage-miner"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 6,
       "surface_count": 11,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 19
     },
     {
       "adapter_score": 29,
@@ -5446,16 +5401,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 6,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 5,
+        "stale_or_failed_count": 6,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -5499,20 +5452,18 @@
         "sn-32-subnetradar-dashboard",
         "sn-32-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-32-website-link-its-ai-org-subnet-api-5"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-32-website-common-openapi-json",
         "sn-32-website-common-swagger-json",
+        "sn-32-website-link-its-ai-org-subnet-api-5",
         "sn-32-website-common-swagger",
-        "sn-32-website-common-api",
-        "sn-32-website-common-health"
+        "sn-32-website-common-api"
       ],
       "sample_target_candidate_ids": [
-        "sn-32-website-link-its-ai-org-subnet-api-5",
         "sn-32-website-common-openapi-json",
         "sn-32-website-common-swagger-json",
+        "sn-32-website-link-its-ai-org-subnet-api-5",
         "sn-32-website-common-swagger",
         "sn-32-website-common-api"
       ],
@@ -5527,9 +5478,9 @@
         "https://subnetradar.com/subnet/32",
         "https://taomarketcap.com/subnets/32"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 6,
       "surface_count": 8,
-      "verified_candidate_count": 19
+      "verified_candidate_count": 18
     },
     {
       "adapter_score": 8,
@@ -6443,13 +6394,13 @@
         "live_kinds": [
           "subnet-api"
         ],
-        "live_or_redirected_count": 2,
+        "live_or_redirected_count": 1,
         "reviewable_count": 6,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 4,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -6492,18 +6443,18 @@
         "sn-114-taomarketcap-dashboard"
       ],
       "sample_live_candidate_ids": [
-        "sn-114-website-link-thesoma-ai-subnet-api-7",
         "sn-114-website-common-api"
       ],
       "sample_stale_candidate_ids": [
+        "sn-114-website-link-thesoma-ai-subnet-api-7",
         "sn-114-website-common-openapi-json",
         "sn-114-website-common-swagger",
         "sn-114-website-common-swagger-json",
         "sn-114-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-114-website-link-thesoma-ai-subnet-api-7",
         "sn-114-website-common-api",
+        "sn-114-website-link-thesoma-ai-subnet-api-7",
         "sn-114-website-common-openapi-json",
         "sn-114-website-common-swagger",
         "sn-114-website-common-swagger-json"
@@ -6519,9 +6470,9 @@
         "https://github.com/tensorplex-labs/subnet-docs/tree/main/data/114",
         "https://subnetradar.com/subnet/114"
       ],
-      "stale_candidate_count": 4,
+      "stale_candidate_count": 5,
       "surface_count": 11,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 7,
@@ -6675,7 +6626,7 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 11,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 9,
@@ -7462,15 +7413,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 4,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 2,
+        "stale_or_failed_count": 4,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -7514,19 +7464,18 @@
         "sn-85-subnetradar-dashboard",
         "sn-85-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-85-website-common-openapi-json",
+        "sn-85-website-common-swagger-json",
         "sn-85-website-common-api",
         "sn-85-website-common-health"
       ],
-      "sample_stale_candidate_ids": [
-        "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger-json"
-      ],
       "sample_target_candidate_ids": [
-        "sn-85-website-common-api",
-        "sn-85-website-common-health",
         "sn-85-website-common-openapi-json",
-        "sn-85-website-common-swagger-json"
+        "sn-85-website-common-swagger-json",
+        "sn-85-website-common-api",
+        "sn-85-website-common-health"
       ],
       "slug": "sn-85",
       "source_urls": [
@@ -7539,9 +7488,9 @@
         "https://taomarketcap.com/subnets/85",
         "https://vidaio.io/"
       ],
-      "stale_candidate_count": 2,
+      "stale_candidate_count": 4,
       "surface_count": 7,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 16
     },
     {
       "adapter_score": 11,
@@ -7552,16 +7501,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 6,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 5,
+        "stale_or_failed_count": 6,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -7605,15 +7552,13 @@
         "sn-14-github-readme-latent-to-taohash-dashboard-1",
         "sn-14-native-chain-github"
       ],
-      "sample_live_candidate_ids": [
-        "sn-14-github-readme-latent-to-cacheon-subnet-api-2"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
+        "sn-14-github-readme-latent-to-cacheon-subnet-api-2",
         "sn-14-website-common-openapi-json",
         "sn-14-website-common-swagger",
         "sn-14-website-common-swagger-json",
-        "sn-14-website-common-api",
-        "sn-14-website-common-health"
+        "sn-14-website-common-api"
       ],
       "sample_target_candidate_ids": [
         "sn-14-github-readme-latent-to-cacheon-subnet-api-2",
@@ -7633,9 +7578,9 @@
         "https://github.com/latent-to/taohash/blob/main/README.md",
         "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/14/subnet.json"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 6,
       "surface_count": 11,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 14
     },
     {
       "adapter_score": 0,
@@ -7938,16 +7883,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 1,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 6,
         "stale_kinds": [
           "openapi",
           "subnet-api"
         ],
-        "stale_or_failed_count": 5,
+        "stale_or_failed_count": 6,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -7989,15 +7932,13 @@
         "sn-88-native-chain-github",
         "sn-88-native-chain-website"
       ],
-      "sample_live_candidate_ids": [
-        "sn-88-github-readme-mobiusfund-investing-subnet-api-2"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
+        "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
         "sn-88-website-common-openapi-json",
         "sn-88-website-common-swagger",
         "sn-88-website-common-swagger-json",
-        "sn-88-website-common-api",
-        "sn-88-website-common-health"
+        "sn-88-website-common-api"
       ],
       "sample_target_candidate_ids": [
         "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
@@ -8017,9 +7958,9 @@
         "https://investing88.ai/",
         "https://subnetradar.com/subnet/88"
       ],
-      "stale_candidate_count": 5,
+      "stale_candidate_count": 6,
       "surface_count": 8,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 9,
@@ -8734,15 +8675,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 4,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 2,
+        "stale_or_failed_count": 4,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -8786,19 +8726,18 @@
         "sn-2-github-readme-inference-labs-inc-subnet-2-docs-1",
         "sn-2-native-chain-github"
       ],
-      "sample_live_candidate_ids": [
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
+        "sn-2-website-common-openapi-json",
+        "sn-2-website-common-swagger-json",
         "sn-2-website-common-api",
         "sn-2-website-common-health"
       ],
-      "sample_stale_candidate_ids": [
-        "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger-json"
-      ],
       "sample_target_candidate_ids": [
-        "sn-2-website-common-api",
-        "sn-2-website-common-health",
         "sn-2-website-common-openapi-json",
-        "sn-2-website-common-swagger-json"
+        "sn-2-website-common-swagger-json",
+        "sn-2-website-common-api",
+        "sn-2-website-common-health"
       ],
       "slug": "dsperse",
       "source_urls": [
@@ -8810,9 +8749,9 @@
         "https://sn2-docs.inferencelabs.com/",
         "https://subnet2.inferencelabs.com/"
       ],
-      "stale_candidate_count": 2,
+      "stale_candidate_count": 4,
       "surface_count": 8,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 8,
@@ -8913,15 +8852,14 @@
           "openapi",
           "subnet-api"
         ],
-        "live_kinds": [
-          "subnet-api"
-        ],
-        "live_or_redirected_count": 2,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
         "reviewable_count": 5,
         "stale_kinds": [
-          "openapi"
+          "openapi",
+          "subnet-api"
         ],
-        "stale_or_failed_count": 3,
+        "stale_or_failed_count": 5,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -8965,21 +8903,20 @@
         "sn-38-subnetradar-dashboard",
         "sn-38-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
-        "sn-38-website-common-api",
-        "sn-38-website-common-health"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [
         "sn-38-website-common-openapi-json",
         "sn-38-website-common-swagger",
-        "sn-38-website-common-swagger-json"
+        "sn-38-website-common-swagger-json",
+        "sn-38-website-common-api",
+        "sn-38-website-common-health"
       ],
       "sample_target_candidate_ids": [
-        "sn-38-website-common-api",
-        "sn-38-website-common-health",
         "sn-38-website-common-openapi-json",
         "sn-38-website-common-swagger",
-        "sn-38-website-common-swagger-json"
+        "sn-38-website-common-swagger-json",
+        "sn-38-website-common-api",
+        "sn-38-website-common-health"
       ],
       "slug": "colosseum",
       "source_urls": [
@@ -8992,9 +8929,9 @@
         "https://subnetradar.com/subnet/38",
         "https://taomarketcap.com/subnets/38"
       ],
-      "stale_candidate_count": 3,
+      "stale_candidate_count": 5,
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 7,
@@ -9219,7 +9156,7 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "adapter_score": 93,
@@ -9437,7 +9374,7 @@
       ],
       "stale_candidate_count": 3,
       "surface_count": 12,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 13
     },
     {
       "adapter_score": 75,
@@ -9501,7 +9438,7 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 15,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "adapter_score": 56,
@@ -9511,13 +9448,13 @@
         "kinds_with_candidates": [
           "subnet-api"
         ],
-        "live_kinds": [
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 2,
+        "stale_kinds": [
           "subnet-api"
         ],
-        "live_or_redirected_count": 2,
-        "reviewable_count": 2,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
+        "stale_or_failed_count": 2,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -9553,11 +9490,11 @@
         "sn-74-native-chain-github",
         "sn-74-native-chain-website"
       ],
-      "sample_live_candidate_ids": [
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
         "sn-74-website-common-api",
         "sn-74-website-common-health"
       ],
-      "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [
         "sn-74-website-common-api",
         "sn-74-website-common-health"
@@ -9573,9 +9510,9 @@
         "https://docs.learnbittensor.org/python-api/html/_modules/bittensor/core/chain_data/subnet_identity.html",
         "https://github.com/e35ventura/taopedia-articles/blob/main/content/pages/subnet_74/index.mdx"
       ],
-      "stale_candidate_count": 0,
+      "stale_candidate_count": 2,
       "surface_count": 16,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 12
     },
     {
       "adapter_score": 31,
@@ -9727,13 +9664,13 @@
         "kinds_with_candidates": [
           "subnet-api"
         ],
-        "live_kinds": [
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 1,
+        "stale_kinds": [
           "subnet-api"
         ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 1,
-        "stale_kinds": [],
-        "stale_or_failed_count": 0,
+        "stale_or_failed_count": 1,
         "unverified_count": 0,
         "unverified_kinds": []
       },
@@ -9746,7 +9683,7 @@
         "data-artifact"
       ],
       "endpoint_count": 8,
-      "evidence_action": "review-existing-evidence",
+      "evidence_action": "replace-stale-evidence",
       "identity_level": "complete",
       "identity_surface_count": 3,
       "lane": "direct-submission",
@@ -9777,10 +9714,10 @@
         "sn-12-subnetradar-dashboard",
         "sn-12-taomarketcap-dashboard"
       ],
-      "sample_live_candidate_ids": [
+      "sample_live_candidate_ids": [],
+      "sample_stale_candidate_ids": [
         "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1"
       ],
-      "sample_stale_candidate_ids": [],
       "sample_target_candidate_ids": [
         "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1"
       ],
@@ -9795,9 +9732,9 @@
         "https://grafana.bactensor.io/d/subnet/metagraph-subnet?var-subnet=12",
         "https://grafana.bittensor.church/d/subnet/metagraph-subnet?var-subnet=12"
       ],
-      "stale_candidate_count": 0,
+      "stale_candidate_count": 1,
       "surface_count": 8,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 7
     },
     {
       "adapter_score": 0,
@@ -10437,7 +10374,7 @@
       ],
       "stale_candidate_count": 0,
       "surface_count": 12,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 11
     },
     {
       "adapter_score": 51,
@@ -10576,8 +10513,7 @@
     "evidence_action_counts": {
       "maintainer-review-existing-evidence": 17,
       "monitor": 1,
-      "replace-stale-evidence": 72,
-      "review-existing-evidence": 1,
+      "replace-stale-evidence": 73,
       "submit-new-evidence": 37,
       "verify-existing-evidence": 1
     },

--- a/public/metagraph/review/gap-priorities.json
+++ b/public/metagraph/review/gap-priorities.json
@@ -15,7 +15,7 @@
       "slug": "allways",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 22,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 19,
@@ -66,7 +66,7 @@
       "slug": "sn-51",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 19
     },
     {
       "candidate_count": 24,
@@ -83,7 +83,7 @@
       "slug": "sn-46",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 16
     },
     {
       "candidate_count": 20,
@@ -119,7 +119,7 @@
       "slug": "sn-65",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 15
     },
     {
       "candidate_count": 20,
@@ -137,7 +137,7 @@
       "slug": "sn-93",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 16
+      "verified_candidate_count": 14
     },
     {
       "candidate_count": 20,
@@ -173,7 +173,7 @@
       "slug": "sn-18",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 19,
@@ -389,7 +389,7 @@
       "slug": "sn-99",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 17,
@@ -461,7 +461,7 @@
       "slug": "sn-60",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 16,
@@ -479,7 +479,7 @@
       "slug": "sn-78",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 10,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 16,
@@ -497,7 +497,7 @@
       "slug": "sn-80",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 19,
@@ -532,7 +532,7 @@
       "slug": "sn-41",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 15,
@@ -550,7 +550,7 @@
       "slug": "sn-50",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 15,
@@ -568,7 +568,7 @@
       "slug": "sn-105",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 15,
@@ -604,7 +604,7 @@
       "slug": "sn-124",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 15,
@@ -622,7 +622,7 @@
       "slug": "sn-128",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 9,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 18,
@@ -639,7 +639,7 @@
       "slug": "sn-97",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 11,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 14,
@@ -657,7 +657,7 @@
       "slug": "sn-71",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 14,
@@ -675,7 +675,7 @@
       "slug": "sn-77",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 14,
@@ -693,7 +693,7 @@
       "slug": "sn-83",
       "suggested_next_action": "review promoted surfaces and mark maintainer-reviewed where provenance is strong",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 14,
@@ -814,7 +814,7 @@
       "slug": "sn-64",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 17,
-      "verified_candidate_count": 22
+      "verified_candidate_count": 21
     },
     {
       "candidate_count": 25,
@@ -829,7 +829,7 @@
       "slug": "gradients",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 14,
-      "verified_candidate_count": 22
+      "verified_candidate_count": 20
     },
     {
       "candidate_count": 26,
@@ -866,7 +866,7 @@
       "slug": "actual",
       "suggested_next_action": "inspect source-repo/docs candidates for official provenance",
       "surface_count": 7,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 25,
@@ -957,7 +957,7 @@
       "slug": "sn-114",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 17
+      "verified_candidate_count": 16
     },
     {
       "candidate_count": 6,
@@ -1130,7 +1130,7 @@
       "slug": "numinous",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 11,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 19,
@@ -1147,7 +1147,7 @@
       "slug": "sn-88",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 12
     },
     {
       "candidate_count": 15,
@@ -1184,7 +1184,7 @@
       "slug": "sn-75",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 20
+      "verified_candidate_count": 19
     },
     {
       "candidate_count": 26,
@@ -1295,7 +1295,7 @@
       "slug": "sn-32",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 19
+      "verified_candidate_count": 18
     },
     {
       "candidate_count": 9,
@@ -1528,7 +1528,7 @@
       "slug": "sn-85",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 18
+      "verified_candidate_count": 16
     },
     {
       "candidate_count": 22,
@@ -1580,7 +1580,7 @@
       "slug": "gittensor",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 16,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 12
     },
     {
       "candidate_count": 20,
@@ -1598,7 +1598,7 @@
       "slug": "cacheon",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 11,
-      "verified_candidate_count": 15
+      "verified_candidate_count": 14
     },
     {
       "candidate_count": 20,
@@ -1895,7 +1895,7 @@
       "slug": "dsperse",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 12
     },
     {
       "candidate_count": 17,
@@ -1999,7 +1999,7 @@
       "slug": "colosseum",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 7,
-      "verified_candidate_count": 10
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 15,
@@ -2053,7 +2053,7 @@
       "slug": "sn-16",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 11
+      "verified_candidate_count": 9
     },
     {
       "candidate_count": 14,
@@ -2069,7 +2069,7 @@
       "slug": "sn-22",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 15,
-      "verified_candidate_count": 12
+      "verified_candidate_count": 10
     },
     {
       "candidate_count": 17,
@@ -2086,7 +2086,7 @@
       "slug": "sn-66",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 12,
-      "verified_candidate_count": 14
+      "verified_candidate_count": 13
     },
     {
       "candidate_count": 11,
@@ -2136,7 +2136,7 @@
       "slug": "sn-96",
       "suggested_next_action": "evaluate for subnet-specific adapter",
       "surface_count": 12,
-      "verified_candidate_count": 13
+      "verified_candidate_count": 11
     },
     {
       "candidate_count": 8,
@@ -2154,7 +2154,7 @@
       "slug": "sn-12",
       "suggested_next_action": "keep baseline entry and wait for public-source or community intake",
       "surface_count": 8,
-      "verified_candidate_count": 8
+      "verified_candidate_count": 7
     },
     {
       "candidate_count": 8,

--- a/public/metagraph/review/profile-completeness.json
+++ b/public/metagraph/review/profile-completeness.json
@@ -5917,6 +5917,7 @@
         ],
         "live_candidate_identity_kinds": [
           "docs",
+          "source-repo",
           "website"
         ],
         "native_contact_present": true,
@@ -5928,8 +5929,7 @@
         ],
         "needs_promotion_kinds": [],
         "stale_candidate_identity_kinds": [
-          "docs",
-          "source-repo"
+          "docs"
         ],
         "unverified_candidate_identity_kinds": []
       },
@@ -5937,7 +5937,7 @@
       "identity_promotion_kind_count": 0,
       "identity_promotion_kinds": [],
       "identity_surface_count": 3,
-      "live_identity_candidate_kind_count": 2,
+      "live_identity_candidate_kind_count": 3,
       "missing_critical_count": 4,
       "missing_identity": [],
       "missing_operational": [
@@ -5957,7 +5957,7 @@
       "review_state": "maintainer-reviewed",
       "slug": "colosseum",
       "source_count": 9,
-      "stale_identity_candidate_kind_count": 2,
+      "stale_identity_candidate_kind_count": 1,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [
         "dashboard",

--- a/public/metagraph/surfaces.json
+++ b/public/metagraph/surfaces.json
@@ -10372,12 +10372,8 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -21232,12 +21228,8 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -26231,12 +26223,8 @@
       "provider": "tensorplex-subnet-docs",
       "public_safe": true,
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [
@@ -27901,12 +27889,8 @@
       "provider": "taomarketcap",
       "public_safe": true,
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
+        "source_tier": "third-party-index"
       },
       "rate_limit_notes": "Candidate only; no recurring probe is configured until maintainer review.",
       "source_urls": [

--- a/registry/verification/promotions.json
+++ b/registry/verification/promotions.json
@@ -2,7 +2,7 @@
   "candidate_count": 2021,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "notes": "Compact promotion snapshot for deterministic Git review. Full latency, timestamp, and probe-detail rows are staged for R2 during refresh/publish runs.",
-  "observed_at": "2026-06-08T22:52:53.437Z",
+  "observed_at": "2026-06-09T05:36:53.950Z",
   "results": [
     {
       "candidate_id": "sn-0-backprop-dashboard",
@@ -12,7 +12,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 0,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22,7 +21,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33,7 +31,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 0,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -43,7 +40,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -54,7 +50,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 0,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -64,7 +59,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -75,7 +69,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 0,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -85,7 +78,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -96,7 +88,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 0,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -106,7 +97,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -117,7 +107,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -127,7 +116,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -138,7 +126,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -176,7 +163,6 @@
       "error": null,
       "kind": "website",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -186,7 +172,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -197,7 +182,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -207,7 +191,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -218,7 +201,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -228,7 +210,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -239,7 +220,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -249,7 +229,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -260,7 +239,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -270,7 +248,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -281,7 +258,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -291,7 +267,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -302,7 +277,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -323,7 +297,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -333,7 +306,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -344,7 +316,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -354,7 +325,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -365,7 +335,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -375,7 +344,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -386,7 +354,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -396,7 +363,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -407,7 +373,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -417,7 +382,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -428,7 +392,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -438,7 +401,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -449,7 +411,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -470,7 +431,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -480,7 +440,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -491,7 +450,6 @@
       "error": null,
       "kind": "website",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -512,7 +470,6 @@
       "error": null,
       "kind": "website",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -533,7 +490,6 @@
       "error": null,
       "kind": "website",
       "netuid": 1,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -554,7 +510,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -564,7 +519,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -575,7 +529,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -585,7 +538,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -596,7 +548,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -606,7 +557,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -617,7 +567,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -627,7 +576,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -655,7 +603,6 @@
       "error": null,
       "kind": "website",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -665,7 +612,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -676,7 +622,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -686,7 +631,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -697,7 +641,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -707,7 +650,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -718,7 +660,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -728,7 +669,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -739,7 +679,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -749,7 +688,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -760,7 +698,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -770,28 +707,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-2-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -802,7 +736,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -812,28 +745,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-2-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -844,7 +774,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -854,7 +783,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -865,7 +793,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -875,7 +802,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -886,7 +812,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 2,
-      "private_redirect_blocked": false,
       "provider": "inference-labs",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -896,7 +821,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -907,7 +831,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 3,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -917,7 +840,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -928,7 +850,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 3,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -938,7 +859,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -949,7 +869,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 3,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -959,7 +878,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -970,7 +888,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 3,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -980,7 +897,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -991,7 +907,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 3,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1001,7 +916,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1012,7 +926,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 3,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1022,12 +935,11 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-3-tensorplex-source-repo-1",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -1040,6 +952,7 @@
         "public_safe": true,
         "source_tier": "community-docs"
       },
+      "redirect_target": "https://github.com/one-covenant/templar",
       "status": "ok"
     },
     {
@@ -1050,7 +963,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1060,7 +972,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1088,7 +999,6 @@
       "error": null,
       "kind": "website",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1098,7 +1008,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1109,7 +1018,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1119,7 +1027,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1130,7 +1037,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1140,7 +1046,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1151,7 +1056,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1161,7 +1065,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1172,7 +1075,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1182,7 +1084,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1193,7 +1094,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1203,7 +1103,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1214,7 +1113,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1224,7 +1122,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1235,7 +1132,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1245,7 +1141,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1256,7 +1151,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1266,7 +1160,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1277,7 +1170,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1287,7 +1179,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1298,7 +1189,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1308,7 +1198,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1319,7 +1208,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1329,7 +1217,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1340,7 +1227,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1350,7 +1236,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1361,7 +1246,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1382,7 +1266,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1392,7 +1275,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1403,7 +1285,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1413,7 +1294,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1424,7 +1304,6 @@
       "error": null,
       "kind": "website",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1434,7 +1313,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1445,7 +1323,6 @@
       "error": null,
       "kind": "website",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1466,7 +1343,6 @@
       "error": null,
       "kind": "website",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1476,7 +1352,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1487,7 +1362,6 @@
       "error": null,
       "kind": "website",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1497,7 +1371,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1508,7 +1381,6 @@
       "error": null,
       "kind": "website",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1518,7 +1390,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1529,7 +1400,6 @@
       "error": null,
       "kind": "website",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1550,7 +1420,6 @@
       "error": null,
       "kind": "website",
       "netuid": 4,
-      "private_redirect_blocked": false,
       "provider": "targon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1571,7 +1440,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1581,7 +1449,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1609,7 +1476,6 @@
       "error": null,
       "kind": "website",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1619,7 +1485,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1630,7 +1495,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1640,7 +1504,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1651,7 +1514,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1661,7 +1523,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1672,7 +1533,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1682,7 +1542,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1693,7 +1552,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1703,7 +1561,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1714,7 +1571,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1724,7 +1580,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1735,7 +1590,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1745,7 +1599,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1756,7 +1609,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1766,7 +1618,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1777,7 +1628,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1787,7 +1637,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1798,7 +1647,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1808,7 +1656,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1819,7 +1666,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1829,7 +1675,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1840,7 +1685,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1850,7 +1694,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1861,7 +1704,6 @@
       "error": null,
       "kind": "website",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1871,7 +1713,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1882,7 +1723,6 @@
       "error": null,
       "kind": "website",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1892,7 +1732,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1903,7 +1742,6 @@
       "error": null,
       "kind": "website",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1913,7 +1751,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1924,7 +1761,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 5,
-      "private_redirect_blocked": false,
       "provider": "hone",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1934,7 +1770,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -1945,7 +1780,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1955,7 +1789,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -1966,7 +1799,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -1976,7 +1808,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2004,7 +1835,6 @@
       "error": null,
       "kind": "website",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2014,7 +1844,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2025,7 +1854,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2035,7 +1863,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2046,7 +1873,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2056,7 +1882,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2067,7 +1892,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2077,7 +1901,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2088,7 +1911,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2098,7 +1920,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2109,7 +1930,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2119,7 +1939,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2130,7 +1949,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2140,7 +1958,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2151,7 +1968,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2161,7 +1977,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2172,7 +1987,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2182,7 +1996,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2193,7 +2006,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2203,7 +2015,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2214,7 +2025,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2224,7 +2034,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2235,7 +2044,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2245,7 +2053,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2256,7 +2063,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2266,28 +2072,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-6-website-link-numinouslabs-io-subnet-api-2",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2298,7 +2101,6 @@
       "error": null,
       "kind": "website",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2308,7 +2110,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2319,7 +2120,6 @@
       "error": null,
       "kind": "website",
       "netuid": 6,
-      "private_redirect_blocked": false,
       "provider": "numinous",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2329,7 +2129,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2340,7 +2139,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "allways",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2350,7 +2148,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2361,7 +2158,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2371,7 +2167,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2399,7 +2194,6 @@
       "error": null,
       "kind": "website",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "allways",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2409,7 +2203,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2420,7 +2213,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2430,7 +2222,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2441,7 +2232,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2451,7 +2241,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2462,7 +2251,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2472,7 +2260,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2483,7 +2270,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2493,7 +2279,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2504,7 +2289,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2514,7 +2298,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2525,7 +2308,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "allways",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2535,7 +2317,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2546,7 +2327,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "allways",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2556,28 +2336,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-7-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "allways",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2588,7 +2365,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "allways",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -2598,7 +2374,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2609,7 +2384,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "allways",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -2619,7 +2393,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2630,7 +2403,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 7,
-      "private_redirect_blocked": false,
       "provider": "allways",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -2640,7 +2412,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2651,7 +2422,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2661,7 +2431,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2689,7 +2458,6 @@
       "error": null,
       "kind": "website",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2699,7 +2467,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2710,7 +2477,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2720,7 +2486,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2731,7 +2496,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2741,7 +2505,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2752,7 +2515,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2762,7 +2524,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2773,7 +2534,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2783,7 +2543,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2794,7 +2553,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2804,7 +2562,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2815,7 +2572,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2825,7 +2581,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2836,7 +2591,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2846,7 +2600,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2857,7 +2610,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2867,7 +2619,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2878,7 +2629,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2888,7 +2638,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2899,7 +2648,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2909,7 +2657,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2920,7 +2667,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2930,7 +2676,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -2941,7 +2686,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2951,7 +2695,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2962,7 +2705,6 @@
       "error": null,
       "kind": "website",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2972,7 +2714,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -2983,7 +2724,6 @@
       "error": null,
       "kind": "website",
       "netuid": 8,
-      "private_redirect_blocked": false,
       "provider": "vanta",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -2993,7 +2733,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3004,7 +2743,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3014,7 +2752,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3025,7 +2762,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3035,7 +2771,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3046,7 +2781,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3056,7 +2790,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3084,7 +2817,6 @@
       "error": null,
       "kind": "website",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3094,7 +2826,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3105,7 +2836,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3115,7 +2845,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3126,7 +2855,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3136,7 +2864,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3147,7 +2874,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3157,7 +2883,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3168,7 +2893,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3178,7 +2902,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3189,7 +2912,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3199,7 +2921,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3210,7 +2931,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3220,7 +2940,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3231,7 +2950,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3252,7 +2970,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3262,7 +2979,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3273,7 +2989,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3283,7 +2998,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3294,7 +3008,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3304,7 +3017,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3315,7 +3027,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3325,7 +3036,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3336,7 +3046,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3346,7 +3055,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3357,7 +3065,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3367,7 +3074,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3378,7 +3084,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3388,7 +3093,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3399,7 +3103,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3409,7 +3112,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3420,7 +3122,6 @@
       "error": null,
       "kind": "website",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3430,7 +3131,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3441,7 +3141,6 @@
       "error": null,
       "kind": "website",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3462,7 +3161,6 @@
       "error": null,
       "kind": "website",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3483,7 +3181,6 @@
       "error": null,
       "kind": "website",
       "netuid": 9,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3493,7 +3190,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3504,7 +3200,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3514,7 +3209,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3542,7 +3236,6 @@
       "error": null,
       "kind": "website",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taofi",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3552,7 +3245,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3563,7 +3255,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3573,7 +3264,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3584,7 +3274,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3594,7 +3283,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3605,7 +3293,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3615,7 +3302,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3626,7 +3312,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3636,7 +3321,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3647,7 +3331,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3657,7 +3340,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3668,7 +3350,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taofi",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3678,7 +3359,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3689,7 +3369,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taofi",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3699,7 +3378,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3710,7 +3388,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taofi",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3720,7 +3397,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3731,7 +3407,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taofi",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3741,7 +3416,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3752,7 +3426,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taofi",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3762,7 +3435,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3773,7 +3445,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 10,
-      "private_redirect_blocked": false,
       "provider": "taofi",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3783,7 +3454,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3794,7 +3464,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3804,7 +3473,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3832,7 +3500,6 @@
       "error": null,
       "kind": "website",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3842,7 +3509,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3853,7 +3519,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3863,7 +3528,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3874,7 +3538,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3884,7 +3547,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3895,7 +3557,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3905,7 +3566,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3916,7 +3576,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3926,7 +3585,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3937,7 +3595,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3947,7 +3604,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -3958,7 +3614,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3968,7 +3623,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -3979,7 +3633,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -3989,7 +3642,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4000,7 +3652,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4010,7 +3661,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4021,7 +3671,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4031,7 +3680,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4042,7 +3690,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4052,7 +3699,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4063,7 +3709,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4073,7 +3718,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4084,7 +3728,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4094,7 +3737,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4105,7 +3747,6 @@
       "error": null,
       "kind": "website",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4115,7 +3756,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4126,7 +3766,6 @@
       "error": null,
       "kind": "website",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4136,7 +3775,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4147,7 +3785,6 @@
       "error": null,
       "kind": "website",
       "netuid": 11,
-      "private_redirect_blocked": false,
       "provider": "trajectoryrl",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4157,7 +3794,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4168,7 +3804,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 12,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4178,21 +3813,19 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-12-github-readme-backend-developers-ltd-computehorde-subnet-api-1",
-      "classification": "redirected",
-      "confidence_score": 53,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=UTF-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 12,
-      "private_redirect_blocked": false,
       "provider": "compute-horde",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -4227,7 +3860,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 12,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4237,7 +3869,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4248,7 +3879,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 12,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4258,7 +3888,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4269,7 +3898,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 12,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4279,7 +3907,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4290,7 +3917,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 12,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4300,7 +3926,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4311,7 +3936,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 12,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4321,7 +3945,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4332,7 +3955,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4342,7 +3964,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4353,7 +3974,6 @@
       "error": "probe-failed",
       "kind": "dashboard",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4373,7 +3993,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4394,7 +4013,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4404,7 +4022,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4432,7 +4049,6 @@
       "error": null,
       "kind": "website",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4453,7 +4069,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4463,7 +4078,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4474,7 +4088,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4484,7 +4097,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4495,7 +4107,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4505,7 +4116,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4516,7 +4126,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4526,7 +4135,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4537,7 +4145,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4547,7 +4154,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4558,7 +4164,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4568,7 +4173,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4579,7 +4183,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4589,7 +4192,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4600,7 +4202,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4610,7 +4211,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4621,7 +4221,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4631,7 +4230,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4642,7 +4240,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4652,7 +4249,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4663,7 +4259,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4673,7 +4268,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -4684,7 +4278,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4694,7 +4287,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4705,7 +4297,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4726,7 +4317,6 @@
       "error": null,
       "kind": "website",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4736,7 +4326,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4747,7 +4336,6 @@
       "error": null,
       "kind": "website",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4768,7 +4356,6 @@
       "error": null,
       "kind": "website",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4789,7 +4376,6 @@
       "error": null,
       "kind": "website",
       "netuid": 13,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4810,7 +4396,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4820,7 +4405,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4831,7 +4415,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4841,28 +4424,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-14-github-readme-latent-to-cacheon-subnet-api-2",
-      "classification": "live",
-      "confidence_score": 58,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4873,7 +4453,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4883,7 +4462,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4911,7 +4489,6 @@
       "error": null,
       "kind": "website",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4921,7 +4498,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4932,7 +4508,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4942,7 +4517,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4953,7 +4527,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4963,7 +4536,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4974,7 +4546,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -4984,7 +4555,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -4995,7 +4565,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5005,7 +4574,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5016,7 +4584,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5026,7 +4593,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5054,7 +4620,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5064,7 +4629,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5075,7 +4639,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5085,7 +4648,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5096,7 +4658,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5106,7 +4667,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5117,7 +4677,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5127,7 +4686,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5138,7 +4696,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5148,7 +4705,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5159,7 +4715,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5169,7 +4724,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5180,7 +4734,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5190,7 +4743,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5201,7 +4753,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 14,
-      "private_redirect_blocked": false,
       "provider": "cacheon",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5211,7 +4762,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5222,7 +4772,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5232,7 +4781,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5243,7 +4791,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5253,7 +4800,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5264,7 +4810,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5274,7 +4819,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5285,7 +4829,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5295,7 +4838,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5323,7 +4865,6 @@
       "error": null,
       "kind": "website",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5333,7 +4874,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5344,7 +4884,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5354,7 +4893,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5365,7 +4903,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5375,7 +4912,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5386,7 +4922,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5396,7 +4931,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5407,7 +4941,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5417,7 +4950,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5428,7 +4960,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5438,7 +4969,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5449,7 +4979,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5459,7 +4988,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5470,7 +4998,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5480,7 +5007,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5491,7 +5017,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5501,7 +5026,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5512,7 +5036,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5522,7 +5045,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5533,7 +5055,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5543,7 +5064,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5554,7 +5074,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5564,7 +5083,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -5575,7 +5093,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5585,7 +5102,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5596,7 +5112,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5606,7 +5121,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5617,7 +5131,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5627,7 +5140,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5638,7 +5150,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5648,7 +5159,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5659,7 +5169,6 @@
       "error": null,
       "kind": "website",
       "netuid": 15,
-      "private_redirect_blocked": false,
       "provider": "oro",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5669,7 +5178,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5680,7 +5188,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5690,7 +5197,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5718,7 +5224,6 @@
       "error": null,
       "kind": "website",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "bitads",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5728,7 +5233,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5739,7 +5243,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5749,7 +5252,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5760,7 +5262,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5770,7 +5271,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5781,7 +5281,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5791,7 +5290,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5802,7 +5300,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5812,7 +5309,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5823,7 +5319,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5833,28 +5328,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-16-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "bitads",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5865,7 +5357,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "bitads",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5875,28 +5366,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-16-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "bitads",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5907,7 +5395,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "bitads",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -5917,7 +5404,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5928,7 +5414,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "bitads",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -5938,7 +5423,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5949,7 +5433,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 16,
-      "private_redirect_blocked": false,
       "provider": "bitads",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -5959,7 +5442,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5970,7 +5452,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -5980,7 +5461,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -5991,7 +5471,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6001,7 +5480,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6029,7 +5507,6 @@
       "error": null,
       "kind": "website",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6039,7 +5516,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6050,7 +5526,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6060,7 +5535,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6071,7 +5545,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6081,7 +5554,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6092,7 +5564,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6102,7 +5573,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6113,7 +5583,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6123,7 +5592,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6134,7 +5602,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6144,7 +5611,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6172,7 +5638,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6182,7 +5647,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6193,7 +5657,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6203,7 +5666,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6214,7 +5676,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6224,7 +5685,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6235,7 +5695,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6245,7 +5704,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6256,7 +5714,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6266,7 +5723,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6277,7 +5733,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6287,7 +5742,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6298,7 +5752,6 @@
       "error": null,
       "kind": "website",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6319,7 +5772,6 @@
       "error": null,
       "kind": "website",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6340,7 +5792,6 @@
       "error": null,
       "kind": "website",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6361,7 +5812,6 @@
       "error": null,
       "kind": "website",
       "netuid": 17,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6382,7 +5832,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6392,7 +5841,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6420,7 +5868,6 @@
       "error": null,
       "kind": "website",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6430,7 +5877,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6441,7 +5887,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6451,7 +5896,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6462,7 +5906,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6472,7 +5915,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6483,7 +5925,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6493,7 +5934,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6504,7 +5944,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6514,7 +5953,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6525,7 +5963,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6535,21 +5972,19 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-18-website-common-api",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -6567,7 +6002,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6577,7 +6011,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6588,7 +6021,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6598,7 +6030,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6609,7 +6040,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6619,7 +6049,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6630,7 +6059,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6640,7 +6068,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6651,7 +6078,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6661,7 +6087,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6672,7 +6097,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6682,7 +6106,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6693,7 +6116,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6703,7 +6125,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6714,7 +6135,6 @@
       "error": null,
       "kind": "website",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6724,7 +6144,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6735,7 +6154,6 @@
       "error": null,
       "kind": "website",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6745,7 +6163,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6756,7 +6173,6 @@
       "error": null,
       "kind": "website",
       "netuid": 18,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6766,7 +6182,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6777,7 +6192,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6787,7 +6201,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6798,7 +6211,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6808,7 +6220,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6836,7 +6247,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6846,7 +6256,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6857,7 +6266,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6867,7 +6275,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6878,7 +6285,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6888,7 +6294,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6899,7 +6304,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6909,7 +6313,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6920,7 +6323,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6930,7 +6332,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6941,7 +6342,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6951,7 +6351,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -6962,7 +6361,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6972,7 +6370,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -6983,7 +6380,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -6993,7 +6389,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7004,7 +6399,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7014,7 +6408,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7025,7 +6418,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7035,7 +6427,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7046,7 +6437,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7056,7 +6446,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7067,7 +6456,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7077,7 +6465,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7088,7 +6475,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7098,7 +6484,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7109,7 +6494,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7119,7 +6503,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7130,7 +6513,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7140,7 +6522,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7151,7 +6532,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7161,7 +6541,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7172,7 +6551,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7182,7 +6560,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7193,7 +6570,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7203,7 +6579,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7214,7 +6589,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7224,7 +6598,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7235,7 +6608,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7245,7 +6617,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7256,7 +6627,6 @@
       "error": null,
       "kind": "website",
       "netuid": 19,
-      "private_redirect_blocked": false,
       "provider": "blockmachine",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7266,7 +6636,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7277,7 +6646,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7287,7 +6655,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7297,17 +6664,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "native-chain",
-        "transient_failure": false
+        "source_tier": "native-chain"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7318,7 +6679,6 @@
       "error": null,
       "kind": "website",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7339,7 +6699,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7349,7 +6708,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7360,7 +6718,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7370,7 +6727,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7381,7 +6737,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7391,7 +6746,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7402,7 +6756,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7412,7 +6765,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7423,7 +6775,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7433,7 +6784,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7444,7 +6794,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7465,7 +6814,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7486,7 +6834,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7507,7 +6854,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7528,7 +6874,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7549,7 +6894,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7570,7 +6914,6 @@
       "error": null,
       "kind": "website",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7591,7 +6934,6 @@
       "error": null,
       "kind": "website",
       "netuid": 20,
-      "private_redirect_blocked": false,
       "provider": "groundlayer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7612,7 +6954,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7622,7 +6963,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7650,7 +6990,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7660,7 +6999,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7671,7 +7009,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7681,7 +7018,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7692,7 +7028,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7702,7 +7037,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7713,7 +7047,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7723,7 +7056,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7734,7 +7066,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7744,7 +7075,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7755,7 +7085,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7765,7 +7094,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -7776,7 +7104,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7786,7 +7113,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7797,7 +7123,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7807,7 +7132,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7818,7 +7142,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7828,7 +7151,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7839,7 +7161,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7849,7 +7170,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7860,7 +7180,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7870,7 +7189,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7881,7 +7199,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7891,7 +7208,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -7902,7 +7218,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7923,7 +7238,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7944,7 +7258,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7965,7 +7278,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -7986,7 +7298,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8007,7 +7318,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8028,7 +7338,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8049,7 +7358,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8059,7 +7367,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8070,7 +7377,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8080,7 +7386,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8091,7 +7396,6 @@
       "error": null,
       "kind": "website",
       "netuid": 21,
-      "private_redirect_blocked": false,
       "provider": "adtao",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8112,7 +7416,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8122,12 +7425,11 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-22-native-chain-github",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -8140,6 +7442,7 @@
         "public_safe": true,
         "source_tier": "native-chain"
       },
+      "redirect_target": "https://github.com/Desearch-ai/subnet-22",
       "status": "ok"
     },
     {
@@ -8150,7 +7453,6 @@
       "error": null,
       "kind": "website",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "desearch",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8171,7 +7473,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8181,7 +7482,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8192,7 +7492,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8202,7 +7501,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8213,7 +7511,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8223,7 +7520,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8234,7 +7530,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8244,7 +7539,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8255,7 +7549,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8265,21 +7558,19 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-22-website-common-api",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "desearch",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -8297,7 +7588,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "desearch",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8312,16 +7602,15 @@
     },
     {
       "candidate_id": "sn-22-website-common-health",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "desearch",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -8339,7 +7628,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "desearch",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8360,7 +7648,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "desearch",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -8381,7 +7668,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 22,
-      "private_redirect_blocked": false,
       "provider": "desearch",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -8402,7 +7688,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8412,7 +7697,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8423,7 +7707,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8433,7 +7716,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8444,7 +7726,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8454,7 +7735,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8482,7 +7762,6 @@
       "error": null,
       "kind": "website",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8492,7 +7771,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8503,7 +7781,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8513,7 +7790,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8524,7 +7800,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8534,7 +7809,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8545,7 +7819,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8555,7 +7828,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8566,7 +7838,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8576,7 +7847,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8587,7 +7857,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8597,7 +7866,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8625,7 +7893,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8635,7 +7902,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8646,7 +7912,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8656,7 +7921,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8667,7 +7931,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8677,7 +7940,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8688,7 +7950,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8698,7 +7959,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8709,7 +7969,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8719,7 +7978,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8730,7 +7988,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8740,7 +7997,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8751,7 +8007,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8761,7 +8016,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8772,7 +8026,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 23,
-      "private_redirect_blocked": false,
       "provider": "trishool",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8782,7 +8035,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8793,7 +8045,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8803,7 +8054,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8814,7 +8064,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8824,7 +8073,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8852,7 +8100,6 @@
       "error": null,
       "kind": "website",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8862,7 +8109,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8873,7 +8119,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8883,7 +8128,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8894,7 +8138,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8904,7 +8147,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8915,7 +8157,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8925,7 +8166,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8936,7 +8176,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8946,7 +8185,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8957,7 +8195,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8967,7 +8204,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -8978,7 +8214,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -8988,7 +8223,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -8999,7 +8233,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9009,7 +8242,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9020,7 +8252,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9030,7 +8261,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9041,7 +8271,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9051,7 +8280,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9062,7 +8290,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9072,7 +8299,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9083,7 +8309,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9093,7 +8318,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9104,7 +8328,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9114,7 +8337,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9125,7 +8347,6 @@
       "error": null,
       "kind": "website",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9135,7 +8356,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9146,7 +8366,6 @@
       "error": null,
       "kind": "website",
       "netuid": 24,
-      "private_redirect_blocked": false,
       "provider": "silx-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9156,7 +8375,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9167,7 +8385,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9177,7 +8394,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9188,7 +8404,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9209,7 +8424,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9219,7 +8433,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9230,7 +8443,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9240,7 +8452,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9268,7 +8479,6 @@
       "error": null,
       "kind": "website",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9289,7 +8499,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9299,7 +8508,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9310,7 +8518,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9320,7 +8527,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9331,7 +8537,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9341,7 +8546,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9352,7 +8556,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9362,7 +8565,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9373,7 +8575,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9383,7 +8584,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9394,7 +8594,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9415,7 +8614,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9436,7 +8634,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9457,7 +8654,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9478,7 +8674,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9499,7 +8694,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9520,7 +8714,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9530,7 +8723,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9541,7 +8733,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9562,7 +8753,6 @@
       "error": null,
       "kind": "website",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9583,7 +8773,6 @@
       "error": null,
       "kind": "website",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9604,7 +8793,6 @@
       "error": null,
       "kind": "website",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9625,7 +8813,6 @@
       "error": null,
       "kind": "website",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9646,7 +8833,6 @@
       "error": null,
       "kind": "website",
       "netuid": 25,
-      "private_redirect_blocked": false,
       "provider": "macrocosmos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9667,7 +8853,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9677,7 +8862,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9705,7 +8889,6 @@
       "error": null,
       "kind": "website",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9715,7 +8898,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9726,7 +8908,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9736,7 +8917,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9747,7 +8927,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9757,7 +8936,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9768,7 +8946,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9778,7 +8955,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9789,7 +8965,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9799,7 +8974,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9810,7 +8984,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9820,7 +8993,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9830,17 +9002,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9851,7 +9017,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9861,7 +9026,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9872,7 +9036,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9882,7 +9045,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9893,7 +9055,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9903,7 +9064,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9914,7 +9074,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9924,7 +9083,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9935,7 +9093,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9945,7 +9102,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9956,7 +9112,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9966,7 +9121,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -9977,7 +9131,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -9987,7 +9140,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -9998,7 +9150,6 @@
       "error": null,
       "kind": "website",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10008,7 +9159,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10019,7 +9169,6 @@
       "error": null,
       "kind": "website",
       "netuid": 26,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10029,7 +9178,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10040,7 +9188,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10050,7 +9197,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10060,17 +9206,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "nodexo",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "native-chain",
-        "transient_failure": false
+        "source_tier": "native-chain"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -10081,7 +9221,6 @@
       "error": "probe-failed",
       "kind": "website",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "nodexo",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10101,7 +9240,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10111,7 +9249,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10122,7 +9259,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10132,7 +9268,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10143,7 +9278,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10153,7 +9287,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10164,7 +9297,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10174,7 +9306,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10185,7 +9316,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10195,7 +9325,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10206,7 +9335,6 @@
       "error": "probe-failed",
       "kind": "subnet-api",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "nodexo",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10226,7 +9354,6 @@
       "error": "probe-failed",
       "kind": "docs",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "nodexo",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10246,7 +9373,6 @@
       "error": "probe-failed",
       "kind": "subnet-api",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "nodexo",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10266,7 +9392,6 @@
       "error": "probe-failed",
       "kind": "openapi",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "nodexo",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10286,7 +9411,6 @@
       "error": "probe-failed",
       "kind": "openapi",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "nodexo",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10306,7 +9430,6 @@
       "error": "probe-failed",
       "kind": "openapi",
       "netuid": 27,
-      "private_redirect_blocked": false,
       "provider": "nodexo",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10326,7 +9449,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 28,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10336,7 +9458,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10347,7 +9468,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 28,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10357,7 +9477,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10368,7 +9487,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 28,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10378,7 +9496,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10389,7 +9506,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 28,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10399,7 +9515,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10410,7 +9525,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 28,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10420,7 +9534,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10431,7 +9544,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 28,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10441,7 +9553,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10452,7 +9563,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 29,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10462,7 +9572,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10490,7 +9599,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 29,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10500,7 +9608,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10511,7 +9618,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 29,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10521,7 +9627,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10532,7 +9637,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 29,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10542,7 +9646,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10553,7 +9656,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 29,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10563,7 +9665,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10574,7 +9675,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 29,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10584,7 +9684,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10612,7 +9711,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10622,7 +9720,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10633,7 +9730,6 @@
       "error": null,
       "kind": "website",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10643,7 +9739,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10654,7 +9749,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10664,7 +9758,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10675,7 +9768,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10685,7 +9777,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10696,7 +9787,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10706,7 +9796,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10717,7 +9806,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10727,7 +9815,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10738,7 +9825,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10748,7 +9834,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10759,7 +9844,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10769,7 +9853,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -10780,7 +9863,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10790,7 +9872,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -10801,7 +9882,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10811,7 +9891,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -10822,7 +9901,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10832,7 +9910,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -10843,7 +9920,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10853,7 +9929,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -10864,7 +9939,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10874,7 +9948,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -10885,7 +9958,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10895,7 +9967,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10906,7 +9977,6 @@
       "error": null,
       "kind": "website",
       "netuid": 30,
-      "private_redirect_blocked": false,
       "provider": "endure",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10916,7 +9986,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -10927,7 +9996,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 31,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10937,7 +10005,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10948,7 +10015,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 31,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10958,7 +10024,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10969,7 +10034,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 31,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -10979,7 +10043,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -10990,7 +10053,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 31,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11000,7 +10062,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11011,7 +10072,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 31,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11021,7 +10081,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11032,7 +10091,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 31,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11042,7 +10100,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11053,7 +10110,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11063,7 +10119,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11091,7 +10146,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11101,7 +10155,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11112,7 +10165,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11122,7 +10174,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11133,7 +10184,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11143,7 +10193,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11154,7 +10203,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11164,7 +10212,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11175,7 +10222,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11185,7 +10231,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11196,7 +10241,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11206,7 +10250,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11217,7 +10260,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11238,7 +10280,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11259,7 +10300,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11280,7 +10320,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -11290,7 +10329,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11301,7 +10339,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11322,7 +10359,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -11332,28 +10368,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-32-website-link-its-ai-org-subnet-api-5",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11364,7 +10397,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11374,7 +10406,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11385,7 +10416,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11395,7 +10425,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11406,7 +10435,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11416,7 +10444,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11427,7 +10454,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11437,7 +10463,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11448,7 +10473,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11458,7 +10482,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11469,7 +10492,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11479,7 +10501,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11490,7 +10511,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11500,7 +10520,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11511,7 +10530,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11521,7 +10539,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11532,7 +10549,6 @@
       "error": null,
       "kind": "website",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11542,7 +10558,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11553,7 +10568,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 32,
-      "private_redirect_blocked": false,
       "provider": "its-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11563,7 +10577,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11574,7 +10587,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 33,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11584,7 +10596,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11595,7 +10606,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 33,
-      "private_redirect_blocked": false,
       "provider": "readyai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11605,7 +10615,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11616,7 +10625,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 33,
-      "private_redirect_blocked": false,
       "provider": "readyai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11626,7 +10634,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -11654,7 +10661,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 33,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11664,7 +10670,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11675,7 +10680,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 33,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11685,7 +10689,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11696,7 +10699,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 33,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11706,7 +10708,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11717,7 +10718,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 33,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11727,7 +10727,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11738,7 +10737,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 33,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11748,7 +10746,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11759,7 +10756,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 34,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11769,7 +10765,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11797,7 +10792,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 34,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11807,7 +10801,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11818,7 +10811,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 34,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11828,7 +10820,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11839,7 +10830,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 34,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11849,7 +10839,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11860,7 +10849,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 34,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11870,7 +10858,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11881,7 +10868,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 34,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11891,7 +10877,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11902,7 +10887,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11912,7 +10896,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11940,7 +10923,6 @@
       "error": null,
       "kind": "website",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11950,7 +10932,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11961,7 +10942,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11971,7 +10951,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -11982,7 +10961,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -11992,7 +10970,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12003,7 +10980,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12013,7 +10989,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12024,7 +10999,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12034,7 +11008,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12045,7 +11018,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12055,7 +11027,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12083,7 +11054,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12093,7 +11063,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12104,7 +11073,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12114,7 +11082,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12125,7 +11092,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12135,7 +11101,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12146,7 +11111,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12156,7 +11120,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12167,7 +11130,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12177,7 +11139,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12188,7 +11149,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12198,7 +11158,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12209,7 +11168,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 35,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12219,7 +11177,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12230,7 +11187,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12240,7 +11196,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12268,7 +11223,6 @@
       "error": null,
       "kind": "website",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12278,7 +11232,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12289,7 +11242,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12299,7 +11251,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12310,7 +11261,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12320,7 +11270,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12331,7 +11280,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12341,7 +11289,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12352,7 +11299,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12362,7 +11308,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12373,7 +11318,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12383,7 +11327,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12394,7 +11337,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12404,7 +11346,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12415,7 +11356,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12436,7 +11376,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12446,7 +11385,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12457,7 +11395,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12467,7 +11404,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12478,7 +11414,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12488,7 +11423,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12499,7 +11433,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12509,7 +11442,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12520,7 +11452,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12530,7 +11461,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12541,7 +11471,6 @@
       "error": null,
       "kind": "website",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12562,7 +11491,6 @@
       "error": null,
       "kind": "website",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12572,7 +11500,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12583,7 +11510,6 @@
       "error": null,
       "kind": "website",
       "netuid": 36,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12593,7 +11519,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12604,7 +11529,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12614,7 +11538,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12642,7 +11565,6 @@
       "error": null,
       "kind": "website",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12652,7 +11574,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12663,7 +11584,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12673,7 +11593,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12684,7 +11603,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12694,7 +11612,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12705,7 +11622,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12715,7 +11631,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12726,7 +11641,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12736,7 +11650,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12747,7 +11660,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12757,7 +11669,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12768,17 +11679,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -12789,7 +11694,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12799,7 +11703,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12810,7 +11713,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12831,7 +11733,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12841,7 +11742,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12852,7 +11752,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12862,7 +11761,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12873,7 +11771,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12883,7 +11780,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12894,7 +11790,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12904,7 +11799,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -12915,7 +11809,6 @@
       "error": null,
       "kind": "website",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12936,7 +11829,6 @@
       "error": null,
       "kind": "website",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12957,7 +11849,6 @@
       "error": null,
       "kind": "website",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12978,7 +11869,6 @@
       "error": null,
       "kind": "website",
       "netuid": 37,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -12999,7 +11889,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13009,25 +11898,21 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-38-native-chain-github",
-      "classification": "unsupported",
-      "confidence_score": 20,
+      "classification": "live",
+      "confidence_score": 45,
       "error": null,
       "kind": "source-repo",
       "netuid": 38,
       "provider": "tao-colosseum",
       "quality_signals": {
-        "archived": true,
-        "has_default_branch": true,
-        "has_recent_push_metadata": true,
         "public_safe": true,
         "source_tier": "native-chain"
       },
-      "status": "failed"
+      "status": "ok"
     },
     {
       "candidate_id": "sn-38-native-chain-website",
@@ -13037,7 +11922,6 @@
       "error": null,
       "kind": "website",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tao-colosseum",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13047,7 +11931,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13058,7 +11941,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13068,7 +11950,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13079,7 +11960,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13089,7 +11969,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13100,7 +11979,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13110,7 +11988,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13121,7 +11998,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13131,7 +12007,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13142,7 +12017,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13152,28 +12026,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-38-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tao-colosseum",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13184,7 +12055,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tao-colosseum",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13194,28 +12064,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-38-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tao-colosseum",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13226,7 +12093,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tao-colosseum",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -13236,7 +12102,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13247,7 +12112,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tao-colosseum",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -13257,7 +12121,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13268,7 +12131,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tao-colosseum",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -13278,7 +12140,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13289,7 +12150,6 @@
       "error": "probe-failed",
       "kind": "docs",
       "netuid": 38,
-      "private_redirect_blocked": false,
       "provider": "tao-colosseum",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13309,7 +12169,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 39,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13319,7 +12178,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13330,7 +12188,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 39,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13340,7 +12197,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13351,7 +12207,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 39,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13361,7 +12216,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13372,7 +12226,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 39,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13382,7 +12235,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13393,7 +12245,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 39,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13403,7 +12254,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13414,7 +12264,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 39,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13424,12 +12273,11 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-39-tensorplex-source-repo-1",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -13442,6 +12290,7 @@
         "public_safe": true,
         "source_tier": "community-docs"
       },
+      "redirect_target": "https://github.com/one-covenant/basilica",
       "status": "ok"
     },
     {
@@ -13452,7 +12301,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 40,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13462,7 +12310,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13472,17 +12319,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 40,
-      "private_redirect_blocked": false,
       "provider": "vectorchat",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "native-chain",
-        "transient_failure": false
+        "source_tier": "native-chain"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -13493,7 +12334,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 40,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13503,7 +12343,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13514,7 +12353,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 40,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13524,7 +12362,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13535,7 +12372,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 40,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13545,7 +12381,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13556,7 +12391,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 40,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13566,7 +12400,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13577,7 +12410,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 40,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13587,7 +12419,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13598,7 +12429,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13608,7 +12438,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13636,7 +12465,6 @@
       "error": null,
       "kind": "website",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13646,7 +12474,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13657,7 +12484,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13667,7 +12493,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13678,7 +12503,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13688,7 +12512,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13699,7 +12522,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13709,7 +12531,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13720,7 +12541,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13730,7 +12550,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13741,7 +12560,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13751,28 +12569,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-41-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13783,7 +12598,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13793,28 +12607,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-41-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13825,7 +12636,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -13835,7 +12645,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13846,7 +12655,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -13856,7 +12664,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13867,7 +12674,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -13877,7 +12683,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13888,7 +12693,6 @@
       "error": null,
       "kind": "website",
       "netuid": 41,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13898,7 +12702,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13909,7 +12712,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 42,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13919,7 +12721,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13930,7 +12731,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 42,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13940,7 +12740,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13951,7 +12750,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 42,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13961,7 +12759,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13972,7 +12769,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 42,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -13982,7 +12778,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -13993,7 +12788,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 42,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14003,7 +12797,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14014,7 +12807,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 42,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14024,7 +12816,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14035,7 +12826,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 43,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14045,7 +12835,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14073,7 +12862,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 43,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14083,7 +12871,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14094,7 +12881,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 43,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14104,7 +12890,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14115,7 +12900,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 43,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14125,7 +12909,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14136,7 +12919,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 43,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14146,7 +12928,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14157,7 +12938,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 43,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14167,7 +12947,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14178,7 +12957,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14188,7 +12966,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14216,7 +12993,6 @@
       "error": null,
       "kind": "website",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14226,7 +13002,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14237,7 +13012,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14247,7 +13021,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14258,7 +13031,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14268,7 +13040,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14279,7 +13050,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14289,7 +13059,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14300,7 +13069,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14310,7 +13078,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14321,7 +13088,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14331,7 +13097,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14359,7 +13124,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14369,7 +13133,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14380,7 +13143,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14390,7 +13152,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14401,7 +13162,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14411,7 +13171,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14422,7 +13181,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14432,7 +13190,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14443,7 +13200,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14453,7 +13209,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14464,7 +13219,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14474,7 +13228,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14485,7 +13238,6 @@
       "error": null,
       "kind": "website",
       "netuid": 44,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14495,7 +13247,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14506,7 +13257,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14516,7 +13266,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14544,7 +13293,6 @@
       "error": null,
       "kind": "website",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14554,7 +13302,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14565,7 +13312,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14575,7 +13321,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14586,7 +13331,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14596,7 +13340,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14607,7 +13350,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14617,7 +13359,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14628,7 +13369,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14638,7 +13378,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14649,7 +13388,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14659,7 +13397,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14670,7 +13407,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14680,7 +13416,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14691,7 +13426,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14701,7 +13435,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14712,7 +13445,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14722,7 +13454,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14733,7 +13464,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14743,7 +13473,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14754,7 +13483,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14764,7 +13492,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14775,7 +13502,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14785,7 +13511,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -14796,7 +13521,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14806,7 +13530,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14817,7 +13540,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14827,7 +13549,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14838,7 +13559,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14848,7 +13568,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14859,7 +13578,6 @@
       "error": null,
       "kind": "website",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14869,7 +13587,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14880,7 +13597,6 @@
       "error": null,
       "kind": "website",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14890,7 +13606,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14901,7 +13616,6 @@
       "error": null,
       "kind": "website",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14911,7 +13625,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14922,7 +13635,6 @@
       "error": null,
       "kind": "website",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14932,7 +13644,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14943,7 +13654,6 @@
       "error": null,
       "kind": "website",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14964,7 +13674,6 @@
       "error": null,
       "kind": "website",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14974,7 +13683,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -14985,7 +13693,6 @@
       "error": null,
       "kind": "website",
       "netuid": 45,
-      "private_redirect_blocked": false,
       "provider": "talisman-ai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -14995,7 +13702,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15006,7 +13712,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15016,7 +13721,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15045,7 +13749,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15055,7 +13758,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15083,7 +13785,6 @@
       "error": null,
       "kind": "website",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15104,7 +13805,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15114,7 +13814,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15125,7 +13824,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15135,7 +13833,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15146,7 +13843,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15156,7 +13852,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15167,7 +13862,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15177,7 +13871,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15188,7 +13881,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15198,7 +13890,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15242,17 +13933,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15263,7 +13948,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15273,7 +13957,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": true
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15284,7 +13967,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15294,7 +13976,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15305,7 +13986,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15315,7 +13995,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": true
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15326,7 +14005,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15336,7 +14014,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15347,7 +14024,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15357,7 +14033,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": true
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15368,7 +14043,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15378,7 +14052,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": true
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15389,7 +14062,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15399,28 +14071,26 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-46-website-link-zipcode-ai-subnet-api-3",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": "https://accounts.google.com/v3/signin/identifier?opparams=%253F&dsh=S521830222%3A1780959584915556&client_id=327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com&code_challenge=6PD3tU6u-PPzGLkNkFmDCxb_3NFR7JdEIAttiBKcHBo&code_challenge_method=S256&nonce=x_Bdis5T4sv11fyuFh9akfEqaM6ms20CWs6NttcRBMg&o2v=2&prompt=select_account&redirect_uri=https%3A%2F%2Fzipcode.ai%2Fapi%2Fportal-auth%2Fgoogle%2Fcallback&response_type=code&scope=openid+email+profile&service=lso&state=TmuRZiTA18hzF2WU-a1dNU8r6DBtIOKosc6upTVLVG8&flowName=GeneralOAuthLite&continue=https%3A%2F%2Faccounts.google.com%2Fsignin%2Foauth%2Flegacy%2Fconsent%3Fauthuser%3Dunknown%26part%3DAJi8hAMyhhR2hdT8IVXq4EcgrCH6qvUXSZiGfIGd1kmVc8OcDq8A_UIXPIg_h5RXpv2snJVi-1DDDOBJz8ycAtZvhH6XBlbRv1GfRxkJcwWbcptdCWfX6zxaCAOjcynjVvdfRqWE02wL6C_iKmMk-Ln2tDkOAHM1Lhy7HHe8ZaX42FZt48qX2aFvMkyZoC8cx-GVOGUkOlzLTiqVbz7wo2fnpeQa6xEBjtRP01OqiMlNbvPlowKCbX2Vv9_Ze1Ncj47_u8qpNQLNVAnLw8BH2-Z2OZJtr80e3-TPH30ZSY3imFCigL0uW3JBVq_gKf74vZxq3fjw--c0sXP3HfpgJiGxeiypGl3_2GSq0bSZoERZKOmO81jd5BY4IV_mXqGQKYDWZGFdd2BTv_IGTtYb-zDyNijwcBxf_H4RObZxec3yztwzuhfrcX-_hFkepux21gyFyV8yXKO3QMnd92bRjSJKuMXBpmCr2w%26flowName%3DGeneralOAuthFlow%26as%3DS521830222%253A1780959584915556%26client_id%3D327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com%23&app_domain=https%3A%2F%2Fzipcode.ai&rart=ANgoxcdTQ2wM3EfH94p6dI_5UfSO5LI58gn-7jjI02cCF4aDCjEnyNe_dZKWnIhsrX73xbapBruCdI2P24RyeXJ5pIIcS_N_yRRcJZF60cNu_g-ESFhjgIQ",
+      "redirect_target": "https://accounts.google.com/v3/signin/identifier?opparams=%253F&dsh=S521455352%3A1780983306825226&client_id=327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com&code_challenge=rE6aTdrgbC5yPAg4h9Zd_FAPxaKUnNBg3bagfswUHfk&code_challenge_method=S256&nonce=VEFqVIOygx8We8cszoEpsnUAOIM3PNFi09kg8lBKXt4&o2v=2&prompt=select_account&redirect_uri=https%3A%2F%2Fzipcode.ai%2Fapi%2Fportal-auth%2Fgoogle%2Fcallback&response_type=code&scope=openid+email+profile&service=lso&state=7eKc4FyGRdGZz-gl50ilFCO395rousomGr5OmS-S44w&flowName=GeneralOAuthLite&continue=https%3A%2F%2Faccounts.google.com%2Fsignin%2Foauth%2Flegacy%2Fconsent%3Fauthuser%3Dunknown%26part%3DAJi8hANbGyJkGr3r2K7TXXPKmSBqV0cxOVZtSri7BAkmnMQvoIdrzbUlrEh8gK4UyrMzaqaaRGeMuSllcfKoc2kdcxiSAGcYrSiNOjb6GdXwhRZN6o9cJTpJwQa_yPawcLevktAoe6_-jQXsAlmkyCseqlFbtXG8NMvKVsnydUiS0NqS7lRtqNxOSJKFT64t38jGb3CvUymP8z7PdPdxovGueA4RfPULNZOXlZaztiQ3AOK00-HF38aQoeiqR9CTbWuvlZcwxHdDD-c0ygwP7E1hJFxUuG1NHAk5M9xaLQTHrUHnXSWWACTwNqYip_1XHWELeHWM8UrmL1q25MfjZ89b_VNjEngJhXMbWMj4tFZUxY1Qs1bIfmnzpWdcpvgTsw2lUoEXytQM2-gb0UnwIQbgQ59u6bAHZpQ7E6PsyTlMNOJmB2zcN137R4zKISGVQxZHm2uNmoy411aKibf0nNT2HDH-fOS3cA%26flowName%3DGeneralOAuthFlow%26as%3DS521455352%253A1780983306825226%26client_id%3D327162582586-ukqmepfk1pkfg24f4qc5i2jr7r3230hb.apps.googleusercontent.com%23&app_domain=https%3A%2F%2Fzipcode.ai&rart=ANgoxcfCMkSh7WKT2p5dsk2-NsqyawYx4ejGH1xHhaH2lqX0yYEf6a_Xy3BMpaVCdHC_z9xyWq5qxW5A3U6Dne-WiNXxVV12QoAwh7PtHfQ3lzJyXOw056A",
       "status": "ok"
     },
     {
@@ -15431,7 +14101,6 @@
       "error": null,
       "kind": "website",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15441,7 +14110,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15452,7 +14120,6 @@
       "error": null,
       "kind": "website",
       "netuid": 46,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15462,7 +14129,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15473,7 +14139,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 47,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15483,7 +14148,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15494,7 +14158,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 47,
-      "private_redirect_blocked": false,
       "provider": "evolai",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15504,12 +14167,11 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-47-native-chain-github",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -15522,6 +14184,7 @@
         "public_safe": true,
         "source_tier": "native-chain"
       },
+      "redirect_target": "https://github.com/openevolai/evolai",
       "status": "ok"
     },
     {
@@ -15532,7 +14195,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 47,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15542,7 +14204,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15553,7 +14214,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 47,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15563,7 +14223,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15574,7 +14233,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 47,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15584,7 +14242,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15595,7 +14252,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 47,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15605,7 +14261,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15616,7 +14271,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 47,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15626,7 +14280,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15654,7 +14307,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15664,7 +14316,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15692,7 +14343,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15702,7 +14352,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15713,7 +14362,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15723,7 +14371,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15734,7 +14381,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15744,7 +14390,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15755,7 +14400,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15765,7 +14409,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15776,7 +14419,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15786,7 +14428,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15797,7 +14438,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15807,7 +14447,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15817,17 +14456,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15838,7 +14471,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15848,7 +14480,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15859,7 +14490,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15869,7 +14499,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15880,7 +14509,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15890,7 +14518,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15901,7 +14528,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15911,7 +14537,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15922,7 +14547,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15932,7 +14556,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15943,7 +14566,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15953,7 +14575,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -15964,7 +14585,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15974,7 +14594,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -15985,7 +14604,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -15995,7 +14613,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16006,7 +14623,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16016,7 +14632,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16027,7 +14642,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16037,7 +14651,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16048,7 +14661,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16058,7 +14670,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16069,7 +14680,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16079,7 +14689,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16090,7 +14699,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16100,7 +14708,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16111,7 +14718,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16121,7 +14727,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16132,7 +14737,6 @@
       "error": null,
       "kind": "website",
       "netuid": 48,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16142,7 +14746,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16153,7 +14756,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16163,7 +14765,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16174,7 +14775,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16184,7 +14784,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16195,7 +14794,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16205,7 +14803,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -16233,7 +14830,6 @@
       "error": "probe-failed",
       "kind": "website",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16253,7 +14849,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16263,7 +14858,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16274,7 +14868,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16284,7 +14877,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16295,7 +14887,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16305,7 +14896,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16316,7 +14906,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16326,7 +14915,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16337,7 +14925,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16347,7 +14934,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16358,7 +14944,6 @@
       "error": "probe-failed",
       "kind": "subnet-api",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16378,7 +14963,6 @@
       "error": "probe-failed",
       "kind": "docs",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16398,7 +14982,6 @@
       "error": "probe-failed",
       "kind": "subnet-api",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16418,7 +15001,6 @@
       "error": "probe-failed",
       "kind": "openapi",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16438,7 +15020,6 @@
       "error": "probe-failed",
       "kind": "openapi",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16458,7 +15039,6 @@
       "error": "probe-failed",
       "kind": "openapi",
       "netuid": 49,
-      "private_redirect_blocked": false,
       "provider": "nepher-robotics",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16478,7 +15058,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16488,33 +15067,30 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-50-github-readme-mode-network-synth-subnet-subnet-api-1",
-      "classification": "live",
-      "confidence_score": 58,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-50-native-chain-github",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -16527,6 +15103,7 @@
         "public_safe": true,
         "source_tier": "native-chain"
       },
+      "redirect_target": "https://github.com/synthdataco/synth-subnet",
       "status": "ok"
     },
     {
@@ -16537,7 +15114,6 @@
       "error": null,
       "kind": "website",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16547,7 +15123,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16558,7 +15133,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16568,7 +15142,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16579,7 +15152,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16589,7 +15161,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16600,7 +15171,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16610,7 +15180,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16621,7 +15190,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16631,7 +15199,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16642,7 +15209,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16652,28 +15218,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-50-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16684,7 +15247,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16694,28 +15256,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-50-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16726,7 +15285,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -16736,7 +15294,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16747,7 +15304,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -16757,7 +15313,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16768,7 +15323,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 50,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -16778,7 +15332,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16789,7 +15342,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16799,7 +15351,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16810,7 +15361,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16848,7 +15398,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16858,7 +15407,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16869,7 +15417,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16879,7 +15426,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16890,7 +15436,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16900,7 +15445,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16911,7 +15455,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16921,7 +15464,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16932,7 +15474,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16942,7 +15483,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16953,7 +15493,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16963,7 +15502,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -16974,7 +15512,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -16995,7 +15532,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17005,7 +15541,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17016,7 +15551,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17026,7 +15560,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17037,7 +15570,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17047,7 +15579,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17058,7 +15589,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17068,7 +15598,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17079,7 +15608,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17089,7 +15617,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17100,7 +15627,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17110,28 +15636,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-51-website-link-lium-io-subnet-api-9",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17142,7 +15665,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17152,7 +15674,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17163,7 +15684,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17173,7 +15693,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17184,7 +15703,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17194,7 +15712,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17205,7 +15722,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17215,7 +15731,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17226,7 +15741,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17236,7 +15750,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17247,7 +15760,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17257,7 +15769,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17268,7 +15779,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17278,7 +15788,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17289,7 +15798,6 @@
       "error": null,
       "kind": "website",
       "netuid": 51,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17299,7 +15807,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17310,7 +15817,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 52,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17320,7 +15826,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17331,7 +15836,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 52,
-      "private_redirect_blocked": false,
       "provider": "tensorplex",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17341,7 +15845,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17369,7 +15872,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 52,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17379,7 +15881,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17390,7 +15891,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 52,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17400,7 +15900,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17411,7 +15910,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 52,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17421,7 +15919,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17432,7 +15929,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 52,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17442,7 +15938,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17453,7 +15948,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 52,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17463,7 +15957,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17473,17 +15966,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 52,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17528,7 +16015,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 53,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17538,7 +16024,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17548,17 +16033,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 53,
-      "private_redirect_blocked": false,
       "provider": "signalplus",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "native-chain",
-        "transient_failure": false
+        "source_tier": "native-chain"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17569,7 +16048,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 53,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17579,7 +16057,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17590,7 +16067,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 53,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17600,7 +16076,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17611,7 +16086,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 53,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17621,7 +16095,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17632,7 +16105,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 53,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17642,7 +16114,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17653,7 +16124,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 53,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17663,7 +16133,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17674,7 +16143,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17684,7 +16152,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17695,7 +16162,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17705,7 +16171,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17733,7 +16198,6 @@
       "error": null,
       "kind": "website",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17743,7 +16207,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17754,7 +16217,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17764,7 +16226,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17775,7 +16236,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17785,7 +16245,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17796,7 +16255,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17806,7 +16264,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17817,7 +16274,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17827,7 +16283,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17838,7 +16293,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17848,7 +16302,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -17859,7 +16312,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17869,7 +16321,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17880,7 +16331,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17890,7 +16340,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17901,7 +16350,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17911,7 +16359,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17922,7 +16369,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17932,7 +16378,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17943,7 +16388,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17953,7 +16397,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17964,7 +16407,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17974,7 +16416,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -17985,7 +16426,6 @@
       "error": null,
       "kind": "website",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -17995,7 +16435,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18006,7 +16445,6 @@
       "error": null,
       "kind": "website",
       "netuid": 54,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18016,7 +16454,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18027,7 +16464,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18037,7 +16473,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18065,7 +16500,6 @@
       "error": null,
       "kind": "website",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18075,7 +16509,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18086,7 +16519,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18096,7 +16528,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18107,7 +16538,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18117,7 +16547,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18128,7 +16557,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18138,7 +16566,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18149,7 +16576,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18159,7 +16585,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18170,7 +16595,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18180,7 +16604,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18191,7 +16614,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18201,7 +16623,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -18212,7 +16633,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18222,7 +16642,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -18233,7 +16652,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18243,7 +16661,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -18254,7 +16671,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18264,7 +16680,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -18275,7 +16690,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18285,7 +16699,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -18296,7 +16709,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18306,7 +16718,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -18317,7 +16728,6 @@
       "error": null,
       "kind": "website",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18327,7 +16737,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18338,7 +16747,6 @@
       "error": null,
       "kind": "website",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18348,7 +16756,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18359,7 +16766,6 @@
       "error": null,
       "kind": "website",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18369,7 +16775,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -18380,7 +16785,6 @@
       "error": null,
       "kind": "website",
       "netuid": 55,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18390,7 +16794,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -18401,7 +16804,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18411,7 +16813,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18439,7 +16840,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18449,7 +16849,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18460,7 +16859,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18470,7 +16868,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18481,7 +16878,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18491,7 +16887,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18502,7 +16897,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18512,7 +16906,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18523,7 +16916,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18533,7 +16925,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18544,7 +16935,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18554,12 +16944,11 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-56-tensorplex-source-repo-1",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -18572,20 +16961,20 @@
         "public_safe": true,
         "source_tier": "community-docs"
       },
+      "redirect_target": "https://github.com/gradients-ai/G.O.D",
       "status": "ok"
     },
     {
       "candidate_id": "sn-56-website-common-api",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -18603,7 +16992,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18618,16 +17006,15 @@
     },
     {
       "candidate_id": "sn-56-website-common-health",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -18645,7 +17032,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -18666,7 +17052,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -18687,7 +17072,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -18708,7 +17092,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18718,7 +17101,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18729,7 +17111,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18739,7 +17120,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18750,7 +17130,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18771,7 +17150,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18781,7 +17159,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18792,7 +17169,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18802,7 +17178,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18813,7 +17188,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18834,7 +17208,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18844,7 +17217,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18855,7 +17227,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18865,7 +17236,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18876,7 +17246,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18886,7 +17255,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18897,7 +17265,6 @@
       "error": null,
       "kind": "website",
       "netuid": 56,
-      "private_redirect_blocked": false,
       "provider": "gradients",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18918,7 +17285,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 57,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18928,7 +17294,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18939,7 +17304,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 57,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18949,7 +17313,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18960,7 +17323,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 57,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18970,7 +17332,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -18981,7 +17342,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 57,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -18991,7 +17351,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19002,7 +17361,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 57,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19012,7 +17370,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19023,7 +17380,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 57,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19033,7 +17389,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19061,7 +17416,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 58,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19071,7 +17425,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19082,7 +17435,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 58,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19092,7 +17444,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19103,7 +17454,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 58,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19113,7 +17463,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19124,7 +17473,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 58,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19134,7 +17482,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19145,7 +17492,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 58,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19155,7 +17501,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19166,7 +17511,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 58,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19176,7 +17520,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19187,7 +17530,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 58,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19197,7 +17539,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19208,7 +17549,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 58,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19218,7 +17558,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19246,7 +17585,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19256,7 +17594,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19267,7 +17604,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19277,7 +17613,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19305,7 +17640,6 @@
       "error": null,
       "kind": "website",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19315,7 +17649,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19326,7 +17659,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19336,7 +17668,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19347,7 +17678,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19357,7 +17687,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19368,7 +17697,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19378,7 +17706,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19389,7 +17716,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19399,7 +17725,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19410,7 +17735,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19420,7 +17744,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19431,7 +17754,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19441,7 +17763,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19452,7 +17773,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19462,7 +17782,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19473,7 +17792,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19483,7 +17801,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19494,7 +17811,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19504,7 +17820,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19515,7 +17830,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19525,7 +17839,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19536,7 +17849,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19546,7 +17858,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19557,7 +17868,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19567,7 +17877,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19578,7 +17887,6 @@
       "error": null,
       "kind": "website",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19588,7 +17896,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19599,7 +17906,6 @@
       "error": null,
       "kind": "website",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19609,7 +17915,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19620,7 +17925,6 @@
       "error": null,
       "kind": "website",
       "netuid": 59,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19630,7 +17934,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19641,7 +17944,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19651,7 +17953,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19662,7 +17963,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19672,7 +17972,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19700,7 +17999,6 @@
       "error": null,
       "kind": "website",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19710,7 +18008,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19721,7 +18018,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19731,7 +18027,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19742,7 +18037,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19752,7 +18046,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19763,7 +18056,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19773,7 +18065,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19784,7 +18075,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19794,7 +18084,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19805,7 +18094,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19815,7 +18103,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19843,7 +18130,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19853,7 +18139,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -19864,7 +18149,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19874,28 +18158,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-60-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19906,7 +18187,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -19916,7 +18196,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19927,7 +18206,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -19937,7 +18215,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19948,7 +18225,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 60,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -19958,7 +18234,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19969,7 +18244,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -19979,7 +18253,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -19990,7 +18263,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20000,7 +18272,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20011,7 +18282,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20021,7 +18291,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20049,7 +18318,6 @@
       "error": null,
       "kind": "website",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20059,7 +18327,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20070,7 +18337,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20080,7 +18346,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20091,7 +18356,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20101,7 +18365,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20112,7 +18375,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20122,7 +18384,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20133,7 +18394,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20143,7 +18403,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20154,7 +18413,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20164,7 +18422,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20175,7 +18432,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20185,7 +18441,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20196,7 +18451,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20206,7 +18460,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20217,7 +18470,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20227,7 +18479,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20238,7 +18489,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20248,7 +18498,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20259,7 +18508,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20269,7 +18517,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20280,7 +18527,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 61,
-      "private_redirect_blocked": false,
       "provider": "redteam",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20290,7 +18536,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20301,7 +18546,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20311,7 +18555,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20339,7 +18582,6 @@
       "error": null,
       "kind": "website",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "ridges",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20349,7 +18591,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20360,7 +18601,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20370,7 +18610,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20381,7 +18620,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20391,7 +18629,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20402,7 +18639,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20412,7 +18648,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20423,7 +18658,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20433,7 +18667,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20444,7 +18677,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20454,7 +18686,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20465,7 +18696,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "ridges",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20475,7 +18705,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20486,7 +18715,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "ridges",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20496,7 +18724,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20507,7 +18734,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "ridges",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20517,7 +18743,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20528,7 +18753,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "ridges",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20538,7 +18762,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20549,7 +18772,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "ridges",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20559,7 +18781,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20570,7 +18791,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "ridges",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20580,7 +18800,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20591,7 +18810,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 62,
-      "private_redirect_blocked": false,
       "provider": "ridges",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20601,7 +18819,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20612,7 +18829,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20622,7 +18838,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20650,7 +18865,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20660,7 +18874,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20671,7 +18884,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20681,7 +18893,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20692,7 +18903,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20702,7 +18912,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20713,7 +18922,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20723,7 +18931,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20734,7 +18941,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20744,7 +18950,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20755,7 +18960,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20765,7 +18969,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20775,17 +18978,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20796,7 +18993,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20806,7 +19002,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20817,7 +19012,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20827,7 +19021,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20838,7 +19031,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20848,7 +19040,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20859,7 +19050,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20869,7 +19059,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20880,7 +19069,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20890,7 +19078,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20901,7 +19088,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20911,7 +19097,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -20922,7 +19107,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20932,7 +19116,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20943,7 +19126,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20953,7 +19135,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20964,7 +19145,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20974,7 +19154,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -20985,7 +19164,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -20995,7 +19173,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21006,7 +19183,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21016,7 +19192,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21027,7 +19202,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21037,7 +19211,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21048,7 +19221,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21058,7 +19230,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21069,7 +19240,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21079,7 +19249,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21090,7 +19259,6 @@
       "error": null,
       "kind": "website",
       "netuid": 63,
-      "private_redirect_blocked": false,
       "provider": "qbittensor-labs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21100,7 +19268,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21111,7 +19278,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21121,7 +19287,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21132,7 +19297,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21142,7 +19306,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21153,7 +19316,6 @@
       "error": "probe-failed",
       "kind": "subnet-api",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21173,7 +19335,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21183,7 +19344,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -21211,7 +19371,6 @@
       "error": null,
       "kind": "website",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21221,7 +19380,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21232,7 +19390,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21242,7 +19399,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21253,7 +19409,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21263,7 +19418,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21274,7 +19428,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21284,7 +19437,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21295,7 +19447,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21305,7 +19456,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21316,7 +19466,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21326,12 +19475,11 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-64-tensorplex-source-repo-1",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -21344,11 +19492,12 @@
         "public_safe": true,
         "source_tier": "community-docs"
       },
+      "redirect_target": "https://github.com/chutesai/chutes-miner",
       "status": "ok"
     },
     {
       "candidate_id": "sn-64-tensorplex-source-repo-2",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -21361,6 +19510,7 @@
         "public_safe": true,
         "source_tier": "community-docs"
       },
+      "redirect_target": "https://github.com/chutesai/chutes",
       "status": "ok"
     },
     {
@@ -21371,7 +19521,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21381,7 +19530,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -21392,7 +19540,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21402,7 +19549,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21413,7 +19559,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21423,7 +19568,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -21434,7 +19578,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21444,7 +19587,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -21455,7 +19597,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21465,7 +19606,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -21476,7 +19616,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21486,7 +19625,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -21497,7 +19635,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21507,7 +19644,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21518,7 +19654,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21528,28 +19663,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-64-website-link-chutes-ai-subnet-api-9",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21560,7 +19692,6 @@
       "error": null,
       "kind": "website",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21570,7 +19701,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21581,7 +19711,6 @@
       "error": null,
       "kind": "website",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21591,7 +19720,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21602,7 +19730,6 @@
       "error": null,
       "kind": "website",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21612,7 +19739,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21623,7 +19749,6 @@
       "error": null,
       "kind": "website",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21633,7 +19758,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21644,7 +19768,6 @@
       "error": null,
       "kind": "website",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21654,7 +19777,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21665,7 +19787,6 @@
       "error": null,
       "kind": "website",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21686,7 +19807,6 @@
       "error": null,
       "kind": "website",
       "netuid": 64,
-      "private_redirect_blocked": false,
       "provider": "chutes",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21696,7 +19816,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21707,7 +19826,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21717,7 +19835,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21745,7 +19862,6 @@
       "error": null,
       "kind": "website",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21755,7 +19871,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21766,7 +19881,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21776,7 +19890,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21787,7 +19900,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21797,7 +19909,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21808,7 +19919,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21818,7 +19928,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21829,7 +19938,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21839,7 +19947,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21850,7 +19957,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21860,28 +19966,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-65-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21892,7 +19995,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -21902,28 +20004,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-65-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21934,7 +20033,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -21944,7 +20042,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21955,7 +20052,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -21965,7 +20061,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21976,7 +20071,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -21986,7 +20080,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -21997,7 +20090,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22018,7 +20110,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22039,7 +20130,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22060,7 +20150,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22081,7 +20170,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22102,7 +20190,6 @@
       "error": null,
       "kind": "website",
       "netuid": 65,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22123,7 +20210,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22133,7 +20219,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22161,7 +20246,6 @@
       "error": null,
       "kind": "website",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22171,7 +20255,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22182,7 +20265,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22192,7 +20274,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22203,7 +20284,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22213,7 +20293,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22224,7 +20303,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22234,7 +20312,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22245,7 +20322,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22255,7 +20331,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22266,7 +20341,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22276,28 +20350,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-66-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22308,7 +20379,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22318,7 +20388,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22329,7 +20398,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22339,7 +20407,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22350,7 +20417,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -22360,7 +20426,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22371,7 +20436,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -22381,7 +20445,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22392,7 +20455,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -22402,7 +20464,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22413,7 +20474,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22423,7 +20483,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22434,7 +20493,6 @@
       "error": null,
       "kind": "website",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22444,7 +20502,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22455,7 +20512,6 @@
       "error": null,
       "kind": "website",
       "netuid": 66,
-      "private_redirect_blocked": false,
       "provider": "unarbos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22465,7 +20521,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22476,7 +20531,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22486,7 +20540,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22497,7 +20550,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22507,7 +20559,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22535,7 +20586,6 @@
       "error": null,
       "kind": "website",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22545,7 +20595,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22556,7 +20605,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22566,7 +20614,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22577,7 +20624,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22587,7 +20633,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22598,7 +20643,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22608,7 +20652,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22619,7 +20662,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22629,7 +20671,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22640,7 +20681,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22650,7 +20690,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22661,7 +20700,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22671,7 +20709,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -22682,7 +20719,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22692,7 +20728,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -22703,7 +20738,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22713,7 +20747,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -22724,7 +20757,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22734,7 +20766,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -22745,7 +20776,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22755,7 +20785,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -22766,7 +20795,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22776,7 +20804,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -22787,7 +20814,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22797,7 +20823,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22808,7 +20833,6 @@
       "error": null,
       "kind": "website",
       "netuid": 67,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22818,7 +20842,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22829,7 +20852,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22839,7 +20861,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22867,7 +20888,6 @@
       "error": null,
       "kind": "website",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22877,7 +20897,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22888,7 +20907,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22898,7 +20916,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22909,7 +20926,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22919,7 +20935,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22930,7 +20945,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22940,7 +20954,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22951,7 +20964,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22961,7 +20973,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22972,7 +20983,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -22982,7 +20992,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -22993,7 +21002,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23003,7 +21011,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -23014,7 +21021,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23024,7 +21030,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -23035,7 +21040,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23045,7 +21049,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -23056,7 +21059,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23066,7 +21068,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -23077,7 +21078,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23087,7 +21087,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -23098,7 +21097,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23108,7 +21106,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -23119,7 +21116,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23129,7 +21125,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23140,7 +21135,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23150,7 +21144,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23161,7 +21154,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23171,7 +21163,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23182,7 +21173,6 @@
       "error": null,
       "kind": "website",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23192,7 +21182,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23203,7 +21192,6 @@
       "error": null,
       "kind": "website",
       "netuid": 68,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23213,7 +21201,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23224,7 +21211,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 69,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23234,7 +21220,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23245,7 +21230,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 69,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23255,7 +21239,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23266,7 +21249,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 69,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23276,7 +21258,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23287,7 +21268,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 69,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23297,7 +21277,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23308,7 +21287,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 69,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23318,7 +21296,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23329,7 +21306,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 69,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23339,7 +21315,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23350,7 +21325,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23360,7 +21334,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23388,7 +21361,6 @@
       "error": null,
       "kind": "website",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23409,7 +21381,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23419,7 +21390,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23430,7 +21400,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23440,7 +21409,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23451,7 +21419,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23461,7 +21428,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23472,7 +21438,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23482,7 +21447,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23493,7 +21457,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23503,7 +21466,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23514,7 +21476,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23535,7 +21496,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23556,7 +21516,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23577,7 +21536,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23598,7 +21556,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23619,7 +21576,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23640,7 +21596,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23661,7 +21616,6 @@
       "error": null,
       "kind": "website",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23682,7 +21636,6 @@
       "error": null,
       "kind": "website",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23703,7 +21656,6 @@
       "error": null,
       "kind": "website",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23724,7 +21676,6 @@
       "error": null,
       "kind": "website",
       "netuid": 70,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23745,7 +21696,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23755,7 +21705,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23783,7 +21732,6 @@
       "error": null,
       "kind": "website",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23793,7 +21741,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23804,7 +21751,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23814,7 +21760,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23825,7 +21770,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23835,7 +21779,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23846,7 +21789,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23856,7 +21798,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23867,7 +21808,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23877,7 +21817,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23888,7 +21827,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23898,28 +21836,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-71-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=UTF-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23930,7 +21865,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -23940,28 +21874,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-71-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=UTF-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23972,7 +21903,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -23982,7 +21912,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -23993,7 +21922,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -24003,7 +21931,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24014,7 +21941,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 71,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -24024,7 +21950,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24035,7 +21960,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24045,7 +21969,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24056,7 +21979,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24066,7 +21988,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24094,7 +22015,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24104,7 +22024,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24115,7 +22034,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24125,7 +22043,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24136,7 +22053,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24146,7 +22062,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24157,7 +22072,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24167,7 +22081,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24178,7 +22091,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24188,7 +22100,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24199,7 +22110,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24209,7 +22119,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24220,7 +22129,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24230,7 +22138,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24241,7 +22148,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24251,7 +22157,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24262,7 +22167,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24272,7 +22176,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24283,7 +22186,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24293,7 +22195,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24304,7 +22205,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24314,7 +22214,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24325,7 +22224,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24335,7 +22233,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24346,7 +22243,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24356,7 +22252,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24367,7 +22262,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24377,7 +22271,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24388,7 +22281,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24398,7 +22290,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24409,7 +22300,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24419,7 +22309,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24430,7 +22319,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24440,7 +22328,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24451,7 +22338,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24472,7 +22358,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24482,7 +22367,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24493,7 +22377,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24503,7 +22386,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24514,7 +22396,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24524,7 +22405,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24535,7 +22415,6 @@
       "error": null,
       "kind": "website",
       "netuid": 72,
-      "private_redirect_blocked": false,
       "provider": "natix",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24545,7 +22424,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24556,7 +22434,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 73,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24566,7 +22443,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24577,7 +22453,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 73,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24587,7 +22462,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24598,7 +22472,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 73,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24608,7 +22481,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24619,7 +22491,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 73,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24629,7 +22500,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24640,7 +22510,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 73,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24650,7 +22519,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24661,7 +22529,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 73,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24671,7 +22538,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24681,17 +22547,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 73,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -24702,7 +22562,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24712,7 +22571,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24723,7 +22581,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24733,7 +22590,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24744,7 +22600,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24754,7 +22609,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24782,7 +22636,6 @@
       "error": null,
       "kind": "website",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24792,7 +22645,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24803,7 +22655,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24813,7 +22664,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24824,7 +22674,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24834,7 +22683,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24845,7 +22693,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24855,7 +22702,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24866,7 +22712,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24876,7 +22721,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24887,7 +22731,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24897,7 +22740,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24919,23 +22761,21 @@
     },
     {
       "candidate_id": "sn-74-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24946,7 +22786,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -24956,28 +22795,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-74-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -24988,7 +22824,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -24998,7 +22833,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25009,7 +22843,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -25019,7 +22852,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25030,7 +22862,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 74,
-      "private_redirect_blocked": false,
       "provider": "gittensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -25040,7 +22871,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25051,7 +22881,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25061,7 +22890,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25089,7 +22917,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25099,7 +22926,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25110,7 +22936,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25120,7 +22945,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25131,7 +22955,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25141,7 +22964,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25152,7 +22974,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25162,7 +22983,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25173,7 +22993,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25183,7 +23002,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25194,7 +23012,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25204,7 +23021,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25249,7 +23065,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25259,7 +23074,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25270,7 +23084,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25280,7 +23093,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25291,7 +23103,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25301,7 +23112,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25312,7 +23122,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25322,7 +23131,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25333,7 +23141,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25343,7 +23150,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25354,7 +23160,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25364,7 +23169,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25375,7 +23179,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25385,28 +23188,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-75-website-link-hippius-com-subnet-api-10",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25417,7 +23217,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25427,7 +23226,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25438,7 +23236,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25448,7 +23245,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25459,7 +23255,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25469,7 +23264,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25480,7 +23274,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25490,7 +23283,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25501,7 +23293,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25511,7 +23302,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25522,7 +23312,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25543,7 +23332,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25553,7 +23341,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25564,7 +23351,6 @@
       "error": null,
       "kind": "website",
       "netuid": 75,
-      "private_redirect_blocked": false,
       "provider": "hippius",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25574,7 +23360,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25585,7 +23370,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25595,7 +23379,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25606,7 +23389,6 @@
       "error": null,
       "kind": "website",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "byzantium",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25616,7 +23398,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25627,7 +23408,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25637,7 +23417,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25648,7 +23427,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25658,7 +23436,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25669,7 +23446,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25679,7 +23455,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25690,7 +23465,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25700,7 +23474,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25711,7 +23484,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25721,7 +23493,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25732,7 +23503,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "byzantium",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25742,7 +23512,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25753,7 +23522,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "byzantium",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25763,7 +23531,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25774,7 +23541,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "byzantium",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25784,7 +23550,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25795,7 +23560,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "byzantium",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25805,7 +23569,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25816,7 +23579,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "byzantium",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25826,7 +23588,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25837,7 +23598,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "byzantium",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25847,7 +23607,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -25858,7 +23617,6 @@
       "error": null,
       "kind": "website",
       "netuid": 76,
-      "private_redirect_blocked": false,
       "provider": "byzantium",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25868,7 +23626,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25879,7 +23636,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25889,7 +23645,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25917,7 +23672,6 @@
       "error": null,
       "kind": "website",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25927,7 +23681,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25938,7 +23691,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25948,7 +23700,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25959,7 +23710,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25969,7 +23719,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -25980,7 +23729,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -25990,7 +23738,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26001,7 +23748,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26011,7 +23757,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26022,7 +23767,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26032,28 +23776,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-77-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26064,7 +23805,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26074,28 +23814,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-77-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26106,7 +23843,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26116,7 +23852,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -26127,7 +23862,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -26137,7 +23871,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26148,7 +23881,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 77,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26158,7 +23890,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -26169,7 +23900,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26179,7 +23909,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26207,7 +23936,6 @@
       "error": null,
       "kind": "website",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26217,7 +23945,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26228,7 +23955,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26238,7 +23964,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26249,7 +23974,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26259,7 +23983,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26270,7 +23993,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26280,7 +24002,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26291,7 +24012,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26301,7 +24021,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26312,7 +24031,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26322,7 +24040,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26333,17 +24050,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26365,23 +24076,21 @@
     },
     {
       "candidate_id": "sn-78-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26392,7 +24101,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26402,28 +24110,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-78-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26434,7 +24139,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -26444,7 +24148,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26455,7 +24158,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -26465,7 +24167,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26476,7 +24177,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 78,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -26486,7 +24186,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26497,7 +24196,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26507,7 +24205,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26518,7 +24215,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26556,7 +24252,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26566,7 +24261,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26577,7 +24271,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26587,7 +24280,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26598,7 +24290,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26608,7 +24299,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26619,7 +24309,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26629,7 +24318,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26640,7 +24328,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26650,7 +24337,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26661,7 +24347,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26671,7 +24356,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -26682,7 +24366,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26692,7 +24375,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -26703,7 +24385,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26713,7 +24394,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -26724,7 +24404,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26734,7 +24413,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -26745,7 +24423,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26755,7 +24432,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -26766,7 +24442,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26776,7 +24451,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -26787,7 +24461,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26797,7 +24470,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -26808,7 +24480,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26829,7 +24500,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26850,7 +24520,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26871,7 +24540,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26892,7 +24560,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26913,7 +24580,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26934,7 +24600,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26955,7 +24620,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26976,7 +24640,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -26997,7 +24660,6 @@
       "error": null,
       "kind": "website",
       "netuid": 79,
-      "private_redirect_blocked": false,
       "provider": "taos-im",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27018,7 +24680,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27028,7 +24689,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27056,7 +24716,6 @@
       "error": null,
       "kind": "website",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27077,7 +24736,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27087,7 +24745,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27098,7 +24755,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27108,7 +24764,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27119,7 +24774,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27129,7 +24783,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27140,7 +24793,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27150,7 +24802,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27161,7 +24812,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27171,7 +24821,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27182,7 +24831,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27203,7 +24851,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27218,23 +24865,21 @@
     },
     {
       "candidate_id": "sn-80-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27245,7 +24890,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -27255,7 +24899,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27266,7 +24909,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -27276,7 +24918,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27287,7 +24928,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -27297,7 +24937,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27308,7 +24947,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27318,7 +24956,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27329,7 +24966,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 80,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27339,7 +24975,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27350,7 +24985,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 81,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27360,7 +24994,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27371,7 +25004,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 81,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27381,7 +25013,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27392,7 +25023,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 81,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27402,7 +25032,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27413,7 +25042,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 81,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27423,7 +25051,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27434,7 +25061,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 81,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27444,7 +25070,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27455,7 +25080,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 81,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27465,12 +25089,11 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-81-tensorplex-source-repo-1",
-      "classification": "live",
+      "classification": "redirected",
       "confidence_score": 80,
       "error": null,
       "kind": "source-repo",
@@ -27483,6 +25106,7 @@
         "public_safe": true,
         "source_tier": "community-docs"
       },
+      "redirect_target": "https://github.com/one-covenant/grail",
       "status": "ok"
     },
     {
@@ -27493,7 +25117,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27503,7 +25126,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27531,7 +25153,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27541,7 +25162,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27552,7 +25172,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27562,7 +25181,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27573,7 +25191,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27583,7 +25200,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27594,7 +25210,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27604,7 +25219,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27615,7 +25229,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27625,7 +25238,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27636,7 +25248,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27646,7 +25257,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27674,7 +25284,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27684,7 +25293,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -27695,7 +25303,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27705,7 +25312,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -27716,7 +25322,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27726,7 +25331,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -27737,7 +25341,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27747,7 +25350,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -27758,7 +25360,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27768,7 +25369,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -27779,7 +25379,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27789,7 +25388,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -27800,7 +25398,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27810,7 +25407,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27821,7 +25417,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27831,7 +25426,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27842,7 +25436,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27852,7 +25445,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27863,7 +25455,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27873,7 +25464,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27884,7 +25474,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27894,7 +25483,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27905,7 +25493,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27915,7 +25502,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27926,7 +25512,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27936,7 +25521,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27947,7 +25531,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27957,7 +25540,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27968,7 +25550,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27978,7 +25559,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -27989,7 +25569,6 @@
       "error": null,
       "kind": "website",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -27999,7 +25578,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28010,7 +25588,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 82,
-      "private_redirect_blocked": false,
       "provider": "compelle",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28020,7 +25597,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -28031,7 +25607,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28041,7 +25616,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28069,7 +25643,6 @@
       "error": null,
       "kind": "website",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28079,7 +25652,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28090,7 +25662,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28100,7 +25671,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28111,7 +25681,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28121,7 +25690,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28132,7 +25700,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28142,7 +25709,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28153,7 +25719,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28163,7 +25728,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28174,7 +25738,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28184,28 +25747,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-83-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28216,7 +25776,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28226,28 +25785,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-83-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28258,7 +25814,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -28268,7 +25823,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28279,7 +25833,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -28289,7 +25842,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28300,7 +25852,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 83,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -28310,7 +25861,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28321,7 +25871,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 84,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28331,7 +25880,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28342,7 +25890,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 84,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28352,7 +25899,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28363,7 +25909,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 84,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28373,7 +25918,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28384,7 +25928,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 84,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28394,7 +25937,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28405,7 +25947,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 84,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28415,7 +25956,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28426,7 +25966,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 84,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28436,7 +25975,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28481,7 +26019,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28491,7 +26028,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28519,7 +26055,6 @@
       "error": null,
       "kind": "website",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28529,7 +26064,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28540,7 +26074,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28550,7 +26083,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28561,7 +26093,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28571,7 +26102,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28582,7 +26112,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28592,7 +26121,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28603,7 +26131,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28613,7 +26140,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28624,7 +26150,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28634,21 +26159,19 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-85-website-common-api",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -28666,7 +26189,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28681,16 +26203,15 @@
     },
     {
       "candidate_id": "sn-85-website-common-health",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -28708,7 +26229,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -28729,7 +26249,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -28750,7 +26269,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -28771,7 +26289,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28781,7 +26298,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28792,7 +26308,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28802,7 +26317,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28813,7 +26327,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28823,7 +26336,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28834,7 +26346,6 @@
       "error": null,
       "kind": "website",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28855,7 +26366,6 @@
       "error": null,
       "kind": "website",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28865,7 +26375,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28876,7 +26385,6 @@
       "error": null,
       "kind": "website",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28897,7 +26405,6 @@
       "error": null,
       "kind": "website",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28907,7 +26414,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28918,7 +26424,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 85,
-      "private_redirect_blocked": false,
       "provider": "vidaio",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28928,7 +26433,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -28939,7 +26443,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 86,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28949,7 +26452,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28960,7 +26462,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 86,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28970,7 +26471,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -28981,7 +26481,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 86,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -28991,7 +26490,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29002,7 +26500,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 86,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29012,7 +26509,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29023,7 +26519,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 86,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29033,7 +26528,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29044,7 +26538,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 86,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29054,7 +26547,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29065,7 +26557,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 87,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29075,7 +26566,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29086,7 +26576,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 87,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29096,7 +26585,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29107,7 +26595,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 87,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29117,7 +26604,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29128,7 +26614,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 87,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29138,7 +26623,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29149,7 +26633,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 87,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29159,7 +26642,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29170,7 +26652,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 87,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29180,7 +26661,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29191,7 +26671,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29201,7 +26680,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29212,7 +26690,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29222,28 +26699,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-88-github-readme-mobiusfund-investing-subnet-api-2",
-      "classification": "live",
-      "confidence_score": 58,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29271,7 +26745,6 @@
       "error": null,
       "kind": "website",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29281,7 +26754,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29292,7 +26764,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29302,7 +26773,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29313,7 +26783,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29323,7 +26792,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29334,7 +26802,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29344,7 +26811,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29355,7 +26821,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29365,7 +26830,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29376,7 +26840,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29386,7 +26849,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29397,7 +26859,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29407,7 +26868,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29418,7 +26878,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29428,7 +26887,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29439,7 +26897,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29449,7 +26906,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29460,7 +26916,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29470,7 +26925,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29481,7 +26935,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29491,7 +26944,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29502,7 +26954,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29512,7 +26963,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29523,7 +26973,6 @@
       "error": null,
       "kind": "website",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29533,7 +26982,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29544,7 +26992,6 @@
       "error": null,
       "kind": "website",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29554,7 +27001,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29565,7 +27011,6 @@
       "error": null,
       "kind": "website",
       "netuid": 88,
-      "private_redirect_blocked": false,
       "provider": "mobiusfund",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29575,7 +27020,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29586,7 +27030,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29596,7 +27039,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29624,7 +27066,6 @@
       "error": null,
       "kind": "website",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "infinitehash",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29634,7 +27075,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29645,7 +27085,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29655,7 +27094,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29666,7 +27104,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29676,7 +27113,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29687,7 +27123,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29697,7 +27132,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29708,7 +27142,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29718,7 +27151,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29729,7 +27161,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29739,7 +27170,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29750,7 +27180,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "infinitehash",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29760,7 +27189,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29771,7 +27199,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "infinitehash",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29781,7 +27208,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29792,7 +27218,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "infinitehash",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29802,7 +27227,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29813,7 +27237,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "infinitehash",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29823,7 +27246,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29834,7 +27256,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "infinitehash",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29844,7 +27265,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29855,7 +27275,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 89,
-      "private_redirect_blocked": false,
       "provider": "infinitehash",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29865,7 +27284,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -29876,7 +27294,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 90,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29886,7 +27303,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29897,7 +27313,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 90,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29907,7 +27322,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29918,7 +27332,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 90,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29928,7 +27341,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29939,7 +27351,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 90,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29949,7 +27360,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29960,7 +27370,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 90,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29970,7 +27379,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -29981,7 +27389,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 90,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -29991,7 +27398,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30002,7 +27408,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30012,7 +27417,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30023,7 +27427,6 @@
       "error": null,
       "kind": "website",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30044,7 +27447,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30054,7 +27456,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30065,7 +27466,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30075,7 +27475,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30086,7 +27485,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30096,7 +27494,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30107,7 +27504,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30117,7 +27513,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30128,7 +27523,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30138,7 +27532,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30149,7 +27542,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30170,7 +27562,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30191,7 +27582,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30212,7 +27602,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30233,7 +27622,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30254,7 +27642,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30275,7 +27662,6 @@
       "error": null,
       "kind": "website",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30285,7 +27671,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30296,7 +27681,6 @@
       "error": null,
       "kind": "website",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30306,7 +27690,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -30317,7 +27700,6 @@
       "error": null,
       "kind": "website",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30338,7 +27720,6 @@
       "error": null,
       "kind": "website",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30359,7 +27740,6 @@
       "error": null,
       "kind": "website",
       "netuid": 91,
-      "private_redirect_blocked": false,
       "provider": "bitstarter",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30380,7 +27760,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 92,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30390,7 +27769,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30401,7 +27779,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 92,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30411,7 +27788,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30422,7 +27798,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 92,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30432,7 +27807,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30443,7 +27817,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 92,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30453,7 +27826,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30464,7 +27836,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 92,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30474,7 +27845,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30485,7 +27855,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 92,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30495,7 +27864,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30505,17 +27873,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 92,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -30526,7 +27888,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30536,7 +27897,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30547,7 +27907,6 @@
       "error": "probe-failed",
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30584,7 +27943,6 @@
       "error": null,
       "kind": "website",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30594,7 +27952,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30605,7 +27962,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30615,7 +27971,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30626,7 +27981,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30636,7 +27990,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30647,7 +28000,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30657,7 +28009,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30668,7 +28019,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30678,7 +28028,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30689,7 +28038,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30699,28 +28047,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-93-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30731,7 +28076,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30741,28 +28085,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-93-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30773,7 +28114,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -30783,7 +28123,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30794,7 +28133,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -30804,7 +28142,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30815,7 +28152,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -30825,7 +28161,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30836,7 +28171,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30846,7 +28180,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30857,7 +28190,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30867,7 +28199,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30878,7 +28209,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30888,7 +28218,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30899,7 +28228,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30909,7 +28237,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30920,7 +28247,6 @@
       "error": null,
       "kind": "website",
       "netuid": 93,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30930,7 +28256,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30941,7 +28266,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30951,7 +28275,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -30979,7 +28302,6 @@
       "error": null,
       "kind": "website",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -30989,7 +28311,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31000,7 +28321,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31010,7 +28330,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31021,7 +28340,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31031,7 +28349,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31042,7 +28359,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31052,7 +28368,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31063,7 +28378,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31073,7 +28387,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31084,7 +28397,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31094,7 +28406,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31105,7 +28416,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31115,7 +28425,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -31126,7 +28435,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31136,7 +28444,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31147,7 +28454,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31157,7 +28463,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -31168,7 +28473,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31178,7 +28482,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -31189,7 +28492,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31199,7 +28501,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -31210,7 +28511,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31220,7 +28520,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -31231,7 +28530,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31241,7 +28539,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31252,7 +28549,6 @@
       "error": null,
       "kind": "website",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31262,7 +28558,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31273,7 +28568,6 @@
       "error": null,
       "kind": "website",
       "netuid": 94,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31283,7 +28577,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31294,7 +28587,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31304,7 +28596,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31314,17 +28605,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "native-chain",
-        "transient_failure": false
+        "source_tier": "native-chain"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -31335,7 +28620,6 @@
       "error": null,
       "kind": "website",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31345,7 +28629,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31356,7 +28639,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31366,7 +28648,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31377,7 +28658,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31387,7 +28667,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31398,7 +28677,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31408,7 +28686,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31419,7 +28696,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31429,7 +28705,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31440,7 +28715,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31450,21 +28724,19 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-95-website-common-api",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -31482,7 +28754,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31497,16 +28768,15 @@
     },
     {
       "candidate_id": "sn-95-website-common-health",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -31524,7 +28794,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -31545,7 +28814,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -31566,7 +28834,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -31587,7 +28854,6 @@
       "error": null,
       "kind": "website",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31597,7 +28863,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31608,7 +28873,6 @@
       "error": null,
       "kind": "website",
       "netuid": 95,
-      "private_redirect_blocked": false,
       "provider": "actual-computer",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31629,7 +28893,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31639,7 +28902,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31650,7 +28912,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "verathos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31660,7 +28921,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31671,7 +28931,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "verathos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31681,7 +28940,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -31709,7 +28967,6 @@
       "error": null,
       "kind": "website",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "verathos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31719,7 +28976,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31730,7 +28986,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31740,7 +28995,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31751,7 +29005,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31761,7 +29014,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31772,7 +29024,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31782,7 +29033,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31793,7 +29043,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31803,7 +29052,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31814,7 +29062,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31824,7 +29071,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31846,44 +29092,40 @@
     },
     {
       "candidate_id": "sn-96-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "verathos",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-96-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "verathos",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31894,7 +29136,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "verathos",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31904,7 +29145,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31915,7 +29155,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "verathos",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -31925,7 +29164,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31936,7 +29174,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 96,
-      "private_redirect_blocked": false,
       "provider": "verathos",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -31946,7 +29183,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31957,7 +29193,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31967,7 +29202,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -31978,7 +29212,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -31988,21 +29221,19 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-97-github-readme-unitone-labs-flamewire-subnet-api-2",
-      "classification": "redirected",
-      "confidence_score": 53,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -32037,7 +29268,6 @@
       "error": null,
       "kind": "website",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32047,7 +29277,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32058,7 +29287,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32068,7 +29296,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32079,7 +29306,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32089,7 +29315,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32100,7 +29325,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32110,7 +29334,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32121,7 +29344,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32131,7 +29353,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32142,7 +29363,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32152,7 +29372,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32180,7 +29399,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32190,7 +29408,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32201,7 +29418,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32211,28 +29427,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-97-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": null,
       "error": null,
       "kind": "subnet-api",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32243,7 +29456,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32253,7 +29465,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32264,7 +29475,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32274,7 +29484,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32285,7 +29494,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32295,7 +29503,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32306,7 +29513,6 @@
       "error": null,
       "kind": "website",
       "netuid": 97,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32316,7 +29522,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32327,7 +29532,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32337,7 +29541,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32365,7 +29568,6 @@
       "error": null,
       "kind": "website",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32375,7 +29577,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32386,7 +29587,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32396,7 +29596,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32407,7 +29606,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32417,7 +29615,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32428,7 +29625,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32438,7 +29634,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32449,7 +29644,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32459,7 +29653,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32470,7 +29663,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32480,7 +29672,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32490,17 +29681,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32511,7 +29696,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32521,7 +29705,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32532,7 +29715,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32542,7 +29724,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32553,7 +29734,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32563,7 +29743,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32574,7 +29753,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32584,7 +29762,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32595,7 +29772,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32605,7 +29781,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32616,7 +29791,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32626,7 +29800,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -32637,7 +29810,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32647,7 +29819,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32658,7 +29829,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32668,7 +29838,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32679,7 +29848,6 @@
       "error": null,
       "kind": "website",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32689,7 +29857,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32700,7 +29867,6 @@
       "error": null,
       "kind": "website",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32710,7 +29876,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32721,7 +29886,6 @@
       "error": null,
       "kind": "website",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32731,7 +29895,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32742,7 +29905,6 @@
       "error": null,
       "kind": "website",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32752,7 +29914,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32763,7 +29924,6 @@
       "error": null,
       "kind": "website",
       "netuid": 98,
-      "private_redirect_blocked": false,
       "provider": "forevermoney",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32773,7 +29933,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32784,7 +29943,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32794,7 +29952,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32805,7 +29962,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32815,28 +29971,25 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-99-github-readme-rendixnetwork-leoma-subnet-api-1",
-      "classification": "live",
-      "confidence_score": 58,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32864,7 +30017,6 @@
       "error": null,
       "kind": "website",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32874,7 +30026,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32885,7 +30036,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32895,7 +30045,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32906,7 +30055,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32916,7 +30064,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32927,7 +30074,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32937,7 +30083,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32948,7 +30093,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32958,7 +30102,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -32969,7 +30112,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -32979,7 +30121,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33001,23 +30142,21 @@
     },
     {
       "candidate_id": "sn-99-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33028,7 +30167,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33038,28 +30176,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-99-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33070,7 +30205,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -33080,7 +30214,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33091,7 +30224,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -33101,7 +30233,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33112,7 +30243,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 99,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -33122,7 +30252,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33133,7 +30262,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33143,7 +30271,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33171,7 +30298,6 @@
       "error": null,
       "kind": "website",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33192,7 +30318,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33202,7 +30327,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33213,7 +30337,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33223,7 +30346,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33234,7 +30356,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33244,7 +30365,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33255,7 +30375,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33265,7 +30384,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33276,7 +30394,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33286,7 +30403,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33314,17 +30430,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33335,7 +30445,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33356,7 +30465,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33377,7 +30485,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33398,7 +30505,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33419,7 +30525,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33440,7 +30545,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33461,7 +30565,6 @@
       "error": null,
       "kind": "website",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33482,7 +30585,6 @@
       "error": null,
       "kind": "website",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33503,7 +30605,6 @@
       "error": null,
       "kind": "website",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33524,7 +30625,6 @@
       "error": null,
       "kind": "website",
       "netuid": 100,
-      "private_redirect_blocked": false,
       "provider": "platform-network",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33545,7 +30645,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 101,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33555,7 +30654,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33566,7 +30664,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 101,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33576,7 +30673,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33587,7 +30683,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 101,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33597,7 +30692,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33608,7 +30702,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 101,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33618,7 +30711,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33629,7 +30721,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 101,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33639,7 +30730,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33650,7 +30740,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 101,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33660,7 +30749,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33671,7 +30759,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33681,7 +30768,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33692,7 +30778,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33702,7 +30787,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -33730,7 +30814,6 @@
       "error": null,
       "kind": "website",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33740,7 +30823,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33751,7 +30833,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33761,7 +30842,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33772,7 +30852,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33782,7 +30861,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33793,7 +30871,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33803,7 +30880,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33814,7 +30890,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33824,7 +30899,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33835,7 +30909,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33845,7 +30918,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -33856,7 +30928,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33866,7 +30937,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -33877,7 +30947,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33898,7 +30967,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33908,7 +30976,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -33919,7 +30986,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33929,7 +30995,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -33940,7 +31005,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33950,7 +31014,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -33961,7 +31024,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33971,7 +31033,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -33982,7 +31043,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -33992,7 +31052,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34003,7 +31062,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34013,7 +31071,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34024,7 +31081,6 @@
       "error": null,
       "kind": "website",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34034,7 +31090,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34045,7 +31100,6 @@
       "error": null,
       "kind": "website",
       "netuid": 102,
-      "private_redirect_blocked": false,
       "provider": "connito",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34055,7 +31109,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34066,7 +31119,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34076,7 +31128,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34104,7 +31155,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34125,7 +31175,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34135,7 +31184,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34146,7 +31194,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34156,7 +31203,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34167,7 +31213,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34177,7 +31222,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34188,7 +31232,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34198,7 +31241,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34209,7 +31251,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34219,7 +31260,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34230,7 +31270,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34251,7 +31290,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34272,7 +31310,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34293,7 +31330,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34314,7 +31350,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34335,7 +31370,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34356,7 +31390,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34377,7 +31410,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34398,7 +31430,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34419,7 +31450,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34440,7 +31470,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34461,7 +31490,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34482,7 +31510,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34503,7 +31530,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34524,7 +31550,6 @@
       "error": null,
       "kind": "website",
       "netuid": 103,
-      "private_redirect_blocked": false,
       "provider": "djinn",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34545,7 +31570,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 104,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34555,7 +31579,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34566,7 +31589,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 104,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34576,7 +31598,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34587,7 +31608,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 104,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34597,7 +31617,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34608,7 +31627,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 104,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34618,7 +31636,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34629,7 +31646,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 104,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34639,7 +31655,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34650,7 +31665,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 104,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34660,7 +31674,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34671,7 +31684,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34681,7 +31693,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34692,7 +31703,6 @@
       "error": null,
       "kind": "repo-registry",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34702,7 +31712,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34713,7 +31722,6 @@
       "error": null,
       "kind": "website",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34723,7 +31731,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34734,7 +31741,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34744,7 +31750,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34755,7 +31760,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34765,7 +31769,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34775,17 +31778,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
+        "source_tier": "third-party-index"
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34796,7 +31793,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34806,7 +31802,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34817,7 +31812,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34827,7 +31821,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -34838,7 +31831,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34848,21 +31840,19 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-105-website-common-api",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -34880,7 +31870,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34895,16 +31884,15 @@
     },
     {
       "candidate_id": "sn-105-website-common-health",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -34922,7 +31910,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34932,7 +31919,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -34943,7 +31929,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -34964,7 +31949,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 105,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34974,7 +31958,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -34985,7 +31968,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -34995,7 +31977,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35023,7 +32004,6 @@
       "error": null,
       "kind": "website",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35033,7 +32013,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35044,7 +32023,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35054,7 +32032,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35065,7 +32042,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35075,7 +32051,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35086,7 +32061,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35096,7 +32070,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35107,7 +32080,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35117,7 +32089,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35128,7 +32099,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35138,7 +32108,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35149,7 +32118,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35159,7 +32127,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35170,7 +32137,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35180,7 +32146,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35191,7 +32156,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35201,7 +32165,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35212,7 +32175,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35222,7 +32184,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35233,7 +32194,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35243,7 +32203,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35254,7 +32213,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 106,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35264,7 +32222,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35275,7 +32232,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35285,7 +32241,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35296,7 +32251,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35306,7 +32260,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35317,7 +32270,6 @@
       "error": "probe-failed",
       "kind": "subnet-api",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35354,7 +32306,6 @@
       "error": null,
       "kind": "website",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35364,7 +32315,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35375,7 +32325,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35385,7 +32334,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35396,7 +32344,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35406,7 +32353,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35417,7 +32363,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35427,7 +32372,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35438,7 +32382,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35448,7 +32391,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35459,7 +32401,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35469,7 +32410,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35497,7 +32437,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35507,7 +32446,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35518,7 +32456,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35528,7 +32465,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35539,7 +32475,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35549,7 +32484,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35560,7 +32494,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35570,7 +32503,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35581,7 +32513,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35591,7 +32522,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35602,7 +32532,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35612,7 +32541,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35623,7 +32551,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35633,7 +32560,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35644,7 +32570,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35665,7 +32590,6 @@
       "error": null,
       "kind": "website",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35675,7 +32599,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35686,7 +32609,6 @@
       "error": null,
       "kind": "website",
       "netuid": 107,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35696,7 +32618,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35707,7 +32628,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35717,7 +32637,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35745,7 +32664,6 @@
       "error": null,
       "kind": "website",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35755,7 +32673,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35766,7 +32683,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35776,7 +32692,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35787,7 +32702,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35797,7 +32711,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35808,7 +32721,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35818,7 +32730,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35829,7 +32740,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35839,7 +32749,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35850,7 +32759,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35860,7 +32768,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -35871,7 +32778,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35881,7 +32787,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35892,7 +32797,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35902,7 +32806,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35913,7 +32816,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35923,7 +32825,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35934,7 +32835,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35944,7 +32844,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35955,7 +32854,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35965,7 +32863,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35976,7 +32873,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -35986,7 +32882,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -35997,7 +32892,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36007,7 +32901,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36018,7 +32911,6 @@
       "error": null,
       "kind": "website",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36028,7 +32920,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36039,7 +32930,6 @@
       "error": null,
       "kind": "website",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36049,7 +32939,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36060,7 +32949,6 @@
       "error": null,
       "kind": "website",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36070,7 +32958,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36081,7 +32968,6 @@
       "error": null,
       "kind": "website",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36091,7 +32977,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36102,7 +32987,6 @@
       "error": null,
       "kind": "website",
       "netuid": 108,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36112,7 +32996,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36123,7 +33006,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 109,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36133,7 +33015,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36161,7 +33042,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 109,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36171,7 +33051,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36182,7 +33061,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 109,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36192,7 +33070,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36203,7 +33080,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 109,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36213,7 +33089,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36224,7 +33099,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 109,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36234,7 +33108,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36245,7 +33118,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 109,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36255,7 +33127,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36266,7 +33137,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36276,7 +33146,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36287,7 +33156,6 @@
       "error": null,
       "kind": "website",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36297,7 +33165,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36308,7 +33175,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36318,7 +33184,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36329,7 +33194,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36339,7 +33203,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36350,7 +33213,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36360,7 +33222,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36371,7 +33232,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36381,7 +33241,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36392,7 +33251,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36402,7 +33260,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36430,7 +33287,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36440,7 +33296,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36451,7 +33306,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36461,7 +33315,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36472,7 +33325,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36482,7 +33334,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36493,7 +33344,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36503,7 +33353,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36514,7 +33363,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36524,7 +33372,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36535,7 +33382,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36545,7 +33391,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -36556,7 +33401,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36577,7 +33421,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36598,7 +33441,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36619,7 +33461,6 @@
       "error": null,
       "kind": "website",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36629,7 +33470,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36640,7 +33480,6 @@
       "error": null,
       "kind": "website",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36650,7 +33489,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36661,7 +33499,6 @@
       "error": null,
       "kind": "website",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36671,7 +33508,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36682,7 +33518,6 @@
       "error": null,
       "kind": "website",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36692,7 +33527,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36703,7 +33537,6 @@
       "error": null,
       "kind": "website",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36724,7 +33557,6 @@
       "error": null,
       "kind": "website",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36745,7 +33577,6 @@
       "error": null,
       "kind": "website",
       "netuid": 110,
-      "private_redirect_blocked": false,
       "provider": "green-compute",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36766,7 +33597,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 111,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36776,7 +33606,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36804,7 +33633,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 111,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36814,7 +33642,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36825,7 +33652,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 111,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36835,7 +33661,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36846,7 +33671,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 111,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36856,7 +33680,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36867,7 +33690,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 111,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36877,7 +33699,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36888,7 +33709,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 111,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36898,7 +33718,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36909,7 +33728,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36919,7 +33737,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36947,7 +33764,6 @@
       "error": null,
       "kind": "website",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36957,7 +33773,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36968,7 +33783,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36978,7 +33792,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -36989,7 +33802,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -36999,7 +33811,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37010,7 +33821,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37020,7 +33830,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37031,7 +33840,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37041,7 +33849,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37052,7 +33859,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37062,7 +33868,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37073,7 +33878,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37083,7 +33887,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37094,7 +33897,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37104,7 +33906,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37115,7 +33916,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37125,7 +33925,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37136,7 +33935,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37146,7 +33944,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37157,7 +33954,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37167,7 +33963,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37178,7 +33973,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37188,7 +33982,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37199,7 +33992,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37209,7 +34001,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37220,7 +34011,6 @@
       "error": null,
       "kind": "website",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37230,7 +34020,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37241,7 +34030,6 @@
       "error": null,
       "kind": "website",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37251,7 +34039,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37262,7 +34049,6 @@
       "error": null,
       "kind": "website",
       "netuid": 112,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37272,7 +34058,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37283,7 +34068,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37293,7 +34077,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37304,7 +34087,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37314,7 +34096,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37342,7 +34123,6 @@
       "error": null,
       "kind": "website",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37352,7 +34132,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37363,7 +34142,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37373,7 +34151,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37384,7 +34161,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37394,7 +34170,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37405,7 +34180,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37415,7 +34189,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37426,7 +34199,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37436,7 +34208,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37447,7 +34218,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37457,7 +34227,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37468,7 +34237,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37478,7 +34246,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37489,7 +34256,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37499,7 +34265,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37510,7 +34275,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37520,7 +34284,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37531,7 +34294,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37541,7 +34303,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37552,7 +34313,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37562,7 +34322,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37573,7 +34332,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37583,7 +34341,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37594,7 +34351,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37604,7 +34360,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37615,7 +34370,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37625,7 +34379,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37636,7 +34389,6 @@
       "error": null,
       "kind": "website",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37657,7 +34409,6 @@
       "error": null,
       "kind": "website",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37678,7 +34429,6 @@
       "error": null,
       "kind": "website",
       "netuid": 113,
-      "private_redirect_blocked": false,
       "provider": "tensorusd",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37688,7 +34438,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37699,7 +34448,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37709,7 +34457,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37737,7 +34484,6 @@
       "error": null,
       "kind": "website",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37747,7 +34493,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37758,7 +34503,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37768,7 +34512,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37779,7 +34522,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37789,7 +34531,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37800,7 +34541,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37810,7 +34550,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37821,7 +34560,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37831,7 +34569,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37842,7 +34579,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37852,7 +34588,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -37880,7 +34615,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37901,7 +34635,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37911,7 +34644,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37922,7 +34654,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37932,7 +34663,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37943,7 +34673,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37953,7 +34682,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37964,7 +34692,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37974,7 +34701,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -37985,7 +34711,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -37995,7 +34720,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -38006,7 +34730,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38016,7 +34739,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38027,7 +34749,6 @@
       "error": null,
       "kind": "data-artifact",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38037,28 +34758,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-114-website-link-thesoma-ai-subnet-api-7",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38069,7 +34787,6 @@
       "error": null,
       "kind": "website",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38079,7 +34796,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38090,7 +34806,6 @@
       "error": null,
       "kind": "website",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38100,7 +34815,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38111,7 +34825,6 @@
       "error": null,
       "kind": "website",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38121,7 +34834,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38132,7 +34844,6 @@
       "error": null,
       "kind": "website",
       "netuid": 114,
-      "private_redirect_blocked": false,
       "provider": "soma",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38142,7 +34853,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38153,7 +34863,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 115,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38163,7 +34872,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38191,7 +34899,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 115,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38201,7 +34908,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38212,7 +34918,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 115,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38222,7 +34927,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38233,7 +34937,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 115,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38243,7 +34946,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38254,7 +34956,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 115,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38264,7 +34965,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38275,7 +34975,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 115,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38285,7 +34984,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38296,7 +34994,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 116,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38306,7 +35003,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38317,7 +35013,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 116,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38327,7 +35022,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38338,7 +35032,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 116,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38348,7 +35041,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38359,7 +35051,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 116,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38369,7 +35060,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38380,7 +35070,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 116,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38390,7 +35079,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38401,7 +35089,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 116,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38411,7 +35098,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38421,17 +35107,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 116,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "community-docs",
-        "transient_failure": false
+        "source_tier": "community-docs"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -38442,7 +35122,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 117,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38452,7 +35131,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38480,7 +35158,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 117,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38490,7 +35167,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38501,7 +35177,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 117,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38511,7 +35186,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38522,7 +35196,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 117,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38532,7 +35205,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38543,7 +35215,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 117,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38553,7 +35224,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38564,7 +35234,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 117,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38574,7 +35243,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38602,7 +35270,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38612,7 +35279,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38623,7 +35289,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38633,7 +35298,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -38644,7 +35308,6 @@
       "error": null,
       "kind": "repo-registry",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38654,7 +35317,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38665,7 +35327,6 @@
       "error": null,
       "kind": "website",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38675,7 +35336,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38686,7 +35346,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38696,7 +35355,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38707,7 +35365,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38717,7 +35374,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38727,17 +35383,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "third-party-index",
-        "transient_failure": false
+        "source_tier": "third-party-index"
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38748,7 +35398,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38758,7 +35407,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38769,7 +35417,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38779,7 +35426,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38790,7 +35436,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38800,7 +35445,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -38828,7 +35472,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38838,7 +35481,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -38849,7 +35491,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38870,7 +35511,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38880,7 +35520,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -38891,7 +35530,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38901,7 +35539,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -38912,7 +35549,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38922,7 +35558,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -38933,7 +35568,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38943,7 +35577,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -38954,7 +35587,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38975,7 +35607,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -38996,7 +35627,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39017,7 +35647,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39038,7 +35667,6 @@
       "error": null,
       "kind": "website",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39059,7 +35687,6 @@
       "error": null,
       "kind": "website",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39080,7 +35707,6 @@
       "error": null,
       "kind": "website",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39101,7 +35727,6 @@
       "error": null,
       "kind": "website",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39111,7 +35736,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39122,7 +35746,6 @@
       "error": null,
       "kind": "website",
       "netuid": 118,
-      "private_redirect_blocked": false,
       "provider": "ditto-assistant",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39143,7 +35766,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 119,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39153,7 +35775,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39163,17 +35784,11 @@
       "error": null,
       "kind": "source-repo",
       "netuid": 119,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
         "public_safe": true,
-        "rate_limited": false,
-        "redirected": false,
-        "source_tier": "native-chain",
-        "transient_failure": false
+        "source_tier": "native-chain"
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39184,7 +35799,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 119,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39194,7 +35808,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39205,7 +35818,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 119,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39215,7 +35827,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39226,7 +35837,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 119,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39236,7 +35846,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39247,7 +35856,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 119,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39257,7 +35865,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39268,7 +35875,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 119,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39278,7 +35884,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39289,7 +35894,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39299,7 +35903,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39310,7 +35913,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39320,7 +35922,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39348,7 +35949,6 @@
       "error": null,
       "kind": "website",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39358,7 +35958,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39369,7 +35968,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39379,7 +35977,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39390,7 +35987,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39400,7 +35996,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39411,7 +36006,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39421,7 +36015,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39432,7 +36025,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39442,7 +36034,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39453,7 +36044,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39463,7 +36053,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39474,7 +36063,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39484,7 +36072,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39495,7 +36082,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39505,7 +36091,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39516,7 +36101,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39526,7 +36110,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39537,7 +36120,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39547,7 +36129,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39558,7 +36139,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39568,7 +36148,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39579,7 +36158,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 120,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39589,7 +36167,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39600,7 +36177,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39610,7 +36186,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39638,7 +36213,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39648,7 +36222,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39659,7 +36232,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39669,7 +36241,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39680,7 +36251,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39690,7 +36260,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39701,7 +36270,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39711,7 +36279,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39722,7 +36289,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39732,7 +36298,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39743,7 +36308,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39753,7 +36317,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39764,7 +36327,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39774,7 +36336,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39785,7 +36346,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39795,7 +36355,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39806,7 +36365,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39816,7 +36374,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39827,7 +36384,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39837,7 +36393,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39848,7 +36403,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39858,7 +36412,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39869,7 +36422,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39879,7 +36431,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -39890,7 +36441,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39900,7 +36450,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39911,7 +36460,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39921,7 +36469,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39932,7 +36479,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39942,7 +36488,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39953,7 +36498,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39963,7 +36507,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39974,7 +36517,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -39984,7 +36526,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -39995,7 +36536,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40005,7 +36545,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40016,7 +36555,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40026,7 +36564,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40037,7 +36574,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40047,7 +36583,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40058,7 +36593,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40068,7 +36602,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40079,7 +36612,6 @@
       "error": null,
       "kind": "website",
       "netuid": 121,
-      "private_redirect_blocked": false,
       "provider": "sundae-bar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40089,7 +36621,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40100,7 +36631,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 122,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40110,7 +36640,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40121,7 +36650,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 122,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40131,7 +36659,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40142,7 +36669,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 122,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40152,7 +36678,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40163,7 +36688,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 122,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40173,7 +36697,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40184,7 +36707,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 122,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40194,7 +36716,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40205,7 +36726,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 122,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40215,7 +36735,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40243,7 +36762,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 123,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40253,7 +36771,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40281,7 +36798,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 123,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40291,7 +36807,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40302,7 +36817,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 123,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40312,7 +36826,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40323,7 +36836,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 123,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40333,7 +36845,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40344,7 +36855,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 123,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40354,7 +36864,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40365,7 +36874,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 123,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40375,7 +36883,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40386,7 +36893,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40396,7 +36902,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40407,7 +36912,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40417,7 +36921,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40445,7 +36948,6 @@
       "error": null,
       "kind": "website",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40466,7 +36968,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40476,7 +36977,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40487,7 +36987,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40497,7 +36996,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40508,7 +37006,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40518,7 +37015,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40529,7 +37025,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40539,7 +37034,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40550,7 +37044,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40560,21 +37053,19 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-124-website-common-api",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -40592,7 +37083,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40607,16 +37097,15 @@
     },
     {
       "candidate_id": "sn-124-website-common-health",
-      "classification": "redirected",
-      "confidence_score": 63,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html; charset=utf-8",
       "error": null,
       "kind": "subnet-api",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": true,
@@ -40634,7 +37123,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -40655,7 +37143,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -40676,7 +37163,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 124,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -40697,7 +37183,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 125,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40707,7 +37192,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40718,7 +37202,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 125,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40728,7 +37211,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40739,7 +37221,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 125,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40749,7 +37230,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40760,7 +37240,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 125,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40770,7 +37249,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40781,7 +37259,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 125,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40791,7 +37268,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40802,7 +37278,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 125,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40812,7 +37287,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40823,7 +37297,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40833,7 +37306,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40861,7 +37333,6 @@
       "error": null,
       "kind": "website",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40871,7 +37342,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40882,7 +37352,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40892,7 +37361,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40903,7 +37371,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40913,7 +37380,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40924,7 +37390,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40934,7 +37399,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40945,7 +37409,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40955,7 +37418,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40966,7 +37428,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40976,7 +37437,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -40987,7 +37447,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -40997,7 +37456,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -41008,7 +37466,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41018,7 +37475,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -41029,7 +37485,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41039,7 +37494,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -41050,7 +37504,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41060,7 +37513,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -41071,7 +37523,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41081,7 +37532,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -41092,7 +37542,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41102,7 +37551,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "failed"
     },
     {
@@ -41113,7 +37561,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41123,7 +37570,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41134,7 +37580,6 @@
       "error": null,
       "kind": "website",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41144,7 +37589,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41155,7 +37599,6 @@
       "error": null,
       "kind": "website",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41165,7 +37608,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41176,7 +37618,6 @@
       "error": null,
       "kind": "website",
       "netuid": 126,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41186,7 +37627,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41197,7 +37637,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41207,7 +37646,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41235,7 +37673,6 @@
       "error": null,
       "kind": "website",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41256,7 +37693,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41266,7 +37702,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41277,7 +37712,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41287,7 +37721,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41298,7 +37731,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41308,7 +37740,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41319,7 +37750,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41329,7 +37759,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41340,7 +37769,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41350,7 +37778,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41361,7 +37788,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41382,7 +37808,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41403,7 +37828,6 @@
       "error": null,
       "kind": "subnet-api",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41424,7 +37848,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41445,7 +37868,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41466,7 +37888,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41487,7 +37908,6 @@
       "error": null,
       "kind": "website",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41497,7 +37917,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41508,7 +37927,6 @@
       "error": null,
       "kind": "website",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41518,7 +37936,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41529,7 +37946,6 @@
       "error": null,
       "kind": "website",
       "netuid": 127,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41539,7 +37955,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41550,7 +37965,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "backprop-finance",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41560,7 +37974,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41588,7 +38001,6 @@
       "error": null,
       "kind": "website",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41598,7 +38010,6 @@
         "source_tier": "native-chain",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41609,7 +38020,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "subnetradar",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41619,7 +38029,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41630,7 +38039,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "taomarketcap",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41640,7 +38048,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41651,7 +38058,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "taopedia-articles",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41661,7 +38067,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41672,7 +38077,6 @@
       "error": null,
       "kind": "dashboard",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "taostats",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41682,7 +38086,6 @@
         "source_tier": "third-party-index",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41693,7 +38096,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "tensorplex-subnet-docs",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41703,7 +38105,6 @@
         "source_tier": "community-docs",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41725,23 +38126,21 @@
     },
     {
       "candidate_id": "sn-128-website-common-api",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41752,7 +38151,6 @@
       "error": null,
       "kind": "docs",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": true,
@@ -41762,28 +38160,25 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
       "candidate_id": "sn-128-website-common-health",
-      "classification": "live",
-      "confidence_score": 68,
+      "classification": "content-mismatch",
+      "confidence_score": 0,
       "content_type": "text/html",
       "error": null,
       "kind": "subnet-api",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
-        "content_type_matches_kind": true,
+        "content_type_matches_kind": false,
         "public_safe": true,
         "rate_limited": false,
         "redirected": false,
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41794,7 +38189,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -41804,7 +38198,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41815,7 +38208,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -41825,7 +38217,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     },
     {
@@ -41836,7 +38227,6 @@
       "error": null,
       "kind": "openapi",
       "netuid": 128,
-      "private_redirect_blocked": false,
       "provider": "opentensor",
       "quality_signals": {
         "content_type_matches_kind": false,
@@ -41846,7 +38236,6 @@
         "source_tier": "provider-claimed",
         "transient_failure": false
       },
-      "redirect_target": null,
       "status": "ok"
     }
   ],
@@ -41854,14 +38243,14 @@
   "summary": {
     "by_classification": {
       "auth-required": 9,
-      "content-mismatch": 71,
+      "content-mismatch": 132,
       "dead": 397,
-      "live": 1349,
+      "live": 1296,
       "rate-limited": 7,
-      "redirected": 153,
+      "redirected": 146,
       "transient": 4,
       "unsafe": 2,
-      "unsupported": 29
+      "unsupported": 28
     },
     "by_kind": {
       "dashboard": 564,
@@ -41947,7 +38336,7 @@
       "verathos": 9,
       "vidaio": 16
     },
-    "promotable_count": 1502
+    "promotable_count": 1442
   },
   "verification_finished_at": null,
   "verification_started_at": null

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -678,7 +678,15 @@ await writeJson(
   }),
 );
 await writeJson(artifactFile("schema-drift.json"), schemaDriftArtifact);
+await fs.rm(r2ArtifactDir("schemas"), { recursive: true, force: true });
 await writeJson(artifactFile("schemas/index.json"), schemaIndexArtifact);
+for (const entry of schemaIndexArtifact.schemas || []) {
+  const relativePath = schemaDetailArtifactPath(entry);
+  if (!relativePath || !entry.snapshot || typeof entry.snapshot !== "object") {
+    continue;
+  }
+  await writeJson(artifactFile(relativePath), entry.snapshot);
+}
 await writeJson(artifactFile("review/curation.json"), curationReview);
 await writeJson(artifactFile("review/gap-priorities.json"), {
   schema_version: 1,
@@ -3791,6 +3799,16 @@ function artifactFile(relativePath) {
 
 function r2ArtifactDir(relativePath) {
   return path.join(r2OutputRoot, relativePath);
+}
+
+function schemaDetailArtifactPath(entry) {
+  const relativePath = String(entry.path || "")
+    .replace(/^\/+metagraph\//, "")
+    .replace(/^\/+/, "");
+  if (!relativePath || relativePath === "schemas/index.json") {
+    return null;
+  }
+  return relativePath;
 }
 
 async function collectArtifactDigests({

--- a/scripts/verification-quality.mjs
+++ b/scripts/verification-quality.mjs
@@ -1,4 +1,23 @@
 export function preservePreviousGithubMetadata(result, previousByCandidate) {
+  const previous = previousByCandidate.get(result.candidate_id);
+  if (isRetryableFailure(result) && isPreviouslyHealthy(previous)) {
+    return {
+      ...result,
+      classification: previous.classification,
+      confidence_score: Math.max(
+        Number(result.confidence_score || 0),
+        Number(previous.confidence_score || 0),
+      ),
+      content_type: previous.content_type ?? result.content_type,
+      error: previous.error ?? null,
+      private_redirect_blocked:
+        previous.private_redirect_blocked ?? result.private_redirect_blocked,
+      quality_signals: previous.quality_signals || result.quality_signals,
+      redirect_target: previous.redirect_target ?? result.redirect_target,
+      status: previous.status || result.status,
+    };
+  }
+
   if (
     result.kind !== "source-repo" ||
     result.status !== "ok" ||
@@ -16,7 +35,6 @@ export function preservePreviousGithubMetadata(result, previousByCandidate) {
     return result;
   }
 
-  const previous = previousByCandidate.get(result.candidate_id);
   if (
     !previous ||
     previous.status !== "ok" ||
@@ -46,6 +64,19 @@ export function preservePreviousGithubMetadata(result, previousByCandidate) {
       ...preservedSignals,
     },
   };
+}
+
+function isRetryableFailure(result) {
+  return ["rate-limited", "timeout", "transient"].includes(
+    result?.classification,
+  );
+}
+
+function isPreviouslyHealthy(previous) {
+  return (
+    previous?.status === "ok" &&
+    ["live", "redirected"].includes(previous?.classification)
+  );
 }
 
 function stripUndefined(value) {

--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -126,7 +126,7 @@ function compactVerificationArtifact(artifactValue) {
 }
 
 function compactVerificationResult(result) {
-  return stripNullish({
+  const compact = {
     candidate_id: result.candidate_id,
     classification: result.classification,
     confidence_score: result.confidence_score,
@@ -135,16 +135,32 @@ function compactVerificationResult(result) {
     kind: result.kind,
     netuid: result.netuid,
     provider: result.provider,
-    redirect_target: result.redirect_target,
-    private_redirect_blocked: result.private_redirect_blocked,
-    quality_signals: compactQualitySignals(result.quality_signals),
+    quality_signals: compactQualitySignals(result.quality_signals, result.kind),
     status: result.status,
-  });
+  };
+
+  if (result.redirect_target) {
+    compact.redirect_target = result.redirect_target;
+  }
+  if (result.private_redirect_blocked) {
+    compact.private_redirect_blocked = result.private_redirect_blocked;
+  }
+
+  return stripNullish(compact);
 }
 
-function compactQualitySignals(signals) {
+function compactQualitySignals(signals, kind = null) {
   if (!signals || typeof signals !== "object") {
     return signals;
+  }
+  if (kind === "source-repo") {
+    return stripNullish({
+      archived: signals.archived,
+      has_default_branch: signals.has_default_branch,
+      has_recent_push_metadata: signals.has_recent_push_metadata,
+      public_safe: signals.public_safe,
+      source_tier: signals.source_tier,
+    });
   }
   return stripNullish({
     archived: signals.archived,
@@ -472,12 +488,25 @@ function isContentMismatch(probe, candidate) {
   if (candidate.kind === "openapi") {
     return !isJsonContentType(probe.content_type);
   }
+  if (candidate.kind === "subnet-api") {
+    return !isMachineReadableApiContentType(probe.content_type);
+  }
   if (candidate.kind === "sse") {
     return !String(probe.content_type || "")
       .toLowerCase()
       .includes("text/event-stream");
   }
   return false;
+}
+
+function isMachineReadableApiContentType(contentType) {
+  const normalized = String(contentType || "").toLowerCase();
+  return (
+    normalized.includes("json") ||
+    normalized.includes("text/plain") ||
+    normalized.includes("text/event-stream") ||
+    normalized.includes("application/octet-stream")
+  );
 }
 
 function scoreCandidate(candidate, probe) {

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -135,6 +135,54 @@ describe("script utility contracts", () => {
     });
   });
 
+  test("preserves previous healthy verification when a candidate probe is retryable", () => {
+    const current = {
+      candidate_id: "sn-29-subnetradar-dashboard",
+      classification: "timeout",
+      confidence_score: 9,
+      content_type: null,
+      error: "probe-failed",
+      kind: "dashboard",
+      quality_signals: {
+        public_safe: true,
+        source_tier: "third-party-index",
+        transient_failure: true,
+      },
+      status: "failed",
+    };
+    const previousByCandidate = new Map([
+      [
+        "sn-29-subnetradar-dashboard",
+        {
+          candidate_id: "sn-29-subnetradar-dashboard",
+          classification: "live",
+          confidence_score: 77,
+          content_type: "text/html; charset=utf-8",
+          error: null,
+          kind: "dashboard",
+          quality_signals: {
+            content_type_matches_kind: true,
+            public_safe: true,
+            source_tier: "third-party-index",
+            transient_failure: false,
+          },
+          status: "ok",
+        },
+      ],
+    ]);
+
+    const preserved = preservePreviousGithubMetadata(
+      current,
+      previousByCandidate,
+    );
+
+    assert.equal(preserved.classification, "live");
+    assert.equal(preserved.status, "ok");
+    assert.equal(preserved.confidence_score, 77);
+    assert.equal(preserved.content_type, "text/html; charset=utf-8");
+    assert.equal(preserved.quality_signals.transient_failure, false);
+  });
+
   test("reads, writes, and lists JSON files deterministically", async () => {
     const dir = await mkdtemp(path.join(os.tmpdir(), "metagraphed-test-"));
     try {


### PR DESCRIPTION
## Summary
- classify HTML-only subnet-api candidates as content-mismatch instead of live API surfaces
- preserve prior healthy candidate state for retryable probe failures so transient network noise does not churn the compact promotion snapshot
- materialize schema detail snapshots during artifact build so R2 manifests include the same files that local Worker tests use
- compact verification rows by omitting false/null redirect fields from the Git-tracked promotion snapshot

## Why
The enrichment queue was overstating API opportunities because common /api and /health HTML pages were treated as live subnet API candidates. This keeps machine-consumable API evidence strict while preserving full probe detail in R2.

## Validation
- npm run check
- npm run test:coverage
- git diff --check

## Notes
- Public surface count remains 1,139.
- Promotable candidate count drops from 1,502 to 1,442 because HTML subnet-api false positives are no longer promotable.
- Full R2 artifact count is now 1,273 because schema detail snapshots are included deterministically in the manifest.