### PR TITLE
fix(rpc): preserve request ids on cache hits

### DIFF
--- a/tests/rpc-cache.test.mjs
+++ b/tests/rpc-cache.test.mjs
@@ -81,10 +81,10 @@ describe("RPC response cache flow", () => {
       },
     },
   };
-  const reqFor = (method, params) =>
+  const reqFor = (method, params, id = 1) =>
     new Request("https://metagraph.sh/rpc/v1/finney", {
       method: "POST",
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
     });
 
   function makeCache() {
@@ -144,6 +144,50 @@ describe("RPC response cache flow", () => {
       assert.equal(r2.headers.get("x-metagraph-rpc-cache"), "hit");
       assert.equal(fetchCount, 1, "cache hit must not call upstream");
       assert.equal((await r2.json()).result, "0xhash");
+    });
+  });
+
+  test("cache hits preserve the current request id", async () => {
+    const cache = makeCache();
+    let fetchCount = 0;
+    const fetchImpl = async (_url, init) => {
+      fetchCount += 1;
+      const upstreamRequest = JSON.parse(init.body);
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: upstreamRequest.id,
+          result: "0xhash",
+        }),
+        { status: 200 },
+      );
+    };
+    await withGlobals({ cache, fetchImpl }, async () => {
+      const waits = [];
+      const ctx = { waitUntil: (p) => waits.push(p) };
+      const r1 = await handleRequest(
+        reqFor("chain_getBlockHash", [1], "attacker-prime-id"),
+        env,
+        ctx,
+      );
+      assert.equal(r1.status, 200);
+      assert.equal(r1.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.equal((await r1.json()).id, "attacker-prime-id");
+      await Promise.all(waits);
+
+      const r2 = await handleRequest(
+        reqFor("chain_getBlockHash", [1], "victim-expected-id"),
+        env,
+        ctx,
+      );
+      assert.equal(r2.status, 200);
+      assert.equal(r2.headers.get("x-metagraph-rpc-cache"), "hit");
+      assert.equal(fetchCount, 1, "cache hit must not call upstream");
+      assert.deepEqual(await r2.json(), {
+        jsonrpc: "2.0",
+        id: "victim-expected-id",
+        result: "0xhash",
+      });
     });
   });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -504,10 +504,22 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     cacheKey = await rpcCacheKey(rpcBody.method, rpcBody.params);
     const hit = await cache.match(cacheKey);
     if (hit) {
-      const headers = new Headers(hit.headers);
-      headers.set("cache-control", "no-store");
-      headers.set("x-metagraph-rpc-cache", "hit");
-      return new Response(hit.body, { status: 200, headers });
+      const cachedText = await hit.text();
+      let cachedPayload;
+      try {
+        cachedPayload = JSON.parse(cachedText);
+      } catch {
+        cachedPayload = null;
+      }
+      if (cachedPayload && cachedPayload.result !== undefined) {
+        const headers = new Headers(hit.headers);
+        headers.set("cache-control", "no-store");
+        headers.set("x-metagraph-rpc-cache", "hit");
+        return new Response(
+          JSON.stringify(rpcResultEnvelope(rpcBody, cachedPayload.result)),
+          { status: 200, headers },
+        );
+      }
     }
   }
 
@@ -527,7 +539,7 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
       // body is not JSON; leave parsed null so it is not cached.
     }
     if (parsed && parsed.result !== undefined && parsed.error === undefined) {
-      const cached = new Response(text, {
+      const cached = new Response(JSON.stringify({ result: parsed.result }), {
         status: 200,
         headers: {
           "content-type": JSON_CONTENT_TYPE,
@@ -604,6 +616,15 @@ export function rpcCachePolicy(method, params) {
     default:
       return { cacheable: false, ttl: 0 };
   }
+}
+
+function rpcResultEnvelope(requestBody, result) {
+  const envelope = { jsonrpc: "2.0" };
+  if (Object.prototype.hasOwnProperty.call(requestBody, "id")) {
+    envelope.id = requestBody.id;
+  }
+  envelope.result = result;
+  return envelope;
 }
 
 async function rpcCacheKey(method, params) {


### PR DESCRIPTION
### Motivation
- Prevent cross-client JSON-RPC envelope replay where the shared cache stored full upstream envelopes (including caller-supplied `id`) and returned them verbatim to later callers.
- Ensure cached RPC results are reusable without leaking or replaying per-request envelope fields such as `id`.

### Description
- On cache hit, parse the cached entry as a payload and return a freshly built JSON-RPC envelope using the current request's `id` via a new helper `rpcResultEnvelope(requestBody, result)` instead of returning the stored envelope verbatim.
- On cache store, persist only the cacheable `result` payload (JSON `{ result: ... }`) rather than the full upstream response envelope to avoid saving caller-controlled fields.
- Add a regression test `cache hits preserve the current request id` to `tests/rpc-cache.test.mjs` that primes the cache with an attacker id and verifies a later victim request receives the victim's id on a cache hit.
- Minor lint/format adjustments to satisfy eslint/prettier for the modified files.

### Testing
- Ran the focused suite: `npx vitest run tests/rpc-cache.test.mjs --reporter=dot`, and the updated RPC-cache tests passed (8/8).
- Ran lint with `npm run lint`, which passed for the modified files after adjustments.
- Ran `npm test` and `npm run format:check`; `npm test` shows unrelated repository-wide failures due to missing generated `public/*` artifacts in the checkout, and `format:check` warns about a pre-existing formatting issue in `docs/adr/0001-r2-only-data-artifacts.md` (these failures are not caused by the change and are environmental/pre-existing).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29b9b77178832aa21420aec7d351ec)