### PR TITLE
fix(enrichment): filter URL-excluded candidates from queue

### DIFF
--- a/public/metagraph/build-summary.json
+++ b/public/metagraph/build-summary.json
@@ -7,7 +7,7 @@
   },
   "artifact_budgets": [],
   "artifact_count": 22,
-  "artifact_size_bytes": 5151597,
+  "artifact_size_bytes": 5149473,
   "artifacts": [
     {
       "path": "api-index.json",
@@ -17,8 +17,8 @@
     },
     {
       "path": "changelog.json",
-      "sha256": "440558cc09602bddad2d4d5efaae85c1025f063b03b638ad85aff028e5f35db0",
-      "size_bytes": 3151,
+      "sha256": "484da6be28397abd82b5d1b7950fa85bae30dd638facb06bfc6bd3e9c15b2724",
+      "size_bytes": 1211,
       "storage_tier": "dual"
     },
     {
@@ -89,8 +89,8 @@
     },
     {
       "path": "review/enrichment-queue.json",
-      "sha256": "c68d4d2c0a2089f00bd28d99b3600c55753abc548ebf7e8bd402e2a648625dc3",
-      "size_bytes": 365804,
+      "sha256": "97f47729b26b3bd9f6f1dbe831e2544ac44d97a67a0830459da914421cd821f1",
+      "size_bytes": 365620,
       "storage_tier": "dual"
     },
     {
@@ -182,7 +182,7 @@
   },
   "endpoint_count": 1139,
   "full_artifact_count": 1272,
-  "full_artifact_size_bytes": 48913401,
+  "full_artifact_size_bytes": 34823484,
   "generated_at": "1970-01-01T00:00:00.000Z",
   "profile_count": 129,
   "provider_count": 90,
@@ -197,9 +197,9 @@
     "r2": 1250
   },
   "storage_tier_size_bytes": {
-    "dual": 4892572,
+    "dual": 4890448,
     "git": 259025,
-    "r2": 43761804
+    "r2": 29674011
   },
   "subnet_count": 129,
   "surface_count": 1139

--- a/public/metagraph/changelog.json
+++ b/public/metagraph/changelog.json
@@ -1,64 +1,7 @@
 {
   "artifacts": {
     "added": [],
-    "modified": [
-      {
-        "hash": "df67ec41708977a3ff5fc541deebda5b53a031f19a01e07a77ed5acd30ac8464",
-        "path": "coverage.json"
-      },
-      {
-        "hash": "45f406f5ac4f2dfbfd7838c79faab1f2b42314587656221769fc2075619699cf",
-        "path": "curation.json"
-      },
-      {
-        "hash": "877ca3c1819e7575f060da54980fb863c247fcf0574cd9b572fd7008f3763b8c",
-        "path": "evidence-ledger.json"
-      },
-      {
-        "hash": "89f9b80ab4dac8c371c8160c43749ab688203349fe0900e33d9ab2dbd5067b2a",
-        "path": "freshness.json"
-      },
-      {
-        "hash": "cab93c91b6280f736e7bc33986da4d018e4e1731a31b17888099f3afeaa4e48a",
-        "path": "gaps.json"
-      },
-      {
-        "hash": "395d687ca50d9924f4668087b7acb04085a8cb21d7b4544f3c2410d2a845f8c6",
-        "path": "profiles.json"
-      },
-      {
-        "hash": "d64ceae8cbeb562efb79581d99a2f44b502e95240cb72a83fa41a550bacce1ca",
-        "path": "review/adapter-candidates.json"
-      },
-      {
-        "hash": "00cf98a6bcf8fbfe5d1d84d461745de1925e90a772efce666b03e67e8d7afda0",
-        "path": "review/curation.json"
-      },
-      {
-        "hash": "c68d4d2c0a2089f00bd28d99b3600c55753abc548ebf7e8bd402e2a648625dc3",
-        "path": "review/enrichment-queue.json"
-      },
-      {
-        "hash": "f766400768949f3d4a6d72a64eaa22356ac7633835617f79ba71e6b2c0af62c6",
-        "path": "review/gap-priorities.json"
-      },
-      {
-        "hash": "033f9155cd1455fb6dacccbf0d0e61345c2119c05b03ca5f9d7838484dd84879",
-        "path": "review/profile-completeness.json"
-      },
-      {
-        "hash": "7e8da0fa3df7a0708842f8a40fa3021ea176284560aa6bb781c0199f2649c07d",
-        "path": "search.json"
-      },
-      {
-        "hash": "4d0d78b579529353f8c6daa982f8f9844e097ad8610a9b6bc744827c35283d41",
-        "path": "subnets.json"
-      },
-      {
-        "hash": "aee6c595e9270dbf965d230e04cb2c219a619eb888b1dd50b474a440de933c70",
-        "path": "surfaces.json"
-      }
-    ],
+    "modified": [],
     "removed": []
   },
   "contract_version": "2026-06-06.1",
@@ -76,7 +19,7 @@
   },
   "summary": {
     "artifact_added_count": 0,
-    "artifact_modified_count": 14,
+    "artifact_modified_count": 0,
     "artifact_removed_count": 0,
     "coverage_delta": {
       "candidate_count": {
@@ -97,8 +40,8 @@
       "provider_count": null,
       "surface_count": {
         "after": 1139,
-        "before": 1140,
-        "delta": -1
+        "before": 1139,
+        "delta": 0
       }
     },
     "netuid_added_count": 0,

--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
   "artifact_count": 23,
-  "artifact_size_bytes": 5355591,
+  "artifact_size_bytes": 5353467,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -16,8 +16,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/changelog.json",
       "latest_key": "latest/changelog.json",
       "path": "/metagraph/changelog.json",
-      "sha256": "440558cc09602bddad2d4d5efaae85c1025f063b03b638ad85aff028e5f35db0",
-      "size_bytes": 3151,
+      "sha256": "484da6be28397abd82b5d1b7950fa85bae30dd638facb06bfc6bd3e9c15b2724",
+      "size_bytes": 1211,
       "storage_tier": "dual"
     },
     {
@@ -124,8 +124,8 @@
       "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
       "latest_key": "latest/review/enrichment-queue.json",
       "path": "/metagraph/review/enrichment-queue.json",
-      "sha256": "c68d4d2c0a2089f00bd28d99b3600c55753abc548ebf7e8bd402e2a648625dc3",
-      "size_bytes": 365804,
+      "sha256": "97f47729b26b3bd9f6f1dbe831e2544ac44d97a67a0830459da914421cd821f1",
+      "size_bytes": 365620,
       "storage_tier": "dual"
     },
     {
@@ -214,7 +214,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1273,
-  "full_artifact_size_bytes": 49117395,
+  "full_artifact_size_bytes": 35027478,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -238,8 +238,8 @@
     "r2": 1250
   },
   "storage_tier_size_bytes": {
-    "dual": 5096566,
+    "dual": 5094442,
     "git": 259025,
-    "r2": 43761804
+    "r2": 29674011
   }
 }

--- a/public/metagraph/review/enrichment-queue.json
+++ b/public/metagraph/review/enrichment-queue.json
@@ -4358,17 +4358,14 @@
       "adapter_score": 6,
       "candidate_count": 15,
       "candidate_evidence_summary": {
-        "candidate_count": 6,
+        "candidate_count": 5,
         "kinds_with_candidates": [
           "openapi",
-          "subnet-api",
-          "website"
+          "subnet-api"
         ],
-        "live_kinds": [
-          "website"
-        ],
-        "live_or_redirected_count": 1,
-        "reviewable_count": 6,
+        "live_kinds": [],
+        "live_or_redirected_count": 0,
+        "reviewable_count": 5,
         "stale_kinds": [
           "openapi",
           "subnet-api"
@@ -4384,7 +4381,7 @@
         "website"
       ],
       "endpoint_count": 6,
-      "evidence_action": "review-existing-evidence",
+      "evidence_action": "submit-new-evidence",
       "identity_level": "partial",
       "identity_surface_count": 2,
       "lane": "direct-submission",
@@ -4412,17 +4409,13 @@
       "sample_candidate_ids": [
         "sn-38-backprop-dashboard",
         "sn-38-native-chain-github",
-        "sn-38-native-chain-website",
         "sn-38-subnetradar-dashboard",
-        "sn-38-taomarketcap-dashboard"
+        "sn-38-taomarketcap-dashboard",
+        "sn-38-taopedia-article"
       ],
-      "sample_live_candidate_ids": [
-        "sn-38-native-chain-website"
-      ],
+      "sample_live_candidate_ids": [],
       "sample_stale_candidate_ids": [],
-      "sample_target_candidate_ids": [
-        "sn-38-native-chain-website"
-      ],
+      "sample_target_candidate_ids": [],
       "slug": "colosseum",
       "source_urls": [
         "https://api.taomarketcap.com/public/v1/subnets/38",
@@ -10505,8 +10498,7 @@
       "maintainer-review-existing-evidence": 17,
       "monitor": 1,
       "replace-stale-evidence": 72,
-      "review-existing-evidence": 1,
-      "submit-new-evidence": 37,
+      "submit-new-evidence": 38,
       "verify-existing-evidence": 1
     },
     "identity_level_counts": {

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1112,6 +1112,16 @@ function buildEnrichmentQueueArtifacts({
       new Set(subnet.baseline_excluded_surface_ids || []),
     ]),
   );
+  const excludedCandidateUrlsByNetuid = new Map(
+    subnets.map((subnet) => [
+      subnet.netuid,
+      new Set(
+        (subnet.baseline_excluded_surface_urls || [])
+          .map((url) => normalizePublicUrl(url))
+          .filter(Boolean),
+      ),
+    ]),
+  );
   const candidatesByNetuid = groupByNetuid(candidates);
 
   const fullQueue = profiles
@@ -1123,6 +1133,7 @@ function buildEnrichmentQueueArtifacts({
         reviewProfile: reviewProfileByNetuid.get(profile.netuid),
         subnetCandidates: enrichmentCandidatesForSubnet({
           excludedIds: excludedCandidateIdsByNetuid.get(profile.netuid),
+          excludedUrls: excludedCandidateUrlsByNetuid.get(profile.netuid),
           subnetCandidates: candidatesByNetuid.get(profile.netuid) || [],
         }),
         verificationByCandidate,
@@ -1200,11 +1211,26 @@ function buildEnrichmentQueueArtifacts({
   return { evidenceArtifact, queueArtifact, targetArtifact };
 }
 
-function enrichmentCandidatesForSubnet({ excludedIds, subnetCandidates }) {
-  if (!excludedIds || excludedIds.size === 0) {
+function enrichmentCandidatesForSubnet({
+  excludedIds,
+  excludedUrls,
+  subnetCandidates,
+}) {
+  const hasExcludedIds = excludedIds && excludedIds.size > 0;
+  const hasExcludedUrls = excludedUrls && excludedUrls.size > 0;
+  if (!hasExcludedIds && !hasExcludedUrls) {
     return subnetCandidates;
   }
-  return subnetCandidates.filter((candidate) => !excludedIds.has(candidate.id));
+  return subnetCandidates.filter((candidate) => {
+    if (hasExcludedIds && excludedIds.has(candidate.id)) {
+      return false;
+    }
+    if (!hasExcludedUrls) {
+      return true;
+    }
+    const candidateUrl = normalizePublicUrl(candidate.url);
+    return !candidateUrl || !excludedUrls.has(candidateUrl);
+  });
 }
 
 function buildEnrichmentTargetsArtifact({ evidenceEntries, queue }) {

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1402,6 +1402,28 @@ test("enrichment guidance ignores maintainer-excluded candidate IDs", () => {
   );
 });
 
+test("enrichment guidance ignores maintainer-excluded candidate URLs", () => {
+  const queue = readArtifact("review/enrichment-queue.json");
+  const colosseum = queue.queue.find((entry) => entry.netuid === 38);
+
+  assert(colosseum, "expected SN38 colosseum enrichment queue entry");
+  assert.equal(colosseum.evidence_action, "submit-new-evidence");
+  assert.equal(
+    colosseum.sample_target_candidate_ids.includes(
+      "sn-38-native-chain-website",
+    ),
+    false,
+  );
+  assert.equal(
+    colosseum.sample_live_candidate_ids.includes("sn-38-native-chain-website"),
+    false,
+  );
+  assert.equal(
+    colosseum.candidate_evidence_summary.live_kinds.includes("website"),
+    false,
+  );
+});
+
 test("Worker API serves public artifact envelopes", async () => {
   const env = createLocalArtifactEnv();
 


### PR DESCRIPTION
## Summary
- Filter `baseline_excluded_surface_urls` out of enrichment queue candidate evidence.
- Remove SN38 Colosseum's excluded parked website candidate from live/target review guidance.
- Regenerate the compact public artifacts affected by the queue change.

## What changed
- Normalized URL exclusions are now applied alongside excluded candidate IDs when building enrichment queue entries.
- Added regression coverage for URL-excluded candidate filtering.
- Updated `review/enrichment-queue.json`, `build-summary.json`, `changelog.json`, and `r2-manifest.json` from `npm run build`.

## Why
SN38's canonical overlay already excludes `https://www.taocolosseum.com/` because it resolves to a parked-domain sale flow. The review queue still treated that candidate as live website evidence because it only honored ID exclusions. This keeps contributor guidance aligned with maintainer-reviewed exclusions without promoting any new website surface.

## Validation
- `npm run build` passed: 129 subnets, 1,139 surfaces, 90 providers.
- `npx vitest run tests/artifacts.test.mjs` passed: 16 tests.
- `npm run check` passed, including the full Vitest suite: 8 files, 113 tests.
- `git diff --check` passed.
- `npm run test:coverage` ran all 113 tests, but failed existing global coverage thresholds: statements 96% and lines 95.98% are below the 97% threshold.

## Notes
- No website surface is promoted in this PR.
- The website enrichment pass found no current safe standalone website promotion for the remaining website gaps.
