### PR TITLE
fix(publish): build probe-derived artifacts in refresh job

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -27,6 +27,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      METAGRAPH_PRODUCTION_BUILD: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -47,7 +49,7 @@ jobs:
 
       - name: Prepare reviewed publish artifacts
         run: |
-          npm run artifacts:prepare-local
+          npm run build
           npm run r2:manifest
 
       - name: Stage reviewed publish artifacts

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -169,16 +169,19 @@ for (const workflow of workflows) {
       workflow,
       "publish workflow must not refresh live registry data during deployment",
     );
+    const refreshJob = workflowJobBlock(content, "refresh");
+    const publishJob = workflowJobBlock(content, "publish");
     check(
-      !content.includes('METAGRAPH_WRITE_PROBE_RESULTS: "1"'),
+      !publishJob.includes('METAGRAPH_WRITE_PROBE_RESULTS: "1"'),
       workflow,
-      "publish workflow must not write live probe results during deployment",
+      "publish job must not write live probe results during deployment",
     );
     check(
-      content.includes("npm run artifacts:prepare-local") &&
-        content.includes("npm run r2:manifest"),
+      refreshJob.includes('METAGRAPH_PRODUCTION_BUILD: "1"') &&
+        refreshJob.includes("npm run build") &&
+        refreshJob.includes("npm run r2:manifest"),
       workflow,
-      "publish workflow must prepare R2 artifacts from reviewed repository inputs",
+      "publish workflow refresh job must prepare R2 artifacts with the production probe-health build path",
     );
     check(
       /\brefresh:\n[\s\S]*\bpublish:\n[\s\S]*needs:\s+refresh/.test(content),
@@ -215,14 +218,14 @@ for (const workflow of workflows) {
       "publish workflow must fail closed when Cloudflare publishing secrets are missing",
     );
     check(
-      content.includes('METAGRAPH_PRODUCTION_BUILD: "1"'),
+      refreshJob.includes('METAGRAPH_PRODUCTION_BUILD: "1"'),
       workflow,
-      "publish workflow must explicitly use the production build path",
+      "publish workflow refresh job must explicitly use the production build path",
     );
     check(
-      content.includes('METAGRAPH_REQUIRE_PROBE_HEALTH: "1"'),
+      publishJob.includes('METAGRAPH_REQUIRE_PROBE_HEALTH: "1"'),
       workflow,
-      "publish workflow must explicitly require probe-derived health",
+      "publish workflow publish job must explicitly require probe-derived health",
     );
     check(
       content.includes("steps.cloudflare-secrets.outputs.dry_run != 'true'"),
@@ -246,4 +249,18 @@ function check(condition, workflow, message) {
   if (!condition) {
     errors.push(`${workflow}: ${message}`);
   }
+}
+
+function workflowJobBlock(content, jobName) {
+  const match = content.match(
+    new RegExp(
+      String.raw`^  ${escapeRegExp(jobName)}:\n[\s\S]*?(?=^  [A-Za-z0-9_-]+:\n|(?![\s\S]))`,
+      "m",
+    ),
+  );
+  return match?.[0] || "";
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }


### PR DESCRIPTION
### Motivation
- The publish job began requiring probe-derived health via `METAGRAPH_REQUIRE_PROBE_HEALTH=1`, but the separate `refresh` job still prepared artifacts without running the production probe path, causing validation to fail in clean runners. 
- The existing workflow validator only checked for literal environment strings anywhere in the file, so it did not guarantee the artifact-producing job actually used the production build + probe path.

### Description
- Update the `refresh` job in `.github/workflows/publish-cloudflare.yml` to set `METAGRAPH_PRODUCTION_BUILD: "1"` and run `npm run build` (instead of `npm run artifacts:prepare-local`) so the production probe path and smoke probes run during artifact creation. 
- Tighten `scripts/validate-workflows.mjs` to inspect `refresh` and `publish` job blocks separately and assert the `refresh` job includes `METAGRAPH_PRODUCTION_BUILD: "1"`, `npm run build`, and `npm run r2:manifest`, while the `publish` job retains `METAGRAPH_REQUIRE_PROBE_HEALTH: "1"` and must not include `METAGRAPH_WRITE_PROBE_RESULTS: "1"`.
- Add `workflowJobBlock` and `escapeRegExp` helpers to `scripts/validate-workflows.mjs` so validations are scoped to specific jobs instead of relying on file-wide substring matches.

### Testing
- Ran `npm run validate:workflows` and it succeeded after the changes. 
- Ran `npx prettier --check .github/workflows/publish-cloudflare.yml scripts/validate-workflows.mjs` and formatting checks passed. 
- Ran repository checks (`git diff --check`) and committed the changes successfully. 
- Ran `npm test`, which failed due to missing generated public/R2 artifacts and DNS resolution/environment limitations in the test environment (missing `public/metagraph/*` and `dist/metagraph-r2/*` outputs), not because of the workflow/validator changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27edab020c832a9b0e92bb5a28d351)