### PR TITLE
fix(api): scope evidence by source netuid

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -4,6 +4,7 @@ import { promisify } from "node:util";
 import path from "node:path";
 import {
   buildEndpointResourceArtifact,
+  buildEvidenceSubjectNetuidIndex,
   buildEndpointPoolArtifact,
   buildEndpointIncidentArtifact,
   buildTimestamp,
@@ -18,6 +19,7 @@ import {
   loadVerification,
   nativeDisplayName,
   nativeNameQuality,
+  netuidForEvidenceClaim,
   normalizePublicUrl,
   publishedAt,
   readJson,
@@ -664,11 +666,16 @@ const evidenceLedger = buildEvidenceLedger({
 });
 await writeJson(artifactFile("evidence-ledger.json"), evidenceLedger);
 // Per-subnet evidence split (R2-tier; powers /api/v1/subnets/{netuid}/evidence).
-// Claims carry no netuid field, so derive it from the structured subject id
-// (`surface:...sn-7-...`, `candidate:...sn-7-...`, or `subnet:7`).
+// Scope generated claims through the authoritative source rows instead of
+// reparsing user-controlled slugs such as candidate IDs.
+const evidenceSubjectNetuids = buildEvidenceSubjectNetuidIndex({
+  candidates,
+  subnets: mergedSubnets,
+  surfaces,
+});
 const claimsByNetuid = new Map();
 for (const claim of evidenceLedger.claims || []) {
-  const netuid = netuidFromEvidenceSubject(claim.subject);
+  const netuid = netuidForEvidenceClaim(claim, evidenceSubjectNetuids);
   if (netuid === null) {
     continue;
   }
@@ -2566,22 +2573,6 @@ function averageScore(profiles) {
 
 function groupByNetuid(items) {
   return groupBy(items, "netuid");
-}
-
-// Evidence claims have no netuid field. Derive it from the structured subject
-// id: `subnet:7`, or any `...sn-7-...` form (`surface:sn-7-...`,
-// `candidate:community-sn-7-...`). Returns null when no netuid is encoded.
-function netuidFromEvidenceSubject(subject) {
-  const value = String(subject || "");
-  const subnetMatch = value.match(/^subnet:(\d+)\b/);
-  if (subnetMatch) {
-    return Number(subnetMatch[1]);
-  }
-  const snMatch = value.match(/sn-(\d+)/);
-  if (snMatch) {
-    return Number(snMatch[1]);
-  }
-  return null;
 }
 
 function groupBy(items, key) {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -67,6 +67,56 @@ unsafeIpBlocks.addSubnet("fc00::", 7, "ipv6");
 unsafeIpBlocks.addSubnet("fe80::", 10, "ipv6");
 unsafeIpBlocks.addSubnet("ff00::", 8, "ipv6");
 
+export function buildEvidenceSubjectNetuidIndex({
+  candidates = [],
+  subnets = [],
+  surfaces = [],
+} = {}) {
+  const index = new Map();
+  const setSubjectNetuid = (subject, netuid) => {
+    if (subject && Number.isInteger(netuid)) {
+      index.set(subject, netuid);
+    }
+  };
+
+  for (const subnet of subnets || []) {
+    setSubjectNetuid(`subnet:${subnet.netuid}`, subnet.netuid);
+  }
+  for (const surface of surfaces || []) {
+    setSubjectNetuid(`surface:${surface.id}`, surface.netuid);
+  }
+  for (const candidate of candidates || []) {
+    setSubjectNetuid(`candidate:${candidate.id}`, candidate.netuid);
+  }
+
+  return index;
+}
+
+export function netuidForEvidenceClaim(claim, subjectNetuids = new Map()) {
+  const subject = String(claim?.subject || "");
+  if (subjectNetuids.has(subject)) {
+    return subjectNetuids.get(subject);
+  }
+  return netuidFromEvidenceSubject(subject);
+}
+
+// Fallback for legacy/imported claims that are not generated from authoritative
+// subnet, surface, or candidate rows in this build. Generated claims should be
+// scoped through buildEvidenceSubjectNetuidIndex() instead of trusting
+// user-controlled subject slugs.
+export function netuidFromEvidenceSubject(subject) {
+  const value = String(subject || "");
+  const subnetMatch = value.match(/^subnet:(\d+)\b/);
+  if (subnetMatch) {
+    return Number(subnetMatch[1]);
+  }
+  const snMatch = value.match(/sn-(\d+)/);
+  if (snMatch) {
+    return Number(snMatch[1]);
+  }
+  return null;
+}
+
 export async function readJson(filePath) {
   const raw = await fs.readFile(filePath, "utf8");
   return JSON.parse(raw);

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -13,6 +13,7 @@ import {
   buildEndpointResourceArtifact,
   buildEndpointPoolArtifact,
   buildEndpointIncidentArtifact,
+  buildEvidenceSubjectNetuidIndex,
   buildRpcEndpointArtifact,
   buildTimestamp,
   classifyNativeName,
@@ -35,6 +36,7 @@ import {
   loadVerification,
   nativeDisplayName,
   nativeNameQuality,
+  netuidForEvidenceClaim,
   normalizePublicUrl,
   readJson,
   redactCredentialedUrl,
@@ -969,6 +971,40 @@ describe("script utility contracts", () => {
     assert.equal(
       isCredentialedUrl("https://example.com/download?file=1"),
       false,
+    );
+  });
+
+  test("scopes evidence claims with authoritative source netuids before subject slugs", () => {
+    const subjectNetuids = buildEvidenceSubjectNetuidIndex({
+      candidates: [{ id: "community-sn-7-misplaced-vanta-example", netuid: 8 }],
+      subnets: [{ netuid: 7 }],
+      surfaces: [{ id: "sn-7-curated-surface", netuid: 7 }],
+    });
+
+    assert.equal(
+      netuidForEvidenceClaim(
+        { subject: "candidate:community-sn-7-misplaced-vanta-example" },
+        subjectNetuids,
+      ),
+      8,
+    );
+    assert.equal(
+      netuidForEvidenceClaim(
+        { subject: "surface:sn-7-curated-surface" },
+        subjectNetuids,
+      ),
+      7,
+    );
+    assert.equal(
+      netuidForEvidenceClaim({ subject: "subnet:7" }, subjectNetuids),
+      7,
+    );
+    assert.equal(
+      netuidForEvidenceClaim(
+        { subject: "legacy:community-sn-9-only-subject" },
+        subjectNetuids,
+      ),
+      9,
     );
   });
 

--- a/tests/subnet-evidence-gaps.test.mjs
+++ b/tests/subnet-evidence-gaps.test.mjs
@@ -16,11 +16,10 @@ describe("per-subnet evidence route", () => {
     assert.equal(body.data.netuid, 7);
     assert.equal(Array.isArray(body.data.claims), true);
     assert.equal(body.data.claims.length > 0, true);
-    // Every claim subject encodes netuid 7 (subnet:7 or ...sn-7-...).
+    // Every generated claim is scoped to SN7, even when a surface/candidate
+    // subject slug does not encode the authoritative netuid.
     assert.equal(
-      body.data.claims.every((claim) =>
-        /(^subnet:7\b|sn-7\b)/.test(String(claim.subject)),
-      ),
+      body.data.claims.every((claim) => /\bSN7\b/.test(String(claim.claim))),
       true,
     );
   });


### PR DESCRIPTION
### Motivation
- The per-subnet evidence splitter previously derived `netuid` by parsing `sn-N` fragments from claim `subject` strings, which lets attacker-controlled candidate `id` slugs misroute evidence to other subnets.
- The change aims to ensure generated evidence is bucketed by the authoritative `netuid` from source rows (subnet/surface/candidate) to preserve integrity of the new per-subnet evidence API.

### Description
- Add `buildEvidenceSubjectNetuidIndex` and `netuidForEvidenceClaim` helpers in `scripts/lib.mjs` to build an index mapping authoritative `subnet:<n>`, `surface:<id>`, and `candidate:<id>` subjects to their source `netuid`, with the old string-parser retained only as a fallback for legacy/imported claims.
- Update `scripts/build-artifacts.mjs` to use the new `buildEvidenceSubjectNetuidIndex()` and `netuidForEvidenceClaim()` when grouping `evidenceLedger.claims` into `evidence/{netuid}.json` buckets instead of trusting `sn-N` fragments in `subject` slugs.
- Add a unit test in `tests/script-utils.test.mjs` for the new scoping helpers and adjust `tests/subnet-evidence-gaps.test.mjs` assertion to validate that generated claims are scoped to the authoritative SN even when subject slugs themselves may not encode that netuid.

### Testing
- Ran formatter: `npx prettier --write scripts/lib.mjs scripts/build-artifacts.mjs tests/script-utils.test.mjs tests/subnet-evidence-gaps.test.mjs` (succeeded).
- Built artifacts: `npm run build:artifacts` (succeeded and produced artifacts).
- Ran unit tests: `npm test -- --run tests/script-utils.test.mjs tests/subnet-evidence-gaps.test.mjs` and then the full two-test-suite run; all tests passed (40 tests total passed).
- Ran linter: `npm run lint -- scripts/build-artifacts.mjs scripts/lib.mjs tests/script-utils.test.mjs tests/subnet-evidence-gaps.test.mjs` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29c6dc2664832a9ffe7383ec137493)