### PR TITLE
fix(ci): route malformed UGC PRs through submission gate

### DIFF
--- a/scripts/ci-validate-route.mjs
+++ b/scripts/ci-validate-route.mjs
@@ -7,11 +7,11 @@ import {
 const options = parseArgs(process.argv.slice(2));
 const changedFiles = await readChangedFiles(options.changedFiles);
 const classification = classifyPrScope(changedFiles);
-const mode =
-  ["direct-candidate", "direct-provider"].includes(classification.scope) &&
-  classification.errors.length === 0
-    ? "ugc"
-    : "full";
+const mode = ["direct-candidate", "direct-provider"].includes(
+  classification.scope,
+)
+  ? "ugc"
+  : "full";
 
 const report = {
   schema_version: 1,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -1,5 +1,8 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { describe, test } from "vitest";
 import {
   loadNativeSnapshot,
@@ -78,6 +81,36 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(scope.scope, "direct-candidate");
     assert.equal(scope.errors.length, 1);
     assert.equal(scope.errors[0].category, "generated-artifact-tampering");
+  });
+
+  test("routes mixed direct candidate PRs through the UGC gate", () => {
+    const tmp = mkdtempSync(join(tmpdir(), "metagraphed-route-"));
+    try {
+      const changedFiles = join(tmp, "changed-files.txt");
+      writeFileSync(
+        changedFiles,
+        [
+          "registry/candidates/community/allways-docs-example.json",
+          "README.md",
+        ].join("\n"),
+      );
+
+      const output = execFileSync(
+        process.execPath,
+        ["scripts/ci-validate-route.mjs", "--changed-files", changedFiles],
+        { encoding: "utf8" },
+      );
+      const report = JSON.parse(output);
+
+      assert.equal(report.mode, "ugc");
+      assert.equal(report.scope, "direct-candidate");
+      assert.deepEqual(
+        report.errors.map((error) => error.category),
+        ["generated-artifact-tampering"],
+      );
+    } finally {
+      rmSync(tmp, { force: true, recursive: true });
+    }
   });
 
   test("routes direct provider profile PRs to manual review", () => {


### PR DESCRIPTION
### Motivation
- Prevent direct community candidate/provider PRs that include unrelated files from being routed around the public submission preflight due to classification errors.

### Description
- Change `scripts/ci-validate-route.mjs` so `mode` is set to `ugc` for any classification scope of `direct-candidate` or `direct-provider` regardless of `classification.errors` (previously required `errors.length === 0`).
- Add a regression test in `tests/submission-gate.test.mjs` that invokes `scripts/ci-validate-route.mjs` with a community candidate file plus an unrelated file and asserts the CLI reports `mode: ugc`, preserves the `direct-*` scope, and includes the `generated-artifact-tampering` error category.

### Testing
- Ran `npm test -- --run tests/submission-gate.test.mjs` and the updated test file passed (26/26 tests in that file).
- Ran `npm run format:check` and `npm run lint`, both succeeded after formatting the new test.
- Ran `node scripts/ci-validate-route.mjs --changed-files /tmp/metagraphed-changed-files.txt` and observed `mode: "ugc"` and reported error categories as expected.
- Ran the full `npm test` suite and it failed in this environment due to missing generated public/R2 artifacts and an environment DNS difference (these failures are unrelated to the CI routing change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27c3d80628832ab0bd4e5b99ac396c)