### PR TITLE
feat(webhooks): publish-time HMAC dispatcher + workflow wiring (completes the change feed)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -235,6 +235,20 @@ jobs:
           METAGRAPH_KV_NAMESPACE_ID: ${{ secrets.METAGRAPH_KV_NAMESPACE_ID }}
           METAGRAPH_ALLOW_KV_WRITE: "1"
 
+      # Change-feed webhooks: now that the new data is live in R2/KV, fire
+      # HMAC-signed POSTs to matching subscribers. No-ops when there are no
+      # subscriptions. The dispatcher always exits 0 — per-subscriber and KV
+      # hiccups are logged as warnings but never fail the run, so a broken
+      # endpoint can't block the data pipeline or the smoke step below.
+      - name: Dispatch change-feed webhooks
+        if: steps.cloudflare-secrets.outputs.kv_publish == 'true' && steps.cloudflare-secrets.outputs.dry_run != 'true'
+        run: npm run webhooks:dispatch
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          METAGRAPH_KV_NAMESPACE_ID: ${{ secrets.METAGRAPH_KV_NAMESPACE_ID }}
+          METAGRAPH_ALLOW_WEBHOOK_DISPATCH: "1"
+
       # Worker CODE is deployed by Cloudflare Workers Builds on push to main;
       # this workflow only refreshes the DATA in R2/KV. The live Worker reads
       # the new KV pointer + R2 on its next origin miss.

--- a/package.json
+++ b/package.json
@@ -74,6 +74,8 @@
     "r2:upload": "node scripts/r2-upload.mjs --write",
     "kv:publish:dry-run": "node scripts/kv-publish-pointer.mjs --dry-run",
     "kv:publish": "node scripts/kv-publish-pointer.mjs --write",
+    "webhooks:dispatch:dry-run": "node scripts/dispatch-webhooks.mjs --dry-run",
+    "webhooks:dispatch": "node scripts/dispatch-webhooks.mjs --write",
     "cloudflare:verify:dry-run": "node scripts/cloudflare-verify.mjs",
     "worker:test": "node scripts/worker-test.mjs",
     "worker:deploy:dry-run": "node scripts/worker-deploy-dry-run.mjs",

--- a/scripts/dispatch-webhooks.mjs
+++ b/scripts/dispatch-webhooks.mjs
@@ -1,0 +1,168 @@
+// Publish-time change-feed dispatcher (ADR 0001 webhooks).
+//
+// Runs after the data publish (r2:upload + kv:publish) in the scheduled refresh.
+// Reads the freshly-built changelog, derives the public change event, lists the
+// webhook subscriptions from the METAGRAPH_CONTROL KV namespace, and fires
+// HMAC-SHA256-signed POSTs to each matching subscriber (bounded fan-out, retries,
+// delivery-time URL re-validation). Individual delivery failures are logged but
+// NEVER fail the publish — a bad subscriber must not block the data pipeline.
+//
+// Safe by default: --dry-run (the default without --write) prints the event and
+// makes no network/KV calls. A real dispatch additionally requires
+// METAGRAPH_ALLOW_WEBHOOK_DISPATCH=1 + METAGRAPH_KV_NAMESPACE_ID.
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+import { readJson, repoRoot, stableStringify } from "./lib.mjs";
+import {
+  buildChangeEvent,
+  dispatchChangeEvent,
+  WEBHOOK_KV_PREFIX,
+} from "../src/webhooks.mjs";
+
+const args = new Set(process.argv.slice(2));
+const write = args.has("--write");
+const dryRun = args.has("--dry-run") || !write;
+
+const changelog = await readJson(
+  path.join(repoRoot, "public/metagraph/changelog.json"),
+);
+const buildSummary = await readJson(
+  path.join(repoRoot, "public/metagraph/build-summary.json"),
+);
+const pointer = {
+  published_at: buildSummary.published_at || null,
+  contract_version:
+    changelog.contract_version || buildSummary.contract_version || null,
+};
+const event = buildChangeEvent({ changelog, pointer });
+
+if (dryRun) {
+  console.log(
+    stableStringify({
+      mode: "dry-run",
+      event: {
+        type: event.type,
+        published_at: event.published_at,
+        change_kinds: event.change_kinds,
+        affected_netuids: event.affected_netuids,
+        summary: event.summary,
+      },
+    }),
+  );
+  process.exit(0);
+}
+
+if (process.env.METAGRAPH_ALLOW_WEBHOOK_DISPATCH !== "1") {
+  console.error(
+    "Refusing to dispatch without METAGRAPH_ALLOW_WEBHOOK_DISPATCH=1.",
+  );
+  process.exit(1);
+}
+const namespaceId = process.env.METAGRAPH_KV_NAMESPACE_ID;
+if (!namespaceId) {
+  console.error("METAGRAPH_KV_NAMESPACE_ID is required to dispatch webhooks.");
+  process.exit(1);
+}
+
+const keys = listKvKeys(namespaceId, WEBHOOK_KV_PREFIX);
+if (keys.length === 0) {
+  console.log("No webhook subscriptions registered; nothing to dispatch.");
+  process.exit(0);
+}
+
+const subscriptions = [];
+for (const key of keys) {
+  const raw = getKvValue(namespaceId, key);
+  if (!raw) continue;
+  try {
+    subscriptions.push(JSON.parse(raw));
+  } catch {
+    console.error(`::warning::skipping malformed subscription at ${key}`);
+  }
+}
+
+const results = await dispatchChangeEvent({
+  subscriptions,
+  event,
+  fetchFn: fetch,
+  now: () => new Date().toISOString(),
+  concurrency: 8,
+  timeoutMs: 8000,
+  maxAttempts: 3,
+});
+
+const tally = results.reduce((acc, result) => {
+  acc[result.status] = (acc[result.status] || 0) + 1;
+  return acc;
+}, {});
+for (const failure of results.filter((result) => result.status === "failed")) {
+  console.error(
+    `::warning::webhook ${failure.id} failed after ${failure.attempts} attempt(s): ${failure.reason} (status ${failure.status_code ?? "-"})`,
+  );
+}
+console.log(
+  stableStringify({
+    mode: "dispatch",
+    subscription_count: subscriptions.length,
+    results: tally,
+  }),
+);
+// Exit 0 regardless of per-subscriber failures: the data publish already
+// succeeded, and one broken endpoint must not fail the run.
+
+function listKvKeys(nsId, prefix) {
+  const stdout = runWrangler([
+    "kv",
+    "key",
+    "list",
+    "--namespace-id",
+    nsId,
+    "--prefix",
+    prefix,
+    "--remote",
+  ]);
+  if (!stdout) return [];
+  try {
+    const entries = JSON.parse(stdout);
+    return Array.isArray(entries)
+      ? entries.map((entry) => entry.name).filter(Boolean)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+function getKvValue(nsId, key) {
+  return runWrangler([
+    "kv",
+    "key",
+    "get",
+    key,
+    "--namespace-id",
+    nsId,
+    "--remote",
+  ]);
+}
+
+// Best-effort: a KV/wrangler hiccup here must NOT fail the publish run (the data
+// is already live and the smoke step still needs to run). Log a warning and
+// return null so the caller degrades to "no subscriptions / skip".
+function runWrangler(wranglerArgs) {
+  const bin = path.join(
+    repoRoot,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "wrangler.cmd" : "wrangler",
+  );
+  const result = spawnSync(bin, wranglerArgs, {
+    encoding: "utf8",
+    stdio: "pipe",
+  });
+  if (result.status !== 0) {
+    console.error(
+      `::warning::wrangler ${wranglerArgs[1] ?? ""} failed; skipping webhook dispatch. ${(result.stderr || result.stdout || "").trim()}`,
+    );
+    return null;
+  }
+  return result.stdout;
+}

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -315,3 +315,125 @@ export function publicSubscriptionView(record) {
     active: record.active !== false,
   };
 }
+
+// --- delivery (publish-time dispatch) -----------------------------------------
+// Deliver one change event to one subscription. Pure w.r.t. I/O: `fetchFn` and
+// `now` are injected so the dispatcher is fully unit-testable. Re-validates the
+// URL at delivery time (defense in depth vs. a record that slipped past intake),
+// skips on filter mismatch, signs with HMAC-SHA256, and retries transient
+// failures (network/timeout/5xx/429) but not deterministic 4xx rejections.
+export async function deliverChangeEvent({
+  subscription,
+  event,
+  fetchFn,
+  now,
+  timeoutMs = 8000,
+  maxAttempts = 3,
+}) {
+  if (!subscription || typeof subscription.url !== "string") {
+    return {
+      id: subscription?.id ?? null,
+      status: "skipped",
+      reason: "invalid",
+    };
+  }
+  if (!isPublicWebhookUrl(subscription.url)) {
+    return { id: subscription.id, status: "skipped", reason: "unsafe-url" };
+  }
+  if (!eventMatchesFilters(event, subscription.filters)) {
+    return { id: subscription.id, status: "filtered" };
+  }
+  if (typeof subscription.secret !== "string" || !subscription.secret) {
+    return { id: subscription.id, status: "skipped", reason: "no-secret" };
+  }
+
+  const bodyText = JSON.stringify(event);
+  const timestamp =
+    typeof now === "function" ? now() : new Date(0).toISOString();
+  const signature = await signPayload(subscription.secret, bodyText);
+  const headers = {
+    "content-type": "application/json",
+    "user-agent": "metagraphed-webhook/1.0",
+    [WEBHOOK_SIGNATURE_HEADER]: signature,
+    [WEBHOOK_TIMESTAMP_HEADER]: timestamp,
+  };
+
+  let lastReason = "unknown";
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let response;
+    try {
+      response = await fetchFn(subscription.url, {
+        method: "POST",
+        headers,
+        body: bodyText,
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+    } catch (error) {
+      lastReason = error?.name === "TimeoutError" ? "timeout" : "network-error";
+      continue; // transient — retry
+    }
+    const status = response.status;
+    if (status >= 200 && status < 300) {
+      return {
+        id: subscription.id,
+        status: "delivered",
+        status_code: status,
+        attempts: attempt,
+      };
+    }
+    lastReason = `http-${status}`;
+    // 4xx (except 429) is a deterministic rejection — do not retry.
+    if (status >= 400 && status < 500 && status !== 429) {
+      return {
+        id: subscription.id,
+        status: "failed",
+        status_code: status,
+        reason: lastReason,
+        attempts: attempt,
+      };
+    }
+    // 5xx / 429 — retry.
+  }
+  return {
+    id: subscription.id,
+    status: "failed",
+    reason: lastReason,
+    attempts: maxAttempts,
+  };
+}
+
+// Bounded fan-out over many subscriptions. Concurrency-capped; never rejects —
+// each subscription resolves to a result record (delivered/failed/filtered/
+// skipped) so one bad endpoint can't sink the batch.
+export async function dispatchChangeEvent({
+  subscriptions,
+  event,
+  fetchFn,
+  now,
+  timeoutMs,
+  maxAttempts,
+  concurrency = 8,
+}) {
+  const queue = [...(subscriptions || [])];
+  const results = [];
+  const worker = async () => {
+    while (queue.length > 0) {
+      const subscription = queue.shift();
+      const result = await deliverChangeEvent({
+        subscription,
+        event,
+        fetchFn,
+        now,
+        timeoutMs,
+        maxAttempts,
+      });
+      results.push(result);
+    }
+  };
+  const workers = Array.from(
+    { length: Math.max(1, Math.min(concurrency, queue.length)) },
+    () => worker(),
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/tests/webhooks.test.mjs
+++ b/tests/webhooks.test.mjs
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
   buildChangeEvent,
+  deliverChangeEvent,
+  dispatchChangeEvent,
   eventMatchesFilters,
   generateSecret,
   generateSubscriptionId,
@@ -13,6 +15,7 @@ import {
   subscriptionStorageKey,
   timingSafeEqual,
   validateSubscriptionInput,
+  WEBHOOK_SIGNATURE_HEADER,
 } from "../src/webhooks.mjs";
 
 describe("isPublicWebhookUrl", () => {
@@ -209,5 +212,153 @@ describe("signing + identity helpers", () => {
     assert.equal(view.secret, undefined);
     assert.equal(view.url, "https://x.com");
     assert.deepEqual(view.filters, { netuids: [7] });
+  });
+});
+
+describe("deliverChangeEvent", () => {
+  const event = {
+    type: "metagraph.publish",
+    change_kinds: ["artifacts"],
+    affected_netuids: [7],
+  };
+  const sub = (over = {}) => ({
+    id: "s1",
+    url: "https://hooks.example.com/mg",
+    secret: "subscription-secret-value",
+    filters: {},
+    ...over,
+  });
+  const now = () => "2026-06-10T00:00:00.000Z";
+
+  test("delivers with a signed body on 2xx", async () => {
+    const calls = [];
+    const fetchFn = async (url, init) => {
+      calls.push({ url, init });
+      return new Response("ok", { status: 200 });
+    };
+    const res = await deliverChangeEvent({
+      subscription: sub(),
+      event,
+      fetchFn,
+      now,
+    });
+    assert.equal(res.status, "delivered");
+    assert.equal(res.attempts, 1);
+    assert.equal(calls.length, 1);
+    const sig = calls[0].init.headers[WEBHOOK_SIGNATURE_HEADER];
+    assert.equal(sig, await signPayload(sub().secret, JSON.stringify(event)));
+  });
+
+  test("skips an unsafe URL without fetching", async () => {
+    let called = false;
+    const fetchFn = async () => {
+      called = true;
+      return new Response("", { status: 200 });
+    };
+    const res = await deliverChangeEvent({
+      subscription: sub({ url: "https://127.0.0.1/x" }),
+      event,
+      fetchFn,
+      now,
+    });
+    assert.equal(res.status, "skipped");
+    assert.equal(res.reason, "unsafe-url");
+    assert.equal(called, false);
+  });
+
+  test("filters out a non-matching subscription", async () => {
+    const res = await deliverChangeEvent({
+      subscription: sub({ filters: { netuids: [999] } }),
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+      now,
+    });
+    assert.equal(res.status, "filtered");
+  });
+
+  test("retries 5xx then succeeds", async () => {
+    let n = 0;
+    const fetchFn = async () => {
+      n += 1;
+      return new Response("", { status: n < 2 ? 503 : 200 });
+    };
+    const res = await deliverChangeEvent({
+      subscription: sub(),
+      event,
+      fetchFn,
+      now,
+    });
+    assert.equal(res.status, "delivered");
+    assert.equal(res.attempts, 2);
+  });
+
+  test("does NOT retry a 4xx rejection", async () => {
+    let n = 0;
+    const fetchFn = async () => {
+      n += 1;
+      return new Response("", { status: 400 });
+    };
+    const res = await deliverChangeEvent({
+      subscription: sub(),
+      event,
+      fetchFn,
+      now,
+    });
+    assert.equal(res.status, "failed");
+    assert.equal(res.status_code, 400);
+    assert.equal(n, 1);
+  });
+
+  test("fails after exhausting retries on persistent 5xx", async () => {
+    const fetchFn = async () => new Response("", { status: 502 });
+    const res = await deliverChangeEvent({
+      subscription: sub(),
+      event,
+      fetchFn,
+      now,
+      maxAttempts: 3,
+    });
+    assert.equal(res.status, "failed");
+    assert.equal(res.attempts, 3);
+    assert.equal(res.reason, "http-502");
+  });
+});
+
+describe("dispatchChangeEvent", () => {
+  test("returns one result per subscription and respects filters/safety", async () => {
+    const event = { change_kinds: ["subnets"], affected_netuids: [7, 9] };
+    const subs = [
+      {
+        id: "a",
+        url: "https://a.example.com/h",
+        secret: "secret-value-aaaaaa",
+        filters: { netuids: [7] },
+      },
+      {
+        id: "b",
+        url: "https://b.example.com/h",
+        secret: "secret-value-bbbbbb",
+        filters: { netuids: [100] },
+      },
+      {
+        id: "c",
+        url: "https://10.0.0.1/h",
+        secret: "secret-value-cccccc",
+        filters: {},
+      },
+    ];
+    const fetchFn = async () => new Response("", { status: 200 });
+    const results = await dispatchChangeEvent({
+      subscriptions: subs,
+      event,
+      fetchFn,
+      now: () => "t",
+      concurrency: 2,
+    });
+    const byId = Object.fromEntries(results.map((r) => [r.id, r.status]));
+    assert.equal(byId.a, "delivered");
+    assert.equal(byId.b, "filtered");
+    assert.equal(byId.c, "skipped");
+    assert.equal(results.length, 3);
   });
 });


### PR DESCRIPTION
## What

The **second half** of the change-feed webhooks. #234 landed the subscription API + SSE feed; this adds the **publish-time dispatcher** that actually pushes the diff to subscribers, completing the feature.

## How

- **`src/webhooks.mjs`**: `deliverChangeEvent` (one subscription) + `dispatchChangeEvent` (bounded concurrent fan-out). Delivery-time URL re-validation (**SSRF defense in depth** — the active outbound surface lives here, not in #234), `HMAC-SHA256` signature + timestamp headers, retry on transient (network / timeout / 5xx / 429), **no** retry on deterministic 4xx. `fetch`/`now` injected → fully unit-tested.
- **`scripts/dispatch-webhooks.mjs`**: reads the freshly-built `changelog.json` + `build-summary.json`, derives the change event, lists subscriptions from `METAGRAPH_CONTROL` KV (wrangler), fans out. **Safe by default**: `--dry-run` (the default) makes no network/KV calls; a real run requires `METAGRAPH_ALLOW_WEBHOOK_DISPATCH=1` + the namespace id. It **always exits 0** — per-subscriber and KV hiccups are logged as warnings, never failing the publish or blocking the smoke step.
- **`publish-cloudflare.yml`**: a `Dispatch change-feed webhooks` step after `kv:publish`, gated on the same `kv_publish` secrets. **No-ops with zero subscriptions**, so it is inert until builders subscribe.
- **`package.json`**: `webhooks:dispatch[:dry-run]`.

## Verification

- `tests/webhooks.test.mjs` delivery matrix: delivered (signed body), filtered, skipped-unsafe-URL, retry-5xx-then-succeed, no-retry-on-4xx, exhausted-retries; `dispatchChangeEvent` returns one result per sub with safety/filter outcomes.
- Full suite green; `lint`, `prettier`, `validate:workflows`, `scan:public-safety`, `validate:private-boundary` all pass. `--dry-run` verified locally; the write path refuses without the allow flag.

## Note

This modifies the production publish workflow, so it **routes to the Superagent human-review gate by design** — the dispatcher is the SSRF-capable component, so your review before it goes into the 6h pipeline is the right checkpoint. It's inert until (a) you approve + merge and (b) a subscriber registers.