### PR TITLE
chore(routing): API + artifacts on api.metagraph.sh; UI owns the apex

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -268,4 +268,4 @@ jobs:
           echo "::error::smoke:live still failing after retries"
           exit 1
         env:
-          METAGRAPH_LIVE_BASE_URL: https://metagraph.sh
+          METAGRAPH_LIVE_BASE_URL: https://api.metagraph.sh

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ The native Bittensor metagraph tells you what is happening at the subnet protoco
 Example routes:
 
 - `https://metagraph.sh/subnets/7`
-- `https://metagraph.sh/metagraph/subnets.json`
-- `https://metagraph.sh/metagraph/health/subnets/7.json`
-- `https://metagraph.sh/metagraph/health/badges/7.json`
+- `https://api.metagraph.sh/metagraph/subnets.json`
+- `https://api.metagraph.sh/metagraph/health/subnets/7.json`
+- `https://api.metagraph.sh/metagraph/health/badges/7.json`
 
 ## What This Is
 
@@ -125,7 +125,7 @@ The generated files are deterministic and suitable for static hosting, R2-backed
 Every subnet has a self-hosted SVG health badge (no third-party badge service):
 
 ```markdown
-![Allways SN7 health](https://metagraph.sh/metagraph/health/badges/7.svg)
+![Allways SN7 health](https://api.metagraph.sh/metagraph/health/badges/7.svg)
 ```
 
 Badges render from the published `/metagraph/health/badges/{netuid}.json`

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -1,7 +1,7 @@
 # Metagraphed API Stability Contract (`/api/v1`)
 
 This is the consumer-facing stability contract for the Worker API served from
-`https://metagraph.sh/api/v1/*`. It is the reference for the frontend
+`https://api.metagraph.sh/api/v1/*`. It is the reference for the frontend
 (`jsonbored/metagraph-finder`) and any external integrator. The canonical machine
 contract is `public/metagraph/openapi.json` plus the generated
 `generated/metagraphed-api.d.ts` and `generated/metagraphed-client.ts`; this doc
@@ -57,7 +57,7 @@ and only changes on a breaking envelope change.
 
 ## Raw Artifact Routes
 
-`https://metagraph.sh/metagraph/*.json` returns the raw artifact (no envelope) for
+`https://api.metagraph.sh/metagraph/*.json` returns the raw artifact (no envelope) for
 any path in the published artifact contract, with `x-metagraph-artifact-source` and
 `x-metagraph-storage-tier` headers. The enveloped `/api/v1/*` routes are preferred
 for app consumption; raw routes are convenient for static/diff tooling.
@@ -71,7 +71,7 @@ for app consumption; raw routes are convenient for static/diff tooling.
 
 ## Operational Route: `/health`
 
-`GET https://metagraph.sh/health` is a no-I/O readiness probe (not part of the
+`GET https://api.metagraph.sh/health` is a no-I/O readiness probe (not part of the
 versioned `/api/v1` contract). It returns `200` with
 `{ status, service, contract_version, rpc_proxy_enabled, bindings: { assets, r2,
 kv } }` so uptime checks and load balancers can confirm the Worker is live and
@@ -149,22 +149,22 @@ Copy-paste against the live beta (`https://metagraph.sh`):
 
 ```bash
 # Registry-wide coverage + the completeness scoreboard (the headline metric)
-curl -s https://metagraph.sh/api/v1/coverage | jq '.data.completeness'
+curl -s https://api.metagraph.sh/api/v1/coverage | jq '.data.completeness'
 
 # Completeness leaderboard — subnets that most need contributions first
-curl -s 'https://metagraph.sh/api/v1/profiles?sort=completeness_score&order=asc&limit=10' \
+curl -s 'https://api.metagraph.sh/api/v1/profiles?sort=completeness_score&order=asc&limit=10' \
   | jq '.data.profiles[] | {netuid, name, completeness_score}'
 
 # One subnet's full profile (identity, surfaces, gaps)
-curl -s https://metagraph.sh/api/v1/subnets/7/profile | jq '.data'
+curl -s https://api.metagraph.sh/api/v1/subnets/7/profile | jq '.data'
 
 # Search across the registry
-curl -s 'https://metagraph.sh/api/v1/search?q=gittensor' | jq '.data'
+curl -s 'https://api.metagraph.sh/api/v1/search?q=gittensor' | jq '.data'
 
 # Probe-derived health for a subnet + its embeddable badge
-curl -s https://metagraph.sh/api/v1/subnets/7/health | jq '.data'
-#   <img src="https://metagraph.sh/metagraph/health/badges/7.svg">
+curl -s https://api.metagraph.sh/api/v1/subnets/7/health | jq '.data'
+#   <img src="https://api.metagraph.sh/metagraph/health/badges/7.svg">
 
 # Worker readiness (not part of /api/v1)
-curl -s https://metagraph.sh/health | jq
+curl -s https://api.metagraph.sh/health | jq
 ```

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -1,6 +1,6 @@
 # Metagraphed Backend Artifact Contracts
 
-Metagraphed v1 is backend-first. The public contract is static JSON under `https://metagraph.sh/metagraph/*`; UI work can consume these artifacts later without changing the registry pipeline.
+Metagraphed v1 is backend-first. The public contract is static JSON under `https://api.metagraph.sh/metagraph/*`; UI work can consume these artifacts later without changing the registry pipeline.
 
 ## Contract Rules
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -127,7 +127,7 @@ METAGRAPH_ALLOW_R2_DOWNLOAD=1 npm run r2:download
   refresh advances every ~6h.
 - When the data is older than `max_age_hours` (default 12 — two missed 6h refreshes;
   override with `METAGRAPH_HEALTH_MAX_AGE_HOURS`), `status` becomes `degraded` and the
-  route returns **HTTP 503**. Point an uptime monitor at `https://metagraph.sh/health`
+  route returns **HTTP 503**. Point an uptime monitor at `https://api.metagraph.sh/health`
   so a silently-broken data-refresh pages instead of serving stale data unnoticed.
 - A present-but-stale pointer trips it; a missing pointer (local/dev) stays `ok`.
 
@@ -164,7 +164,7 @@ Before flipping the flag:
      action: managed challenge/block) to absorb distributed abuse;
    - a **custom rule** to block non-`POST` methods and oversized bodies on `/rpc/*`;
    - ensure the zone's Managed Ruleset / Bot Fight Mode is on.
-2. **Verify the pool.** `curl https://metagraph.sh/metagraph/rpc/pools.json` and confirm
+2. **Verify the pool.** `curl https://api.metagraph.sh/metagraph/rpc/pools.json` and confirm
    at least one endpoint per pool has `"pool_eligible": true` (otherwise the proxy
    returns `503 rpc_endpoint_unavailable`).
 3. **Flip the flag.** Set `METAGRAPH_ENABLE_RPC_PROXY` to `"true"` in `wrangler.jsonc`;

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -793,7 +793,7 @@ export interface components {
             /** @constant */
             openapi_url: "/api/v1/openapi.json";
             /** @constant */
-            primary_domain: "metagraph.sh";
+            primary_domain: "api.metagraph.sh";
             response_envelope: components["schemas"]["ResponseEnvelopeContract"];
             routes: components["schemas"]["ApiRoute"][];
             /** @constant */
@@ -944,7 +944,7 @@ export interface components {
             /** @constant */
             openapi_url: "/metagraph/openapi.json";
             /** @constant */
-            primary_domain: "metagraph.sh";
+            primary_domain: "api.metagraph.sh";
             status_domain: null;
             /** @constant */
             type_definitions_url: "/metagraph/types.d.ts";

--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -67,7 +67,7 @@ export async function metagraphedFetch<Path extends ApiPath>(
   path: Path,
   options: MetagraphedFetchOptions<Path> = {},
 ): Promise<JsonResponse<Path>> {
-  const { baseUrl = "https://metagraph.sh", pathParams, query, ...init } =
+  const { baseUrl = "https://api.metagraph.sh", pathParams, query, ...init } =
     options;
   const resolvedPath = interpolatePath(
     String(path),

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -404,7 +404,7 @@
   "contract_version": "2026-06-06.1",
   "generated_at": "1970-01-01T00:00:00.000Z",
   "openapi_url": "/api/v1/openapi.json",
-  "primary_domain": "metagraph.sh",
+  "primary_domain": "api.metagraph.sh",
   "response_envelope": {
     "error_schema_ref": "#/components/schemas/ErrorEnvelope",
     "fields": [

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -525,7 +525,7 @@
     "Health and schema artifacts are operational observations, not protocol authority."
   ],
   "openapi_url": "/metagraph/openapi.json",
-  "primary_domain": "metagraph.sh",
+  "primary_domain": "api.metagraph.sh",
   "schema_version": 1,
   "status_domain": null,
   "type_definitions_url": "/metagraph/types.d.ts"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -79,7 +79,7 @@
                 "const": "/api/v1/openapi.json"
               },
               "primary_domain": {
-                "const": "metagraph.sh"
+                "const": "api.metagraph.sh"
               },
               "response_envelope": {
                 "$ref": "#/components/schemas/ResponseEnvelopeContract"
@@ -694,7 +694,7 @@
                 "const": "/metagraph/openapi.json"
               },
               "primary_domain": {
-                "const": "metagraph.sh"
+                "const": "api.metagraph.sh"
               },
               "status_domain": {
                 "type": "null"
@@ -14595,7 +14595,7 @@
   "servers": [
     {
       "description": "Production",
-      "url": "https://metagraph.sh"
+      "url": "https://api.metagraph.sh"
     }
   ],
   "x-metagraphed": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -793,7 +793,7 @@ export interface components {
             /** @constant */
             openapi_url: "/api/v1/openapi.json";
             /** @constant */
-            primary_domain: "metagraph.sh";
+            primary_domain: "api.metagraph.sh";
             response_envelope: components["schemas"]["ResponseEnvelopeContract"];
             routes: components["schemas"]["ApiRoute"][];
             /** @constant */
@@ -944,7 +944,7 @@ export interface components {
             /** @constant */
             openapi_url: "/metagraph/openapi.json";
             /** @constant */
-            primary_domain: "metagraph.sh";
+            primary_domain: "api.metagraph.sh";
             status_domain: null;
             /** @constant */
             type_definitions_url: "/metagraph/types.d.ts";

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -65,7 +65,7 @@
                 "const": "/api/v1/openapi.json"
               },
               "primary_domain": {
-                "const": "metagraph.sh"
+                "const": "api.metagraph.sh"
               },
               "response_envelope": {
                 "$ref": "#/components/schemas/ResponseEnvelopeContract"
@@ -680,7 +680,7 @@
                 "const": "/metagraph/openapi.json"
               },
               "primary_domain": {
-                "const": "metagraph.sh"
+                "const": "api.metagraph.sh"
               },
               "status_domain": {
                 "type": "null"

--- a/schemas/components/10-contracts-build.schema.json
+++ b/schemas/components/10-contracts-build.schema.json
@@ -97,7 +97,7 @@
                 "const": "/metagraph/openapi.json"
               },
               "primary_domain": {
-                "const": "metagraph.sh"
+                "const": "api.metagraph.sh"
               },
               "status_domain": {
                 "type": "null"
@@ -140,7 +140,7 @@
                 "const": "/api/v1/openapi.json"
               },
               "primary_domain": {
-                "const": "metagraph.sh"
+                "const": "api.metagraph.sh"
               },
               "response_envelope": {
                 "$ref": "#/components/schemas/ResponseEnvelopeContract"

--- a/scripts/cloudflare-verify.mjs
+++ b/scripts/cloudflare-verify.mjs
@@ -91,12 +91,12 @@ check(
   "R2 manifest artifacts must include sha256 and /metagraph paths",
 );
 check(
-  contracts.primary_domain === "metagraph.sh",
-  "contracts primary domain must be metagraph.sh",
+  contracts.primary_domain === "api.metagraph.sh",
+  "contracts primary domain must be api.metagraph.sh",
 );
 check(
-  apiIndex.primary_domain === "metagraph.sh",
-  "api index primary domain must be metagraph.sh",
+  apiIndex.primary_domain === "api.metagraph.sh",
+  "api index primary domain must be api.metagraph.sh",
 );
 
 if (!kvBinding && requireKvBinding) {

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -87,7 +87,7 @@ export async function metagraphedFetch<Path extends ApiPath>(
   path: Path,
   options: MetagraphedFetchOptions<Path> = {},
 ): Promise<JsonResponse<Path>> {
-  const { baseUrl = "https://metagraph.sh", pathParams, query, ...init } =
+  const { baseUrl = "https://api.metagraph.sh", pathParams, query, ...init } =
     options;
   const resolvedPath = interpolatePath(
     String(path),

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import { API_ROUTES } from "../src/contracts.mjs";
 
-const DEFAULT_BASE_URL = "https://metagraph.sh";
+const DEFAULT_BASE_URL = "https://api.metagraph.sh";
 const baseUrl = normalizeBaseUrl(
   process.env.METAGRAPH_LIVE_BASE_URL || DEFAULT_BASE_URL,
 );

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -315,7 +315,7 @@ const checks = [
   ],
   [
     "/api/v1/contracts",
-    (body) => assert.equal(body.data.primary_domain, "metagraph.sh"),
+    (body) => assert.equal(body.data.primary_domain, "api.metagraph.sh"),
   ],
   ["/api/v1/openapi.json", (body) => assert.equal(body.data.openapi, "3.1.0")],
   [

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1004,8 +1004,8 @@ async function validateGeneratedArtifacts(
     "type definitions artifact: public/metagraph/types.d.ts is required",
   );
   assert(
-    contractsArtifact.primary_domain === "metagraph.sh",
-    "contracts artifact: primary_domain must be metagraph.sh",
+    contractsArtifact.primary_domain === "api.metagraph.sh",
+    "contracts artifact: primary_domain must be api.metagraph.sh",
   );
   assert(
     contractsArtifact.status_domain === null,
@@ -1041,8 +1041,8 @@ async function validateGeneratedArtifacts(
     );
   }
   assert(
-    apiIndexArtifact.primary_domain === "metagraph.sh",
-    "api index: primary_domain must be metagraph.sh",
+    apiIndexArtifact.primary_domain === "api.metagraph.sh",
+    "api index: primary_domain must be api.metagraph.sh",
   );
   assert(
     Array.isArray(apiIndexArtifact.routes),

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -2,7 +2,10 @@ import { artifactStorageTierForPath } from "./artifact-storage.mjs";
 
 export const CONTRACT_VERSION = "2026-06-06.1";
 export const SCHEMA_VERSION = 1;
-export const PRIMARY_DOMAIN = "metagraph.sh";
+// The API + artifacts are served from the api subdomain; the bare apex
+// (metagraph.sh) is the metagraph-finder UI. PRIMARY_DOMAIN drives the OpenAPI
+// server URL and the consumer metadata in contracts.json / api-index.json.
+export const PRIMARY_DOMAIN = "api.metagraph.sh";
 export const API_BASE_PATH = "/api/v1";
 export const ARTIFACT_BASE_PATH = "/metagraph";
 export const TYPE_DEFINITIONS_PATH = "/metagraph/types.d.ts";

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -816,7 +816,7 @@ test("public artifacts are internally consistent", () => {
     true,
   );
   assert.equal(reviewQueue.count, reviewQueue.candidates.length);
-  assert.equal(contracts.primary_domain, "metagraph.sh");
+  assert.equal(contracts.primary_domain, "api.metagraph.sh");
   assert.equal(contracts.status_domain, null);
   assert.equal(
     contracts.artifacts.some(

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -107,7 +107,7 @@ describe("public contract registry", () => {
       await loadOpenApiComponentSchemas(generatedAt),
     );
 
-    assert.equal(contracts.primary_domain, "metagraph.sh");
+    assert.equal(contracts.primary_domain, "api.metagraph.sh");
     assert.equal(contracts.openapi_url, "/metagraph/openapi.json");
     assert.equal(contracts.type_definitions_url, "/metagraph/types.d.ts");
     assert.equal(apiIndex.openapi_url, "/api/v1/openapi.json");

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -197,7 +197,7 @@ async function handleRawArtifactRequest(request, env, url) {
 }
 
 // Self-hosted SVG health badges for subnet READMEs, e.g.
-// ![](https://metagraph.sh/metagraph/health/badges/7.svg) — no shields.io
+// ![](https://api.metagraph.sh/metagraph/health/badges/7.svg) — no shields.io
 // dependency, which drives backlinks/adoption. Rendered from the badge JSON
 // artifact (label/message/color), degrading to a neutral "unavailable" badge.
 const BADGE_SVG_PATTERN = /^\/metagraph\/health\/badges\/(\d+)\.svg$/;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -32,10 +32,7 @@
     "METAGRAPH_R2_LATEST_PREFIX": "latest/",
   },
   "routes": [
-    {
-      "pattern": "metagraph.sh",
-      "custom_domain": true,
-    },
+    { "pattern": "api.metagraph.sh", "custom_domain": true },
   ],
   "kv_namespaces": [
     {


### PR DESCRIPTION
## What

Makes the repo consistent with the **now-live** subdomain split:
- **`metagraph.sh`** → metagraph-finder **UI** (custom_domain on the frontend Worker).
- **`api.metagraph.sh`** → backend **API + artifacts** (custom_domain on `metagraphed`).

Both are deployed and verified live. This PR aligns the code/config so nothing reverts:
- `wrangler.jsonc`: `custom_domain metagraph.sh` → `api.metagraph.sh` (Workers Builds keeps the backend on the api subdomain).
- `PRIMARY_DOMAIN = api.metagraph.sh` → OpenAPI server URL + `primary_domain` metadata.
- SDK default `baseUrl` + generated client → `https://api.metagraph.sh`.
- `smoke-live-api` default + `publish-cloudflare.yml` `METAGRAPH_LIVE_BASE_URL` → `https://api.metagraph.sh` (so the 6h publish smoke hits the API, not the UI).
- docs/README API + badge URLs → `api.metagraph.sh`; schema `const`/validators/tests updated.

## Verification

246 tests, `lint`, `validate:api/openapi/schemas/types/docs/workflows` green; committed contract artifacts reproduce (subset-commit). Live: `metagraph.sh/` → UI, `api.metagraph.sh/api/v1/*` → API, both 200.