### PR TITLE
fix(api): handle malformed subnet slug encodings

### DIFF
--- a/tests/subnet-slug.test.mjs
+++ b/tests/subnet-slug.test.mjs
@@ -40,6 +40,14 @@ describe("subnet slug aliases", () => {
     assert.equal((await res.json()).error.code, "subnet_not_found");
   });
 
+  test("a malformed percent-encoded slug returns 404 subnet_not_found", async () => {
+    for (const path of ["/api/v1/subnets/%E0%A4%A", "/api/v1/subnets/%"]) {
+      const res = await get(path);
+      assert.equal(res.status, 404);
+      assert.equal((await res.json()).error.code, "subnet_not_found");
+    }
+  });
+
   test("the subnets list route is unaffected", async () => {
     const res = await get("/api/v1/subnets?limit=2");
     assert.equal(res.status, 200);

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -274,7 +274,10 @@ async function resolveSubnetSlugRoute(env, url, now = Date.now()) {
   if (!match || /^\d+$/.test(match[1])) {
     return { url };
   }
-  const slug = decodeURIComponent(match[1]);
+  const slug = decodeSlugPathSegment(match[1]);
+  if (slug === null) {
+    return { notFound: true, slug: match[1] };
+  }
   const netuid = await lookupSubnetNetuid(env, slug, now);
   if (netuid === null) {
     return { notFound: true, slug };
@@ -282,6 +285,17 @@ async function resolveSubnetSlugRoute(env, url, now = Date.now()) {
   const rewritten = new URL(url);
   rewritten.pathname = `/api/v1/subnets/${netuid}${match[2] || ""}`;
   return { url: rewritten };
+}
+
+function decodeSlugPathSegment(segment) {
+  try {
+    return decodeURIComponent(segment);
+  } catch (error) {
+    if (error instanceof URIError) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 async function lookupSubnetNetuid(env, slug, now = Date.now()) {


### PR DESCRIPTION
### Motivation
- Prevent unhandled `URIError` from `decodeURIComponent` when a requester sends a malformed percent-encoded subnet slug so the Worker does not throw a 500-class error for crafted paths.
- Preserve existing behavior where numeric netuids and normal routes are unchanged while returning the controlled `subnet_not_found` JSON error for unresolved slugs.

### Description
- Replace direct `decodeURIComponent(match[1])` with a guarded `decodeSlugPathSegment(segment)` that returns `null` on `URIError` and rethrows other errors.
- Update `resolveSubnetSlugRoute` to treat a `null` decoded slug as `{ notFound: true, slug: <raw-segment> }` so the existing `subnet_not_found` flow is used instead of letting an exception escape. 
- Add regression tests in `tests/subnet-slug.test.mjs` exercising malformed inputs `/%E0%A4%A` and `/%` to assert they return 404 with `error.code === "subnet_not_found"`.
- Keep lookup and rewrite logic unchanged for numeric netuids and valid slugs.

### Testing
- Ran `vitest` for the subnet slug tests: targeted regression `npm test -- tests/subnet-slug.test.mjs -t "malformed percent-encoded slug"` passed (1 passed, 6 skipped). 
- Earlier `npm test -- tests/subnet-slug.test.mjs` showed unrelated local artifact 404s for subnet detail artifacts (local R2/static staging limitation), which caused some assertions to fail before the guarded decode was added; the malformed-slug regression itself succeeds after the fix. 
- Ran `npm run lint` and `npx prettier --check workers/api.mjs tests/subnet-slug.test.mjs` which passed for the modified files; `npm run format:check` reported a pre-existing formatting warning in an unrelated docs file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29af1cc704832a821922d06dd068f7)