### PR TITLE
[GATED] Enable the read-only RPC proxy (go-live)

### DIFF
--- a/scripts/cloudflare-verify.mjs
+++ b/scripts/cloudflare-verify.mjs
@@ -63,8 +63,8 @@ check(
   "public/.assetsignore must block OS metadata uploads",
 );
 check(
-  config.vars?.METAGRAPH_ENABLE_RPC_PROXY === "false",
-  "RPC proxy must be disabled by default",
+  ["true", "false"].includes(config.vars?.METAGRAPH_ENABLE_RPC_PROXY),
+  "RPC proxy enable flag must be explicitly 'true' or 'false'",
 );
 check(
   config.vars?.METAGRAPH_R2_LATEST_PREFIX === "latest/",

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -81,7 +81,12 @@ assert.equal(
   "invalid query should return invalid_query error",
 );
 
-const disabledRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
+// RPC proxy is enabled in production: a non-allowlisted method must be refused
+// (proves the proxy is live and the read-only allowlist holds, with no
+// dependency on a live upstream), and a safe read method must not report
+// "disabled". (The enable gate runs before the method check, so a disabled
+// proxy would 501 here rather than 403.)
+const blockedRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
   method: "POST",
   headers: {
     "content-type": "application/json",
@@ -89,19 +94,37 @@ const disabledRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
   body: JSON.stringify({
     jsonrpc: "2.0",
     id: 1,
-    method: "chain_getHeader",
+    method: "author_submitExtrinsic",
     params: [],
   }),
 });
 assert.equal(
-  disabledRpcProxy.status,
-  501,
-  "RPC proxy should remain disabled in v1 production",
+  blockedRpcProxy.status,
+  403,
+  "enabled RPC proxy must refuse non-allowlisted methods",
 );
 assert.equal(
-  disabledRpcProxy.body?.error?.code,
-  "rpc_proxy_disabled",
-  "disabled RPC proxy should return rpc_proxy_disabled",
+  blockedRpcProxy.body?.error?.code,
+  "rpc_method_blocked",
+  "blocked RPC method should return rpc_method_blocked",
+);
+
+const safeRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney`, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "system_health",
+    params: [],
+  }),
+});
+assert.notEqual(
+  safeRpcProxy.status,
+  501,
+  "enabled RPC proxy must not report rpc_proxy_disabled",
 );
 
 console.log(

--- a/scripts/worker-deploy-dry-run.mjs
+++ b/scripts/worker-deploy-dry-run.mjs
@@ -49,8 +49,8 @@ check(
   "public/.assetsignore must block OS metadata uploads",
 );
 check(
-  config.vars?.METAGRAPH_ENABLE_RPC_PROXY === "false",
-  "RPC proxy must be disabled by default",
+  ["true", "false"].includes(config.vars?.METAGRAPH_ENABLE_RPC_PROXY),
+  "RPC proxy enable flag must be explicitly 'true' or 'false'",
 );
 check(
   config.vars?.METAGRAPH_R2_LATEST_PREFIX === "latest/",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -28,7 +28,7 @@
   },
   "vars": {
     "METAGRAPH_CONTRACT_VERSION": "2026-06-06.1",
-    "METAGRAPH_ENABLE_RPC_PROXY": "false",
+    "METAGRAPH_ENABLE_RPC_PROXY": "true",
     "METAGRAPH_R2_LATEST_PREFIX": "latest/",
   },
   "routes": [


### PR DESCRIPTION
> **DRAFT / GATED — do not merge until the checklist below is complete.** This is the production go-live for the read-only RPC proxy.

Flips `METAGRAPH_ENABLE_RPC_PROXY` to `"true"` and lands the coordinated changes enabling requires. All Worker controls shipped in Phase C (#214); endpoint eligibility is verified — a CI build produces **finney-rpc 2/2, finney-wss 4/4, finney-archive 6/6** `pool_eligible` endpoints once real probe health is published (#216, now merged).

### Changes
- **`wrangler.jsonc`** — `METAGRAPH_ENABLE_RPC_PROXY` `"false"` → `"true"`.
- **`worker-deploy-dry-run.mjs` + `cloudflare-verify.mjs`** — the deliberate "RPC proxy must be disabled by default" guard becomes "must be explicitly `'true'` or `'false'`" (still catches a missing/typo'd flag; permits enablement).
- **`smoke-live-api.mjs`** — asserts the **enabled** proxy refuses a non-allowlisted method (`403 rpc_method_blocked`, no upstream dependency) and that a safe method isn't reported disabled — replacing the old `rpc_proxy_disabled` assertion.

### ✅ Merge checklist (all required)
1. [ ] A real data publish has run (`publish-cloudflare.yml` → `publish`) so the live pools have eligible endpoints — otherwise the proxy returns `503 rpc_endpoint_unavailable`.
2. [ ] Cloudflare **WAF `/rpc/*` rules** are configured (`docs/operations.md` → "Enabling the RPC Proxy"). The in-Worker rate limiter is active regardless; WAF is defense-in-depth.
3. [ ] Explicit go-ahead — this is the go-live.

On merge, Cloudflare Workers Builds deploys the enabled proxy and the next data-refresh smoke verifies it (blocked method → 403, safe method → 200/503, never 501).

> Note: this is security-relevant (opens a public surface + loosens a safety guard), so it will also get the Superagent review.