### PR TITLE
fix(webhooks): harden publish dispatcher SSRF checks

### DIFF
--- a/scripts/dispatch-webhooks.mjs
+++ b/scripts/dispatch-webhooks.mjs
@@ -11,17 +11,21 @@
 // makes no network/KV calls. A real dispatch additionally requires
 // METAGRAPH_ALLOW_WEBHOOK_DISPATCH=1 + METAGRAPH_KV_NAMESPACE_ID.
 import { spawnSync } from "node:child_process";
+import { resolve4, resolve6 } from "node:dns/promises";
+import { request as httpsRequest } from "node:https";
 import path from "node:path";
 import { readJson, repoRoot, stableStringify } from "./lib.mjs";
 import {
   buildChangeEvent,
   dispatchChangeEvent,
+  isPublicWebhookAddress,
   WEBHOOK_KV_PREFIX,
 } from "../src/webhooks.mjs";
 
 const args = new Set(process.argv.slice(2));
 const write = args.has("--write");
 const dryRun = args.has("--dry-run") || !write;
+const MAX_DISPATCH_SUBSCRIPTIONS = 128;
 
 const changelog = await readJson(
   path.join(repoRoot, "public/metagraph/changelog.json"),
@@ -64,7 +68,13 @@ if (!namespaceId) {
   process.exit(1);
 }
 
-const keys = listKvKeys(namespaceId, WEBHOOK_KV_PREFIX);
+const allKeys = listKvKeys(namespaceId, WEBHOOK_KV_PREFIX);
+if (allKeys.length > MAX_DISPATCH_SUBSCRIPTIONS) {
+  console.error(
+    `::warning::webhook dispatch capped at ${MAX_DISPATCH_SUBSCRIPTIONS} of ${allKeys.length} registered subscriptions`,
+  );
+}
+const keys = allKeys.slice(0, MAX_DISPATCH_SUBSCRIPTIONS);
 if (keys.length === 0) {
   console.log("No webhook subscriptions registered; nothing to dispatch.");
   process.exit(0);
@@ -84,11 +94,12 @@ for (const key of keys) {
 const results = await dispatchChangeEvent({
   subscriptions,
   event,
-  fetchFn: fetch,
+  fetchFn: safeWebhookFetch,
   now: () => new Date().toISOString(),
   concurrency: 8,
   timeoutMs: 8000,
   maxAttempts: 3,
+  resolveHostnames: resolvePublicHostnames,
 });
 
 const tally = results.reduce((acc, result) => {
@@ -142,6 +153,79 @@ function getKvValue(nsId, key) {
     nsId,
     "--remote",
   ]);
+}
+
+async function resolvePublicHostnames(hostname) {
+  return (await resolvePublicAddressRecords(hostname)).map(
+    (record) => record.address,
+  );
+}
+
+async function resolvePublicAddressRecords(hostname) {
+  const [v4, v6] = await Promise.allSettled([
+    resolve4(hostname),
+    resolve6(hostname),
+  ]);
+  const records = [
+    ...(v4.status === "fulfilled"
+      ? v4.value.map((address) => ({ address, family: 4 }))
+      : []),
+    ...(v6.status === "fulfilled"
+      ? v6.value.map((address) => ({ address, family: 6 }))
+      : []),
+  ];
+  if (
+    records.length === 0 ||
+    records.some((record) => !isPublicWebhookAddress(record.address))
+  ) {
+    throw new Error("unsafe webhook DNS result");
+  }
+  return records;
+}
+
+function safeWebhookFetch(requestUrl, init = {}) {
+  return new Promise((resolve, reject) => {
+    let url;
+    try {
+      url = new URL(String(requestUrl));
+    } catch (error) {
+      reject(error);
+      return;
+    }
+
+    const req = httpsRequest(
+      url,
+      {
+        method: init.method || "GET",
+        headers: init.headers,
+        signal: init.signal,
+        lookup(hostname, options, callback) {
+          resolvePublicAddressRecords(hostname)
+            .then((records) => {
+              const family = options?.family;
+              const match = family
+                ? records.find((record) => record.family === family)
+                : records[0];
+              if (!match) {
+                callback(new Error("no public webhook DNS result"));
+                return;
+              }
+              callback(null, match.address, match.family);
+            })
+            .catch((error) => callback(error));
+        },
+      },
+      (response) => {
+        response.resume();
+        response.on("end", () => {
+          resolve(new Response(null, { status: response.statusCode || 0 }));
+        });
+      },
+    );
+    req.on("error", reject);
+    if (init.body) req.write(init.body);
+    req.end();
+  });
 }
 
 // Best-effort: a KV/wrangler hiccup here must NOT fail the publish run (the data

--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -23,11 +23,9 @@ export function subscriptionStorageKey(id) {
 }
 
 // --- URL safety: best-effort SSRF guard ---------------------------------------
-// Blocks the obvious foot-guns (non-https, embedded credentials, non-standard
-// ports, localhost, and literal private/loopback/link-local IPs). It cannot stop
-// DNS rebinding (a public hostname resolving to a private address at delivery
-// time); the dispatcher runs on GitHub-hosted runners with no access to our
-// network, which bounds that residual risk. Documented as a known limitation.
+// Blocks non-https URLs, embedded credentials, non-standard ports, localhost-like
+// names, literal private/loopback/link-local IPs, unsafe DNS answers when a
+// resolver is injected, and redirects at delivery time.
 const PRIVATE_IPV4_PATTERNS = [
   /^0\./,
   /^10\./,
@@ -41,25 +39,28 @@ const PRIVATE_IPV4_PATTERNS = [
   /^255\./,
 ];
 
-export function isPublicWebhookUrl(value) {
-  let url;
-  try {
-    url = new URL(String(value));
-  } catch {
-    return false;
-  }
-  if (url.protocol !== "https:") return false;
-  if (url.username || url.password) return false;
-  if (url.port && url.port !== "443") return false;
+function normalizedHostname(value) {
+  return String(value || "")
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+}
 
-  // URL keeps the brackets on an IPv6 literal hostname; strip them so the
-  // private-range prefix checks below see the bare address.
-  const host = url.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+function isIpv4Literal(host) {
+  if (!/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) return false;
+  return host.split(".").every((part) => {
+    const value = Number(part);
+    return Number.isInteger(value) && value >= 0 && value <= 255;
+  });
+}
+
+function isLiteralIp(host) {
+  return isIpv4Literal(host) || host.includes(":");
+}
+
+export function isPublicWebhookAddress(value) {
+  const host = normalizedHostname(value);
   if (!host) return false;
-  if (host === "localhost" || host.endsWith(".localhost")) return false;
-  if (host.endsWith(".internal") || host.endsWith(".local")) return false;
 
-  // Literal IPv6 (URL strips the brackets from hostname).
   if (host.includes(":")) {
     if (
       host === "::1" ||
@@ -74,14 +75,61 @@ export function isPublicWebhookUrl(value) {
     return true;
   }
 
-  // Literal IPv4.
-  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(host)) {
+  if (isIpv4Literal(host)) {
     return !PRIVATE_IPV4_PATTERNS.some((pattern) => pattern.test(host));
   }
+
+  return false;
+}
+
+export function isPublicWebhookUrl(value) {
+  let url;
+  try {
+    url = new URL(String(value));
+  } catch {
+    return false;
+  }
+  if (url.protocol !== "https:") return false;
+  if (url.username || url.password) return false;
+  if (url.port && url.port !== "443") return false;
+
+  // URL keeps the brackets on an IPv6 literal hostname; strip them so the
+  // private-range prefix checks below see the bare address.
+  const host = normalizedHostname(url.hostname);
+  if (!host) return false;
+  if (host === "localhost" || host.endsWith(".localhost")) return false;
+  if (host.endsWith(".internal") || host.endsWith(".local")) return false;
+
+  if (isLiteralIp(host)) return isPublicWebhookAddress(host);
 
   // Registrable hostname: require at least one dot so bare labels ("router")
   // that may resolve to LAN hosts are rejected.
   return host.includes(".");
+}
+
+export async function isResolvedPublicWebhookUrl(value, resolveHostnames) {
+  if (!isPublicWebhookUrl(value)) return false;
+  if (typeof resolveHostnames !== "function") return true;
+
+  let host;
+  try {
+    host = normalizedHostname(new URL(String(value)).hostname);
+  } catch {
+    return false;
+  }
+  if (isLiteralIp(host)) return isPublicWebhookAddress(host);
+
+  let addresses;
+  try {
+    addresses = await resolveHostnames(host);
+  } catch {
+    return false;
+  }
+  return (
+    Array.isArray(addresses) &&
+    addresses.length > 0 &&
+    addresses.every((address) => isPublicWebhookAddress(address))
+  );
 }
 
 // --- subscription validation --------------------------------------------------
@@ -329,6 +377,7 @@ export async function deliverChangeEvent({
   now,
   timeoutMs = 8000,
   maxAttempts = 3,
+  resolveHostnames,
 }) {
   if (!subscription || typeof subscription.url !== "string") {
     return {
@@ -345,6 +394,9 @@ export async function deliverChangeEvent({
   }
   if (typeof subscription.secret !== "string" || !subscription.secret) {
     return { id: subscription.id, status: "skipped", reason: "no-secret" };
+  }
+  if (!(await isResolvedPublicWebhookUrl(subscription.url, resolveHostnames))) {
+    return { id: subscription.id, status: "skipped", reason: "unsafe-url" };
   }
 
   const bodyText = JSON.stringify(event);
@@ -366,6 +418,7 @@ export async function deliverChangeEvent({
         method: "POST",
         headers,
         body: bodyText,
+        redirect: "manual",
         signal: AbortSignal.timeout(timeoutMs),
       });
     } catch (error) {
@@ -382,6 +435,15 @@ export async function deliverChangeEvent({
       };
     }
     lastReason = `http-${status}`;
+    if (status >= 300 && status < 400) {
+      return {
+        id: subscription.id,
+        status: "failed",
+        status_code: status,
+        reason: "redirect-not-followed",
+        attempts: attempt,
+      };
+    }
     // 4xx (except 429) is a deterministic rejection — do not retry.
     if (status >= 400 && status < 500 && status !== 429) {
       return {
@@ -412,6 +474,7 @@ export async function dispatchChangeEvent({
   now,
   timeoutMs,
   maxAttempts,
+  resolveHostnames,
   concurrency = 8,
 }) {
   const queue = [...(subscriptions || [])];
@@ -426,6 +489,7 @@ export async function dispatchChangeEvent({
         now,
         timeoutMs,
         maxAttempts,
+        resolveHostnames,
       });
       results.push(result);
     }

--- a/tests/webhooks.test.mjs
+++ b/tests/webhooks.test.mjs
@@ -7,7 +7,9 @@ import {
   eventMatchesFilters,
   generateSecret,
   generateSubscriptionId,
+  isPublicWebhookAddress,
   isPublicWebhookUrl,
+  isResolvedPublicWebhookUrl,
   isValidSubscriptionId,
   normalizeFilters,
   publicSubscriptionView,
@@ -55,6 +57,35 @@ describe("isPublicWebhookUrl", () => {
   test("accepts a public IPv4/IPv6 literal", () => {
     assert.equal(isPublicWebhookUrl("https://8.8.8.8/x"), true);
     assert.equal(isPublicWebhookUrl("https://[2606:4700:4700::1111]/x"), true);
+  });
+
+  test("classifies resolved addresses and rejects private DNS answers", async () => {
+    assert.equal(isPublicWebhookAddress("8.8.8.8"), true);
+    assert.equal(isPublicWebhookAddress("10.0.0.1"), false);
+    assert.equal(isPublicWebhookAddress("2606:4700:4700::1111"), true);
+    assert.equal(isPublicWebhookAddress("fd00::1"), false);
+
+    assert.equal(
+      await isResolvedPublicWebhookUrl(
+        "https://hooks.example.com/mg",
+        async () => ["93.184.216.34"],
+      ),
+      true,
+    );
+    assert.equal(
+      await isResolvedPublicWebhookUrl(
+        "https://hooks.example.com/mg",
+        async () => ["93.184.216.34", "127.0.0.1"],
+      ),
+      false,
+    );
+    assert.equal(
+      await isResolvedPublicWebhookUrl(
+        "https://hooks.example.com/mg",
+        async () => [],
+      ),
+      false,
+    );
   });
 });
 
@@ -264,6 +295,44 @@ describe("deliverChangeEvent", () => {
     assert.equal(res.status, "skipped");
     assert.equal(res.reason, "unsafe-url");
     assert.equal(called, false);
+  });
+
+  test("skips DNS-resolved private destinations without fetching", async () => {
+    let called = false;
+    const res = await deliverChangeEvent({
+      subscription: sub(),
+      event,
+      fetchFn: async () => {
+        called = true;
+        return new Response("", { status: 200 });
+      },
+      resolveHostnames: async () => ["169.254.169.254"],
+      now,
+    });
+    assert.equal(res.status, "skipped");
+    assert.equal(res.reason, "unsafe-url");
+    assert.equal(called, false);
+  });
+
+  test("does not follow redirects", async () => {
+    const calls = [];
+    const fetchFn = async (url, init) => {
+      calls.push({ url, init });
+      return new Response("", {
+        status: 302,
+        headers: { location: "http://127.0.0.1/admin" },
+      });
+    };
+    const res = await deliverChangeEvent({
+      subscription: sub(),
+      event,
+      fetchFn,
+      now,
+    });
+    assert.equal(res.status, "failed");
+    assert.equal(res.status_code, 302);
+    assert.equal(res.reason, "redirect-not-followed");
+    assert.equal(calls[0].init.redirect, "manual");
   });
 
   test("filters out a non-matching subscription", async () => {


### PR DESCRIPTION
### Motivation
- The publish-time dispatcher sent subscriber-provided URLs through the real runner `fetch` after only string-level validation, allowing redirects or DNS rebinding to reach private/loopback/link-local addresses (blind SSRF) and enabling amplification across many subscriptions.
- The dispatcher also had no cap on the number of subscriptions dispatched in a single run, permitting runtime amplification of requests on the publish runner.

### Description
- Add DNS-aware address validation helpers (`isPublicWebhookAddress`, `isResolvedPublicWebhookUrl`) and normalize hostname/IP checks to detect private/link-local/loopback addresses at delivery time in `src/webhooks.mjs`.
- Revalidate subscription destinations at delivery using an injectable resolver, and disable automatic redirect following by sending webhook POSTs with `redirect: "manual"` and treating 3xx as failures in `deliverChangeEvent` and `dispatchChangeEvent`.
- Replace the publish worker's direct `fetch` usage with a `safeWebhookFetch` HTTPS client that performs a validating DNS lookup (`resolve4`/`resolve6`) and pins connections to resolved public addresses, and thread a DNS resolver into `dispatchChangeEvent` via `scripts/dispatch-webhooks.mjs`.
- Add a publish-time cap (`MAX_DISPATCH_SUBSCRIPTIONS = 128`) to limit the number of subscriptions processed per dispatch run and add unit tests covering DNS-resolved private answers and redirect behavior in `tests/webhooks.test.mjs`.

### Testing
- Ran unit tests for webhooks with `npm test -- tests/webhooks.test.mjs`, and the focused webhook test file passed: 27 tests, 27 passed.
- Ran `npm run lint` and `npx prettier --check src/webhooks.mjs scripts/dispatch-webhooks.mjs tests/webhooks.test.mjs`, both succeeded for the modified files.
- Full `npm test` (entire suite) failed due to missing generated public artifacts in this checkout (ENOENT errors such as `public/metagraph/providers.json`), which caused many unrelated tests to fail and prevented a full-suite green run; the failures are unrelated to the webhook changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29c699a600832a8e3463dc134691ef)