### PR TITLE
feat(api): batch subnet lookups + advisory RPC rate-limit headers

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -5021,6 +5021,7 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
+                netuids?: string;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 status?: "active" | "inactive";

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -441,6 +441,7 @@
       "query_collection": "subnets",
       "query_filter_names": [
         "netuid",
+        "netuids",
         "coverage_level",
         "curation_level",
         "status",
@@ -452,6 +453,13 @@
           "schema": {
             "minimum": 0,
             "type": "integer"
+          }
+        },
+        {
+          "name": "netuids",
+          "schema": {
+            "pattern": "^\\d+(,\\d+)*$",
+            "type": "string"
           }
         },
         {

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -12777,6 +12777,15 @@
           },
           {
             "in": "query",
+            "name": "netuids",
+            "required": false,
+            "schema": {
+              "pattern": "^\\d+(,\\d+)*$",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
             "name": "coverage_level",
             "required": false,
             "schema": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -5021,6 +5021,7 @@ export interface operations {
         parameters: {
             query?: {
                 netuid?: number;
+                netuids?: string;
                 coverage_level?: "native-only" | "manifested" | "probed";
                 curation_level?: "native" | "candidate-discovered" | "machine-verified" | "maintainer-reviewed" | "adapter-backed";
                 status?: "active" | "inactive";

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -491,8 +491,10 @@ export const API_QUERY_COLLECTIONS = {
     sort: ["id", "kind", "path", "record_count"],
   }),
   subnets: queryCollection("subnets", {
+    csvFilters: { netuids: "netuid" },
     filters: {
       netuid: integerSchema,
+      netuids: { type: "string", pattern: "^\\d+(,\\d+)*$" },
       coverage_level: enumSchema(QUERY_ENUMS.coverageLevel),
       curation_level: enumSchema(QUERY_ENUMS.curationLevel),
       status: enumSchema(QUERY_ENUMS.subnetStatus),
@@ -1598,6 +1600,9 @@ function queryCollection(dataKey, options = {}) {
   return {
     data_key: dataKey,
     filters: options.filters || {},
+    // CSV membership filters: param name -> the row field it matches against.
+    // e.g. { netuids: "netuid" } makes `?netuids=1,7,74` return those rows.
+    csv_filters: options.csvFilters || {},
     search_keys: options.search || [],
     sort_fields: options.sort || [],
   };

--- a/tests/batch-ratelimit.test.mjs
+++ b/tests/batch-ratelimit.test.mjs
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import { handleRequest } from "../workers/api.mjs";
+
+const env = createLocalArtifactEnv();
+const get = (path) =>
+  handleRequest(new Request(`https://metagraph.sh${path}`), env, {});
+
+describe("batch subnet lookups (?netuids=)", () => {
+  test("returns only the requested netuids", async () => {
+    const res = await get("/api/v1/subnets?netuids=0,7&sort=netuid");
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    const netuids = body.data.subnets
+      .map((s) => s.netuid)
+      .sort((a, b) => a - b);
+    assert.deepEqual(netuids, [0, 7]);
+  });
+
+  test("a single netuid works", async () => {
+    const res = await get("/api/v1/subnets?netuids=7");
+    assert.equal(res.status, 200);
+    const netuids = (await res.json()).data.subnets.map((s) => s.netuid);
+    assert.deepEqual(netuids, [7]);
+  });
+
+  test("rejects a malformed netuids value with 400 invalid_query", async () => {
+    const res = await get("/api/v1/subnets?netuids=abc");
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_query");
+  });
+
+  test("the single netuid filter still works alongside", async () => {
+    const res = await get("/api/v1/subnets?netuid=7");
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).data.subnets[0].netuid, 7);
+  });
+});
+
+describe("RPC proxy rate-limit headers", () => {
+  const pool = {
+    pools: [
+      {
+        id: "finney-rpc",
+        endpoints: [
+          {
+            id: "fx",
+            provider: "fx",
+            pool_eligible: true,
+            status: "ok",
+            score: 100,
+            url: "https://bittensor-finney.api.onfinality.io/public",
+          },
+        ],
+      },
+    ],
+  };
+  const rpcEnv = {
+    METAGRAPH_ENABLE_RPC_PROXY: "true",
+    ASSETS: {
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/metagraph/rpc/pools.json") {
+          return Response.json(pool);
+        }
+        return new Response("{}", { status: 404 });
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          async json() {
+            return pool;
+          },
+        };
+      },
+    },
+  };
+
+  test("a successful proxied response carries the advisory rate-limit headers", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { peers: 1 } }),
+        { status: 200 },
+      );
+    try {
+      const res = await handleRequest(
+        new Request("https://metagraph.sh/rpc/v1/finney", {
+          method: "POST",
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "system_health",
+            params: [],
+          }),
+        }),
+        rpcEnv,
+        {},
+      );
+      assert.notEqual(res.status, 501);
+      assert.equal(res.headers.get("x-ratelimit-limit"), "100");
+      assert.equal(res.headers.get("x-ratelimit-policy"), "100;w=60");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("a rate-limited request returns 429 with Retry-After + policy", async () => {
+    const limitedEnv = {
+      ...rpcEnv,
+      RPC_RATE_LIMITER: {
+        async limit() {
+          return { success: false };
+        },
+      },
+    };
+    const res = await handleRequest(
+      new Request("https://metagraph.sh/rpc/v1/finney", {
+        method: "POST",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "system_health",
+          params: [],
+        }),
+      }),
+      limitedEnv,
+      {},
+    );
+    assert.equal(res.status, 429);
+    assert.equal((await res.json()).error.code, "rpc_rate_limited");
+    assert.equal(res.headers.get("retry-after"), "60");
+    assert.equal(res.headers.get("x-ratelimit-remaining"), "0");
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -432,7 +432,12 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
         "Too many RPC proxy requests from this client; slow down.",
         429,
         {},
-        { "retry-after": "60" },
+        {
+          "retry-after": String(RPC_RATE_LIMIT.windowSeconds),
+          "x-ratelimit-limit": String(RPC_RATE_LIMIT.limit),
+          "x-ratelimit-policy": `${RPC_RATE_LIMIT.limit};w=${RPC_RATE_LIMIT.windowSeconds}`,
+          "x-ratelimit-remaining": "0",
+        },
       );
     }
   }
@@ -558,6 +563,7 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
         const headers = new Headers(hit.headers);
         headers.set("cache-control", "no-store");
         headers.set("x-metagraph-rpc-cache", "hit");
+        setRpcRateLimitHeaders(headers);
         return new Response(
           JSON.stringify(rpcResultEnvelope(rpcBody, cachedPayload.result)),
           { status: 200, headers },
@@ -749,7 +755,21 @@ function streamRpcResponse(upstream, endpoint, attempts, status) {
   headers.set("x-metagraph-rpc-endpoint-id", endpoint.id);
   headers.set("x-metagraph-rpc-provider", endpoint.provider);
   headers.set("x-metagraph-rpc-attempts", String(attempts.length + 1));
+  setRpcRateLimitHeaders(headers);
   return new Response(upstream.body, { status: status || 502, headers });
+}
+
+// Advisory rate-limit headers on RPC proxy responses. The Cloudflare rate-limit
+// binding (RPC_RATE_LIMITER) only returns {success}, so an exact remaining/reset
+// is unavailable — we surface the static policy (mirrors wrangler.jsonc:
+// 100 requests / 60s) plus Retry-After on a 429.
+const RPC_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
+function setRpcRateLimitHeaders(headers) {
+  headers.set("x-ratelimit-limit", String(RPC_RATE_LIMIT.limit));
+  headers.set(
+    "x-ratelimit-policy",
+    `${RPC_RATE_LIMIT.limit};w=${RPC_RATE_LIMIT.windowSeconds}`,
+  );
 }
 
 // Try each ordered endpoint in turn; return the first success / non-transient
@@ -1393,13 +1413,24 @@ function applyQueryFilters(data, url, queryCollection, queryFilterNames = []) {
   });
 }
 
-function filterRows(rows, params, keys) {
+function filterRows(rows, params, keys, csvFilters = {}) {
   return rows.filter((row) =>
     keys.every((key) => {
       if (!params.has(key)) {
         return true;
       }
       const expected = params.get(key);
+      // CSV membership filter (e.g. ?netuids=1,7,74 -> match row.netuid).
+      const csvField = csvFilters[key];
+      if (csvField) {
+        const wanted = new Set(
+          expected
+            .split(",")
+            .map((value) => value.trim())
+            .filter(Boolean),
+        );
+        return wanted.has(String(row[csvField]));
+      }
       const value = row[key];
       if (Array.isArray(value)) {
         return value.map(String).includes(expected);
@@ -1420,6 +1451,7 @@ function applyListTransform(data, params, config) {
     searchRows(data[key], params, config.search_keys),
     params,
     filterKeys,
+    config.csv_filters,
   );
   const sorted = sortRows(filtered, params);
   const paginated = paginateRows(sorted, params);
@@ -1551,6 +1583,12 @@ function validateListQuery(params, config) {
       return {
         parameter: key,
         message: `${key} is not supported for this route.`,
+      };
+    }
+    if (schema.pattern && !new RegExp(schema.pattern).test(value)) {
+      return {
+        parameter: key,
+        message: `${key} is not in the expected format.`,
       };
     }
   }


### PR DESCRIPTION
## What

Two quick DX wins:

- **Batch lookups** — `GET /api/v1/subnets?netuids=1,7,74` returns just those subnets in one call. Adds a generic **CSV-membership filter** (`csv_filters` maps a query param to a row field), so `?netuids` matches `row.netuid`; the single `?netuid` integer filter is unchanged. `validateListQuery` now also enforces a filter's string `pattern`, so `?netuids=abc` → `400 invalid_query`.
- **RPC rate-limit headers** — successful proxy responses (incl. cache hits) and the 429 now carry `X-RateLimit-Limit` + `X-RateLimit-Policy` (`100;w=60`, mirroring `wrangler.jsonc`); the 429 adds `X-RateLimit-Remaining: 0` alongside `Retry-After`.

## Constraint (documented in code)

Cloudflare's `RPC_RATE_LIMITER.limit()` returns only `{success}` — an exact remaining/reset isn't available from the binding, so we surface the **static policy** + `Retry-After`. A precise counter would need a KV tally (out of scope).

## Verification

- `tests/batch-ratelimit.test.mjs`: batch filtering (multi, single, malformed→400, single+plural coexistence), success-path + 429 header assertions.
- 239 tests, `lint`, `prettier`, `validate:api/openapi/schemas/types/docs` (45 routes) all green. Reproducible contract artifacts (subset-commit).