### PR TITLE
fix(rpc): block full block reads in proxy

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -694,6 +694,27 @@ describe("Worker runtime", () => {
     assert.equal(blocked.status, 403);
     assert.equal((await blocked.json()).error.code, "rpc_method_blocked");
 
+    const fullBlockRead = await handleRequest(
+      new Request("https://metagraph.sh/rpc/v1/finney", {
+        method: "POST",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 2,
+          method: "chain_getBlock",
+          params: [
+            "0x0000000000000000000000000000000000000000000000000000000000000000",
+          ],
+        }),
+      }),
+      { ...env, METAGRAPH_ENABLE_RPC_PROXY: "true" },
+      {},
+    );
+    assert.equal(fullBlockRead.status, 403);
+    assert.equal(
+      (await fullBlockRead.json()).error.code,
+      "rpc_method_blocked",
+    );
+
     const tooLargeByHeader = await handleRequest(
       new Request("https://metagraph.sh/rpc/v1/finney", {
         method: "POST",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -34,7 +34,6 @@ const ROUTES = API_ROUTES.map((entry) => ({
 // state_getStorage) and anything mutating — those stay blocked by the allowlist
 // plus DENIED_RPC_PREFIXES.
 const SAFE_RPC_METHODS = new Set([
-  "chain_getBlock",
   "chain_getBlockHash",
   "chain_getFinalizedHead",
   "chain_getHeader",


### PR DESCRIPTION
### Motivation
- Prevent the unauthenticated read-only RPC proxy from being used to fetch full block bodies (expensive/large responses) by removing `chain_getBlock` from the safe-method allowlist.

### Description
- Remove `chain_getBlock` from `SAFE_RPC_METHODS` in `workers/api.mjs` and add a regression in `tests/worker-runtime.test.mjs` that asserts `chain_getBlock` is rejected with `403 rpc_method_blocked` before any upstream selection or forwarding.

### Testing
- Ran `npm test -- --run tests/worker-runtime.test.mjs`, which shows some unrelated fixture/archive-dependent API tests failing with `404` in this environment but confirms the added RPC regression and proxy-related checks behave as expected.
- Ran `npm test -- --run tests/rpc-endpoint-selection.test.mjs` which passed all cases, and ran `npm test -- --run tests/worker-runtime.test.mjs -t "keeps RPC proxy disabled"` which passed; `npm run lint` completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a28f0bf2ae0832a94873f622ef615fa)