### PR TITLE
fix(rpc): reject /wss route cleanly + never 500 on upstream errors

### DIFF
--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -127,6 +127,31 @@ assert.notEqual(
   "enabled RPC proxy must not report rpc_proxy_disabled",
 );
 
+// The /wss route is WebSocket-only and cannot be HTTP-proxied; it must return a
+// clean client error, never a 500.
+const wssRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney/wss`, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "system_health",
+    params: [],
+  }),
+});
+assert.equal(
+  wssRpcProxy.status,
+  400,
+  "the /wss RPC route must be rejected with a clean 400, not 500",
+);
+assert.equal(
+  wssRpcProxy.body?.error?.code,
+  "rpc_websocket_unsupported",
+  "the /wss RPC route should return rpc_websocket_unsupported",
+);
+
 console.log(
   JSON.stringify(
     {

--- a/scripts/worker-test.mjs
+++ b/scripts/worker-test.mjs
@@ -329,6 +329,29 @@ try {
     proxied.headers.get("x-metagraph-rpc-provider"),
     "proxied responses should expose provider metadata",
   );
+
+  const wssRejected = await handleRequest(
+    new Request("https://metagraph.sh/rpc/v1/finney/wss", {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "system_health",
+        params: [],
+      }),
+    }),
+    proxyEnv,
+    {},
+  );
+  assert.equal(
+    wssRejected.status,
+    400,
+    "the /wss route is not HTTP-proxyable and must be rejected, not 500",
+  );
+  assert.equal(
+    (await wssRejected.json()).error.code,
+    "rpc_websocket_unsupported",
+  );
 } finally {
   globalThis.fetch = originalFetch;
 }

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1008,6 +1008,8 @@ describe("Worker runtime", () => {
       assert.equal(called, true);
       assert.ok(response.headers.get("x-metagraph-rpc-provider"));
 
+      // The /wss route targets WebSocket-only endpoints that cannot be
+      // HTTP-POSTed, so it is rejected with a clean 400 rather than proxied.
       const wssResponse = await handleRequest(
         new Request("https://metagraph.sh/rpc/v1/wss", {
           method: "POST",
@@ -1021,7 +1023,11 @@ describe("Worker runtime", () => {
         proxyEnv,
         {},
       );
-      assert.equal(wssResponse.status, 200);
+      assert.equal(wssResponse.status, 400);
+      assert.equal(
+        (await wssResponse.json()).error.code,
+        "rpc_websocket_unsupported",
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -400,7 +400,18 @@ async function handleRpcProxyRequest(request, env, url) {
     );
   }
 
-  const poolId = url.pathname.includes("/wss") ? "finney-wss" : "finney-rpc";
+  // The proxy forwards an HTTP JSON-RPC POST, so it can only reach HTTP(S)
+  // upstreams. The /wss route points at WebSocket-only endpoints that cannot be
+  // HTTP-POSTed, so reject it with a clear error instead of failing the upstream
+  // fetch (which would surface as a 500).
+  if (url.pathname.endsWith("/wss")) {
+    return errorResponse(
+      "rpc_websocket_unsupported",
+      "WebSocket JSON-RPC is not available through this HTTP proxy. POST to /rpc/v1/finney for HTTP JSON-RPC, or connect to a public WSS endpoint directly.",
+      400,
+    );
+  }
+  const poolId = "finney-rpc";
   const pool = (poolArtifact.data.pools || []).find(
     (candidate) => candidate.id === poolId,
   );
@@ -428,14 +439,34 @@ async function handleRpcProxyRequest(request, env, url) {
   }
 
   const endpoint = endpointSelection.endpoint;
-  const upstream = await fetch(endpoint.url, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: bodyText,
-    signal: AbortSignal.timeout(10000),
-  });
+  // Defense in depth: the proxy can only HTTP-POST to an https upstream. A wss://
+  // endpoint that somehow reached selection is not proxyable.
+  if (!endpoint.url.startsWith("https://")) {
+    return errorResponse(
+      "rpc_endpoint_unavailable",
+      "No eligible HTTP RPC upstream is available for proxy routing.",
+      503,
+      { pool_id: poolId },
+    );
+  }
+  let upstream;
+  try {
+    upstream = await fetch(endpoint.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: bodyText,
+      signal: AbortSignal.timeout(10000),
+    });
+  } catch {
+    return errorResponse(
+      "rpc_upstream_error",
+      "The selected RPC upstream could not be reached.",
+      502,
+      { endpoint_id: endpoint.id, pool_id: poolId },
+    );
+  }
   const headers = apiHeaders("short");
   headers.set("cache-control", "no-store");
   headers.set("x-metagraph-rpc-endpoint-id", endpoint.id);


### PR DESCRIPTION
The RPC proxy is **live and working** — `POST /rpc/v1/finney system_health` returns real chain data (`{"peers":48,"isSyncing":false}`) load-balanced via the onfinality HTTP endpoint, the allowlist blocks unsafe methods (403), and the WAF blocks non-POST (403).

**But `POST /rpc/v1/finney/wss` returned 500.** The proxy makes an HTTP JSON-RPC POST, and the `/wss` route points at WebSocket-only (`wss://`) endpoints that can't be HTTP-POSTed — so `fetch()` threw and the unhandled error surfaced as a 500.

## Fix
- **Reject `/wss`** with a clean **`400 rpc_websocket_unsupported`** ("POST to `/rpc/v1/finney` for HTTP JSON-RPC, or use a public WSS endpoint directly"); the proxy now always uses the `finney-rpc` (HTTP) pool.
- **Wrap the upstream fetch in try/catch → `502 rpc_upstream_error`**, so an unreachable/erroring upstream can never leak a 500.
- **Guard:** refuse to proxy to a non-`https` upstream (503) — defense in depth.

## Tests
- `worker:test` + `tests/worker-runtime.test.mjs`: `/wss → 400 rpc_websocket_unsupported` (the latter's fixture previously mocked the wss fetch, hiding the real failure — now corrected).
- `smoke-live-api.mjs`: asserts `/wss → 400` against the live site.
- Full suite **148** ✅ · `worker:deploy:dry-run` ✅ · eslint · prettier ✅

On merge, Cloudflare Builds redeploys; `/rpc/v1/finney` keeps working, `/wss` returns a clean 400.