### PR TITLE
fix(rpc): reject unsupported WSS proxy routes

### DIFF
--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -9,6 +9,7 @@ import {
 const SAFE_A = "https://bittensor-finney.api.onfinality.io/public";
 const SAFE_B = "https://bittensor-public.nodies.app/rpc";
 const UNSAFE = "https://evil.example.com/rpc";
+const WSS_UPSTREAM = "wss://lite.chain.opentensor.ai:443";
 
 const ep = (id, url, extra = {}) => ({
   id,
@@ -42,6 +43,14 @@ describe("selectSafeRpcEndpoint", () => {
     });
     assert.equal(endpoint, null);
     assert.equal(unsafeEndpoint.id, "u");
+  });
+
+  test("treats WebSocket endpoints as unsafe for the HTTP POST proxy", () => {
+    const { endpoint, unsafeEndpoint } = selectSafeRpcEndpoint({
+      endpoints: [ep("wss", WSS_UPSTREAM)],
+    });
+    assert.equal(endpoint, null);
+    assert.equal(unsafeEndpoint.id, "wss");
   });
 
   test("returns null endpoint (503) when none are eligible", () => {

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -919,6 +919,59 @@ describe("Worker runtime", () => {
     }
   });
 
+  test("returns a controlled error when an RPC upstream fetch fails", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () => {
+      throw new TypeError("fetch failed");
+    };
+
+    try {
+      const response = await handleRequest(
+        new Request("https://metagraph.sh/rpc/v1/finney", {
+          method: "POST",
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "chain_getHeader",
+            params: [],
+          }),
+        }),
+        {
+          METAGRAPH_ENABLE_RPC_PROXY: "true",
+          METAGRAPH_ARCHIVE: r2ArchiveFixture({
+            "rpc/pools.json": {
+              schema_version: 1,
+              generated_at: "1970-01-01T00:00:00.000Z",
+              pools: [
+                {
+                  id: "finney-rpc",
+                  endpoints: [
+                    {
+                      id: "fixture-rpc",
+                      pool_eligible: true,
+                      provider: "fixture",
+                      status: "ok",
+                      url: "https://bittensor-finney.api.onfinality.io/public",
+                    },
+                  ],
+                },
+              ],
+            },
+          }),
+        },
+        {},
+      );
+
+      assert.equal(response.status, 502);
+      assert.equal(
+        (await response.json()).error.code,
+        "rpc_upstream_fetch_failed",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   test("proxies explicitly enabled safe RPC methods through eligible pools", async () => {
     const originalFetch = globalThis.fetch;
     let called = false;
@@ -1021,7 +1074,30 @@ describe("Worker runtime", () => {
         proxyEnv,
         {},
       );
-      assert.equal(wssResponse.status, 200);
+      assert.equal(wssResponse.status, 501);
+      assert.equal(
+        (await wssResponse.json()).error.code,
+        "rpc_wss_proxy_unsupported",
+      );
+
+      const nestedWssResponse = await handleRequest(
+        new Request("https://metagraph.sh/rpc/v1/finney/wss", {
+          method: "POST",
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 3,
+            method: "system_health",
+            params: [],
+          }),
+        }),
+        proxyEnv,
+        {},
+      );
+      assert.equal(nestedWssResponse.status, 404);
+      assert.equal(
+        (await nestedWssResponse.json()).error.code,
+        "rpc_route_not_found",
+      );
     } finally {
       globalThis.fetch = originalFetch;
     }

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -58,10 +58,6 @@ const METAGRAPH_LATEST_KEY = "metagraph:latest";
 const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
   "https://bittensor-finney.api.onfinality.io",
   "https://bittensor-public.nodies.app",
-  "wss://archive.chain.opentensor.ai",
-  "wss://bittensor-finney.api.onfinality.io",
-  "wss://entrypoint-finney.opentensor.ai",
-  "wss://lite.chain.opentensor.ai",
 ]);
 
 export default {
@@ -388,6 +384,25 @@ async function handleRpcProxyRequest(request, env, url) {
     );
   }
 
+  const poolId = rpcPoolIdForPath(url.pathname);
+  if (!poolId) {
+    return errorResponse(
+      "rpc_route_not_found",
+      "No public RPC proxy route matched this path.",
+      404,
+      { rpc_path: url.pathname },
+    );
+  }
+
+  if (poolId === "finney-wss") {
+    return errorResponse(
+      "rpc_wss_proxy_unsupported",
+      "The HTTP JSON-RPC proxy does not support WebSocket upstream pools.",
+      501,
+      { pool_id: poolId },
+    );
+  }
+
   const poolArtifact = await readArtifact(env, "/metagraph/rpc/pools.json");
   if (!poolArtifact.ok) {
     return errorResponse(
@@ -400,7 +415,6 @@ async function handleRpcProxyRequest(request, env, url) {
     );
   }
 
-  const poolId = url.pathname.includes("/wss") ? "finney-wss" : "finney-rpc";
   const pool = (poolArtifact.data.pools || []).find(
     (candidate) => candidate.id === poolId,
   );
@@ -428,14 +442,27 @@ async function handleRpcProxyRequest(request, env, url) {
   }
 
   const endpoint = endpointSelection.endpoint;
-  const upstream = await fetch(endpoint.url, {
-    method: "POST",
-    headers: {
-      "content-type": "application/json",
-    },
-    body: bodyText,
-    signal: AbortSignal.timeout(10000),
-  });
+  let upstream;
+  try {
+    upstream = await fetch(endpoint.url, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+      },
+      body: bodyText,
+      signal: AbortSignal.timeout(10000),
+    });
+  } catch {
+    return errorResponse(
+      "rpc_upstream_fetch_failed",
+      "The selected RPC upstream could not be reached by the proxy.",
+      502,
+      {
+        endpoint_id: endpoint.id || null,
+        pool_id: poolId,
+      },
+    );
+  }
   const headers = apiHeaders("short");
   headers.set("cache-control", "no-store");
   headers.set("x-metagraph-rpc-endpoint-id", endpoint.id);
@@ -444,6 +471,16 @@ async function handleRpcProxyRequest(request, env, url) {
     status: upstream.status,
     headers,
   });
+}
+
+function rpcPoolIdForPath(pathname) {
+  if (pathname === "/rpc/v1/finney") {
+    return "finney-rpc";
+  }
+  if (pathname === "/rpc/v1/wss") {
+    return "finney-wss";
+  }
+  return null;
 }
 
 function matchRawArtifact(pathname) {
@@ -1052,7 +1089,7 @@ function isSafeRpcEndpointUrl(value) {
     return false;
   }
 
-  if (!["https:", "wss:"].includes(parsed.protocol)) {
+  if (parsed.protocol !== "https:") {
     return false;
   }
 


### PR DESCRIPTION
### Motivation
- Enabling the read-only RPC proxy made a previously unreachable crash path reachable when the proxy selected `wss://` upstreams and called `fetch()` with a `wss:` URL, which throws a `TypeError` and caused uncaught worker failures. 
- The HTTP POST JSON-RPC proxy must not attempt WebSocket upstreams and must return controlled errors for unsupported routes and upstream fetch failures. 

### Description
- Limit upstream safety checks to HTTPS-only by removing `wss:` entries from `TRUSTED_RPC_UPSTREAM_ORIGINS` and requiring `https:` in `isSafeRpcEndpointUrl`. 
- Replace substring-based `/wss` routing with exact RPC route matching via a new `rpcPoolIdForPath()` helper that returns `finney-rpc`, `finney-wss`, or `null`. 
- Explicitly reject the WSS proxy path with a `501 rpc_wss_proxy_unsupported` response and return `404 rpc_route_not_found` for non-contract RPC paths. 
- Wrap the upstream `fetch()` in a `try/catch` and return a controlled `502 rpc_upstream_fetch_failed` error on network/fetch exceptions. 
- Add/adjust unit tests to assert WSS endpoints are treated unsafe for the HTTP POST proxy, that `/rpc/v1/wss` returns `rpc_wss_proxy_unsupported`, that unknown RPC paths return `rpc_route_not_found`, and that upstream fetch failures produce `rpc_upstream_fetch_failed`.

### Testing
- Ran `npm test -- tests/rpc-endpoint-selection.test.mjs` and the file's tests passed. 
- Ran `npm test -- tests/worker-runtime.test.mjs -t 'RPC|rpc|upstream|selectSafe'` and the RPC-focused subset passed. 
- Ran `npm run worker:test` (scripted worker runtime tests) and it passed. 
- Ran `npm run lint` and `npx prettier --check` for the changed files and they passed for the modified files. 
- Note: a full run of the entire `tests/worker-runtime.test.mjs` in this environment previously showed unrelated fixture-dependent 404/null failures, but the RPC-targeted tests and endpoint-selection tests included in this PR passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29951d9394832ab14bbd67423267d2)