### PR TITLE
fix(verification): omit missing GitHub API statuses

### DIFF
--- a/scripts/verification-quality.mjs
+++ b/scripts/verification-quality.mjs
@@ -66,6 +66,10 @@ export function preservePreviousGithubMetadata(result, previousByCandidate) {
   };
 }
 
+export function optionalHttpStatus(statusCode) {
+  return Number.isInteger(statusCode) ? statusCode : undefined;
+}
+
 function isRetryableFailure(result) {
   return ["rate-limited", "timeout", "transient"].includes(
     result?.classification,

--- a/scripts/verify-candidates.mjs
+++ b/scripts/verify-candidates.mjs
@@ -16,7 +16,10 @@ import {
   classifyHttpProbe,
   isContentMismatch,
 } from "./http-probe-classification.mjs";
-import { preservePreviousGithubMetadata } from "./verification-quality.mjs";
+import {
+  optionalHttpStatus,
+  preservePreviousGithubMetadata,
+} from "./verification-quality.mjs";
 
 const args = new Set(process.argv.slice(2));
 const shouldWrite = args.has("--write");
@@ -240,7 +243,7 @@ async function verifyGithubRepo(base, repo) {
     if (redirectApi.ok) {
       return githubMetadataResult(base, redirectApiUrl, redirectApi.body, {
         api_error: api.error || null,
-        api_status: api.status_code || null,
+        api_status: optionalHttpStatus(api.status_code),
         classification: "redirected",
         latency_ms: fallback.latency_ms,
         method_tested: fallback.method_tested,
@@ -259,7 +262,7 @@ async function verifyGithubRepo(base, repo) {
     ),
     error: api.error || fallback.error || null,
     github_api_url: apiUrl,
-    github_api_status: api.status_code || null,
+    github_api_status: optionalHttpStatus(api.status_code),
     latency_ms: fallback.latency_ms,
     method_tested: fallback.method_tested,
     private_redirect_blocked: fallback.private_redirect_blocked || false,

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -66,7 +66,10 @@ import {
 } from "../scripts/endpoint-ops-brief.mjs";
 import { generateBaselineOverlaySet } from "../scripts/generated-overlays.mjs";
 import { classifyHttpProbe } from "../scripts/http-probe-classification.mjs";
-import { preservePreviousGithubMetadata } from "../scripts/verification-quality.mjs";
+import {
+  optionalHttpStatus,
+  preservePreviousGithubMetadata,
+} from "../scripts/verification-quality.mjs";
 import {
   buildIssueIntakeReport,
   buildEndpointStatusReportIntakeReport,
@@ -174,6 +177,13 @@ describe("script utility contracts", () => {
       public_safe: true,
       source_tier: "native-chain",
     });
+  });
+
+  test("omits missing optional HTTP statuses from verification metadata", () => {
+    assert.equal(optionalHttpStatus(null), undefined);
+    assert.equal(optionalHttpStatus(undefined), undefined);
+    assert.equal(optionalHttpStatus(200), 200);
+    assert.equal(optionalHttpStatus(404), 404);
   });
 
   test("preserves previous healthy verification when a candidate probe is retryable", () => {


### PR DESCRIPTION
## Summary
- omit absent GitHub API status metadata instead of serializing it as `null`
- reuse a small integer-only HTTP status normalizer for GitHub verification metadata
- add unit coverage for optional status normalization

## What changed
- `scripts/verify-candidates.mjs` now passes only integer GitHub API status values into verification output.
- `scripts/verification-quality.mjs` exposes `optionalHttpStatus()` for verification metadata helpers.
- `tests/script-utils.test.mjs` covers null, undefined, and integer status handling.

## Why
- `VerificationResult.github_api_status` is typed as an integer. Failure fallbacks could still emit `github_api_status: null`, which is invalid for refreshed verification artifacts.

## Validation
- `npx vitest run tests/script-utils.test.mjs`
- `npm run check`
- `git diff --check`
- `npm run test:coverage` ran all 112 tests successfully but failed the existing global coverage thresholds: statements 96% and lines 95.98%, below the configured 97% minimum.

## Notes
- Current committed public artifacts and `registry/verification/promotions.json` do not contain `github_api_status: null`; this hardens future refreshes.