### PR TITLE
fix(ci): unblock publish — skip committed-artifact reproducibility check in production

### DIFF
--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -232,7 +232,15 @@ describe("Metagraphed submission gate policy", () => {
     }
   });
 
-  test("diff-checks submitted public artifacts from the generated indexes", () => {
+  // The publish workflow runs `npm test` against freshly *production-built*
+  // artifacts (real `generated_at` timestamps + live probe/adapter data), which
+  // by design differ from the committed copies. This diff-check validates the
+  // reproducibility of *committed* artifacts for contributor PRs, so it is
+  // meaningless — and always fails — in the production-build context. It is
+  // removed entirely once data artifacts move to R2-only (see docs/adr/0001).
+  test.skipIf(process.env.METAGRAPH_PRODUCTION_BUILD === "1")(
+    "diff-checks submitted public artifacts from the generated indexes",
+    () => {
     const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-artifacts-"));
     try {
       const changedFiles = path.join(tmp, "changed-files.txt");


### PR DESCRIPTION
Second blocker in the publish job, exposed once Phase 1 (#203) got `Validate registry` to pass: the `Test` step ran `npm test` against freshly **production-built** artifacts and the submission-gate reproducibility diff-check saw the real `generated_at` timestamp vs the committed epoch — so it always fails in the publish context. Skip it under `METAGRAPH_PRODUCTION_BUILD=1` (still runs for PR validation); removed entirely when data moves to R2-only (docs/adr/0001). Verified: production build + `npm test` → 121 passed, 1 skipped. Advances the publish into the real deploy steps for the first time.