### PR TITLE
fix(submission): enforce candidate schema shape in UGC preflight

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -39,6 +39,72 @@ const STATUS_REPORT_TYPES = new Set([
   "other",
 ]);
 
+const CANDIDATE_STATES = new Set([
+  "schema-invalid",
+  "schema-valid",
+  "maintainer-review",
+  "verified",
+  "stale",
+  "rejected",
+]);
+
+const CANDIDATE_SOURCE_TIERS = new Set([
+  "native-chain",
+  "provider-claimed",
+  "third-party-index",
+  "community-docs",
+]);
+
+const CANDIDATE_CONFIDENCE_LEVELS = new Set(["low", "medium", "high"]);
+
+const CANDIDATE_VERIFICATION_CLASSIFICATIONS = new Set([
+  "live",
+  "redirected",
+  "auth-required",
+  "dead",
+  "unsafe",
+  "unsupported",
+  "rate-limited",
+  "transient",
+  "timeout",
+  "content-mismatch",
+]);
+
+const CANDIDATE_SCHEMA_FIELDS = new Set([
+  "schema_version",
+  "id",
+  "netuid",
+  "state",
+  "name",
+  "kind",
+  "url",
+  "source_url",
+  "source_urls",
+  "source_type",
+  "source_tier",
+  "confidence",
+  "provider",
+  "auth_required",
+  "public_safe",
+  "verification",
+  "rate_limit_notes",
+  "review_notes",
+]);
+
+const REQUIRED_CANDIDATE_SCHEMA_FIELDS = [
+  "schema_version",
+  "id",
+  "netuid",
+  "state",
+  "name",
+  "kind",
+  "url",
+  "source_url",
+  "provider",
+  "auth_required",
+  "public_safe",
+];
+
 export const PUBLIC_PREFLIGHT_STATES = new Set([
   "submit_pr",
   "fix_required",
@@ -683,6 +749,130 @@ export function extractSingleProvider(document) {
   };
 }
 
+function validateCandidateSchemaShape(candidate) {
+  const errors = [];
+
+  for (const field of REQUIRED_CANDIDATE_SCHEMA_FIELDS) {
+    if (candidate[field] === undefined) {
+      errors.push({
+        category: "unsupported-shape",
+        message: `candidate ${field} is required`,
+      });
+    }
+  }
+
+  for (const field of Object.keys(candidate)) {
+    if (!CANDIDATE_SCHEMA_FIELDS.has(field)) {
+      errors.push({
+        category: "unsupported-shape",
+        message: `candidate ${field} is not allowed`,
+      });
+    }
+  }
+
+  if (candidate.state !== undefined && !CANDIDATE_STATES.has(candidate.state)) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate state is unsupported",
+    });
+  }
+  if (
+    candidate.name !== undefined &&
+    (typeof candidate.name !== "string" || candidate.name.length === 0)
+  ) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate name is required",
+    });
+  }
+  if (
+    candidate.auth_required !== undefined &&
+    typeof candidate.auth_required !== "boolean"
+  ) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate auth_required must be boolean",
+    });
+  }
+  if (
+    candidate.public_safe !== undefined &&
+    typeof candidate.public_safe !== "boolean"
+  ) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate public_safe must be boolean",
+    });
+  }
+  if (
+    candidate.source_tier !== undefined &&
+    !CANDIDATE_SOURCE_TIERS.has(candidate.source_tier)
+  ) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate source_tier is unsupported",
+    });
+  }
+  if (
+    candidate.confidence !== undefined &&
+    !CANDIDATE_CONFIDENCE_LEVELS.has(candidate.confidence)
+  ) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate confidence is unsupported",
+    });
+  }
+  if (
+    candidate.source_type !== undefined &&
+    typeof candidate.source_type !== "string"
+  ) {
+    errors.push({
+      category: "unsupported-shape",
+      message: "candidate source_type must be a string",
+    });
+  }
+  for (const field of ["rate_limit_notes", "review_notes"]) {
+    if (
+      candidate[field] !== undefined &&
+      typeof candidate[field] !== "string"
+    ) {
+      errors.push({
+        category: "unsupported-shape",
+        message: `candidate ${field} must be a string`,
+      });
+    }
+  }
+  if (candidate.verification !== undefined && candidate.verification !== null) {
+    if (
+      typeof candidate.verification !== "object" ||
+      Array.isArray(candidate.verification)
+    ) {
+      errors.push({
+        category: "unsupported-shape",
+        message: "candidate verification must be an object",
+      });
+    } else {
+      if (
+        !CANDIDATE_VERIFICATION_CLASSIFICATIONS.has(
+          candidate.verification.classification,
+        )
+      ) {
+        errors.push({
+          category: "unsupported-shape",
+          message: "candidate verification classification is unsupported",
+        });
+      }
+      if (typeof candidate.verification.verified_at !== "string") {
+        errors.push({
+          category: "unsupported-shape",
+          message: "candidate verification verified_at must be a string",
+        });
+      }
+    }
+  }
+
+  return errors;
+}
+
 export function validateCandidateForSubmission({
   candidate,
   document = {},
@@ -712,6 +902,8 @@ export function validateCandidateForSubmission({
       manual_reasons,
     };
   }
+
+  errors.push(...validateCandidateSchemaShape(candidate));
 
   if (candidate.schema_version !== 1) {
     errors.push({

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -69,6 +69,38 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(report.candidate.id, "community-sn-7-docs-example");
   });
 
+  test("blocks direct candidates with malformed schema metadata", () => {
+    const document = structuredClone(validCandidateDocument);
+    delete document.candidates[0].state;
+    delete document.candidates[0].name;
+    document.candidates[0].auth_required = "false";
+    document.candidates[0].unexpected_extra_property = true;
+
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/malformed-metadata.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(report.blocking, true);
+    assert.equal(report.errors.includes("candidate state is required"), true);
+    assert.equal(report.errors.includes("candidate name is required"), true);
+    assert.equal(
+      report.errors.includes("candidate auth_required must be boolean"),
+      true,
+    );
+    assert.equal(
+      report.errors.includes(
+        "candidate unexpected_extra_property is not allowed",
+      ),
+      true,
+    );
+  });
+
   test("blocks direct candidates that edit unrelated files", () => {
     const scope = classifyPrScope([
       "registry/candidates/community/allways-docs-example.json",


### PR DESCRIPTION
### Motivation
- The UGC shortcut route allowed one-file community candidate PRs to bypass the full registry and JSON schema validators, letting malformed candidate metadata pass the PR gate.
- The change ensures the UGC preflight enforces the same required fields, types, and additional-properties constraints expected by the full validators to prevent registry integrity issues.

### Description
- Add allowlists and required-field definitions for candidate shape (`CANDIDATE_SCHEMA_FIELDS`, `REQUIRED_CANDIDATE_SCHEMA_FIELDS`, and related enum sets) in `scripts/submission-policy.mjs`.
- Implement `validateCandidateSchemaShape(candidate)` which checks required fields, rejects unexpected extra properties, enforces field types and supported enum values, and validates nested `verification` structure.
- Call `validateCandidateSchemaShape` from `validateCandidateForSubmission` so UGC direct-candidate preflight returns schema errors before routing can mark the submission as acceptable.
- Add a regression test `tests/submission-gate.test.mjs` that asserts malformed one-file candidate metadata (missing `state`/`name`, non-boolean `auth_required`, unexpected extra property) is rejected and results in a blocking `fix_required` outcome.

### Testing
- Ran the targeted unit tests with `npm test -- tests/submission-gate.test.mjs tests/script-utils.test.mjs` and they passed (all tests in those files succeeded). 
- Ran `npm run lint` and `npm run format:check` (formatting issues auto-fixed) and both pass after formatting.
- Ran the full test suite with `npm test`; it failed due to missing generated public/R2 artifacts and environment-specific DNS resolution behaviour in this checkout, which are unrelated to the submitted schema-shape enforcement change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c64d4724832a9feb45a5e7549d79)