### PR TITLE
Phase A: freshness-aware /health + adapter data-quality guard

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -72,6 +72,12 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           METAGRAPH_REQUIRE_ADAPTER_AUTH: "1"
 
+      # Belt-and-suspenders for Finding 1: the build just re-snapshotted adapters
+      # from live GitHub metadata. Refuse to publish if any degraded to broken
+      # auth / all-HTML-fallback (strict via METAGRAPH_PRODUCTION_BUILD).
+      - name: Validate adapter data quality
+        run: npm run validate:adapters
+
       - name: Stage reviewed publish artifacts
         run: |
           set -euo pipefail

--- a/.github/workflows/sync-subnets.yml
+++ b/.github/workflows/sync-subnets.yml
@@ -46,6 +46,13 @@ jobs:
           # fail loudly instead of silently shipping degraded adapter data.
           METAGRAPH_REQUIRE_ADAPTER_AUTH: "1"
 
+      # Belt-and-suspenders for Finding 1: refuse to commit adapter snapshots that
+      # degraded to broken auth / all-HTML-fallback during the refresh above.
+      - name: Validate adapter data quality
+        run: npm run validate:adapters
+        env:
+          METAGRAPH_REQUIRE_ADAPTER_AUTH: "1"
+
       - name: Generate sync summary
         run: |
           mkdir -p "$RUNNER_TEMP/sync-output"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -105,6 +105,40 @@ Write mode verifies downloaded SHA-256 hashes against `public/metagraph/r2-manif
 METAGRAPH_ALLOW_R2_DOWNLOAD=1 npm run r2:download
 ```
 
+## Health & Freshness Monitoring
+
+`GET /health` is the readiness + freshness probe (no auth, lightweight, edge-cached
+60s). It reports binding wiring and the age of the published data:
+
+```json
+{
+  "status": "ok",
+  "bindings": { "assets": true, "r2": true, "kv": true },
+  "freshness": {
+    "published_at": "…",
+    "age_hours": 1.2,
+    "max_age_hours": 12,
+    "stale": false
+  }
+}
+```
+
+- `published_at` comes from the KV `metagraph:latest` pointer, which the scheduled
+  refresh advances every ~6h.
+- When the data is older than `max_age_hours` (default 12 — two missed 6h refreshes;
+  override with `METAGRAPH_HEALTH_MAX_AGE_HOURS`), `status` becomes `degraded` and the
+  route returns **HTTP 503**. Point an uptime monitor at `https://metagraph.sh/health`
+  so a silently-broken data-refresh pages instead of serving stale data unnoticed.
+- A present-but-stale pointer trips it; a missing pointer (local/dev) stays `ok`.
+
+## Adapter Data-Quality Guard
+
+`npm run validate:adapters` rejects an adapter snapshot that degraded to broken
+GitHub auth / all-HTML-fallback (Finding 1). It **warns** in ordinary PR validation
+and **fails** (exit 1) when `METAGRAPH_PRODUCTION_BUILD=1` or
+`METAGRAPH_REQUIRE_ADAPTER_AUTH=1` — so the scheduled publish and `sync-subnets` runs
+refuse to ship degraded adapter data after a token break.
+
 ## Rollback
 
 Rollback is pointer-first:

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "contract:summary": "node scripts/contract-change-summary.mjs",
     "validate:artifact-budgets": "node scripts/validate-artifact-budgets.mjs",
     "validate:docs": "node scripts/validate-docs.mjs",
+    "validate:adapters": "node scripts/validate-adapters.mjs",
     "validate:intake": "node scripts/validate-intake.mjs",
     "validate:private-boundary": "node scripts/validate-private-boundary.mjs",
     "validate:workflows": "node scripts/validate-workflows.mjs",

--- a/scripts/validate-adapters.mjs
+++ b/scripts/validate-adapters.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+// Adapter data-quality guard (beta-roadmap Finding 1 — belt-and-suspenders).
+//
+// An adapter snapshot can silently degrade when GitHub auth breaks or rate
+// limits hit: dimensions fall back to unauthenticated HTML scraping and lose
+// their machine-readable metadata (captured_count -> 0, html_fallback_count up,
+// status -> "html-fallback", error -> "Bad credentials" / 401). Publishing or
+// committing that degraded data poisons the completeness/provenance story.
+//
+// This guard inspects every committed adapter and rejects degradation. It runs
+// STRICT (exit 1) in production / auth-required contexts so a broken token
+// fails the publish loudly; otherwise it WARNS (exit 0) so a locally-degraded
+// snapshot doesn't block ordinary PR validation.
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ADAPTER_DIR = "registry/adapters/latest";
+
+// Returns a list of human-readable degradation issues for one adapter snapshot
+// (empty when the adapter is healthy). Exported for unit testing.
+export function inspectAdapter(adapter) {
+  const issues = [];
+  const dimensions =
+    adapter && adapter.dimensions && typeof adapter.dimensions === "object"
+      ? adapter.dimensions
+      : {};
+
+  for (const [name, dim] of Object.entries(dimensions)) {
+    if (!dim || typeof dim !== "object") continue;
+
+    // Broken GitHub auth surfaced on the dimension.
+    if (
+      dim.status_code === 401 ||
+      /bad credentials/i.test(String(dim.error ?? "")) ||
+      /bad credentials/i.test(String(dim.fallback_reason ?? ""))
+    ) {
+      issues.push(
+        `${name}: auth failure (status_code=${dim.status_code ?? "?"}, error=${dim.error ?? "?"})`,
+      );
+    }
+
+    // Dimension itself fell back to HTML scraping (no machine-readable capture).
+    if (dim.status === "html-fallback") {
+      issues.push(`${name}: status=html-fallback`);
+    }
+
+    // Repository metadata degraded to all-HTML-fallback: nothing captured via
+    // the API, everything scraped from HTML.
+    if (
+      typeof dim.captured_count === "number" &&
+      typeof dim.html_fallback_count === "number" &&
+      dim.captured_count === 0 &&
+      dim.html_fallback_count > 0
+    ) {
+      issues.push(
+        `${name}: captured_count=0 with html_fallback_count=${dim.html_fallback_count} (all HTML-fallback)`,
+      );
+    }
+  }
+
+  return issues;
+}
+
+function main() {
+  const strict =
+    process.env.METAGRAPH_REQUIRE_ADAPTER_AUTH === "1" ||
+    process.env.METAGRAPH_PRODUCTION_BUILD === "1";
+
+  let files;
+  try {
+    files = readdirSync(ADAPTER_DIR).filter((f) => f.endsWith(".json"));
+  } catch {
+    console.log(
+      `validate:adapters — no adapter directory at ${ADAPTER_DIR}; nothing to check.`,
+    );
+    return 0;
+  }
+
+  const degraded = [];
+  for (const file of files) {
+    const slug = file.replace(/\.json$/, "");
+    let adapter;
+    try {
+      adapter = JSON.parse(readFileSync(join(ADAPTER_DIR, file), "utf8"));
+    } catch (error) {
+      degraded.push({ slug, issues: [`unreadable: ${error.message}`] });
+      continue;
+    }
+    const issues = inspectAdapter(adapter);
+    if (issues.length) degraded.push({ slug, issues });
+  }
+
+  if (!degraded.length) {
+    console.log(
+      `validate:adapters — ${files.length} adapter(s) OK; no auth / HTML-fallback degradation.`,
+    );
+    return 0;
+  }
+
+  const label = strict ? "ERROR" : "WARNING";
+  console.error(
+    `validate:adapters — ${degraded.length} of ${files.length} adapter(s) degraded (${label}):`,
+  );
+  for (const { slug, issues } of degraded) {
+    console.error(`  • ${slug}`);
+    for (const issue of issues) console.error(`      - ${issue}`);
+  }
+
+  if (strict) {
+    console.error(
+      "\nStrict mode (METAGRAPH_PRODUCTION_BUILD / METAGRAPH_REQUIRE_ADAPTER_AUTH set): " +
+        "refusing to publish degraded adapter data. Re-snapshot with a valid GITHUB_TOKEN.",
+    );
+    return 1;
+  }
+  console.error(
+    "\nNon-strict mode: warning only. Re-run `npm run adapters:snapshot` with a valid " +
+      "GITHUB_TOKEN to capture full metadata before publishing.",
+  );
+  return 0;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(main());
+}

--- a/tests/validate-adapters.test.mjs
+++ b/tests/validate-adapters.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { inspectAdapter } from "../scripts/validate-adapters.mjs";
+
+describe("validate-adapters inspectAdapter", () => {
+  test("reports no issues for a fully captured adapter", () => {
+    const adapter = {
+      dimensions: {
+        master_repositories: { status: "captured", status_code: 200 },
+        repository_metadata: {
+          status: "captured",
+          captured_count: 18,
+          html_fallback_count: 0,
+        },
+      },
+    };
+    assert.deepEqual(inspectAdapter(adapter), []);
+  });
+
+  test("flags a dimension that fell back to HTML scraping", () => {
+    const issues = inspectAdapter({
+      dimensions: { mirror_freshness: { status: "html-fallback" } },
+    });
+    assert.equal(issues.length, 1);
+    assert.match(issues[0], /mirror_freshness: status=html-fallback/);
+  });
+
+  test("flags broken GitHub auth (401 / Bad credentials)", () => {
+    const issues = inspectAdapter({
+      dimensions: {
+        mirror_freshness: { status_code: 401, error: "Bad credentials" },
+      },
+    });
+    assert.equal(issues.length, 1);
+    assert.match(issues[0], /auth failure/);
+  });
+
+  test("flags repository metadata degraded to all-HTML-fallback", () => {
+    const issues = inspectAdapter({
+      dimensions: {
+        repository_metadata: {
+          status: "captured",
+          captured_count: 0,
+          html_fallback_count: 18,
+        },
+      },
+    });
+    assert.equal(issues.length, 1);
+    assert.match(issues[0], /all HTML-fallback/);
+  });
+
+  test("tolerates missing / malformed dimensions", () => {
+    assert.deepEqual(inspectAdapter({}), []);
+    assert.deepEqual(inspectAdapter({ dimensions: null }), []);
+    assert.deepEqual(inspectAdapter(null), []);
+    assert.deepEqual(inspectAdapter({ dimensions: { x: "nope" } }), []);
+  });
+
+  test("captured_count > 0 with some fallbacks is not flagged as all-fallback", () => {
+    const issues = inspectAdapter({
+      dimensions: {
+        repository_metadata: {
+          status: "captured",
+          captured_count: 15,
+          html_fallback_count: 3,
+        },
+      },
+    });
+    assert.deepEqual(issues, []);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -477,7 +477,7 @@ async function withTimeout(promise, ms) {
 
 // Lightweight readiness probe for uptime checks and load balancers. Reports
 // which bindings are wired without touching R2/KV (no I/O, no cold-start cost).
-function handleHealthRequest(request, env) {
+async function handleHealthRequest(request, env) {
   if (request.method !== "GET" && request.method !== "HEAD") {
     return errorResponse(
       "method_not_allowed",
@@ -487,21 +487,49 @@ function handleHealthRequest(request, env) {
       { allow: "GET, HEAD, OPTIONS" },
     );
   }
+
+  const bindings = {
+    assets: Boolean(env.ASSETS?.fetch),
+    r2: Boolean(env.METAGRAPH_ARCHIVE?.get),
+    kv: Boolean(env.METAGRAPH_CONTROL?.get),
+  };
+
+  // Data freshness — the scheduled refresh (ADR 0001) advances the KV `latest`
+  // pointer's published_at every ~6h. If that pipeline silently stops, the
+  // pointer goes stale; report `degraded` + HTTP 503 so an uptime monitor
+  // pointed at /health catches a broken data-refresh. Only a *present* stale
+  // pointer trips it, so local/dev and the worker-test harness (no published
+  // pointer) stay healthy.
+  const maxAgeHours = Number(env.METAGRAPH_HEALTH_MAX_AGE_HOURS) || 12;
+  const pointer = bindings.kv ? await latestPointer(env) : null;
+  const publishedAtIso =
+    pointer && typeof pointer.published_at === "string"
+      ? pointer.published_at
+      : null;
+  const publishedMs = publishedAtIso ? Date.parse(publishedAtIso) : NaN;
+  const ageHours = Number.isFinite(publishedMs)
+    ? (Date.now() - publishedMs) / 3_600_000
+    : null;
+  const stale = ageHours !== null && ageHours > maxAgeHours;
+
   const body = JSON.stringify({
-    status: "ok",
+    status: stale ? "degraded" : "ok",
     service: "metagraphed",
     contract_version: contractVersion(env),
     rpc_proxy_enabled: env.METAGRAPH_ENABLE_RPC_PROXY === "true",
-    bindings: {
-      assets: Boolean(env.ASSETS?.fetch),
-      r2: Boolean(env.METAGRAPH_ARCHIVE?.get),
-      kv: Boolean(env.METAGRAPH_CONTROL?.get),
+    bindings,
+    freshness: {
+      published_at: publishedAtIso,
+      age_hours: ageHours === null ? null : Math.round(ageHours * 100) / 100,
+      max_age_hours: maxAgeHours,
+      stale,
     },
   });
+
   const headers = apiHeaders("short");
-  headers.set("x-metagraph-health", "ok");
+  headers.set("x-metagraph-health", stale ? "degraded" : "ok");
   return new Response(request.method === "HEAD" ? null : body, {
-    status: 200,
+    status: stale ? 503 : 200,
     headers,
   });
 }


### PR DESCRIPTION
**Phase A** of the production-readiness hardening — operational trust. Backend only (no Sentry, no UX).

## What changed

### A1 — Freshness-aware `/health`
`GET /health` now reads the KV `metagraph:latest` pointer's `published_at` and reports data age:
- Returns `status: "degraded"` + **HTTP 503** when data is older than `METAGRAPH_HEALTH_MAX_AGE_HOURS` (default **12h** = two missed 6h refreshes).
- An uptime monitor pointed at `https://metagraph.sh/health` now catches a silently-broken data-refresh instead of serving stale data unnoticed.
- Only a *present-but-stale* pointer trips it → local/dev and the worker-test harness stay healthy (return `ok`).
- Response gains a `freshness` block (`published_at`, `age_hours`, `max_age_hours`, `stale`).

### A2 — Adapter data-quality guard (Finding 1, belt-and-suspenders)
`npm run validate:adapters` rejects an adapter snapshot that degraded to broken GitHub auth / all-HTML-fallback:
- **Warns** (exit 0) on ordinary PR validation so a locally-degraded snapshot doesn't block contributors.
- **Fails** (exit 1) under `METAGRAPH_PRODUCTION_BUILD` / `METAGRAPH_REQUIRE_ADAPTER_AUTH`.
- Wired into the **publish** (refresh job, after re-snapshot) and **sync-subnets** workflows so degraded adapter data can't ship/commit.

> Note: the currently-committed `gittensor` snapshot is **degraded** (`mirror_freshness` 401 "Bad credentials"; `repository_metadata` `captured_count: 0` / `html_fallback_count: 18`). This guard would block re-publishing it in that state. A clean `sync-subnets` run (CI token) re-snapshots it healthy.

## Verification
- `validate:adapters` — WARN non-strict / FAIL strict, correctly flags only `gittensor` (9/10 OK) ✅
- New unit suite `tests/validate-adapters.test.mjs` (6 tests) ✅
- Full test suite (127 tests, 9 files) ✅
- `worker:test` ✅ (`/health` change safe)
- `validate:workflows`, `validate:docs`, eslint, prettier ✅

Part of the multi-phase plan: A (this), B freshness auto-demotion, C RPC proxy enablement, D docs.