### PR TITLE
fix(rpc): preserve request id on cache hits (integrates #235 onto #230)

### DIFF
--- a/tests/rpc-cache.test.mjs
+++ b/tests/rpc-cache.test.mjs
@@ -81,10 +81,10 @@ describe("RPC response cache flow", () => {
       },
     },
   };
-  const reqFor = (method, params) =>
+  const reqFor = (method, params, id = 1) =>
     new Request("https://metagraph.sh/rpc/v1/finney", {
       method: "POST",
-      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
     });
 
   function makeCache() {
@@ -144,6 +144,48 @@ describe("RPC response cache flow", () => {
       assert.equal(r2.headers.get("x-metagraph-rpc-cache"), "hit");
       assert.equal(fetchCount, 1, "cache hit must not call upstream");
       assert.equal((await r2.json()).result, "0xhash");
+    });
+  });
+
+  test("cache hits preserve the current request id (no cross-caller replay)", async () => {
+    const cache = makeCache();
+    let fetchCount = 0;
+    const fetchImpl = async (_url, init) => {
+      fetchCount += 1;
+      const upstreamRequest = JSON.parse(init.body);
+      return new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          id: upstreamRequest.id,
+          result: "0xhash",
+        }),
+        { status: 200 },
+      );
+    };
+    await withGlobals({ cache, fetchImpl }, async () => {
+      const waits = [];
+      const ctx = { waitUntil: (p) => waits.push(p) };
+      const primed = await handleRequest(
+        reqFor("chain_getBlockHash", [1], "attacker-prime-id"),
+        env,
+        ctx,
+      );
+      assert.equal(primed.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.equal((await primed.json()).id, "attacker-prime-id");
+      await Promise.all(waits);
+
+      const victim = await handleRequest(
+        reqFor("chain_getBlockHash", [1], "victim-expected-id"),
+        env,
+        ctx,
+      );
+      assert.equal(victim.headers.get("x-metagraph-rpc-cache"), "hit");
+      assert.equal(fetchCount, 1, "cache hit must not call upstream");
+      assert.deepEqual(await victim.json(), {
+        jsonrpc: "2.0",
+        id: "victim-expected-id",
+        result: "0xhash",
+      });
     });
   });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -544,10 +544,25 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     cacheKey = await rpcCacheKey(rpcBody.method, rpcBody.params);
     const hit = await cache.match(cacheKey);
     if (hit) {
-      const headers = new Headers(hit.headers);
-      headers.set("cache-control", "no-store");
-      headers.set("x-metagraph-rpc-cache", "hit");
-      return new Response(hit.body, { status: 200, headers });
+      // Only the JSON-RPC `result` is cached (never caller-controlled envelope
+      // fields like `id`), so rebuild the envelope with THIS request's id. This
+      // stops a cache entry primed by one caller from replaying that caller's id
+      // back to a later requester.
+      let cachedPayload = null;
+      try {
+        cachedPayload = JSON.parse(await hit.text());
+      } catch {
+        // Malformed cache entry; treat as a miss and re-fetch below.
+      }
+      if (cachedPayload && cachedPayload.result !== undefined) {
+        const headers = new Headers(hit.headers);
+        headers.set("cache-control", "no-store");
+        headers.set("x-metagraph-rpc-cache", "hit");
+        return new Response(
+          JSON.stringify(rpcResultEnvelope(rpcBody, cachedPayload.result)),
+          { status: 200, headers },
+        );
+      }
     }
   }
 
@@ -575,7 +590,10 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
       // body is not JSON; leave parsed null so it is not cached.
     }
     if (parsed && parsed.result !== undefined && parsed.error === undefined) {
-      const cached = new Response(inspect.text, {
+      // Persist ONLY the cacheable `result` — not the upstream envelope, which
+      // carries the priming caller's `id`. The envelope is rebuilt per request
+      // on a cache hit above.
+      const cached = new Response(JSON.stringify({ result: parsed.result }), {
         status: 200,
         headers: {
           "content-type": JSON_CONTENT_TYPE,
@@ -652,6 +670,18 @@ export function rpcCachePolicy(method, params) {
     default:
       return { cacheable: false, ttl: 0 };
   }
+}
+
+// Build a minimal JSON-RPC success envelope around a cached `result`, echoing
+// the current request's `id` (when present) so cache hits never replay another
+// caller's id.
+function rpcResultEnvelope(requestBody, result) {
+  const envelope = { jsonrpc: "2.0" };
+  if (Object.prototype.hasOwnProperty.call(requestBody, "id")) {
+    envelope.id = requestBody.id;
+  }
+  envelope.result = result;
+  return envelope;
 }
 
 async function rpcCacheKey(method, params) {


### PR DESCRIPTION
## What

The RPC response cache stored the **full upstream JSON-RPC envelope**, so a cache hit replayed the *priming* caller's `id` back to later requesters — a cross-client envelope-replay bug. Now the cache persists only the `result`, and the hit path rebuilds the envelope with the **current** request's `id`.

## Why this PR (vs merging #235 directly)

#235 fixed this against pre-#230 `main` and **conflicts** with the bounded-streaming cache-store that landed in #230 (both rewrite the cache-store line). Rather than a fragile sequential merge, this re-implements #235's fix cleanly on top of #230:

- **Cache hit**: parse the stored payload; return `rpcResultEnvelope(rpcBody, result)` carrying this request's `id`. Legacy full-envelope entries are also corrected (we read `.result` and rebuild).
- **Cache store**: persist `{ result }` from #230's bounded `inspect.text`, never the envelope.
- **Regression test**: prime the cache with `attacker-prime-id`, assert a later caller gets `victim-expected-id` on the hit and upstream is not re-called.

## Verification

- `tests/rpc-cache.test.mjs` + `tests/rpc-failover.test.mjs` (33 cases incl. the new id-preservation test), `worker:test`, full suite (222), `lint`, `prettier`, `scan:public-safety` all green. No artifact change.

Closes #235 (integrated here).