### PR TITLE
fix(ci): keep deleted files visible to validation routing

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,19 +30,25 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
-          # --diff-filter=d excludes deletions: removing a public artifact (e.g.
-          # moving it to R2-only, ADR 0001) is not a "submitted" artifact and
-          # must not be flagged by the submitted-artifact verification below.
+          # Keep the global changed-files list unfiltered so PR routing and
+          # policy checks still see deletions. Only the submitted-artifact
+          # verifier receives a deletion-filtered list, because removing a
+          # public artifact (for example moving it to R2-only, ADR 0001) is not
+          # a submitted artifact.
           if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-            git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+            git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" > submitted-artifact-files.txt
           else
             git fetch origin "$BASE_REF"
-            git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > changed-files.txt
+            git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
+            git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > submitted-artifact-files.txt
           fi
 
       - name: Capture changed files for full validation
         if: github.event_name != 'pull_request'
-        run: ": > changed-files.txt"
+        run: |
+          : > changed-files.txt
+          : > submitted-artifact-files.txt
 
       - name: Classify validation route
         id: route
@@ -144,7 +150,7 @@ jobs:
 
       - name: Verify submitted public artifacts are reproducible
         if: steps.route.outputs.mode == 'full' && github.event_name == 'pull_request'
-        run: node scripts/ci-verify-submitted-artifacts.mjs --changed-files changed-files.txt
+        run: node scripts/ci-verify-submitted-artifacts.mjs --changed-files submitted-artifact-files.txt
 
       - name: Validate registry
         if: steps.route.outputs.mode == 'full'

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -111,6 +111,17 @@ for (const workflow of workflows) {
       "intake import pull request must allowlist generated registry artifact paths",
     );
   }
+  if (workflow === "validate.yml") {
+    check(
+      content.includes("git diff --name-only ") &&
+        content.includes("> changed-files.txt") &&
+        content.includes("--diff-filter=d") &&
+        content.includes("> submitted-artifact-files.txt") &&
+        content.includes("--changed-files submitted-artifact-files.txt"),
+      workflow,
+      "validate workflow must keep PR routing diffs unfiltered and filter deletions only for submitted-artifact verification",
+    );
+  }
   if (workflow === "submission-gate.yml") {
     check(
       content.includes("metagraphed-submission-gate:"),


### PR DESCRIPTION
### Motivation
- The validate workflow previously used `git diff --name-only --diff-filter=d` to produce a shared `changed-files.txt`, which hid deleted paths from the PR route classifier and allowed deletions to bypass full validation.
- The intended behavior is for PR routing and policy checks to see deletions, while the submitted-artifact verifier should alone ignore deletions when validating reproducibility.

### Description
- Update `.github/workflows/validate.yml` to write an unfiltered `changed-files.txt` for routing and a separate `submitted-artifact-files.txt` produced with `--diff-filter=d` for artifact verification. 
- Initialize both lists for non-PR runs and switch the `ci-verify-submitted-artifacts.mjs` invocation to use `submitted-artifact-files.txt` instead of the global list. 
- Add a workflow validation assertion in `scripts/validate-workflows.mjs` that requires `validate.yml` to keep PR routing diffs unfiltered and to filter deletions only for submitted-artifact verification.

### Testing
- Ran `npm run validate:workflows` which completed successfully and reported validated workflow files. 
- Ran `npm test -- tests/submission-gate.test.mjs` and all tests passed (`33` tests). 
- Ran `npx prettier --check .github/workflows/validate.yml scripts/validate-workflows.mjs` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a288b2d8230832aab87e433b28e54d5)