### PR TITLE
fix(intake): sanitize Discord notification fields

### DIFF
--- a/scripts/submission-notifications.mjs
+++ b/scripts/submission-notifications.mjs
@@ -93,8 +93,13 @@ export function buildSubmissionDiscordPayload(decision = {}) {
   }
 
   const meta = VERDICT_META[decision.verdict];
-  const number = decision.pr_number || decision.issue_number || "submission";
-  const targetUrl = decision.pr_url || decision.issue_url || undefined;
+  const number = sanitizeNotificationText(
+    decision.pr_number || decision.issue_number || "submission",
+    "submission",
+  );
+  const targetUrl = sanitizeNotificationUrl(
+    decision.pr_url || decision.issue_url || undefined,
+  );
   const candidate = decision.candidate || {};
   const sourceUrl =
     candidate.source_url ||
@@ -129,7 +134,7 @@ export function buildSubmissionDiscordPayload(decision = {}) {
           `#${number} ${meta.action} · ${compactSubject(decision.title, subjectSource)}`,
           DISCORD_MAX_TITLE_LENGTH,
         ),
-        url: targetUrl,
+        ...(targetUrl ? { url: targetUrl } : {}),
         color: meta.color,
         description:
           sanitizeNotificationSummary(decision.summary) ||
@@ -145,23 +150,47 @@ export function buildSubmissionDiscordPayload(decision = {}) {
 }
 
 export function sanitizeNotificationSummary(value) {
-  const lines = String(value || "")
+  const lines = publicNotificationLines(value).filter(
+    (line) => !SECTION_HEADING_PATTERN.test(line),
+  );
+
+  return truncate(lines.slice(0, 2).join(" "), DISCORD_MAX_DESCRIPTION_LENGTH);
+}
+
+function sanitizeNotificationText(value, fallback = "n/a", limit) {
+  const text = publicNotificationLines(value).join(" ");
+  return truncate(text || fallback, limit ?? DISCORD_MAX_FIELD_LENGTH);
+}
+
+function sanitizeNotificationUrl(value) {
+  const text = publicNotificationLines(value).join(" ");
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return new URL(text).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+function publicNotificationLines(value) {
+  return String(value || "")
     .split(/\r?\n/)
-    .map((line) =>
-      stripHtmlComments(line)
-        .replace(/^#{1,6}\s*/, "")
-        .replace(/^[-*]\s*/, "")
-        .replace(/\*\*/g, "")
-        .replace(/`/g, "")
-        .trim(),
-    )
+    .map(normalizeNotificationLine)
     .filter(Boolean)
-    .filter((line) => !SECTION_HEADING_PATTERN.test(line))
     .filter(
       (line) => !SENSITIVE_LINE_PATTERNS.some((pattern) => pattern.test(line)),
     );
+}
 
-  return truncate(lines.slice(0, 2).join(" "), DISCORD_MAX_DESCRIPTION_LENGTH);
+function normalizeNotificationLine(line) {
+  return stripHtmlComments(String(line || ""))
+    .replace(/^#{1,6}\s*/, "")
+    .replace(/^[-*]\s*/, "")
+    .replace(/\*\*/g, "")
+    .replace(/`/g, "")
+    .trim();
 }
 
 export function truncate(value, limit) {
@@ -200,19 +229,18 @@ export function validateDiscordWebhookUrl(value) {
 function field(name, value, inline = true) {
   return {
     name,
-    value: truncate(value || "n/a", DISCORD_MAX_FIELD_LENGTH),
+    value: sanitizeNotificationText(value, "n/a", DISCORD_MAX_FIELD_LENGTH),
     inline,
   };
 }
 
 function compactSubject(title, candidate = {}) {
-  const fromCandidate = [
-    candidate.netuid ? `SN${candidate.netuid}` : "",
-    candidate.kind,
-  ]
+  const safeNetuid = sanitizeNotificationText(candidate.netuid, "");
+  const safeKind = sanitizeNotificationText(candidate.kind, "");
+  const fromCandidate = [safeNetuid ? `SN${safeNetuid}` : "", safeKind]
     .filter(Boolean)
     .join(" ");
-  const text = String(title || fromCandidate || "submission")
+  const text = sanitizeNotificationText(title, "", 120)
     .replace(/^[a-z]+(?:\([^)]+\))?:\s*/i, "")
     .replace(/^(add|create|submit|update)\s+/i, "")
     .trim();
@@ -220,11 +248,10 @@ function compactSubject(title, candidate = {}) {
 }
 
 function fallbackNotificationSummary(meta, candidate = {}) {
-  const kind = candidate.kind ? `${candidate.kind} ` : "";
-  const netuid =
-    candidate.netuid !== undefined && candidate.netuid !== null
-      ? `for SN${candidate.netuid}`
-      : "for the registry";
+  const safeKind = sanitizeNotificationText(candidate.kind, "");
+  const safeNetuid = sanitizeNotificationText(candidate.netuid, "");
+  const kind = safeKind ? `${safeKind} ` : "";
+  const netuid = safeNetuid ? `for SN${safeNetuid}` : "for the registry";
   return truncate(
     `Metagraphed ${meta.action} this ${kind}submission ${netuid}.`,
     DISCORD_MAX_DESCRIPTION_LENGTH,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -643,6 +643,52 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(serialized.includes("private prompt"), false);
   });
 
+  test("sanitizes Discord payload fields beyond the summary", () => {
+    const payload = buildSubmissionDiscordPayload({
+      verdict: "closed",
+      status: "closed",
+      pr_number: 77,
+      pr_url:
+        "https://github.com/JSONbored/metagraphed/pull/77?token=ghp_should_not_leak",
+      title:
+        "feat(intake): https://discord.com/api/webhooks/redacted github_pat_should_not_leak",
+      submitter: "wallet private key should not leak",
+      candidate: {
+        netuid: 7,
+        kind: "docs",
+        source_url: "https://discord.com/api/webhooks/redacted",
+      },
+      summary: [
+        "Summary:",
+        "- Public review completed.",
+        "- private threshold github_pat_should_not_leak",
+      ].join("\n"),
+      now: "1970-01-01T00:00:00.000Z",
+    });
+
+    const serialized = JSON.stringify(payload);
+    assert.equal(payload.embeds[0].title, "#77 closed · SN7 docs");
+    assert.equal(payload.embeds[0].url, undefined);
+    assert.equal(
+      payload.embeds[0].fields.find((field) => field.name === "Source").value,
+      "n/a",
+    );
+    assert.equal(
+      payload.embeds[0].fields.some((field) => field.name === "GitHub"),
+      false,
+    );
+    assert.equal(
+      payload.embeds[0].fields.find((field) => field.name === "Submitter")
+        .value,
+      "n/a",
+    );
+    assert.equal(serialized.includes("discord.com/api/webhooks"), false);
+    assert.equal(serialized.includes("github_pat"), false);
+    assert.equal(serialized.includes("ghp_should"), false);
+    assert.equal(serialized.includes("private threshold"), false);
+    assert.equal(serialized.includes("private key"), false);
+  });
+
   test("sanitizes notification summaries and preserves code points", () => {
     assert.equal(
       sanitizeNotificationSummary(


### PR DESCRIPTION
### Motivation
- The Discord notification builder only filtered `decision.summary` for sensitive patterns, leaving titles, source/GitHub URLs, submitter text, and compact subjects unsanitized and able to leak webhook URLs, PAT-like tokens, wallet text, or private reviewer content.

### Description
- Reused the public notification sanitization pipeline by adding `sanitizeNotificationText`, `sanitizeNotificationUrl`, `publicNotificationLines`, and `normalizeNotificationLine` to centralize normalization and sensitive-line filtering using the existing `SENSITIVE_LINE_PATTERNS` and `SECTION_HEADING_PATTERN` rules.
- Applied sanitization to payload pieces beyond the summary: PR/issue `number`, embed `url` (omitted if unsafe), embed `fields` (via `field()`), compact title formatting (`compactSubject`), and fallback summaries so all candidate/reviewer-influenced values are redacted/normalized before truncation.
- Kept existing truncation behavior and safe URL parsing while ensuring invalid or sensitive URLs are not used as embed `url`/GitHub fields by using `sanitizeNotificationUrl`.
- Added a regression test `sanitizes Discord payload fields beyond the summary` to assert that title, source URL, GitHub URL, submitter, and summary inputs do not serialize sensitive strings into the Discord payload.

### Testing
- Ran lint and format checks with `npm run lint` and `npm run format:check`, which completed successfully after formatting fixes.
- Ran private-boundary and intake validators with `npm run validate:private-boundary` and `npm run validate:intake`, both of which passed after adjusting test fixtures to avoid real webhook strings in test source.
- Ran the unit test suite with `npm test -- --run tests/submission-gate.test.mjs`, and all tests passed (`26 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c6d79244832a8527d6f2a85b458a)