### PR TITLE
fix(health): preserve object-shaped methods_supported in preserved health rows

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -2516,7 +2516,12 @@ function buildSurfaceHealthRow(surface, previous) {
   ) {
     row.method_results = previous.method_results;
   }
-  if (Array.isArray(previous.methods_supported)) {
+  if (
+    Array.isArray(previous.methods_supported) ||
+    (previous.methods_supported &&
+      typeof previous.methods_supported === "object" &&
+      !Array.isArray(previous.methods_supported))
+  ) {
     row.methods_supported = previous.methods_supported;
   }
   return row;

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
   existsSync,
+  mkdirSync,
   readFileSync,
   readdirSync,
   rmSync,
@@ -207,6 +208,114 @@ test("artifact build ignores forged committed health observations by default", (
     assert.equal(rebuilt.summary.status_counts.ok || 0, 0);
   } finally {
     writeFileSync(artifactPath, original);
+    if (originalCache === null) {
+      rmSync(cachePath, { force: true });
+    } else {
+      writeFileSync(cachePath, originalCache);
+    }
+    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
+      },
+      stdio: "pipe",
+    });
+    execFileSync(process.execPath, ["scripts/generate-types.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+    execFileSync(process.execPath, ["scripts/generate-client.mjs", "--write"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+    execFileSync(process.execPath, ["scripts/r2-manifest.mjs", "--write"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: process.env,
+      stdio: "pipe",
+    });
+    restoreSupportArtifacts(supportArtifacts);
+  }
+}, 30_000);
+
+test("artifact build preserves object-shaped live RPC method support", () => {
+  const healthPath = artifactFilePath("health/latest.json");
+  const rpcPath = artifactFilePath("rpc-endpoints.json");
+  const endpointsPath = artifactFilePath("endpoints.json");
+  const cachePath = ".cache/metagraphed/health/latest.json";
+  const originalCache = existsSync(cachePath)
+    ? readFileSync(cachePath, "utf8")
+    : null;
+  const supportArtifacts = snapshotSupportArtifacts();
+  const previousHealth = JSON.parse(readFileSync(healthPath, "utf8"));
+  const target = previousHealth.surfaces.find(
+    (surface) =>
+      surface.kind === "subtensor-rpc" && surface.public_safe === true,
+  );
+  assert(target, "expected a public-safe subtensor RPC health row");
+
+  previousHealth.source = "live-smoke-probe";
+  previousHealth.generated_at = "2999-01-01T00:00:00.000Z";
+  target.status = "ok";
+  target.classification = "live";
+  target.last_checked = "2999-01-01T00:00:00.000Z";
+  target.last_ok = "2999-01-01T00:00:00.000Z";
+  target.verified_at = "2999-01-01T00:00:00.000Z";
+  target.latency_ms = 7;
+  target.archive_support = true;
+  target.latest_block = 4242424;
+  target.rpc_method_count = 4;
+  target.method_results = {
+    chain_getHeader: { ok: true },
+    rpc_methods: { ok: true },
+  };
+  target.methods_supported = {
+    chain_getHeader: true,
+    system_health: true,
+    rpc_methods: true,
+    chain_getBlockHash: true,
+  };
+
+  try {
+    mkdirSync(".cache/metagraphed/health", { recursive: true });
+    writeFileSync(cachePath, `${JSON.stringify(previousHealth, null, 2)}\n`);
+    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: { ...process.env, METAGRAPH_PRESERVE_PROBE_HEALTH: "1" },
+      stdio: "pipe",
+    });
+
+    const rebuiltHealth = JSON.parse(readFileSync(healthPath, "utf8"));
+    const rebuiltHealthTarget = rebuiltHealth.surfaces.find(
+      (surface) => surface.surface_id === target.surface_id,
+    );
+    const rpcEndpoint = JSON.parse(
+      readFileSync(rpcPath, "utf8"),
+    ).endpoints.find((endpoint) => endpoint.id === target.surface_id);
+    const endpointResource = JSON.parse(
+      readFileSync(endpointsPath, "utf8"),
+    ).endpoints.find((endpoint) => endpoint.surface_id === target.surface_id);
+
+    assert.deepEqual(
+      rebuiltHealthTarget.methods_supported,
+      target.methods_supported,
+    );
+    assert.deepEqual(rpcEndpoint.methods_supported, target.methods_supported);
+    assert.deepEqual(endpointResource.method_support, target.methods_supported);
+    assert(
+      endpointResource.score_reasons.some(
+        (reason) => reason.reason === "method-support" && reason.points === 20,
+      ),
+      "expected endpoint scoring to include preserved method support",
+    );
+  } finally {
     if (originalCache === null) {
       rmSync(cachePath, { force: true });
     } else {


### PR DESCRIPTION
### Motivation
- The artifact-build preservation logic copied prior `methods_supported` only when it was an array, but live subtensor smoke probes emit an object map of method-name booleans which was getting dropped, degrading downstream endpoint metadata and scoring.
- The change intends to preserve method-support information from live probe rows so RPC endpoint artifacts and scoring retain accurate method-support points.

### Description
- Update `scripts/build-artifacts.mjs` to copy `previous.methods_supported` when it is either an array or an object-shaped map (non-array object) so object-shaped probe outputs are preserved.
- Add a regression test `tests/artifacts.test.mjs` that injects a `live-smoke-probe` cache row with object-shaped `methods_supported`, runs the artifact build, and asserts the value propagates into `health/latest.json`, `rpc-endpoints.json`, `endpoints.json`, and endpoint scoring.
- Include a small test helper import (`mkdirSync`) and run Prettier formatting on the modified files.

### Testing
- Ran the targeted test with `npx vitest run tests/artifacts.test.mjs -t "artifact build preserves object-shaped live RPC method support"`, which passed (1 test passed).
- Ran the full test suite with `npm run test`; the suite executed but `tests/public-safety.test.mjs` failed in this environment due to DNS resolution behavior, while the rest of the tests completed (95 passed, 1 failed).
- Ran `npm run lint` and `npm run format:check`, both of which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c5b5e430832a9eadc54604a4cfc7)