### PR TITLE
Phase B: freshness auto-demotion for stale operational surfaces

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -25,6 +25,7 @@ import {
   repoRoot,
   sha256Hex,
   slugify,
+  staleOperationalKinds,
   writeJson,
 } from "./lib.mjs";
 import {
@@ -44,6 +45,13 @@ import {
 } from "../src/artifact-storage.mjs";
 
 const execFileAsync = promisify(execFile);
+
+// Freshness auto-demotion (Finding 9): an operational surface not probed healthy
+// within this many days is treated as stale and contributes a reduced share of
+// the completeness score (and is flagged via gap_reasons `stale-<kind>`).
+const FRESHNESS_STALE_AFTER_DAYS =
+  Number(process.env.METAGRAPH_FRESHNESS_STALE_AFTER_DAYS) || 7;
+const FRESHNESS_DEMOTION_FACTOR = 0.5;
 
 const providers = await loadProviders();
 const overlays = await loadSubnets();
@@ -321,12 +329,14 @@ const canonicalCandidateIndex = candidates.map((candidate) => ({
 const profileArtifacts = buildSubnetProfileArtifacts({
   candidates: canonicalCandidateIndex,
   endpoints: endpointResources.endpoints,
+  healthSurfaces: healthArtifacts.latest.surfaces,
   nativeIdentitiesByNetuid: new Map(
     chainSubnets.map((subnet) => [
       subnet.netuid,
       subnet.chain_identity || null,
     ]),
   ),
+  probeFinishedAt: healthArtifacts.latest.probe_finished_at || null,
   subnets: mergedSubnets,
   surfaces,
 });
@@ -969,22 +979,45 @@ function endpointSummary(endpoints) {
   };
 }
 
+// Group probed health rows into netuid -> (surface kind -> rows[]) so the
+// profile builder can check, per subnet, whether each operational surface kind
+// is currently verified healthy-and-fresh.
+function groupHealthByNetuidAndKind(healthSurfaces) {
+  const byNetuid = new Map();
+  for (const row of healthSurfaces || []) {
+    if (!byNetuid.has(row.netuid)) {
+      byNetuid.set(row.netuid, new Map());
+    }
+    const byKind = byNetuid.get(row.netuid);
+    if (!byKind.has(row.kind)) {
+      byKind.set(row.kind, []);
+    }
+    byKind.get(row.kind).push(row);
+  }
+  return byNetuid;
+}
+
 function buildSubnetProfileArtifacts({
   subnets,
   surfaces,
   endpoints,
   candidates,
   nativeIdentitiesByNetuid = new Map(),
+  healthSurfaces = [],
+  probeFinishedAt = null,
 }) {
   const surfacesByNetuid = groupByNetuid(surfaces);
   const endpointsByNetuid = groupByNetuid(endpoints);
   const candidatesByNetuid = groupByNetuid(candidates);
+  const healthByNetuidAndKind = groupHealthByNetuidAndKind(healthSurfaces);
   const profiles = subnets
     .map((subnet) =>
       buildSubnetProfile({
         candidates: candidatesByNetuid.get(subnet.netuid) || [],
         endpoints: endpointsByNetuid.get(subnet.netuid) || [],
+        healthByKind: healthByNetuidAndKind.get(subnet.netuid) || new Map(),
         nativeIdentity: nativeIdentitiesByNetuid.get(subnet.netuid) || null,
+        probeFinishedAt,
         subnet,
         surfaces: surfacesByNetuid.get(subnet.netuid) || [],
       }),
@@ -2065,6 +2098,8 @@ function buildSubnetProfile({
   endpoints,
   candidates,
   nativeIdentity,
+  healthByKind = new Map(),
+  probeFinishedAt = null,
 }) {
   const archiveSupported = surfaces.some(surfaceHasArchiveSupport);
   const supportedKinds = [
@@ -2076,6 +2111,12 @@ function buildSubnetProfile({
   const operationalKinds = supportedKinds.filter((kind) =>
     operationalKindsForSubnetType(subnet.subnet_type).includes(kind),
   );
+  const staleKinds = staleOperationalKinds({
+    operationalKinds,
+    healthByKind,
+    probeFinishedAt,
+    staleAfterDays: FRESHNESS_STALE_AFTER_DAYS,
+  });
   const primaryLinks = {
     website_url: subnet.website_url || firstSurfaceUrl(surfaces, "website"),
     docs_url: subnet.docs_url || firstSurfaceUrl(surfaces, "docs"),
@@ -2086,6 +2127,7 @@ function buildSubnetProfile({
   const completeness = subnetProfileCompleteness({
     curationLevel: subnet.curation.level,
     primaryLinks,
+    staleOperationalKinds: staleKinds,
     subnetType: subnet.subnet_type,
     supportedKinds,
   });
@@ -2257,10 +2299,21 @@ function cleanProfileText(value) {
 function subnetProfileCompleteness({
   curationLevel,
   primaryLinks,
+  staleOperationalKinds: staleKinds = new Set(),
   subnetType,
   supportedKinds,
 }) {
   const kindSet = new Set(supportedKinds);
+  const staleSet = staleKinds instanceof Set ? staleKinds : new Set(staleKinds);
+  // Operational surfaces that exist but are not currently verified healthy-and-
+  // fresh contribute reduced points (freshness auto-demotion, Finding 9): an
+  // unverifiable surface should not read as "complete".
+  const operationalKindPoints = (kind, points) => {
+    if (!kindSet.has(kind)) return 0;
+    return staleSet.has(kind)
+      ? Math.round(points * FRESHNESS_DEMOTION_FACTOR)
+      : points;
+  };
   const identityEntries = [
     ["docs", primaryLinks.docs_url || kindSet.has("docs")],
     ["source-repo", primaryLinks.source_repo || kindSet.has("source-repo")],
@@ -2298,13 +2351,16 @@ function subnetProfileCompleteness({
   const operationalCount = operationalKinds.length - missingOperational.length;
   const operationalScore =
     subnetType === "root"
-      ? (kindSet.has("subtensor-rpc") ? 20 : 0) +
-        (kindSet.has("subtensor-wss") ? 15 : 0) +
-        (kindSet.has("archive") ? 10 : 0)
-      : (kindSet.has("openapi") ? 15 : 0) +
-        (kindSet.has("subnet-api") ? 15 : 0) +
-        (kindSet.has("sse") ? 7 : 0) +
-        (kindSet.has("data-artifact") ? 8 : 0);
+      ? operationalKindPoints("subtensor-rpc", 20) +
+        operationalKindPoints("subtensor-wss", 15) +
+        operationalKindPoints("archive", 10)
+      : operationalKindPoints("openapi", 15) +
+        operationalKindPoints("subnet-api", 15) +
+        operationalKindPoints("sse", 7) +
+        operationalKindPoints("data-artifact", 8);
+  const staleOperational = [...staleSet]
+    .filter((kind) => kindSet.has(kind))
+    .sort();
   const score = Math.min(
     100,
     (primaryLinks.docs_url || kindSet.has("docs") ? 15 : 0) +
@@ -2329,6 +2385,7 @@ function subnetProfileCompleteness({
     ...missingRequired.map((kind) => `missing-${kind}`),
     ...missingRecommended.map((kind) => `missing-${kind}`),
     ...missingOperational.map((kind) => `missing-${kind}`),
+    ...staleOperational.map((kind) => `stale-${kind}`),
   ];
 
   return {
@@ -4053,11 +4110,7 @@ async function gitBuffer(args) {
     // e.g. an R2-only artifact with no committed baseline). execFileAsync exposes
     // the exit code as error.code (number); execFileSync uses error.status —
     // handle both so a missing HEAD path returns null instead of throwing.
-    if (
-      error.code === "ENOENT" ||
-      error.code === 128 ||
-      error.status === 128
-    ) {
+    if (error.code === "ENOENT" || error.code === 128 || error.status === 128) {
       return null;
     }
     throw error;

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -569,6 +569,53 @@ export function publishedAt() {
   return value || null;
 }
 
+// Freshness auto-demotion (beta-roadmap Finding 9). Given a subnet's probed
+// health rows grouped by surface kind and the probe run's reference time,
+// returns the set of operational kinds that are present but NOT currently
+// verified healthy-and-fresh (status "ok" with a last_ok within
+// `staleAfterDays` of the probe run). Such kinds are demoted in the
+// completeness score and flagged, so "complete" reflects *current* liveness
+// rather than a one-time observation.
+//
+// Determinism: when there is no probe reference time (a committed / non-probe
+// build, like CI's artifact-verify checkout with no probe cache), this returns
+// an empty set — so the demotion only manifests in probe-backed production
+// builds and never churns the committed "shop window" artifacts. A kind with no
+// health rows is treated as unverified (not stale), so subnets whose surfaces
+// simply were not probed are never penalised.
+export function staleOperationalKinds({
+  operationalKinds,
+  healthByKind,
+  probeFinishedAt,
+  staleAfterDays = 7,
+}) {
+  const stale = new Set();
+  const referenceMs = probeFinishedAt ? Date.parse(probeFinishedAt) : NaN;
+  if (!Number.isFinite(referenceMs)) {
+    return stale;
+  }
+  const staleAfterMs = staleAfterDays * 24 * 60 * 60 * 1000;
+  const lookup = (kind) =>
+    healthByKind && typeof healthByKind.get === "function"
+      ? healthByKind.get(kind)
+      : healthByKind?.[kind];
+  for (const kind of operationalKinds || []) {
+    const rows = lookup(kind);
+    if (!rows || !rows.length) {
+      continue;
+    }
+    const verifiedFresh = rows.some((row) => {
+      if (!row || row.status !== "ok") return false;
+      const okMs = row.last_ok ? Date.parse(row.last_ok) : NaN;
+      return Number.isFinite(okMs) && referenceMs - okMs <= staleAfterMs;
+    });
+    if (!verifiedFresh) {
+      stale.add(kind);
+    }
+  }
+  return stale;
+}
+
 export const README_LINK_LIMIT = 5;
 
 export const README_KIND_LIMITS = {

--- a/tests/freshness-demotion.test.mjs
+++ b/tests/freshness-demotion.test.mjs
@@ -1,0 +1,90 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { staleOperationalKinds } from "../scripts/lib.mjs";
+
+const PROBE_AT = "2026-06-09T00:00:00.000Z";
+const day = (n) =>
+  new Date(Date.parse(PROBE_AT) - n * 86_400_000).toISOString();
+
+describe("staleOperationalKinds (freshness auto-demotion)", () => {
+  test("returns empty set when there is no probe reference time (determinism)", () => {
+    const stale = staleOperationalKinds({
+      operationalKinds: ["subtensor-rpc"],
+      healthByKind: new Map([
+        ["subtensor-rpc", [{ status: "failed", last_ok: null }]],
+      ]),
+      probeFinishedAt: null,
+    });
+    assert.equal(stale.size, 0);
+  });
+
+  test("a kind verified ok within the window is not stale", () => {
+    const stale = staleOperationalKinds({
+      operationalKinds: ["subtensor-rpc"],
+      healthByKind: new Map([
+        ["subtensor-rpc", [{ status: "ok", last_ok: day(2) }]],
+      ]),
+      probeFinishedAt: PROBE_AT,
+    });
+    assert.deepEqual([...stale], []);
+  });
+
+  test("a kind last ok beyond the window is stale", () => {
+    const stale = staleOperationalKinds({
+      operationalKinds: ["subtensor-rpc"],
+      healthByKind: new Map([
+        ["subtensor-rpc", [{ status: "ok", last_ok: day(10) }]],
+      ]),
+      probeFinishedAt: PROBE_AT,
+    });
+    assert.deepEqual([...stale], ["subtensor-rpc"]);
+  });
+
+  test("a kind that is currently failed/degraded is stale", () => {
+    const stale = staleOperationalKinds({
+      operationalKinds: ["subnet-api", "openapi"],
+      healthByKind: new Map([
+        ["subnet-api", [{ status: "failed", last_ok: day(1) }]],
+        ["openapi", [{ status: "degraded", last_ok: day(1) }]],
+      ]),
+      probeFinishedAt: PROBE_AT,
+    });
+    assert.deepEqual([...stale].sort(), ["openapi", "subnet-api"]);
+  });
+
+  test("a kind with no health rows is unverified, not stale", () => {
+    const stale = staleOperationalKinds({
+      operationalKinds: ["subtensor-rpc"],
+      healthByKind: new Map(),
+      probeFinishedAt: PROBE_AT,
+    });
+    assert.equal(stale.size, 0);
+  });
+
+  test("multiple rows: one fresh ok is enough to stay healthy", () => {
+    const stale = staleOperationalKinds({
+      operationalKinds: ["subtensor-wss"],
+      healthByKind: new Map([
+        [
+          "subtensor-wss",
+          [
+            { status: "failed", last_ok: day(30) },
+            { status: "ok", last_ok: day(1) },
+          ],
+        ],
+      ]),
+      probeFinishedAt: PROBE_AT,
+    });
+    assert.equal(stale.size, 0);
+  });
+
+  test("accepts a plain object lookup and honours staleAfterDays", () => {
+    const stale = staleOperationalKinds({
+      operationalKinds: ["archive"],
+      healthByKind: { archive: [{ status: "ok", last_ok: day(5) }] },
+      probeFinishedAt: PROBE_AT,
+      staleAfterDays: 3,
+    });
+    assert.deepEqual([...stale], ["archive"]);
+  });
+});


### PR DESCRIPTION
**Phase B** of the production-readiness hardening — the completeness moat (roadmap **Finding 9**). Backend only.

## Problem
The completeness score is presence-based: a subnet's RPC/API surface scored full points just for *existing*, even if it hadn't been probed healthy in weeks. "Trustworthy, **current** completeness" was not actually enforced — "complete" could silently drift stale.

## What changed
- **`staleOperationalKinds()`** (new pure helper in `lib.mjs`): for each operational surface kind a subnet supports, it's **stale** when the kind is present and probed but no health row is `status: "ok"` with a `last_ok` within `METAGRAPH_FRESHNESS_STALE_AFTER_DAYS` (default **7**) of the probe run's reference time.
- **`subnetProfileCompleteness()`** now demotes stale operational kinds to **50%** of their points and emits **`stale-<kind>`** entries in `gap_reasons` (auto-flag + auto-demote).
- The reference "now" is `health.latest.probe_finished_at` — a **captured** timestamp, not wall-clock.

## Determinism & zero churn (verified)
- With **no probe data** (committed builds / CI's artifact-verify checkout with no probe cache), the helper returns an empty set → **no demotion → committed `coverage.json` is unchanged** (confirmed: a full `npm run build` produced no committed-artifact diff).
- The demotion only manifests in **probe-backed production refreshes** → the R2 `profiles.json` / `coverage.json` the live site serves. No schema changes (`gap_reasons` is a free-string array).
- A kind with no health rows is treated as **unverified, not stale** (never penalised), so subnets whose surfaces simply weren't probed are unaffected.

## Verification
- `tests/freshness-demotion.test.mjs` — 7 cases (no-probe determinism, fresh-ok, aged-ok→stale, failed/degraded→stale, no-rows→unverified, multi-row, custom threshold) ✅
- Full suite **134 tests / 10 files** ✅ · eslint · prettier ✅
- Clean build → **no committed-artifact churn** ✅

Independent of Phase A (#212); touches only `lib.mjs`, `build-artifacts.mjs`, and the new test.