### PR TITLE
fix(r2): restage manifests after restoring public artifacts

### DIFF
--- a/scripts/prepare-local-r2-staging.mjs
+++ b/scripts/prepare-local-r2-staging.mjs
@@ -40,16 +40,7 @@ const result = spawnSync(process.execPath, ["scripts/build-artifacts.mjs"], {
   stdio: "pipe",
 });
 
-for (const [relativePath, original] of originals) {
-  const filePath = path.join(repoRoot, relativePath);
-  if (!original.existed) {
-    await rm(filePath, { force: true });
-    continue;
-  }
-  await mkdir(path.dirname(filePath), { recursive: true });
-  await writeFile(filePath, original.content);
-}
-
+await restorePublicArtifacts();
 for (const [relativePath, content] of schemaSnapshotDetails) {
   const filePath = stagedSnapshotPath(relativePath);
   await mkdir(path.dirname(filePath), { recursive: true });
@@ -61,6 +52,25 @@ process.stderr.write(result.stderr || "");
 
 if (result.status !== 0) {
   process.exit(result.status || 1);
+}
+
+const manifestResult = spawnSync(
+  process.execPath,
+  ["scripts/r2-manifest.mjs", "--write"],
+  {
+    cwd: repoRoot,
+    encoding: "utf8",
+    stdio: "pipe",
+  },
+);
+
+await restorePublicArtifacts();
+
+process.stdout.write(manifestResult.stdout || "");
+process.stderr.write(manifestResult.stderr || "");
+
+if (manifestResult.status !== 0) {
+  process.exit(manifestResult.status || 1);
 }
 
 console.log(
@@ -88,6 +98,18 @@ function stagedSnapshotPath(relativePath) {
     );
   }
   return filePath;
+}
+
+async function restorePublicArtifacts() {
+  for (const [relativePath, original] of originals) {
+    const filePath = path.join(repoRoot, relativePath);
+    if (!original.existed) {
+      await rm(filePath, { force: true });
+      continue;
+    }
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, original.content);
+  }
 }
 
 async function loadSchemaSnapshotDetails() {

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1446,4 +1446,13 @@ function restoreSupportArtifacts(snapshot) {
   for (const [filePath, content] of snapshot) {
     writeFileSync(filePath, content);
   }
+  execFileSync(process.execPath, ["scripts/r2-manifest.mjs", "--write"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: process.env,
+    stdio: "pipe",
+  });
+  for (const [filePath, content] of snapshot) {
+    writeFileSync(filePath, content);
+  }
 }


### PR DESCRIPTION
## Summary
- regenerate the staged full R2 manifest after `artifacts:prepare-local` restores reviewed public artifacts
- restore public artifacts again after manifest restaging so local checks do not rewrite committed public files
- keep artifact tests from leaving staged manifests that disagree with restored public artifacts

## What changed
- `scripts/prepare-local-r2-staging.mjs` now runs the R2 manifest writer after public artifact restoration, then restores the public tree again.
- `tests/artifacts.test.mjs` restages the manifest in its support-artifact restore helper so later R2 upload tests use matching staged manifests.

## Why
- The previous helper could leave `dist/metagraph-r2/metagraph/r2-manifest.json` pointing at transient build output while `public/metagraph/*` had been restored to reviewed committed artifacts. R2 upload validation then failed on local hash mismatches for compact artifacts such as `changelog.json`.

## Validation
- `npm run artifacts:prepare-local`
- `npx vitest run tests/artifacts.test.mjs -t "R2 history upload writes every planned run-prefix artifact"`
- `npx vitest run tests/artifacts.test.mjs`
- `npm run check`
- `git diff --check`
- `npm run test:coverage` ran all 109 tests successfully but failed the existing global coverage thresholds: statements 96% and lines 95.98%, below the configured 97% minimum.

## Notes
- Public compact artifacts remain unchanged by this PR.
- Both public and staged R2 manifests were locally checked against their referenced artifact bytes.