### PR TITLE
fix(rpc): fail over on upstream body read errors

### DIFF
--- a/tests/rpc-failover.test.mjs
+++ b/tests/rpc-failover.test.mjs
@@ -206,6 +206,28 @@ describe("proxyWithFailover", () => {
     assert.equal(canceled, true);
   });
 
+  test("fails over when a 2xx upstream body errors during inspection", async () => {
+    const healthMap = new Map();
+    const brokenBody = new globalThis.ReadableStream({
+      pull(controller) {
+        controller.error(new Error("upstream reset"));
+      },
+    });
+    const fetchFn = scriptedFetch(
+      new Response(brokenBody, { status: 200 }),
+      jsonResponse(200, { result: 1 }),
+    );
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      ...base,
+      fetchFn,
+      healthMap,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
+    assert.equal(res.headers.get("x-metagraph-rpc-attempts"), "2");
+    assert.equal(healthMap.get("a").fails, 1);
+  });
+
   test("fails over on a node-internal JSON-RPC error", async () => {
     const fetchFn = scriptedFetch(
       jsonResponse(200, { error: { code: -32603, message: "internal" } }),

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -578,10 +578,17 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
 
   // Cacheable method, cache miss: inspect a bounded clone so oversized upstream
   // results are streamed back to the client instead of buffered in the Worker.
-  const inspect = await readResponseTextWithLimit(
-    response.clone(),
-    RPC_CLASSIFY_BODY_LIMIT_BYTES,
-  );
+  let inspect;
+  try {
+    inspect = await readResponseTextWithLimit(
+      response.clone(),
+      RPC_CLASSIFY_BODY_LIMIT_BYTES,
+    );
+  } catch {
+    // Classification is best-effort: a flaky upstream body should not turn a
+    // proxied response into a Worker exception while cache inspection is active.
+    return new Response(response.body, { status: response.status, headers });
+  }
   if (!inspect.truncated) {
     let parsed = null;
     try {
@@ -800,63 +807,76 @@ export async function proxyWithFailover(
     }
 
     if (upstream && status < 400) {
-      if (upstream.body?.tee) {
-        const [inspectBody, clientBody] = upstream.body.tee();
-        const inspect = await readResponseTextWithLimit(
-          new Response(inspectBody),
-          RPC_CLASSIFY_BODY_LIMIT_BYTES,
-        );
-        if (!inspect.truncated) {
-          try {
-            parsedBody = JSON.parse(inspect.text);
-          } catch {
-            parsedBody = null;
+      let clientBodyToCancel = null;
+      try {
+        if (upstream.body?.tee) {
+          const [inspectBody, clientBody] = upstream.body.tee();
+          clientBodyToCancel = clientBody;
+          const inspect = await readResponseTextWithLimit(
+            new Response(inspectBody),
+            RPC_CLASSIFY_BODY_LIMIT_BYTES,
+          );
+          if (!inspect.truncated) {
+            try {
+              parsedBody = JSON.parse(inspect.text);
+            } catch {
+              parsedBody = null;
+            }
+            if (
+              classifyUpstreamAttempt({ thrown, status, parsedBody }) ===
+              "transient"
+            ) {
+              await clientBody.cancel();
+              recordRpcFailure(healthMap, endpoint.id, Date.now());
+              attempts.push({
+                endpoint_id: endpoint.id,
+                reason: `status-${status}`,
+              });
+              continue;
+            }
           }
-          if (
-            classifyUpstreamAttempt({ thrown, status, parsedBody }) ===
-            "transient"
-          ) {
-            await clientBody.cancel();
-            recordRpcFailure(healthMap, endpoint.id, Date.now());
-            attempts.push({
-              endpoint_id: endpoint.id,
-              reason: `status-${status}`,
-            });
-            continue;
+          upstream = new Response(clientBody, {
+            status: upstream.status,
+            statusText: upstream.statusText,
+            headers: upstream.headers,
+          });
+        } else {
+          const inspect = await readResponseTextWithLimit(
+            upstream,
+            RPC_CLASSIFY_BODY_LIMIT_BYTES,
+          );
+          if (!inspect.truncated) {
+            try {
+              parsedBody = JSON.parse(inspect.text);
+            } catch {
+              parsedBody = null;
+            }
+            if (
+              classifyUpstreamAttempt({ thrown, status, parsedBody }) ===
+              "transient"
+            ) {
+              recordRpcFailure(healthMap, endpoint.id, Date.now());
+              attempts.push({
+                endpoint_id: endpoint.id,
+                reason: `status-${status}`,
+              });
+              continue;
+            }
           }
+          upstream = new Response(inspect.text, {
+            status,
+            headers: upstream.headers,
+          });
         }
-        upstream = new Response(clientBody, {
-          status: upstream.status,
-          statusText: upstream.statusText,
-          headers: upstream.headers,
+      } catch {
+        await clientBodyToCancel?.cancel?.().catch(() => {});
+        await upstream?.body?.cancel?.().catch(() => {});
+        recordRpcFailure(healthMap, endpoint.id, Date.now());
+        attempts.push({
+          endpoint_id: endpoint.id,
+          reason: "body-read-error",
         });
-      } else {
-        const inspect = await readResponseTextWithLimit(
-          upstream,
-          RPC_CLASSIFY_BODY_LIMIT_BYTES,
-        );
-        if (!inspect.truncated) {
-          try {
-            parsedBody = JSON.parse(inspect.text);
-          } catch {
-            parsedBody = null;
-          }
-          if (
-            classifyUpstreamAttempt({ thrown, status, parsedBody }) ===
-            "transient"
-          ) {
-            recordRpcFailure(healthMap, endpoint.id, Date.now());
-            attempts.push({
-              endpoint_id: endpoint.id,
-              reason: `status-${status}`,
-            });
-            continue;
-          }
-        }
-        upstream = new Response(inspect.text, {
-          status,
-          headers: upstream.headers,
-        });
+        continue;
       }
     }
 


### PR DESCRIPTION
### Motivation
- Bounded upstream body inspection was performed outside the network `try/catch`, so a 2xx response whose body errors or aborts could throw and abort the Worker instead of being classified as a transient failure and failed over.  
- Both the failover path (`proxyWithFailover`) and the cache-classification path (`handleRpcProxyRequest`) read upstream bodies without guarding read/abort errors, risking availability of the RPC proxy and omission of circuit-breaker bookkeeping.

### Description
- Wrap the cache-classification bounded clone read in a `try/catch` around `readResponseTextWithLimit` so classification is best-effort and a flaky upstream body causes the proxied response to be streamed and caching to be skipped.  
- Wrap the upstream body inspection (both the `tee()` branch and the buffered branch) in a `try/catch` inside `proxyWithFailover` so `tee`/reader/`response.text()`/abort errors cause the attempt to be recorded with reason `body-read-error`, the endpoint to be failed via `recordRpcFailure`, and the loop to continue to the next endpoint.  
- Add a regression test `fails over when a 2xx upstream body errors during inspection` to `tests/rpc-failover.test.mjs` that verifies failover, attempt counting, and circuit-breaker bookkeeping when a 2xx response body errors during inspection.

### Testing
- Ran `npx vitest run tests/rpc-failover.test.mjs tests/rpc-cache.test.mjs` and the focused suites passed (all new and affected tests passed).  
- Ran `npm run lint` and the linting errors introduced by the change were resolved and the lint run succeeded.  
- Ran `npx prettier --check workers/api.mjs tests/rpc-failover.test.mjs` to verify formatting of touched files and it succeeded.  
- Note: running the full test suite via `npm test` currently fails due to missing generated public artifacts (e.g. `public/metagraph/providers.json`) that are unrelated to this change, so the full-suite failures are outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29c4b0f050832abac95e184915bec5)