### PR TITLE
fix(publish): stop clobbering live probe health before R2 upload

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -162,6 +162,25 @@ jobs:
       - name: Validate private boundary
         run: npm run validate:private-boundary
 
+      # The validate/test steps above rebuild artifacts in-place WITHOUT the
+      # probe-result cache, which clobbers the probe-derived health/pools/
+      # freshness the refresh job built (real probe_finished_at + "ok" statuses
+      # become the 1970 epoch placeholder + all "unknown"). r2:upload/kv:publish
+      # below would then publish that unprobed dataset — leaving every RPC pool
+      # with zero eligible endpoints. Re-restore the immutable reviewed artifacts
+      # so we publish exactly what was reviewed, then assert they carry live
+      # probe health so an all-"unknown" dataset can never ship silently.
+      - name: Re-restore reviewed artifacts and assert probe health
+        run: |
+          set -euo pipefail
+          rm -rf public/metagraph dist/metagraph-r2
+          cp -R "$RUNNER_TEMP/publish-artifacts/public/metagraph" public/metagraph
+          if [ -d "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" ]; then
+            mkdir -p dist
+            cp -R "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" dist/metagraph-r2
+          fi
+          npm run assert:probe-health
+
       - name: Check Cloudflare publishing secrets
         id: cloudflare-secrets
         run: |

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "validate:artifact-budgets": "node scripts/validate-artifact-budgets.mjs",
     "validate:docs": "node scripts/validate-docs.mjs",
     "validate:adapters": "node scripts/validate-adapters.mjs",
+    "assert:probe-health": "node scripts/assert-published-probe-health.mjs",
     "validate:intake": "node scripts/validate-intake.mjs",
     "validate:private-boundary": "node scripts/validate-private-boundary.mjs",
     "validate:workflows": "node scripts/validate-workflows.mjs",

--- a/scripts/assert-published-probe-health.mjs
+++ b/scripts/assert-published-probe-health.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Publish guard: refuse to publish unprobed health data.
+//
+// The publish job restores the refresh job's probe-health artifacts and then
+// runs validate/test, which rebuild artifacts in-place WITHOUT a probe-result
+// cache and clobber the probe-derived health/pools/freshness (real
+// probe_finished_at + "ok" statuses become the 1970 epoch placeholder + all
+// "unknown"). After re-restoring the reviewed artifacts, this guard asserts they
+// actually carry live probe health, so a regression can never again silently
+// publish an all-"unknown" dataset — which would also leave the RPC pools with
+// zero eligible endpoints and break the read-only proxy.
+import { existsSync, readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+const HEALTH_PATH = "dist/metagraph-r2/metagraph/health/latest.json";
+
+export function assessProbeHealth(health) {
+  const finishedAt = String(health?.probe_finished_at || "");
+  const surfaces = Array.isArray(health?.surfaces) ? health.surfaces : [];
+  const okCount = surfaces.filter((s) => s && s.status === "ok").length;
+  const problems = [];
+  if (!finishedAt || finishedAt.startsWith("1970")) {
+    problems.push(
+      `probe_finished_at is epoch/empty (${finishedAt || "unset"})`,
+    );
+  }
+  if (okCount === 0) {
+    problems.push(`0 of ${surfaces.length} surfaces are status=ok`);
+  }
+  return { finishedAt, okCount, total: surfaces.length, problems };
+}
+
+function main() {
+  if (!existsSync(HEALTH_PATH)) {
+    console.error(`::error::${HEALTH_PATH} missing from reviewed artifacts`);
+    return 1;
+  }
+  let health;
+  try {
+    health = JSON.parse(readFileSync(HEALTH_PATH, "utf8"));
+  } catch (error) {
+    console.error(`::error::${HEALTH_PATH} is unreadable: ${error.message}`);
+    return 1;
+  }
+  const { finishedAt, okCount, total, problems } = assessProbeHealth(health);
+  if (problems.length) {
+    console.error(
+      `::error::Reviewed artifacts lack live probe health — refusing to publish unprobed data: ${problems.join("; ")}`,
+    );
+    return 1;
+  }
+  console.log(
+    `probe health OK: probe_finished_at=${finishedAt}, ${okCount}/${total} surfaces ok`,
+  );
+  return 0;
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  process.exit(main());
+}

--- a/tests/assert-probe-health.test.mjs
+++ b/tests/assert-probe-health.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { assessProbeHealth } from "../scripts/assert-published-probe-health.mjs";
+
+describe("assessProbeHealth (publish guard)", () => {
+  test("passes for a real probe run with ok surfaces", () => {
+    const r = assessProbeHealth({
+      probe_finished_at: "2026-06-09T22:10:22.771Z",
+      surfaces: [{ status: "ok" }, { status: "degraded" }],
+    });
+    assert.deepEqual(r.problems, []);
+    assert.equal(r.okCount, 1);
+    assert.equal(r.total, 2);
+  });
+
+  test("flags the 1970 epoch probe_finished_at placeholder", () => {
+    const r = assessProbeHealth({
+      probe_finished_at: "1970-01-01T00:00:00.000Z",
+      surfaces: [{ status: "ok" }],
+    });
+    assert.ok(r.problems.some((p) => /epoch/.test(p)));
+  });
+
+  test("flags missing probe_finished_at", () => {
+    const r = assessProbeHealth({ surfaces: [{ status: "ok" }] });
+    assert.ok(r.problems.some((p) => /epoch\/empty/.test(p)));
+  });
+
+  test("flags zero ok surfaces (the clobbered all-unknown case)", () => {
+    const r = assessProbeHealth({
+      probe_finished_at: "2026-06-09T00:00:00.000Z",
+      surfaces: [{ status: "unknown" }, { status: "failed" }],
+    });
+    assert.ok(r.problems.some((p) => /status=ok/.test(p)));
+  });
+
+  test("tolerates a missing surfaces array", () => {
+    const r = assessProbeHealth({
+      probe_finished_at: "2026-06-09T00:00:00.000Z",
+    });
+    assert.equal(r.total, 0);
+    assert.ok(r.problems.length > 0);
+  });
+});


### PR DESCRIPTION
## Critical: the live API is serving an entirely unprobed health dataset

`https://metagraph.sh/metagraph/health/latest.json` currently shows **`probe_finished_at: 1970-01-01` and 0 of 1133 surfaces `ok`**. Because pool eligibility requires `status === "ok"`, **every RPC pool has 0 `pool_eligible` endpoints** — the read-only RPC proxy could never route even if enabled, and the freshness/health story is empty.

## Root cause

The `publish` job restores the `refresh` job's probe-health artifacts, then runs `npm test`. `tests/artifacts.test.mjs` rebuilds artifacts in-place (`build-artifacts.mjs` at `cwd: process.cwd()`) **without a probe-result cache**, clobbering the probe-derived health/pools/freshness in the working tree — real `probe_finished_at` + `ok` statuses become the **1970 epoch placeholder + all `unknown`**. `r2:upload` / `kv:publish` then publish the clobbered versions.

**Reproduced locally:**
- `build-artifacts-with-probe-health` (with cache) → `probe_finished_at` real, **1121/1133 ok**, base-layer endpoints healthy.
- run `npm test` → same dist now **0/1133 ok**, `probe_finished_at: null`.

(This is also the "test pollution" that's dirtied `public/metagraph` in every PR.)

## Fix

After the validate/test gates, **re-restore the immutable reviewed artifacts** the refresh job built (from `$RUNNER_TEMP/publish-artifacts`) so `r2:upload`/`kv:publish` publish exactly what was reviewed — then **assert** the staged health carries live probe data via `scripts/assert-published-probe-health.mjs` (non-epoch `probe_finished_at`, >0 `ok` surfaces). The publish now **fails loudly** rather than ever shipping an all-`unknown` dataset again.

## Verification
- Guard **fails** on the clobbered dist, **passes** on probe-health dist (1121/1133 ok) ✅
- `tests/assert-probe-health.test.mjs` — 5 cases ✅
- `validate:workflows` ✅ · eslint · prettier ✅
- Once real health is published, the base-layer RPC/WSS endpoints (onfinality/opentensor) become `pool_eligible` → unblocks the RPC proxy (Phase C / Finding 7).

> Touches `.github/workflows/publish-cloudflare.yml`, so it needs the Superagent workflow-review approval.