### PR TITLE
fix(api): require token for webhook subscription creation

### DIFF
--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -22,13 +22,22 @@ function makeKv() {
   };
 }
 
-const envWith = (kv) => createLocalArtifactEnv({ METAGRAPH_CONTROL: kv });
+const SUBSCRIPTION_TOKEN = "test-webhook-subscription-token";
+const envWith = (kv, extra = {}) =>
+  createLocalArtifactEnv({
+    METAGRAPH_CONTROL: kv,
+    METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN: SUBSCRIPTION_TOKEN,
+    ...extra,
+  });
 const req = (path, init) => new Request(`https://metagraph.sh${path}`, init);
 const postSub = (env, body) =>
   handleRequest(
     req("/api/v1/webhooks/subscriptions", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-metagraph-webhook-subscription-token": SUBSCRIPTION_TOKEN,
+      },
       body: JSON.stringify(body),
     }),
     env,
@@ -75,7 +84,10 @@ describe("webhook subscription routes", () => {
     const res = await handleRequest(
       req("/api/v1/webhooks/subscriptions", {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          "x-metagraph-webhook-subscription-token": SUBSCRIPTION_TOKEN,
+        },
         body: "{not json",
       }),
       envWith(makeKv()),
@@ -83,6 +95,42 @@ describe("webhook subscription routes", () => {
     );
     assert.equal(res.status, 400);
     assert.equal((await res.json()).error.code, "invalid_json");
+  });
+
+  test("rejects subscription creation without the subscription token", async () => {
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ url: "https://hooks.example.com/mg" }),
+      }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 401);
+    assert.equal((await res.json()).error.code, "unauthorized");
+  });
+
+  test("disables subscription creation when the subscription token is unconfigured", async () => {
+    const kv = makeKv();
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-metagraph-webhook-subscription-token": SUBSCRIPTION_TOKEN,
+        },
+        body: JSON.stringify({ url: "https://hooks.example.com/mg" }),
+      }),
+      envWith(kv, { METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN: "" }),
+      {},
+    );
+    assert.equal(res.status, 503);
+    assert.equal(
+      (await res.json()).error.code,
+      "webhook_subscriptions_disabled",
+    );
+    assert.equal(kv.store.size, 0);
   });
 
   test("returns 503 when the KV store is unbound", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -68,6 +68,8 @@ const DENIED_RPC_PREFIXES = [
 const MAX_RPC_BODY_BYTES = 65536;
 const METAGRAPH_LATEST_KEY = "metagraph:latest";
 const MAX_WEBHOOK_BODY_BYTES = 8192;
+const WEBHOOK_SUBSCRIPTION_TOKEN_HEADER =
+  "x-metagraph-webhook-subscription-token";
 // Dormant subscriptions self-clean after 180 days; the publish-time dispatcher
 // refreshes the TTL on each successful delivery.
 const WEBHOOK_TTL_SECONDS = 180 * 24 * 60 * 60;
@@ -1186,6 +1188,11 @@ async function createWebhookSubscription(request, env) {
     return errorResponse("invalid_subscription", validated.error, 400);
   }
 
+  const authorized = validateWebhookSubscriptionToken(request, env);
+  if (!authorized.ok) {
+    return authorized.response;
+  }
+
   const id = generateSubscriptionId();
   // Short local name (`hookSecret`) keeps the public-safety scanner's
   // hardcoded-credential heuristic from false-positiving on `secret = <expr>`.
@@ -1233,6 +1240,34 @@ async function createWebhookSubscription(request, env) {
     },
     201,
   );
+}
+
+function validateWebhookSubscriptionToken(request, env) {
+  const configured = env.METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN;
+  if (typeof configured !== "string" || configured.length === 0) {
+    return {
+      ok: false,
+      response: errorResponse(
+        "webhook_subscriptions_disabled",
+        "Webhook subscription creation requires METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN to be configured.",
+        503,
+      ),
+    };
+  }
+
+  const provided = request.headers.get(WEBHOOK_SUBSCRIPTION_TOKEN_HEADER) || "";
+  if (!provided || !timingSafeEqual(provided, configured)) {
+    return {
+      ok: false,
+      response: errorResponse(
+        "unauthorized",
+        `Provide a valid ${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER} header to create webhook subscriptions.`,
+        401,
+      ),
+    };
+  }
+
+  return { ok: true };
 }
 
 async function getWebhookSubscription(env, id) {
@@ -1638,7 +1673,7 @@ function corsPreflight(request) {
   headers.set("access-control-allow-methods", methods);
   headers.set(
     "access-control-allow-headers",
-    `content-type, if-none-match, ${WEBHOOK_SECRET_HEADER}`,
+    `content-type, if-none-match, ${WEBHOOK_SECRET_HEADER}, ${WEBHOOK_SUBSCRIPTION_TOKEN_HEADER}`,
   );
   headers.set("access-control-max-age", "86400");
   return new Response(null, { status: 204, headers });


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated clients from creating persistent KV-backed webhook subscriptions that can exhaust the shared `METAGRAPH_CONTROL` namespace and enable amplification abuse.

### Description
- Require a pre-shared creation token by checking `env.METAGRAPH_WEBHOOK_SUBSCRIPTION_TOKEN` and the `x-metagraph-webhook-subscription-token` request header before persisting a subscription.  Creation returns `401` for missing/invalid token and `503` when the server-side token is not configured.
- Added `validateWebhookSubscriptionToken(request, env)` and a `WEBHOOK_SUBSCRIPTION_TOKEN_HEADER` constant and invoked the check in `createWebhookSubscription` before generating IDs/secrets or calling `METAGRAPH_CONTROL.put`.
- Update CORS preflight to advertise the `x-metagraph-webhook-subscription-token` header so authorized clients can send it (`corsPreflight`).
- Update worker route tests to send the subscription token and add tests for missing-token rejection and disabled creation when the server token is unconfigured (`tests/webhooks-worker.test.mjs`).

### Testing
- Ran `npm test -- tests/webhooks-worker.test.mjs` and the file-specific worker route tests passed (all webhook-worker tests green).
- Ran `npm test -- tests/webhooks.test.mjs` and `npm run worker:test`, both passed for the webhook-related suites and worker runtime checks exercised here.
- Ran `npm run lint`, `npx prettier --check workers/api.mjs tests/webhooks-worker.test.mjs`, and `npm run scan:public-safety`, all succeeded for the changed files and public-safety scan passed.
- Full `npm test` and `npm run format:check` were not fully green in this checkout due to pre-existing unrelated issues: missing generated public artifacts (e.g., `public/metagraph/providers.json`) caused unrelated test failures and a docs file formatting warning; these are outside the scope of the webhook gate change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29c6f9a6c0832aaf5e4de070c638df)