### PR TITLE
fix(ci): isolate Cloudflare publish refresh

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -23,11 +23,62 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish:
+  refresh:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@d0d8abe699bfb85fec6de9f7adb5ae17292296ff # v6
+
+      - name: Install
+        run: npm ci
+
+      - name: Refresh publish artifacts
+        run: npm run pipeline:refresh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          METAGRAPH_WRITE_PROBE_RESULTS: "1"
+
+      - name: Stage refreshed publish artifacts
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/publish-artifacts"
+          cp -R public "$RUNNER_TEMP/publish-artifacts/public"
+          mkdir -p "$RUNNER_TEMP/publish-artifacts/dist"
+          if [ -d dist/metagraph-r2 ]; then
+            cp -R dist/metagraph-r2 "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2"
+          fi
+
+      - name: Upload refreshed publish artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: cloudflare-publish-artifacts
+          path: ${{ runner.temp }}/publish-artifacts
+          if-no-files-found: error
+          retention-days: 1
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: refresh
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -38,18 +89,25 @@ jobs:
       - name: Install
         run: npm ci
 
-      - name: Install uv runtime
+      - name: Download refreshed publish artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: cloudflare-publish-artifacts
+          path: ${{ runner.temp }}/publish-artifacts
+
+      - name: Restore refreshed publish artifacts
         run: |
           set -euo pipefail
-          python3 -m pip install --user uv==0.11.19
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/uvx" --version
-
-      - name: Refresh publish artifacts
-        run: npm run pipeline:refresh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          METAGRAPH_WRITE_PROBE_RESULTS: "1"
+          find "$RUNNER_TEMP/publish-artifacts" -type l -print -quit | grep -q . && {
+            echo "::error::Refusing to restore artifact containing symbolic links."
+            exit 1
+          }
+          rm -rf public/metagraph dist/metagraph-r2
+          cp -R "$RUNNER_TEMP/publish-artifacts/public/metagraph" public/metagraph
+          if [ -d "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" ]; then
+            mkdir -p dist
+            cp -R "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" dist/metagraph-r2
+          fi
 
       - name: Validate registry
         run: npm run validate

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -133,6 +133,22 @@ for (const workflow of workflows) {
   }
   if (workflow === "publish-cloudflare.yml") {
     check(
+      /\brefresh:\n[\s\S]*\bpublish:\n[\s\S]*needs:\s+refresh/.test(content),
+      workflow,
+      "publish workflow must isolate refresh tooling from Cloudflare publishing secrets",
+    );
+    check(
+      !/python3\s+-m\s+pip\s+install[\s\S]*\buv==/.test(content),
+      workflow,
+      "publish workflow must not install uv from PyPI in a secret-bearing path",
+    );
+    check(
+      content.includes("astral-sh/setup-uv@") &&
+        content.includes("cloudflare-publish-artifacts"),
+      workflow,
+      "publish workflow must pass refreshed artifacts from the isolated refresh job",
+    );
+    check(
       content.includes('METAGRAPH_R2_UPLOAD_HISTORY: "1"'),
       workflow,
       "publish workflow must upload versioned R2 history objects",


### PR DESCRIPTION
### Motivation
- Prevent executing unverified PyPI-installed tooling in a job that later receives Cloudflare deployment secrets by isolating refresh-time native tooling into a no-secrets job.
- Stop the refresh step from being able to persist modifications into the workspace that could be used to exfiltrate or misuse deployment credentials.

### Description
- Split `.github/workflows/publish-cloudflare.yml` into a `refresh` job that runs the refresh pipeline with read-only permissions and a dependent `publish` job that re-checks out and restores only uploaded generated artifacts.
- Replace the direct `python3 -m pip install uv==...` approach with the pinned `astral-sh/setup-uv@...` action in the isolated `refresh` job and remove the un-hash-pinned PyPI install from the secret-bearing path.
- Add artifact staging/upload in `refresh` and artifact download/restore (with a symlink rejection check) in `publish` to ensure a clean workspace before secrets are exposed.
- Add validation checks in `scripts/validate-workflows.mjs` to require refresh/publish isolation, forbid `pip install ... uv` in the publish path, and require the artifact handoff pattern.

### Testing
- Ran `npm run validate:workflows` which reported "Validated 6 workflow file(s)." and returned successfully.
- Ran `npm test -- --run tests/script-utils.test.mjs` which completed with all tests passing (23 passed in the run).
- Ran `npm run format:check` which succeeded and confirmed Prettier formatting, and ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27185ea284832aaa1172810b51aad1)