### PR TITLE
fix(publish): rescan restored artifacts before upload

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -168,9 +168,10 @@ jobs:
       # become the 1970 epoch placeholder + all "unknown"). r2:upload/kv:publish
       # below would then publish that unprobed dataset — leaving every RPC pool
       # with zero eligible endpoints. Re-restore the immutable reviewed artifacts
-      # so we publish exactly what was reviewed, then assert they carry live
-      # probe health so an all-"unknown" dataset can never ship silently.
-      - name: Re-restore reviewed artifacts and assert probe health
+      # so we publish exactly what was reviewed, then re-run publish-critical
+      # guards on that final tree. This keeps probe-health assurance while
+      # ensuring no unscanned network-derived metadata reaches R2/KV.
+      - name: Re-restore reviewed artifacts and run final publish guards
         run: |
           set -euo pipefail
           rm -rf public/metagraph dist/metagraph-r2
@@ -180,6 +181,8 @@ jobs:
             cp -R "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" dist/metagraph-r2
           fi
           npm run assert:probe-health
+          npm run scan:public-safety
+          npm run validate:private-boundary
 
       - name: Check Cloudflare publishing secrets
         id: cloudflare-secrets

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -232,6 +232,30 @@ for (const workflow of workflows) {
       workflow,
       "publish workflow must skip deploy/upload steps only in explicit dry-run mode",
     );
+    const finalPublishGuard = stepBlock(
+      content,
+      "Re-restore reviewed artifacts and run final publish guards",
+    );
+    check(
+      finalPublishGuard.includes("npm run assert:probe-health") &&
+        finalPublishGuard.includes("npm run scan:public-safety") &&
+        finalPublishGuard.includes("npm run validate:private-boundary"),
+      workflow,
+      "publish workflow must run final probe-health and safety guards after restoring reviewed artifacts",
+    );
+    const finalGuardIndex = content.indexOf(
+      "- name: Re-restore reviewed artifacts and run final publish guards",
+    );
+    const cloudflareSecretsIndex = content.indexOf(
+      "- name: Check Cloudflare publishing secrets",
+    );
+    check(
+      finalGuardIndex !== -1 &&
+        cloudflareSecretsIndex !== -1 &&
+        finalGuardIndex < cloudflareSecretsIndex,
+      workflow,
+      "publish workflow must run final publish guards before Cloudflare upload decisions",
+    );
   }
 }
 
@@ -255,6 +279,16 @@ function workflowJobBlock(content, jobName) {
   const match = content.match(
     new RegExp(
       String.raw`^  ${escapeRegExp(jobName)}:\n[\s\S]*?(?=^  [A-Za-z0-9_-]+:\n|(?![\s\S]))`,
+      "m",
+    ),
+  );
+  return match?.[0] || "";
+}
+
+function stepBlock(content, stepName) {
+  const match = content.match(
+    new RegExp(
+      String.raw`^      - name: ${escapeRegExp(stepName)}\n[\s\S]*?(?=^      - name: |(?![\s\S]))`,
       "m",
     ),
   );


### PR DESCRIPTION
### Motivation
- The publish job restored immutable reviewed artifacts after safety scans, so the final R2/KV payload could differ from the tree that `scan:public-safety` and `validate:private-boundary` inspected, allowing network-derived probe metadata to be published without a final safety scan.

### Description
- Re-runs the post-restore checks by updating the publish workflow step to run `npm run assert:probe-health`, `npm run scan:public-safety`, and `npm run validate:private-boundary` after restoring the reviewed artifacts in `.github/workflows/publish-cloudflare.yml`.
- Renamed the step to `Re-restore reviewed artifacts and run final publish guards` so intent is explicit and ordering is clear.
- Extended `scripts/validate-workflows.mjs` to require the new post-restore publish guards and assert they run before Cloudflare upload decisions by adding a `stepBlock` helper and new assertions.
- Kept changes minimal and focused on ordering/validation to preserve existing publish behavior while closing the safety-scan bypass.

### Testing
- Ran `npm run validate:workflows` which succeeded and validated the new workflow assertions.
- Ran `npm run scan:public-safety` and `npm run validate:private-boundary` which both passed locally in this environment.
- Ran `npx prettier --check` on the modified files and `npx eslint scripts/validate-workflows.mjs` which passed for the edited files.
- Ran `npm test` which failed in this checkout because generated artifacts (`public/metagraph/*.json`, `dist/metagraph-r2/...`) are not present in the workspace and one DNS-dependent expectation failed in this environment, so the failure is due to missing test fixtures rather than the workflow change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28f1a9bd80832a9433e0d0c94f56f9)