### PR TITLE
Phase 1: self-sufficient publish (re-snapshot adapters in production build)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -55,6 +55,14 @@ jobs:
         run: |
           npm run build
           npm run r2:manifest
+        env:
+          # The production build re-snapshots adapters from live GitHub metadata
+          # so the publish is fresh by construction. A token is always present
+          # here, so a 401 means the token is broken; fail loudly instead of
+          # shipping degraded adapter data (mirrors sync-subnets.yml).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          METAGRAPH_REQUIRE_ADAPTER_AUTH: "1"
 
       - name: Stage reviewed publish artifacts
         run: |

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -3358,7 +3358,11 @@ function buildFreshnessArtifact({
       lane: "adapter-snapshot",
       pathValue: "registry/adapters/latest",
       requiredForPublish: true,
-      staleAfterHours: 12,
+      // Aligned with the other publish-blocking sources (candidate-discovery,
+      // candidate-verification, native-subnets all 24h). The publish re-snapshots
+      // adapters, so this is a safety buffer for the carry-forward path rather
+      // than the primary freshness mechanism.
+      staleAfterHours: 24,
       timestampField: "adapter_snapshot_as_of",
     }),
     freshnessSource({

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -69,6 +69,14 @@ function localSteps() {
 function productionSteps() {
   return [
     nodeStep("bundle-schemas", "scripts/bundle-schemas.mjs", "--write"),
+    // Re-snapshot adapters from live GitHub metadata so the publish is
+    // self-sufficient for freshness: adapter-snapshots are then fresh by
+    // construction at publish time (the publish already re-probes health),
+    // so the freshness gate never depends on a recently-merged sync PR.
+    // Auth posture (METAGRAPH_REQUIRE_ADAPTER_AUTH) + token are supplied by
+    // the caller (publish-cloudflare.yml); without a token this carries
+    // forward committed adapter data rather than failing.
+    nodeStep("adapters-snapshot", "scripts/snapshot-adapters.mjs", "--write"),
     nodeStep("build-artifacts", "scripts/build-artifacts.mjs"),
     nodeStep("probes-smoke", "scripts/probes-smoke.mjs", {
       METAGRAPH_WRITE_PROBE_RESULTS: "1",


### PR DESCRIPTION
## What

Makes the production build self-sufficient for data freshness so the publish is **green by construction** — no dependency on a recently-merged sync PR.

- `scripts/build.mjs`: add an `adapters-snapshot` step to `productionSteps()` (before `build-artifacts`). The publish already re-probes health; now it also re-snapshots adapters from live GitHub metadata.
- `.github/workflows/publish-cloudflare.yml`: pass `GITHUB_TOKEN` + `METAGRAPH_REQUIRE_ADAPTER_AUTH=1` to the build step (mirrors `sync-subnets.yml` — fail loudly on a broken token, carry-forward on transient/rate-limit).
- `scripts/build-artifacts.mjs`: align `adapter-snapshots` freshness `12h → 24h` with the other publish-blocking sources (candidate-discovery / verification / native-subnets). With self-refresh this is a carry-forward safety buffer, not the primary mechanism.

## Why

The publish-only freshness gate requires probe-derived health **and** fresh adapter snapshots. The build re-probed health but read adapters from committed data, which ages past the 12h block — so every push to `main` failed `validate` on `adapter-snapshots is stale`, unless a sync PR had been merged within the window (a 12h race against a 12h sync cadence with zero margin).

## Churn

**Zero added git churn** — the publish never commits; it builds in `dist/` (gitignored) and ships to R2 ephemerally.

## Verification

- Production build (mirroring the publish job) → all steps pass incl. new `adapters-snapshot`; `adapter-snapshots` freshness now `captured` / fresh.
- Publish-gate validate (`METAGRAPH_REQUIRE_PROBE_HEALTH=1`, Publish workflow env) → **fully green** (was failing on adapter staleness).
- Clean deterministic `build` + `validate` → green; `validate:workflows` → green.

## Closes

- Roadmap **Finding 3** (green production publish) — the failure was the `validate` gate (adapter staleness), upstream of secrets, **not** missing Cloudflare credentials. Secrets were separately configured.
- Auto-heals the degraded committed gittensor adapter (**Finding 1**) — the publish re-snapshots with a token each run.

First of a phased migration to eliminate generated-artifact churn (Phases 2–5 to follow).