### PR TITLE
feat(rpc): response cache for idempotent reads (Cache API)

### DIFF
--- a/tests/rpc-cache.test.mjs
+++ b/tests/rpc-cache.test.mjs
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest, rpcCachePolicy } from "../workers/api.mjs";
+
+describe("rpcCachePolicy", () => {
+  const c = (m, p) => rpcCachePolicy(m, p);
+
+  test("block-pinned reads are cacheable long", () => {
+    assert.deepEqual(c("chain_getBlockHash", [100]), {
+      cacheable: true,
+      ttl: 3600,
+    });
+    assert.deepEqual(c("chain_getBlock", ["0xabc"]), {
+      cacheable: true,
+      ttl: 3600,
+    });
+    assert.deepEqual(c("chain_getHeader", ["0xabc"]), {
+      cacheable: true,
+      ttl: 3600,
+    });
+  });
+
+  test("head-moving / param-less reads are NOT cacheable", () => {
+    assert.equal(c("chain_getBlockHash", []).cacheable, false);
+    assert.equal(c("chain_getBlock", []).cacheable, false);
+    assert.equal(c("chain_getHeader", []).cacheable, false);
+    assert.equal(c("chain_getFinalizedHead", []).cacheable, false);
+    assert.equal(c("system_health", []).cacheable, false);
+  });
+
+  test("quasi-static reads are cacheable medium", () => {
+    assert.deepEqual(c("state_getRuntimeVersion", []), {
+      cacheable: true,
+      ttl: 300,
+    });
+    assert.deepEqual(c("system_version", []), { cacheable: true, ttl: 300 });
+    assert.deepEqual(c("rpc_methods", []), { cacheable: true, ttl: 300 });
+  });
+
+  test("unknown methods default-deny", () => {
+    assert.equal(c("foo_bar", []).cacheable, false);
+  });
+});
+
+describe("RPC response cache flow", () => {
+  const pool = {
+    pools: [
+      {
+        id: "finney-rpc",
+        endpoints: [
+          {
+            id: "fx",
+            provider: "fx",
+            pool_eligible: true,
+            status: "ok",
+            score: 100,
+            url: "https://bittensor-finney.api.onfinality.io/public",
+          },
+        ],
+      },
+    ],
+  };
+  const env = {
+    METAGRAPH_ENABLE_RPC_PROXY: "true",
+    ASSETS: {
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/metagraph/rpc/pools.json") {
+          return Response.json(pool);
+        }
+        return new Response("{}", { status: 404 });
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          async json() {
+            return pool;
+          },
+        };
+      },
+    },
+  };
+  const reqFor = (method, params) =>
+    new Request("https://metagraph.sh/rpc/v1/finney", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+
+  function makeCache() {
+    const store = new Map();
+    return {
+      store,
+      async match(req) {
+        const hit = store.get(req.url);
+        return hit ? hit.clone() : undefined;
+      },
+      async put(req, resp) {
+        store.set(req.url, resp);
+      },
+    };
+  }
+
+  function withGlobals({ cache, fetchImpl }, run) {
+    const originalCaches = globalThis.caches;
+    const originalFetch = globalThis.fetch;
+    globalThis.caches = { default: cache };
+    globalThis.fetch = fetchImpl;
+    return Promise.resolve(run()).finally(() => {
+      globalThis.caches = originalCaches;
+      globalThis.fetch = originalFetch;
+    });
+  }
+
+  test("caches a block-pinned read; second call is a hit (no upstream fetch)", async () => {
+    const cache = makeCache();
+    let fetchCount = 0;
+    const fetchImpl = async () => {
+      fetchCount += 1;
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0xhash" }),
+        { status: 200 },
+      );
+    };
+    await withGlobals({ cache, fetchImpl }, async () => {
+      const waits = [];
+      const ctx = { waitUntil: (p) => waits.push(p) };
+      const r1 = await handleRequest(
+        reqFor("chain_getBlockHash", [1]),
+        env,
+        ctx,
+      );
+      assert.equal(r1.status, 200);
+      assert.equal(r1.headers.get("x-metagraph-rpc-cache"), "miss");
+      await Promise.all(waits);
+      assert.equal(fetchCount, 1);
+
+      const r2 = await handleRequest(
+        reqFor("chain_getBlockHash", [1]),
+        env,
+        ctx,
+      );
+      assert.equal(r2.status, 200);
+      assert.equal(r2.headers.get("x-metagraph-rpc-cache"), "hit");
+      assert.equal(fetchCount, 1, "cache hit must not call upstream");
+      assert.equal((await r2.json()).result, "0xhash");
+    });
+  });
+
+  test("does NOT cache a head-moving read", async () => {
+    const cache = makeCache();
+    let fetchCount = 0;
+    const fetchImpl = async () => {
+      fetchCount += 1;
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { peers: 1 } }),
+        { status: 200 },
+      );
+    };
+    await withGlobals({ cache, fetchImpl }, async () => {
+      await handleRequest(reqFor("system_health", []), env, { waitUntil() {} });
+      await handleRequest(reqFor("system_health", []), env, { waitUntil() {} });
+      assert.equal(fetchCount, 2, "head-moving reads always hit upstream");
+      assert.equal(cache.store.size, 0);
+    });
+  });
+
+  test("does NOT cache a JSON-RPC error envelope", async () => {
+    const cache = makeCache();
+    const fetchImpl = async () =>
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, error: { code: -32000 } }),
+        { status: 200 },
+      );
+    await withGlobals({ cache, fetchImpl }, async () => {
+      const waits = [];
+      await handleRequest(reqFor("chain_getBlockHash", [1]), env, {
+        waitUntil: (p) => waits.push(p),
+      });
+      await Promise.all(waits);
+      assert.equal(cache.store.size, 0);
+    });
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -70,7 +70,7 @@ export default {
   },
 };
 
-export async function handleRequest(request, env = {}, _ctx = {}) {
+export async function handleRequest(request, env = {}, ctx = {}) {
   const url = new URL(request.url);
 
   if (request.method === "OPTIONS") {
@@ -78,7 +78,7 @@ export async function handleRequest(request, env = {}, _ctx = {}) {
   }
 
   if (url.pathname.startsWith("/rpc/v1/")) {
-    return handleRpcProxyRequest(request, env, url);
+    return handleRpcProxyRequest(request, env, url, ctx);
   }
 
   if (!["GET", "HEAD"].includes(request.method)) {
@@ -294,7 +294,7 @@ async function handleApiRequest(request, env, url) {
   );
 }
 
-async function handleRpcProxyRequest(request, env, url) {
+async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   if (request.method !== "POST") {
     return errorResponse(
       "method_not_allowed",
@@ -433,7 +433,51 @@ async function handleRpcProxyRequest(request, env, url) {
     );
   }
 
-  return proxyWithFailover(candidates, { bodyText, poolId });
+  // Response cache for idempotent reads (Cache API). Cache hit short-circuits
+  // the upstream call; a successful, cacheable response is stored async.
+  const cachePolicy = rpcCachePolicy(rpcBody.method, rpcBody.params);
+  const cache = cachePolicy.cacheable ? globalThis.caches?.default : null;
+  let cacheKey = null;
+  if (cache) {
+    cacheKey = await rpcCacheKey(rpcBody.method, rpcBody.params);
+    const hit = await cache.match(cacheKey);
+    if (hit) {
+      const headers = new Headers(hit.headers);
+      headers.set("cache-control", "no-store");
+      headers.set("x-metagraph-rpc-cache", "hit");
+      return new Response(hit.body, { status: 200, headers });
+    }
+  }
+
+  const response = await proxyWithFailover(candidates, { bodyText, poolId });
+  if (!cacheKey) {
+    return response;
+  }
+
+  // Cacheable method, cache miss: read the body once, cache it if it is a
+  // genuine JSON-RPC result (never cache an error envelope), and return.
+  const text = await response.text();
+  if (response.status === 200) {
+    let parsed = null;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      // body is not JSON; leave parsed null so it is not cached.
+    }
+    if (parsed && parsed.result !== undefined && parsed.error === undefined) {
+      const cached = new Response(text, {
+        status: 200,
+        headers: {
+          "content-type": JSON_CONTENT_TYPE,
+          "cache-control": `public, s-maxage=${cachePolicy.ttl}`,
+        },
+      });
+      ctx?.waitUntil?.(cache.put(cacheKey, cached));
+    }
+  }
+  const headers = new Headers(response.headers);
+  headers.set("x-metagraph-rpc-cache", "miss");
+  return new Response(text, { status: response.status, headers });
 }
 
 const RPC_MAX_ATTEMPTS = 3;
@@ -467,6 +511,54 @@ export function recordRpcSuccess(map, id) {
 export function isRpcEndpointEjected(map, id, now) {
   const entry = map.get(id);
   return Boolean(entry && entry.ejectedUntil > now);
+}
+
+// Per-method response-cache policy for idempotent reads. Default-deny: only
+// block-pinned (by an explicit block number/hash param) or quasi-static reads
+// are cacheable; head-moving forms (param-less block reads, finalized head,
+// system_health) are never cached.
+export function rpcCachePolicy(method, params) {
+  const args = Array.isArray(params) ? params : [];
+  switch (method) {
+    case "chain_getBlockHash":
+      return args.length &&
+        (typeof args[0] === "number" || /^\d+$/.test(String(args[0])))
+        ? { cacheable: true, ttl: 3600 }
+        : { cacheable: false, ttl: 0 };
+    case "chain_getBlock":
+    case "chain_getHeader":
+      return args.length &&
+        typeof args[0] === "string" &&
+        args[0].startsWith("0x")
+        ? { cacheable: true, ttl: 3600 }
+        : { cacheable: false, ttl: 0 };
+    case "state_getRuntimeVersion":
+    case "system_chain":
+    case "system_name":
+    case "system_version":
+    case "system_properties":
+    case "rpc_methods":
+      return { cacheable: true, ttl: 300 };
+    default:
+      return { cacheable: false, ttl: 0 };
+  }
+}
+
+async function rpcCacheKey(method, params) {
+  const normalized = JSON.stringify([
+    method,
+    Array.isArray(params) ? params : [],
+  ]);
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(normalized),
+  );
+  const hash = [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return new Request(
+    `https://rpc-cache.metagraph.internal/finney/${method}/${hash}`,
+  );
 }
 
 // Decide how to treat one upstream attempt: "transient" (fail over to the next


### PR DESCRIPTION
Part of the RPC-LB plan. Worker-only (no artifact churn). Builds on the failover/breaker in #224.

### What changed (workers/api.mjs)
- **`rpcCachePolicy(method, params)`** — default-deny per-method policy:
  - **Cacheable 1h (block-pinned, immutable):** `chain_getBlockHash(<number>)`, `chain_getBlock`/`chain_getHeader` with an explicit `0x…` block hash.
  - **Cacheable 5m (quasi-static):** `state_getRuntimeVersion`, `system_chain/name/version/properties`, `rpc_methods`.
  - **Never cached:** head-moving forms (param-less block reads, `chain_getFinalizedHead`, `system_health`) and unknown methods.
- Around the failover call: on a cacheable method, check `caches.default` first (hit → `x-metagraph-rpc-cache: hit`, no upstream call); on a miss, store a successful **JSON-RPC result** (never an error envelope) async via `ctx.waitUntil`. Cache key = `sha256(method + normalized params)`.
- Threads `ctx` through `handleRequest → handleRpcProxyRequest`.

### Verification
- `tests/rpc-cache.test.mjs` — policy table + flow (hit/miss, no-cache for head-moving, no-cache for error envelopes) ✅
- Full suite **179** · `worker:test` · `worker:deploy:dry-run` · eslint · prettier ✅