### PR TITLE
Phase C: harden the read-only RPC proxy (LB + methods + rate limiting, still gated off)

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -139,6 +139,42 @@ and **fails** (exit 1) when `METAGRAPH_PRODUCTION_BUILD=1` or
 `METAGRAPH_REQUIRE_ADAPTER_AUTH=1` — so the scheduled publish and `sync-subnets` runs
 refuse to ship degraded adapter data after a token break.
 
+## Enabling the RPC Proxy
+
+The read-only Subtensor RPC proxy (`POST /rpc/v1/finney`, `/rpc/v1/finney/wss`) ships
+**disabled** (`METAGRAPH_ENABLE_RPC_PROXY: "false"`). The Worker-side abuse controls
+are in place; enable it only after the dashboard-side WAF step and a live smoke.
+
+Already enforced in the Worker:
+
+- **Method allowlist** — read-only `SAFE_RPC_METHODS` only; `DENIED_RPC_PREFIXES`
+  (`author_`, `state_call`, `sudo_`, `payment_`, `contracts_`) and heavy reads
+  (`state_getMetadata`, `state_getStorage`) stay blocked.
+- **Upstream SSRF guard** — only `TRUSTED_RPC_UPSTREAM_ORIGINS`, https/wss, no private IPs.
+- **Load balancing** — weighted-random across all eligible+safe pool endpoints.
+- **Body cap** 64 KB, **upstream timeout** 10 s, single JSON-RPC object only.
+- **Rate limit** — the `RPC_RATE_LIMITER` binding: 100 requests / 60 s per client IP
+  (returns `429 rpc_rate_limited`). Enforced on Cloudflare; skipped locally.
+
+Before flipping the flag:
+
+1. **Cloudflare WAF (dashboard — required).** Add zone rules scoped to
+   `http.request.uri.path contains "/rpc/"`:
+   - a **Rate Limiting rule** as a coarse pre-Worker cap (e.g. 120 req / min per IP,
+     action: managed challenge/block) to absorb distributed abuse;
+   - a **custom rule** to block non-`POST` methods and oversized bodies on `/rpc/*`;
+   - ensure the zone's Managed Ruleset / Bot Fight Mode is on.
+2. **Verify the pool.** `curl https://metagraph.sh/metagraph/rpc/pools.json` and confirm
+   at least one endpoint per pool has `"pool_eligible": true` (otherwise the proxy
+   returns `503 rpc_endpoint_unavailable`).
+3. **Flip the flag.** Set `METAGRAPH_ENABLE_RPC_PROXY` to `"true"` in `wrangler.jsonc`;
+   the push deploys via Cloudflare Workers Builds.
+4. **Smoke.** `POST /rpc/v1/finney` with `{"jsonrpc":"2.0","id":1,"method":"system_health"}`
+   expects `200`; a blocked method (e.g. `author_submitExtrinsic`) expects
+   `403 rpc_method_blocked`; a burst past the limit expects `429`.
+
+To disable in an incident, set the flag back to `"false"` (or via env override) and redeploy.
+
 ## Rollback
 
 Rollback is pointer-first:

--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -1,0 +1,100 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  selectSafeRpcEndpoint,
+  weightedPickEndpoint,
+} from "../workers/api.mjs";
+
+// Origins in TRUSTED_RPC_UPSTREAM_ORIGINS.
+const SAFE_A = "https://bittensor-finney.api.onfinality.io/public";
+const SAFE_B = "https://bittensor-public.nodies.app/rpc";
+const UNSAFE = "https://evil.example.com/rpc";
+
+const ep = (id, url, extra = {}) => ({
+  id,
+  url,
+  provider: "fixture",
+  pool_eligible: true,
+  score: 100,
+  status: "ok",
+  ...extra,
+});
+
+describe("selectSafeRpcEndpoint", () => {
+  test("returns the single eligible+safe endpoint", () => {
+    const { endpoint, unsafeEndpoint } = selectSafeRpcEndpoint({
+      endpoints: [ep("a", SAFE_A)],
+    });
+    assert.equal(endpoint.id, "a");
+    assert.equal(unsafeEndpoint, null);
+  });
+
+  test("skips ineligible endpoints", () => {
+    const { endpoint } = selectSafeRpcEndpoint({
+      endpoints: [ep("x", SAFE_A, { pool_eligible: false }), ep("b", SAFE_B)],
+    });
+    assert.equal(endpoint.id, "b");
+  });
+
+  test("reports an unsafe endpoint (502) when every eligible URL is unsafe", () => {
+    const { endpoint, unsafeEndpoint } = selectSafeRpcEndpoint({
+      endpoints: [ep("u", UNSAFE)],
+    });
+    assert.equal(endpoint, null);
+    assert.equal(unsafeEndpoint.id, "u");
+  });
+
+  test("returns null endpoint (503) when none are eligible", () => {
+    const { endpoint, unsafeEndpoint } = selectSafeRpcEndpoint({
+      endpoints: [ep("x", SAFE_A, { pool_eligible: false })],
+    });
+    assert.equal(endpoint, null);
+    assert.equal(unsafeEndpoint, null);
+  });
+
+  test("load-balances across multiple safe endpoints (injected randomFn)", () => {
+    const pool = { endpoints: [ep("a", SAFE_A), ep("b", SAFE_B)] };
+    assert.equal(selectSafeRpcEndpoint(pool, () => 0).endpoint.id, "a");
+    assert.equal(selectSafeRpcEndpoint(pool, () => 0.99).endpoint.id, "b");
+  });
+
+  test("tolerates an empty/missing pool", () => {
+    assert.deepEqual(selectSafeRpcEndpoint(null), {
+      endpoint: null,
+      unsafeEndpoint: null,
+    });
+    assert.deepEqual(selectSafeRpcEndpoint({ endpoints: [] }), {
+      endpoint: null,
+      unsafeEndpoint: null,
+    });
+  });
+});
+
+describe("weightedPickEndpoint", () => {
+  test("returns the only endpoint without consulting randomFn", () => {
+    const only = ep("a", SAFE_A);
+    assert.equal(
+      weightedPickEndpoint([only], () => {
+        throw new Error("randomFn should not be called");
+      }),
+      only,
+    );
+  });
+
+  test("weights selection by score", () => {
+    const eps = [ep("a", SAFE_A, { score: 3 }), ep("b", SAFE_B, { score: 1 })];
+    // total weight 4: cursor in [0,3) -> a, [3,4) -> b
+    assert.equal(weightedPickEndpoint(eps, () => 0).id, "a");
+    assert.equal(weightedPickEndpoint(eps, () => 0.7).id, "a"); // 2.8 < 3
+    assert.equal(weightedPickEndpoint(eps, () => 0.9).id, "b"); // 3.6 >= 3
+  });
+
+  test("falls back to uniform weighting when scores are absent", () => {
+    const eps = [
+      ep("a", SAFE_A, { score: null }),
+      ep("b", SAFE_B, { score: null }),
+    ];
+    assert.equal(weightedPickEndpoint(eps, () => 0).id, "a");
+    assert.equal(weightedPickEndpoint(eps, () => 0.6).id, "b");
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -29,11 +29,22 @@ const ROUTES = API_ROUTES.map((entry) => ({
   },
 }));
 
+// Read-only, bounded Substrate/Subtensor methods safe to expose through the
+// public proxy. Deliberately excludes heavy/abusable reads (state_getMetadata,
+// state_getStorage) and anything mutating — those stay blocked by the allowlist
+// plus DENIED_RPC_PREFIXES.
 const SAFE_RPC_METHODS = new Set([
-  "chain_getHeader",
+  "chain_getBlock",
   "chain_getBlockHash",
-  "system_health",
+  "chain_getFinalizedHead",
+  "chain_getHeader",
   "rpc_methods",
+  "state_getRuntimeVersion",
+  "system_chain",
+  "system_health",
+  "system_name",
+  "system_properties",
+  "system_version",
 ]);
 const DENIED_RPC_PREFIXES = [
   "author_",
@@ -302,6 +313,26 @@ async function handleRpcProxyRequest(request, env, url) {
       "Read-only RPC proxying is intentionally disabled until endpoint scoring, abuse controls, and method filtering are enabled.",
       501,
     );
+  }
+
+  // Per-client abuse control. Skipped when the ratelimit binding is absent
+  // (local dev / not yet provisioned) so tests and local runs are unaffected;
+  // enforced on Cloudflare where the binding is bound.
+  if (env.RPC_RATE_LIMITER?.limit) {
+    const clientKey =
+      request.headers.get("cf-connecting-ip") ||
+      request.headers.get("x-forwarded-for") ||
+      "anonymous";
+    const { success } = await env.RPC_RATE_LIMITER.limit({ key: clientKey });
+    if (!success) {
+      return errorResponse(
+        "rpc_rate_limited",
+        "Too many RPC proxy requests from this client; slow down.",
+        429,
+        {},
+        { "retry-after": "60" },
+      );
+    }
   }
 
   const contentLength = Number(request.headers.get("content-length") || 0);
@@ -961,19 +992,52 @@ function contractVersion(env) {
   return env.METAGRAPH_CONTRACT_VERSION || CONTRACT_VERSION;
 }
 
-function selectSafeRpcEndpoint(pool) {
+// Load-balance across ALL eligible + upstream-safe endpoints rather than always
+// picking the highest-scored one, so no single upstream becomes a hotspot.
+// Returns an unsafe endpoint (for a 502) only when every eligible endpoint fails
+// the upstream safety policy, and a null endpoint when none are eligible (503).
+export function selectSafeRpcEndpoint(pool, randomFn = Math.random) {
+  const safe = [];
   let unsafeEndpoint = null;
   for (const endpoint of pool?.endpoints || []) {
     if (!endpoint?.pool_eligible) {
       continue;
     }
     if (isSafeRpcEndpointUrl(endpoint.url)) {
-      return { endpoint, unsafeEndpoint: null };
+      safe.push(endpoint);
+    } else {
+      unsafeEndpoint ||= endpoint;
     }
-    unsafeEndpoint ||= endpoint;
   }
 
-  return { endpoint: null, unsafeEndpoint };
+  if (!safe.length) {
+    return { endpoint: null, unsafeEndpoint };
+  }
+  return {
+    endpoint: weightedPickEndpoint(safe, randomFn),
+    unsafeEndpoint: null,
+  };
+}
+
+// Weighted-random pick favouring higher-scored (healthier/faster) endpoints,
+// falling back to uniform weighting when scores are absent so traffic still
+// spreads. randomFn is injectable for deterministic tests.
+export function weightedPickEndpoint(endpoints, randomFn = Math.random) {
+  if (endpoints.length === 1) {
+    return endpoints[0];
+  }
+  const weights = endpoints.map((endpoint) =>
+    Number.isFinite(endpoint.score) && endpoint.score > 0 ? endpoint.score : 1,
+  );
+  const total = weights.reduce((sum, weight) => sum + weight, 0);
+  let cursor = randomFn() * total;
+  for (let index = 0; index < endpoints.length; index += 1) {
+    cursor -= weights[index];
+    if (cursor < 0) {
+      return endpoints[index];
+    }
+  }
+  return endpoints[endpoints.length - 1];
 }
 
 function isSafeRpcEndpointUrl(value) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -49,4 +49,18 @@
       "bucket_name": "metagraphed-artifacts",
     },
   ],
+  // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite
+  // for enabling METAGRAPH_ENABLE_RPC_PROXY). 100 requests / 60s per client IP;
+  // `period` must be 10 or 60. The Worker skips the check when this binding is
+  // absent (local dev), so it only enforces on Cloudflare.
+  "ratelimits": [
+    {
+      "name": "RPC_RATE_LIMITER",
+      "namespace_id": "1001",
+      "simple": {
+        "limit": 100,
+        "period": 60,
+      },
+    },
+  ],
 }


### PR DESCRIPTION
**Phase C** of the production-readiness hardening — the RPC-proxy differentiator (roadmap **Finding 7**). The proxy stays **disabled** (`METAGRAPH_ENABLE_RPC_PROXY: "false"`); this lands the abuse-control prerequisites so it can be safely flipped on after the one dashboard-side WAF step.

## What changed (Worker + config only — no workflow edits)
- **C1 — real load balancing.** `selectSafeRpcEndpoint()` is now **weighted-random across all** eligible + upstream-safe pool endpoints (favouring higher `score`) instead of always picking the first/highest — no single upstream hotspot. `randomFn` is injectable for deterministic tests.
- **C2 — expanded read methods.** `SAFE_RPC_METHODS` grows from 4 to a bounded read-only set (block/header/finalized-head, `state_getRuntimeVersion`, `system_*` info). Heavy/abusable reads (`state_getMetadata`, `state_getStorage`) and all mutating methods stay blocked by the allowlist + `DENIED_RPC_PREFIXES`.
- **C3 — rate limiting.** New `RPC_RATE_LIMITER` binding (Workers Rate Limiting, GA) at **100 req / 60 s per client IP** → `429 rpc_rate_limited`. Enforced on Cloudflare; **skipped when the binding is absent** (local/tests), so existing behavior is unaffected.
- **Runbook.** `operations.md` → "Enabling the RPC Proxy": the controls already in place, the **Cloudflare WAF rules you add in the dashboard (C4)**, the pool-eligibility check, the flag flip, and the smoke steps.

Unchanged and still enforced: SSRF/origin guard, 64 KB body cap, 10 s upstream timeout, single-JSON-RPC-object rule.

## What still needs you (not in this PR)
- **C4 — Cloudflare WAF**: add the zone rules on `/rpc/*` (documented in the runbook). WAF isn't exposed by the Cloudflare MCP, so it's a dashboard step.
- **C5 — the flip**: set the flag to `"true"` (a separate 1-line change I'll prepare on your go, once WAF is live and `/metagraph/rpc/pools.json` shows eligible endpoints).

## Verification
- `tests/rpc-endpoint-selection.test.mjs` — 9 cases (single/skip-ineligible, unsafe→502, none→503, LB distribution, score weighting, uniform fallback) ✅
- `worker:test` ✅ (proxy still proxies a safe method end-to-end)
- `worker:deploy:dry-run` ✅ (validates the `ratelimits` binding)
- Full suite **143 tests / 11 files** · eslint · prettier · validate:docs ✅
- Source/config only (no `.github/workflows` edits) → should clear the Superagent gate like #213.