### PR TITLE
feat(rpc): resilient proxy — /wss fix + failover/retry + circuit breaker

### DIFF
--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -127,6 +127,31 @@ assert.notEqual(
   "enabled RPC proxy must not report rpc_proxy_disabled",
 );
 
+// The /wss route is WebSocket-only and cannot be HTTP-proxied; it must return a
+// clean client error, never a 500.
+const wssRpcProxy = await fetchJson(`${baseUrl}/rpc/v1/finney/wss`, {
+  method: "POST",
+  headers: {
+    "content-type": "application/json",
+  },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "system_health",
+    params: [],
+  }),
+});
+assert.equal(
+  wssRpcProxy.status,
+  400,
+  "the /wss RPC route must be rejected with a clean 400, not 500",
+);
+assert.equal(
+  wssRpcProxy.body?.error?.code,
+  "rpc_websocket_unsupported",
+  "the /wss RPC route should return rpc_websocket_unsupported",
+);
+
 console.log(
   JSON.stringify(
     {

--- a/scripts/worker-test.mjs
+++ b/scripts/worker-test.mjs
@@ -329,6 +329,29 @@ try {
     proxied.headers.get("x-metagraph-rpc-provider"),
     "proxied responses should expose provider metadata",
   );
+
+  const wssRejected = await handleRequest(
+    new Request("https://metagraph.sh/rpc/v1/finney/wss", {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "system_health",
+        params: [],
+      }),
+    }),
+    proxyEnv,
+    {},
+  );
+  assert.equal(
+    wssRejected.status,
+    400,
+    "the /wss route is not HTTP-proxyable and must be rejected, not 500",
+  );
+  assert.equal(
+    (await wssRejected.json()).error.code,
+    "rpc_websocket_unsupported",
+  );
 } finally {
   globalThis.fetch = originalFetch;
 }

--- a/tests/rpc-failover.test.mjs
+++ b/tests/rpc-failover.test.mjs
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  classifyUpstreamAttempt,
+  orderSafeRpcEndpoints,
+  proxyWithFailover,
+} from "../workers/api.mjs";
+
+const SAFE_A = "https://bittensor-finney.api.onfinality.io/public";
+const SAFE_B = "https://bittensor-public.nodies.app/rpc";
+const WSS = "wss://lite.chain.opentensor.ai:443"; // trusted origin, but not HTTP-proxyable
+const UNSAFE = "https://evil.example.com/rpc";
+
+const ep = (id, url, extra = {}) => ({
+  id,
+  url,
+  provider: "fixture",
+  pool_eligible: true,
+  score: 100,
+  status: "ok",
+  ...extra,
+});
+
+const jsonResponse = (status, body) => ({
+  status,
+  async text() {
+    return typeof body === "string" ? body : JSON.stringify(body);
+  },
+});
+
+// fetchFn that returns the i-th scripted reply (a thunk that may throw, or a
+// response object), recording the URLs it was called with.
+function scriptedFetch(...replies) {
+  const calls = [];
+  const fn = async (url) => {
+    const reply = replies[calls.length];
+    calls.push(url);
+    if (typeof reply === "function") return reply();
+    return reply;
+  };
+  fn.calls = calls;
+  return fn;
+}
+
+describe("classifyUpstreamAttempt", () => {
+  const cases = [
+    ["network throw", { thrown: true }, "transient"],
+    ["http 500", { status: 500 }, "transient"],
+    ["http 503", { status: 503 }, "transient"],
+    ["http 429", { status: 429 }, "transient"],
+    ["http 400", { status: 400 }, "fatal"],
+    ["http 404", { status: 404 }, "fatal"],
+    ["200 result", { status: 200, parsedBody: { result: {} } }, "success"],
+    [
+      "200 node-internal error",
+      { status: 200, parsedBody: { error: { code: -32603 } } },
+      "transient",
+    ],
+    [
+      "200 method-not-found (app error)",
+      { status: 200, parsedBody: { error: { code: -32601 } } },
+      "success",
+    ],
+    ["200 unparseable", { status: 200, parsedBody: null }, "success"],
+  ];
+  for (const [name, input, expected] of cases) {
+    test(name, () => assert.equal(classifyUpstreamAttempt(input), expected));
+  }
+});
+
+describe("orderSafeRpcEndpoints", () => {
+  test("returns the full ordered safe https list", () => {
+    const { endpoints, unsafeEndpoint } = orderSafeRpcEndpoints(
+      { endpoints: [ep("a", SAFE_A), ep("b", SAFE_B)] },
+      () => 0,
+    );
+    assert.deepEqual(
+      endpoints.map((e) => e.id),
+      ["a", "b"],
+    );
+    assert.equal(unsafeEndpoint, null);
+  });
+
+  test("drops wss endpoints (not HTTP-proxyable) without flagging unsafe", () => {
+    const { endpoints, unsafeEndpoint } = orderSafeRpcEndpoints({
+      endpoints: [ep("w", WSS), ep("a", SAFE_A)],
+    });
+    assert.deepEqual(
+      endpoints.map((e) => e.id),
+      ["a"],
+    );
+    assert.equal(unsafeEndpoint, null);
+  });
+
+  test("reports an unsafe endpoint only when no safe endpoint exists", () => {
+    const { endpoints, unsafeEndpoint } = orderSafeRpcEndpoints({
+      endpoints: [ep("u", UNSAFE)],
+    });
+    assert.equal(endpoints.length, 0);
+    assert.equal(unsafeEndpoint.id, "u");
+  });
+
+  test("skips ineligible endpoints", () => {
+    const { endpoints } = orderSafeRpcEndpoints({
+      endpoints: [ep("x", SAFE_A, { pool_eligible: false }), ep("b", SAFE_B)],
+    });
+    assert.deepEqual(
+      endpoints.map((e) => e.id),
+      ["b"],
+    );
+  });
+});
+
+describe("proxyWithFailover", () => {
+  const base = { bodyText: "{}", poolId: "finney-rpc" };
+
+  test("fails over from a network throw to the next endpoint", async () => {
+    const fetchFn = scriptedFetch(
+      () => {
+        throw new Error("network");
+      },
+      jsonResponse(200, { jsonrpc: "2.0", id: 1, result: { ok: true } }),
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
+    assert.equal(res.headers.get("x-metagraph-rpc-attempts"), "2");
+    assert.deepEqual(fetchFn.calls, [SAFE_A, SAFE_B]);
+  });
+
+  test("fails over on HTTP 5xx", async () => {
+    const fetchFn = scriptedFetch(
+      jsonResponse(503, ""),
+      jsonResponse(200, { result: 1 }),
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
+  });
+
+  test("fails over on a node-internal JSON-RPC error", async () => {
+    const fetchFn = scriptedFetch(
+      jsonResponse(200, { error: { code: -32603, message: "internal" } }),
+      jsonResponse(200, { result: 1 }),
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
+  });
+
+  test("returns an application JSON-RPC error immediately (no failover)", async () => {
+    const fetchFn = scriptedFetch(
+      jsonResponse(200, {
+        error: { code: -32601, message: "Method not found" },
+      }),
+      jsonResponse(200, { result: "should-not-be-used" }),
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "a");
+    assert.equal(fetchFn.calls.length, 1);
+    assert.equal((await res.json()).error.code, -32601);
+  });
+
+  test("returns 502 rpc_upstream_unavailable when all attempts fail", async () => {
+    const fetchFn = scriptedFetch(
+      () => {
+        throw new Error("net");
+      },
+      () => {
+        throw new Error("net");
+      },
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+    });
+    assert.equal(res.status, 502);
+    const body = await res.json();
+    assert.equal(body.error.code, "rpc_upstream_unavailable");
+    assert.deepEqual(body.meta.attempts, ["a", "b"]);
+  });
+
+  test("bounds attempts to maxAttempts (3) even with more endpoints", async () => {
+    const fetchFn = scriptedFetch(...Array(5).fill(jsonResponse(503, "")));
+    const endpoints = ["a", "b", "c", "d", "e"].map((id) => ep(id, SAFE_A));
+    const res = await proxyWithFailover(endpoints, { ...base, fetchFn });
+    assert.equal(res.status, 502);
+    assert.equal(fetchFn.calls.length, 3);
+  });
+});

--- a/tests/rpc-failover.test.mjs
+++ b/tests/rpc-failover.test.mjs
@@ -2,8 +2,11 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   classifyUpstreamAttempt,
+  isRpcEndpointEjected,
   orderSafeRpcEndpoints,
   proxyWithFailover,
+  recordRpcFailure,
+  recordRpcSuccess,
 } from "../workers/api.mjs";
 
 const SAFE_A = "https://bittensor-finney.api.onfinality.io/public";
@@ -111,8 +114,54 @@ describe("orderSafeRpcEndpoints", () => {
   });
 });
 
+describe("circuit breaker", () => {
+  test("ejects after 3 consecutive failures, half-opens after cooldown", () => {
+    const map = new Map();
+    recordRpcFailure(map, "a", 1000);
+    recordRpcFailure(map, "a", 1000);
+    assert.equal(isRpcEndpointEjected(map, "a", 1000), false);
+    recordRpcFailure(map, "a", 1000);
+    assert.equal(isRpcEndpointEjected(map, "a", 1000), true);
+    assert.equal(isRpcEndpointEjected(map, "a", 1000 + 31_000), false);
+  });
+
+  test("success clears breaker state", () => {
+    const map = new Map();
+    for (let i = 0; i < 3; i += 1) recordRpcFailure(map, "a", 0);
+    assert.equal(isRpcEndpointEjected(map, "a", 0), true);
+    recordRpcSuccess(map, "a");
+    assert.equal(isRpcEndpointEjected(map, "a", 0), false);
+  });
+
+  test("ordering deprioritises an ejected endpoint to the back", () => {
+    const map = new Map();
+    for (let i = 0; i < 3; i += 1) recordRpcFailure(map, "a", 0);
+    const { endpoints } = orderSafeRpcEndpoints(
+      { endpoints: [ep("a", SAFE_A), ep("b", SAFE_B)] },
+      () => 0,
+      { healthMap: map, now: 0 },
+    );
+    assert.deepEqual(
+      endpoints.map((e) => e.id),
+      ["b", "a"],
+    );
+  });
+
+  test("a fully-ejected pool still returns all endpoints (half-open)", () => {
+    const map = new Map();
+    for (const id of ["a", "b"])
+      for (let i = 0; i < 3; i += 1) recordRpcFailure(map, id, 0);
+    const { endpoints } = orderSafeRpcEndpoints(
+      { endpoints: [ep("a", SAFE_A), ep("b", SAFE_B)] },
+      () => 0,
+      { healthMap: map, now: 0 },
+    );
+    assert.equal(endpoints.length, 2);
+  });
+});
+
 describe("proxyWithFailover", () => {
-  const base = { bodyText: "{}", poolId: "finney-rpc" };
+  const base = { bodyText: "{}", poolId: "finney-rpc", healthMap: new Map() };
 
   test("fails over from a network throw to the next endpoint", async () => {
     const fetchFn = scriptedFetch(

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1008,6 +1008,8 @@ describe("Worker runtime", () => {
       assert.equal(called, true);
       assert.ok(response.headers.get("x-metagraph-rpc-provider"));
 
+      // The /wss route targets WebSocket-only endpoints that cannot be
+      // HTTP-POSTed, so it is rejected with a clean 400 rather than proxied.
       const wssResponse = await handleRequest(
         new Request("https://metagraph.sh/rpc/v1/wss", {
           method: "POST",
@@ -1021,7 +1023,11 @@ describe("Worker runtime", () => {
         proxyEnv,
         {},
       );
-      assert.equal(wssResponse.status, 200);
+      assert.equal(wssResponse.status, 400);
+      assert.equal(
+        (await wssResponse.json()).error.code,
+        "rpc_websocket_unsupported",
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -443,6 +443,32 @@ const RPC_ATTEMPT_TIMEOUT_MS = 6000;
 // error by trying every node).
 const TRANSIENT_RPC_ERROR_CODES = new Set([-32603]); // internal error
 
+// In-isolate circuit breaker: count consecutive transient failures per endpoint
+// and temporarily eject (deprioritise) repeat offenders. Per-isolate only (no
+// global view, resets on cold start) — cheap and enough to ride out the burst
+// that matters. RPC_HEALTH is the module-default map; injectable for tests.
+const RPC_HEALTH = new Map(); // endpointId -> { fails, ejectedUntil }
+const RPC_EJECT_THRESHOLD = 3;
+const RPC_EJECT_COOLDOWN_MS = 30_000;
+
+export function recordRpcFailure(map, id, now) {
+  const entry = map.get(id) || { fails: 0, ejectedUntil: 0 };
+  entry.fails += 1;
+  if (entry.fails >= RPC_EJECT_THRESHOLD) {
+    entry.ejectedUntil = now + RPC_EJECT_COOLDOWN_MS;
+  }
+  map.set(id, entry);
+}
+
+export function recordRpcSuccess(map, id) {
+  map.delete(id);
+}
+
+export function isRpcEndpointEjected(map, id, now) {
+  const entry = map.get(id);
+  return Boolean(entry && entry.ejectedUntil > now);
+}
+
 // Decide how to treat one upstream attempt: "transient" (fail over to the next
 // endpoint), "success"/"fatal" (return this upstream's response to the client).
 export function classifyUpstreamAttempt({ thrown, status, parsedBody }) {
@@ -469,6 +495,7 @@ export async function proxyWithFailover(
     fetchFn = fetch,
     maxAttempts = RPC_MAX_ATTEMPTS,
     timeoutMs = RPC_ATTEMPT_TIMEOUT_MS,
+    healthMap = RPC_HEALTH,
   },
 ) {
   const attempts = [];
@@ -500,6 +527,7 @@ export async function proxyWithFailover(
     if (
       classifyUpstreamAttempt({ thrown, status, parsedBody }) === "transient"
     ) {
+      recordRpcFailure(healthMap, endpoint.id, Date.now());
       attempts.push({
         endpoint_id: endpoint.id,
         reason: thrown ? "unreachable" : `status-${status}`,
@@ -507,6 +535,9 @@ export async function proxyWithFailover(
       continue;
     }
 
+    // The endpoint responded (success, or an application-level error) — it is
+    // reachable, so clear any breaker state for it.
+    recordRpcSuccess(healthMap, endpoint.id);
     const headers = apiHeaders("short");
     headers.set("cache-control", "no-store");
     headers.set("content-type", JSON_CONTENT_TYPE);
@@ -1081,8 +1112,14 @@ function contractVersion(env) {
 // (favour higher score, keep load spread) so failover walks best→worst without
 // always hammering one upstream. wss:// endpoints are dropped (not HTTP-
 // proxyable); a genuinely unsafe URL is reported (for a 502) only when no safe
-// endpoint exists. randomFn injectable for tests.
-export function orderSafeRpcEndpoints(pool, randomFn = Math.random) {
+// endpoint exists. Circuit-breaker-ejected endpoints are deprioritised to the
+// back (never removed) so a fully-ejected pool still self-heals via half-open
+// retries. randomFn / healthMap / now injectable for tests.
+export function orderSafeRpcEndpoints(
+  pool,
+  randomFn = Math.random,
+  { healthMap = RPC_HEALTH, now = Date.now() } = {},
+) {
   const safe = [];
   let unsafeEndpoint = null;
   for (const endpoint of pool?.endpoints || []) {
@@ -1100,12 +1137,19 @@ export function orderSafeRpcEndpoints(pool, randomFn = Math.random) {
   }
 
   const remaining = [...safe];
-  const ordered = [];
+  const shuffled = [];
   while (remaining.length) {
     const pick = weightedPickEndpoint(remaining, randomFn);
-    ordered.push(pick);
+    shuffled.push(pick);
     remaining.splice(remaining.indexOf(pick), 1);
   }
+  const live = shuffled.filter(
+    (e) => !isRpcEndpointEjected(healthMap, e.id, now),
+  );
+  const ejected = shuffled.filter((e) =>
+    isRpcEndpointEjected(healthMap, e.id, now),
+  );
+  const ordered = [...live, ...ejected];
   return {
     endpoints: ordered,
     unsafeEndpoint: ordered.length ? null : unsafeEndpoint,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -400,7 +400,18 @@ async function handleRpcProxyRequest(request, env, url) {
     );
   }
 
-  const poolId = url.pathname.includes("/wss") ? "finney-wss" : "finney-rpc";
+  // The proxy forwards an HTTP JSON-RPC POST, so it can only reach HTTP(S)
+  // upstreams. The /wss route points at WebSocket-only endpoints that cannot be
+  // HTTP-POSTed, so reject it with a clear error instead of failing the upstream
+  // fetch (which would surface as a 500).
+  if (url.pathname.endsWith("/wss")) {
+    return errorResponse(
+      "rpc_websocket_unsupported",
+      "WebSocket JSON-RPC is not available through this HTTP proxy. POST to /rpc/v1/finney for HTTP JSON-RPC, or connect to a public WSS endpoint directly.",
+      400,
+    );
+  }
+  const poolId = "finney-rpc";
   const pool = (poolArtifact.data.pools || []).find(
     (candidate) => candidate.id === poolId,
   );
@@ -428,14 +439,34 @@ async function handleRpcProxyRequest(request, env, url) {
   }
 
   const endpoint = endpointSelection.endpoint;
-  const upstream = await fetch(endpoint.url, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: bodyText,
-    signal: AbortSignal.timeout(10000),
-  });
+  // Defense in depth: the proxy can only HTTP-POST to an https upstream. A wss://
+  // endpoint that somehow reached selection is not proxyable.
+  if (!endpoint.url.startsWith("https://")) {
+    return errorResponse(
+      "rpc_endpoint_unavailable",
+      "No eligible HTTP RPC upstream is available for proxy routing.",
+      503,
+      { pool_id: poolId },
+    );
+  }
+  let upstream;
+  try {
+    upstream = await fetch(endpoint.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: bodyText,
+      signal: AbortSignal.timeout(10000),
+    });
+  } catch {
+    return errorResponse(
+      "rpc_upstream_error",
+      "The selected RPC upstream could not be reached.",
+      502,
+      { endpoint_id: endpoint.id, pool_id: poolId },
+    );
+  }
   const headers = apiHeaders("short");
   headers.set("cache-control", "no-store");
   headers.set("x-metagraph-rpc-endpoint-id", endpoint.id);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -415,66 +415,119 @@ async function handleRpcProxyRequest(request, env, url) {
   const pool = (poolArtifact.data.pools || []).find(
     (candidate) => candidate.id === poolId,
   );
-  const endpointSelection = selectSafeRpcEndpoint(pool);
-  if (endpointSelection.unsafeEndpoint) {
-    return errorResponse(
-      "rpc_endpoint_unsafe",
-      "Eligible RPC endpoint URL is not allowed by the Worker upstream safety policy.",
-      502,
-      {
-        endpoint_id: endpointSelection.unsafeEndpoint.id || null,
-        pool_id: poolId,
-      },
-    );
-  }
-  if (!endpointSelection.endpoint) {
+  const { endpoints: candidates, unsafeEndpoint } = orderSafeRpcEndpoints(pool);
+  if (!candidates.length) {
+    if (unsafeEndpoint) {
+      return errorResponse(
+        "rpc_endpoint_unsafe",
+        "Eligible RPC endpoint URL is not allowed by the Worker upstream safety policy.",
+        502,
+        { endpoint_id: unsafeEndpoint.id || null, pool_id: poolId },
+      );
+    }
     return errorResponse(
       "rpc_endpoint_unavailable",
       "No eligible public RPC endpoint is available for proxy routing.",
       503,
-      {
-        pool_id: poolId,
-      },
-    );
-  }
-
-  const endpoint = endpointSelection.endpoint;
-  // Defense in depth: the proxy can only HTTP-POST to an https upstream. A wss://
-  // endpoint that somehow reached selection is not proxyable.
-  if (!endpoint.url.startsWith("https://")) {
-    return errorResponse(
-      "rpc_endpoint_unavailable",
-      "No eligible HTTP RPC upstream is available for proxy routing.",
-      503,
       { pool_id: poolId },
     );
   }
-  let upstream;
-  try {
-    upstream = await fetch(endpoint.url, {
-      method: "POST",
-      headers: {
-        "content-type": "application/json",
-      },
-      body: bodyText,
-      signal: AbortSignal.timeout(10000),
-    });
-  } catch {
-    return errorResponse(
-      "rpc_upstream_error",
-      "The selected RPC upstream could not be reached.",
-      502,
-      { endpoint_id: endpoint.id, pool_id: poolId },
-    );
+
+  return proxyWithFailover(candidates, { bodyText, poolId });
+}
+
+const RPC_MAX_ATTEMPTS = 3;
+const RPC_ATTEMPT_TIMEOUT_MS = 6000;
+// JSON-RPC error codes that signal node trouble (retry another upstream) rather
+// than a client/application error (return immediately so we don't mask a real
+// error by trying every node).
+const TRANSIENT_RPC_ERROR_CODES = new Set([-32603]); // internal error
+
+// Decide how to treat one upstream attempt: "transient" (fail over to the next
+// endpoint), "success"/"fatal" (return this upstream's response to the client).
+export function classifyUpstreamAttempt({ thrown, status, parsedBody }) {
+  if (thrown) return "transient"; // network error or AbortSignal timeout
+  if (status >= 500 || status === 429) return "transient";
+  if (status >= 400) return "fatal"; // upstream rejected the request itself
+  if (parsedBody && typeof parsedBody === "object" && parsedBody.error) {
+    if (TRANSIENT_RPC_ERROR_CODES.has(Number(parsedBody.error.code))) {
+      return "transient";
+    }
   }
-  const headers = apiHeaders("short");
-  headers.set("cache-control", "no-store");
-  headers.set("x-metagraph-rpc-endpoint-id", endpoint.id);
-  headers.set("x-metagraph-rpc-provider", endpoint.provider);
-  return new Response(upstream.body, {
-    status: upstream.status,
-    headers,
-  });
+  return "success";
+}
+
+// Try each ordered endpoint in turn; return the first success / non-transient
+// response, and a clean 502 only when every attempt is a transient failure.
+// Reads the body once (allowlisted read responses are small) so we can classify
+// JSON-RPC error envelopes. fetchFn injectable for tests.
+export async function proxyWithFailover(
+  orderedEndpoints,
+  {
+    bodyText,
+    poolId,
+    fetchFn = fetch,
+    maxAttempts = RPC_MAX_ATTEMPTS,
+    timeoutMs = RPC_ATTEMPT_TIMEOUT_MS,
+  },
+) {
+  const attempts = [];
+  const limit = Math.min(orderedEndpoints.length, maxAttempts);
+  for (let index = 0; index < limit; index += 1) {
+    const endpoint = orderedEndpoints[index];
+    let status = 0;
+    let text = "";
+    let parsedBody = null;
+    let thrown = false;
+    try {
+      const upstream = await fetchFn(endpoint.url, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: bodyText,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      status = upstream.status;
+      text = await upstream.text();
+      try {
+        parsedBody = JSON.parse(text);
+      } catch {
+        parsedBody = null;
+      }
+    } catch {
+      thrown = true;
+    }
+
+    if (
+      classifyUpstreamAttempt({ thrown, status, parsedBody }) === "transient"
+    ) {
+      attempts.push({
+        endpoint_id: endpoint.id,
+        reason: thrown ? "unreachable" : `status-${status}`,
+      });
+      continue;
+    }
+
+    const headers = apiHeaders("short");
+    headers.set("cache-control", "no-store");
+    headers.set("content-type", JSON_CONTENT_TYPE);
+    headers.set("x-metagraph-rpc-endpoint-id", endpoint.id);
+    headers.set("x-metagraph-rpc-provider", endpoint.provider);
+    headers.set("x-metagraph-rpc-attempts", String(attempts.length + 1));
+    return new Response(text, { status: status || 502, headers });
+  }
+
+  // Every attempt failed transiently. Return a fixed message — never echo an
+  // upstream error body (leak hygiene).
+  return errorResponse(
+    "rpc_upstream_unavailable",
+    "All eligible RPC upstreams failed; try again shortly.",
+    502,
+    {
+      pool_id: poolId,
+      attempts: attempts.map((a) => a.endpoint_id),
+      last_reason: attempts.at(-1)?.reason || null,
+    },
+  );
 }
 
 function matchRawArtifact(pathname) {
@@ -1023,31 +1076,47 @@ function contractVersion(env) {
   return env.METAGRAPH_CONTRACT_VERSION || CONTRACT_VERSION;
 }
 
-// Load-balance across ALL eligible + upstream-safe endpoints rather than always
-// picking the highest-scored one, so no single upstream becomes a hotspot.
-// Returns an unsafe endpoint (for a 502) only when every eligible endpoint fails
-// the upstream safety policy, and a null endpoint when none are eligible (503).
-export function selectSafeRpcEndpoint(pool, randomFn = Math.random) {
+// Build the FULL ordered candidate list of eligible, upstream-safe, HTTP(S)
+// endpoints for the proxy to fail over across. Ordering is a weighted shuffle
+// (favour higher score, keep load spread) so failover walks best→worst without
+// always hammering one upstream. wss:// endpoints are dropped (not HTTP-
+// proxyable); a genuinely unsafe URL is reported (for a 502) only when no safe
+// endpoint exists. randomFn injectable for tests.
+export function orderSafeRpcEndpoints(pool, randomFn = Math.random) {
   const safe = [];
   let unsafeEndpoint = null;
   for (const endpoint of pool?.endpoints || []) {
     if (!endpoint?.pool_eligible) {
       continue;
     }
-    if (isSafeRpcEndpointUrl(endpoint.url)) {
-      safe.push(endpoint);
-    } else {
+    if (!isSafeRpcEndpointUrl(endpoint.url)) {
       unsafeEndpoint ||= endpoint;
+      continue;
+    }
+    // Safe origin but wss:// — not HTTP-POST-able; skip without flagging unsafe.
+    if (endpoint.url.startsWith("https://")) {
+      safe.push(endpoint);
     }
   }
 
-  if (!safe.length) {
-    return { endpoint: null, unsafeEndpoint };
+  const remaining = [...safe];
+  const ordered = [];
+  while (remaining.length) {
+    const pick = weightedPickEndpoint(remaining, randomFn);
+    ordered.push(pick);
+    remaining.splice(remaining.indexOf(pick), 1);
   }
   return {
-    endpoint: weightedPickEndpoint(safe, randomFn),
-    unsafeEndpoint: null,
+    endpoints: ordered,
+    unsafeEndpoint: ordered.length ? null : unsafeEndpoint,
   };
+}
+
+// Back-compat single-pick wrapper (still used by tests): the first of the
+// weighted-ordered list.
+export function selectSafeRpcEndpoint(pool, randomFn = Math.random) {
+  const { endpoints, unsafeEndpoint } = orderSafeRpcEndpoints(pool, randomFn);
+  return { endpoint: endpoints[0] ?? null, unsafeEndpoint };
 }
 
 // Weighted-random pick favouring higher-scored (healthier/faster) endpoints,


### PR DESCRIPTION
Resilient RPC load balancer (approved plan, Part 1). **Supersedes #222** (closed) — includes its `/wss` fix plus failover/retry and an in-isolate circuit breaker.

### What changed (workers/api.mjs + tests)
The proxy was a load *distributor* (pick one endpoint, single `fetch`, 502 on any failure). Now it's a resilient balancer:
- **`orderSafeRpcEndpoints()`** — full weighted-shuffled list of eligible + upstream-safe + `https://` endpoints (wss dropped). `selectSafeRpcEndpoint` kept as a thin wrapper (existing tests unchanged).
- **`proxyWithFailover()`** — up to **3** endpoints, **6s** per-attempt timeout, returns the first success, clean **`502 rpc_upstream_unavailable`** only when all fail (never echoes upstream bodies; adds `x-metagraph-rpc-attempts`).
- **`classifyUpstreamAttempt()`** — network/timeout/5xx/429/node-internal `-32603` → **fail over**; 2xx success or app JSON-RPC error (e.g. `-32601`) → **return immediately**.
- **In-isolate circuit breaker** — eject an endpoint after 3 consecutive transient failures for 30s (half-open after); ejected endpoints are deprioritised, never removed, so a fully-ejected pool self-heals.
- Carries #222: `/wss` → clean 400 `rpc_websocket_unsupported`.

### Verification
- `tests/rpc-failover.test.mjs` — 24 cases (classify table, ordering, wss-drop, failover matrix, app-error-immediate, all-fail 502, attempt bound, breaker threshold/cooldown/ordering/self-heal) ✅
- `worker:test` · `worker:deploy:dry-run` · eslint · prettier · full suite ✅

### Deferred to follow-ups (noted in the plan)
- **Deepen the pool** — verified the three Opentensor hosts (`entrypoint-finney`/`lite`/`archive`.`chain.opentensor.ai`) also serve HTTPS JSON-RPC (real `system_health` results), which would grow the HTTPS pool 2→5. Held back because adding them regenerates committed artifacts and collides with a separate local-vs-CI manifest drift; will land via a clean follow-up.
- **Response caching** of idempotent reads.