### PR TITLE
Fix stale compact R2 manifest storage tiers

### DIFF
--- a/public/metagraph/r2-manifest.json
+++ b/public/metagraph/r2-manifest.json
@@ -1,6 +1,6 @@
 {
-  "artifact_count": 23,
-  "artifact_size_bytes": 5360612,
+  "artifact_count": 9,
+  "artifact_size_bytes": 1084923,
   "artifacts": [
     {
       "content_type": "application/json",
@@ -40,110 +40,11 @@
     },
     {
       "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/curation.json",
-      "latest_key": "latest/curation.json",
-      "path": "/metagraph/curation.json",
-      "sha256": "94951b064424425243ad8f6b3c91b021930a1d39f870190baef845c6ceab1ae2",
-      "size_bytes": 178260,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/evidence-ledger.json",
-      "latest_key": "latest/evidence-ledger.json",
-      "path": "/metagraph/evidence-ledger.json",
-      "sha256": "28b6a29cb00ddf0e401177ca0d2dfea7b9d1aff7d1831d819e932eccc21f5eb9",
-      "size_bytes": 858365,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/freshness.json",
-      "latest_key": "latest/freshness.json",
-      "path": "/metagraph/freshness.json",
-      "sha256": "f3efe62128910a2c9b6e24a67e54ccab48d8731422f2854e94ff80d33eb330a5",
-      "size_bytes": 7549,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/gaps.json",
-      "latest_key": "latest/gaps.json",
-      "path": "/metagraph/gaps.json",
-      "sha256": "19b9c9fd60df8caccd05ad506c836ab40e695080cd32878e18c1a0281ead8f20",
-      "size_bytes": 100781,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/openapi.json",
       "latest_key": "latest/openapi.json",
       "path": "/metagraph/openapi.json",
       "sha256": "49ea2e9fb82ac6880755381c06c1e0d2632c5cc8d87709e3fdfc8db259cfc5fc",
       "size_bytes": 367795,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/profiles.json",
-      "latest_key": "latest/profiles.json",
-      "path": "/metagraph/profiles.json",
-      "sha256": "bc9d3fcb4c5a34bc5e5d19b70c859cf539fb4dc5cf823df62f6c86f01f30c8c8",
-      "size_bytes": 605675,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/providers.json",
-      "latest_key": "latest/providers.json",
-      "path": "/metagraph/providers.json",
-      "sha256": "cdf6a067428f3a4c962e7c1231572aff59eb6c267ff19a0089390bbeda9a2eef",
-      "size_bytes": 40327,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/review/adapter-candidates.json",
-      "latest_key": "latest/review/adapter-candidates.json",
-      "path": "/metagraph/review/adapter-candidates.json",
-      "sha256": "d64ceae8cbeb562efb79581d99a2f44b502e95240cb72a83fa41a550bacce1ca",
-      "size_bytes": 90429,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/review/curation.json",
-      "latest_key": "latest/review/curation.json",
-      "path": "/metagraph/review/curation.json",
-      "sha256": "3dc0434e7c62f924b625b2850e12e9aef12694e6b78954953796a184f72c0a25",
-      "size_bytes": 157068,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/review/enrichment-queue.json",
-      "latest_key": "latest/review/enrichment-queue.json",
-      "path": "/metagraph/review/enrichment-queue.json",
-      "sha256": "dae0157226fba0e97b4b2e7b6d22e28140a8b04054ce39b53088066c071e7591",
-      "size_bytes": 365724,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/review/gap-priorities.json",
-      "latest_key": "latest/review/gap-priorities.json",
-      "path": "/metagraph/review/gap-priorities.json",
-      "sha256": "6192d0d280e24f261d0308ee6cb54abccce99c5a4951207212681db2e9198cdb",
-      "size_bytes": 65471,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/review/maintainer-decisions.json",
-      "latest_key": "latest/review/maintainer-decisions.json",
-      "path": "/metagraph/review/maintainer-decisions.json",
-      "sha256": "2e57a1b5a17d8212169056572adb6ea7e55e74d0cb2b73a5ba581c597eac371f",
-      "size_bytes": 1714,
       "storage_tier": "dual"
     },
     {
@@ -157,15 +58,6 @@
     },
     {
       "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/schema-drift.json",
-      "latest_key": "latest/schema-drift.json",
-      "path": "/metagraph/schema-drift.json",
-      "sha256": "99cbea31cf494f48e908ea2de021c306bcea5e2924d22266e384c26096c6f0a8",
-      "size_bytes": 6298,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/schemas/index.json",
       "latest_key": "latest/schemas/index.json",
       "path": "/metagraph/schemas/index.json",
@@ -175,29 +67,11 @@
     },
     {
       "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/search.json",
-      "latest_key": "latest/search.json",
-      "path": "/metagraph/search.json",
-      "sha256": "7edaf4290a787aadb901a70c35b19c91baf2ddad70037af986fcf6686a2bca0d",
-      "size_bytes": 659251,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
       "key": "runs/1970-01-01T00-00-00-000Z/subnets.json",
       "latest_key": "latest/subnets.json",
       "path": "/metagraph/subnets.json",
       "sha256": "c7778bdd46afe11104c6b6755e0132917ae3bda466432b53115b30f2daa4a40e",
       "size_bytes": 124080,
-      "storage_tier": "dual"
-    },
-    {
-      "content_type": "application/json",
-      "key": "runs/1970-01-01T00-00-00-000Z/surfaces.json",
-      "latest_key": "latest/surfaces.json",
-      "path": "/metagraph/surfaces.json",
-      "sha256": "e0abec4a9eeeabd29230c7bf58613f0690d7421f28a5c9cd8b12f24f4e3fb1fc",
-      "size_bytes": 1138777,
       "storage_tier": "dual"
     },
     {
@@ -214,7 +88,7 @@
   "bucket_name": "metagraphed-artifacts",
   "contract_version": "2026-06-06.1",
   "full_artifact_count": 1273,
-  "full_artifact_size_bytes": 49139177,
+  "full_artifact_size_bytes": 35050239,
   "full_manifest_key": "latest/r2-manifest.json",
   "full_manifest_run_key": "runs/1970-01-01T00-00-00-000Z/r2-manifest.json",
   "generated_at": "1970-01-01T00:00:00.000Z",
@@ -233,13 +107,13 @@
   "run_prefix": "runs/1970-01-01T00-00-00-000Z/",
   "schema_version": 1,
   "storage_tier_counts": {
-    "dual": 22,
+    "dual": 8,
     "git": 1,
-    "r2": 1250
+    "r2": 1264
   },
   "storage_tier_size_bytes": {
-    "dual": 5101601,
+    "dual": 825912,
     "git": 259011,
-    "r2": 43778565
+    "r2": 33965316
   }
 }

--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -79,6 +79,19 @@ for (const artifact of validationManifest.artifacts) {
     );
     process.exit(1);
   }
+
+  const expectedTier = artifactStorageTierForRelativePath(artifact.path);
+  if (artifact.storage_tier !== expectedTier) {
+    console.error(
+      stableStringify({
+        error: "r2 manifest artifact storage tier is stale",
+        path: artifact.path,
+        expected_storage_tier: expectedTier,
+        actual_storage_tier: artifact.storage_tier,
+      }),
+    );
+    process.exit(1);
+  }
 }
 
 console.log(stableStringify(summary));


### PR DESCRIPTION
### Motivation
- The compact public R2 manifest committed in `public/metagraph/r2-manifest.json` advertised several artifacts (freshness/schema-drift/surfaces and others) as `storage_tier: "dual"` after those artifacts were reclassified as R2-only, producing a contradictory public manifest and breaking integrity/provenance checks.

### Description
- Regenerated the compact public manifest at `public/metagraph/r2-manifest.json` so R2-only artifacts are no longer included and the artifact counts/sizes/storage-tier aggregates are updated accordingly. 
- Added a validation guard to `scripts/r2-manifest.mjs` that checks each manifest entry's `storage_tier` against `artifactStorageTierForRelativePath()` and fails the script if any entry is stale. 
- The change updates manifest totals and storage-tier aggregates to reflect the new classifier output and ensures future stale manifests are rejected by the manifest generation tool.

### Testing
- Ran `npm run artifacts:prepare-local` to stage artifacts for manifest generation and it completed successfully. 
- Ran `npm run r2:manifest` and `npm run r2:manifest:dry-run` to regenerate and validate the manifest and both completed successfully. 
- Ran `npm run validate` to exercise repository validations and it completed successfully. 
- Ran the targeted test suite `npx vitest run tests/artifacts.test.mjs --testNamePattern "r2 manifest"` and the test file passed (1 passed, 15 skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288ba8010c832aa0b178a1cad4601f)