### PR TITLE
fix(publish): require probe health for dispatch publishes

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -25,6 +25,9 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      METAGRAPH_PRODUCTION_BUILD: "1"
+      METAGRAPH_REQUIRE_PROBE_HEALTH: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -151,6 +151,16 @@ for (const workflow of workflows) {
       "publish workflow must fail closed when Cloudflare publishing secrets are missing",
     );
     check(
+      content.includes('METAGRAPH_PRODUCTION_BUILD: "1"'),
+      workflow,
+      "publish workflow must explicitly use the production build path",
+    );
+    check(
+      content.includes('METAGRAPH_REQUIRE_PROBE_HEALTH: "1"'),
+      workflow,
+      "publish workflow must explicitly require probe-derived health",
+    );
+    check(
       content.includes("steps.cloudflare-secrets.outputs.dry_run != 'true'"),
       workflow,
       "publish workflow must skip deploy/upload steps only in explicit dry-run mode",


### PR DESCRIPTION
### Motivation
- Prevent manual `workflow_dispatch` executions of the publish workflow from bypassing probe-derived health checks and production build steps by making the production/probe gating explicit at the job level.

### Description
- Add job-level environment variables `METAGRAPH_PRODUCTION_BUILD: "1"` and `METAGRAPH_REQUIRE_PROBE_HEALTH: "1"` to `.github/workflows/publish-cloudflare.yml` so all publish job executions (including manual dispatches) take the production build path and require probe health.
- Update `scripts/validate-workflows.mjs` to assert the presence of `METAGRAPH_PRODUCTION_BUILD: "1"` and `METAGRAPH_REQUIRE_PROBE_HEALTH: "1"` in the publish workflow to avoid regressions.
- This leverages existing `isProductionPublishBuild()` and `requiresProbeHealth()` checks which already honor the corresponding environment variables, preserving existing build and validation logic.

### Testing
- Ran `npm run validate:workflows` which succeeded and reported validated workflows. 
- Ran `npm run format:check -- .github/workflows/publish-cloudflare.yml scripts/validate-workflows.mjs` which succeeded with no formatting issues. 
- Ran `npm test` which failed due to missing generated public/R2 artifacts and environment preconditions unrelated to these changes (unit tests expect generated files like `public/metagraph/candidates.json` and `dist/metagraph-r2/metagraph/r2-manifest.json`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c63f40d0832a8b1be04245defff5)