### PR TITLE
fix(r2): upload complete history artifacts and avoid publishing control manifests during limited uploads

### DIFF
--- a/docs/cloudflare-backend.md
+++ b/docs/cloudflare-backend.md
@@ -67,7 +67,7 @@ If no KV binding is configured, the Worker falls back to `METAGRAPH_R2_LATEST_PR
 Write operations require explicit environment flags:
 
 - `METAGRAPH_ALLOW_R2_UPLOAD=1 npm run r2:upload` uploads only artifacts whose SHA-256 differs from `latest/r2-manifest.json`, plus the current `latest/r2-manifest.json` and `latest/build-summary.json` control files.
-- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_HISTORY=1 npm run r2:upload` also writes run-prefix copies for changed artifacts and control files.
+- `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_HISTORY=1 npm run r2:upload` also writes run-prefix copies for all planned artifacts and control files.
 - `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_FORCE=1 npm run r2:upload` bypasses remote manifest comparison and republishes all planned artifacts.
 - `METAGRAPH_ALLOW_R2_UPLOAD=1 METAGRAPH_R2_UPLOAD_LIMIT=5 npm run r2:upload` can be used for a remote permission smoke. Limited smoke uploads skip `latest/r2-manifest.json` and `latest/build-summary.json` control files so the latest manifest cannot claim that unuploaded artifacts exist.
 - `METAGRAPH_ALLOW_R2_DOWNLOAD=1 npm run r2:download`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -74,7 +74,7 @@ npm run worker:deploy:dry-run
 Actual writes require explicit environment gates:
 
 - `METAGRAPH_ALLOW_R2_UPLOAD=1`
-- `METAGRAPH_R2_UPLOAD_HISTORY=1` when the publish job should also write run-prefix history copies for changed artifacts and control files.
+- `METAGRAPH_R2_UPLOAD_HISTORY=1` when the publish job should also write run-prefix history copies for all planned artifacts and control files.
 - `METAGRAPH_R2_UPLOAD_FORCE=1` when a publish job should ignore the remote `latest/r2-manifest.json` comparison and republish every planned artifact.
 - `METAGRAPH_R2_UPLOAD_LIMIT` for smoke-only uploads against a small artifact subset. Limited smoke uploads skip control files so `latest/r2-manifest.json` continues to describe only a complete latest artifact set.
 - `METAGRAPH_ALLOW_KV_WRITE=1`

--- a/scripts/r2-upload.mjs
+++ b/scripts/r2-upload.mjs
@@ -87,20 +87,20 @@ for (const artifact of plannedArtifacts) {
     forceUpload ||
     remoteManifestResult.status !== "found" ||
     remoteManifestByPath.get(artifact.path) !== artifact.sha256;
-  if (!changed) {
+  if (changed) {
+    changedArtifactCount += 1;
+    artifactUploadJobs.push(
+      uploadJob(
+        localPath,
+        artifact.latest_key,
+        manifest.bucket_name,
+        artifact.content_type,
+        "latest",
+      ),
+    );
+  } else {
     skippedArtifactCount += 1;
-    continue;
   }
-  changedArtifactCount += 1;
-  artifactUploadJobs.push(
-    uploadJob(
-      localPath,
-      artifact.latest_key,
-      manifest.bucket_name,
-      artifact.content_type,
-      "latest",
-    ),
-  );
   if (uploadHistory) {
     artifactUploadJobs.push(
       uploadJob(
@@ -404,10 +404,13 @@ function summarizeError(error) {
 }
 
 function wranglerBin() {
-  return path.join(
-    repoRoot,
-    "node_modules",
-    ".bin",
-    process.platform === "win32" ? "wrangler.cmd" : "wrangler",
+  return (
+    process.env.METAGRAPH_WRANGLER_BIN ||
+    path.join(
+      repoRoot,
+      "node_modules",
+      ".bin",
+      process.platform === "win32" ? "wrangler.cmd" : "wrangler",
+    )
   );
 }

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1,12 +1,16 @@
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
+  mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { test } from "vitest";
 import {
   artifactDirectoryPath,
@@ -1037,6 +1041,87 @@ test("R2-only generated artifacts stay out of the public git tree", () => {
       true,
       `${relativePath} should be generated into the R2 staging tree`,
     );
+  }
+});
+
+test("R2 history upload writes every planned run-prefix artifact", () => {
+  const temporaryDirectory = mkdtempSync(
+    path.join(tmpdir(), "metagraphed-r2-upload-"),
+  );
+  const wranglerPath = path.join(temporaryDirectory, "wrangler");
+  const putLogPath = path.join(temporaryDirectory, "put-log.jsonl");
+  const manifestPath = path.join(r2StagingRoot, "r2-manifest.json");
+  const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+  writeFileSync(
+    wranglerPath,
+    String.raw`#!/usr/bin/env node
+import { appendFileSync, readFileSync } from "node:fs";
+
+const args = process.argv.slice(2);
+if (args[0] !== "r2" || args[1] !== "object") {
+  process.exit(2);
+}
+if (args[2] === "get") {
+  process.stdout.write(readFileSync(process.env.FAKE_REMOTE_MANIFEST, "utf8"));
+  process.exit(0);
+}
+if (args[2] === "put") {
+  appendFileSync(
+    process.env.FAKE_PUT_LOG,
+    JSON.stringify({ key: args[3].slice(args[3].indexOf("/") + 1) }) + "\n",
+  );
+  process.exit(0);
+}
+process.exit(2);
+`,
+  );
+  chmodSync(wranglerPath, 0o755);
+
+  try {
+    const output = execFileSync(
+      process.execPath,
+      ["scripts/r2-upload.mjs", "--write"],
+      {
+        cwd: process.cwd(),
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          FAKE_PUT_LOG: putLogPath,
+          FAKE_REMOTE_MANIFEST: manifestPath,
+          METAGRAPH_ALLOW_R2_UPLOAD: "1",
+          METAGRAPH_R2_UPLOAD_CONCURRENCY: "16",
+          METAGRAPH_R2_UPLOAD_HISTORY: "1",
+          METAGRAPH_WRANGLER_BIN: wranglerPath,
+        },
+        stdio: "pipe",
+      },
+    );
+    const summary = JSON.parse(output);
+    const putKeys = readFileSync(putLogPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => JSON.parse(line).key);
+
+    assert.equal(summary.remote_manifest_status, "found");
+    assert.equal(summary.changed_artifact_count, 0);
+    assert.equal(summary.skipped_artifact_count, manifest.artifacts.length);
+    assert.equal(summary.uploaded_latest_count, 0);
+    assert.equal(summary.uploaded_control_count, 3);
+    assert.equal(
+      summary.uploaded_history_count,
+      manifest.artifacts.length + summary.uploaded_control_count,
+    );
+    assert.equal(
+      putKeys.filter((key) => key.startsWith(manifest.run_prefix)).length,
+      manifest.artifacts.length + summary.uploaded_control_count,
+    );
+    assert(
+      putKeys.includes(manifest.artifacts.at(-1).key),
+      "expected history upload to include artifacts unchanged in latest",
+    );
+  } finally {
+    rmSync(temporaryDirectory, { force: true, recursive: true });
   }
 });
 


### PR DESCRIPTION
### Motivation

- Prevent publishing inconsistent `latest`/run-prefix manifests when `METAGRAPH_R2_UPLOAD_LIMIT` or delta mode uploads only a subset of artifacts by ensuring control manifests never claim artifacts that were not uploaded.  
- Ensure `METAGRAPH_R2_UPLOAD_HISTORY=1` produces run-prefix history copies for every planned artifact so history manifests accurately describe the run.  

### Description

- Always enqueue run-prefix (`history`) uploads for every planned artifact when `METAGRAPH_R2_UPLOAD_HISTORY=1` so unchanged `latest/` artifacts are still written under the run prefix; this is implemented by moving history job creation out of the `changed` branch in `scripts/r2-upload.mjs`.  
- Preserve the smoke/limited-upload behavior by keeping control artifacts out of the planned uploads when `METAGRAPH_R2_UPLOAD_LIMIT` is set (the uploader uses `plannedControlArtifacts = uploadLimit ? [] : controlArtifacts`).  
- Add `METAGRAPH_WRANGLER_BIN` support in `scripts/r2-upload.mjs` to allow injecting a fake `wrangler` binary during tests and tooling.  
- Update operator docs in `docs/cloudflare-backend.md` and `docs/operations.md` and add a regression test in `tests/artifacts.test.mjs` that uses a fake `wrangler` to verify history uploads include unchanged artifacts.  

### Testing

- Ran `npm run r2:manifest` and it completed successfully.  
- Ran the focused test set `npm test -- tests/artifacts.test.mjs -t "R2 history upload writes|limited R2 upload dry run"` and both tests passed.  
- Verified `npm run r2:upload:dry-run`, `npm run lint`, and `npm run format:check` and they succeeded (dry-run produced the expected summary and lint/format checks passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c63f2104832a846fa8c09c7bcb9f)