### PR TITLE
ci(sdk): npm trusted publishing (OIDC) for @metagraphed/client

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -1,43 +1,101 @@
 name: Publish client SDK
 
-# Publishes @metagraphed/client (packages/client) to npm. Triggered by a GitHub
-# Release (or manual dispatch). The package syncs the committed generated client
-# + API types at build time, so it always tracks the live /api/v1 contract.
-# Requires the NPM_TOKEN secret; provenance is attached via OIDC.
+# Publishes @metagraphed/client (packages/client) to npm via OIDC trusted
+# publishing — no NPM_TOKEN. Manual trigger; the version is read from
+# packages/client/package.json. Requires a one-time npm-side setup (see
+# packages/client/PUBLISHING.md): the @metagraphed org, a first bootstrap
+# publish, and a Trusted Publisher pointing at this repo + workflow + the
+# `npm-production` environment.
 on:
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: publish-client-${{ github.ref }}
+  group: client-package-release
   cancel-in-progress: false
 
 jobs:
-  publish:
+  validate:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node
+      - name: Setup Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 22
+          node-version: 24.16.0
           registry-url: https://registry.npmjs.org
 
-      - name: Build and publish @metagraphed/client
+      - name: Validate release version
+        run: bash scripts/validate-client-release.sh
+
+      - name: Build + pack dry-run
         working-directory: packages/client
         run: |
           npm install --no-audit --no-fund
-          npm publish --access public --provenance
+          npm run build
+          npm pack --dry-run
+
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: validate
+    environment: npm-production
+    permissions:
+      contents: write
+      id-token: write
+    concurrency:
+      group: client-package-release
+      cancel-in-progress: false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 24.16.0
+          registry-url: https://registry.npmjs.org
+
+      - name: Validate release version
+        id: release
+        run: bash scripts/validate-client-release.sh
+
+      - name: Build
+        working-directory: packages/client
+        run: |
+          npm install --no-audit --no-fund
+          npm run build
+
+      - name: Publish to npm (OIDC trusted publishing)
+        working-directory: packages/client
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: "true"
+        run: npm publish --access public --provenance --ignore-scripts
+
+      - name: Tag + GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$RELEASE_TAG" -m "@metagraphed/client v$RELEASE_VERSION"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          gh auth setup-git
+          git push origin "$RELEASE_TAG"
+          gh release create "$RELEASE_TAG" \
+            --title "@metagraphed/client v$RELEASE_VERSION" \
+            --notes "Published \`@metagraphed/client@$RELEASE_VERSION\` to npm with provenance via OIDC trusted publishing. https://www.npmjs.com/package/@metagraphed/client/v/$RELEASE_VERSION"

--- a/packages/client/PUBLISHING.md
+++ b/packages/client/PUBLISHING.md
@@ -1,0 +1,44 @@
+# Publishing `@metagraphed/client`
+
+Releases use **npm OIDC trusted publishing** — no `NPM_TOKEN` is stored. The
+`publish-client.yml` workflow authenticates to npm via GitHub's OIDC token and
+publishes with provenance. Same pattern as `@heyclaude/mcp`.
+
+## One-time setup (npm side — must be done once before the first OIDC release)
+
+npm requires a package to **exist** before you can attach a Trusted Publisher, so
+a brand-new package needs a bootstrap step:
+
+1. **Create the `@metagraphed` org on npmjs.com** (free for public packages):
+   npmjs.com → your avatar → _Add organization_ → `metagraphed`.
+2. **Bootstrap the package so it exists** (pick one):
+   - Modern (npm 11.10.0+): `npm trust` to register the trusted publisher without
+     a placeholder publish, **or**
+   - Bootstrap publish from a clean checkout of `main`:
+     ```sh
+     npm login                       # interactive; or use a granular token once
+     cd packages/client && npm publish --access public
+     ```
+     (One-time only; all later releases are tokenless via the workflow.)
+3. **Add the Trusted Publisher** at npmjs.com → package `@metagraphed/client` →
+   _Settings_ → _Trusted Publisher_ → **GitHub Actions**:
+   - Organization or user: `JSONbored`
+   - Repository: `metagraphed`
+   - Workflow filename: `publish-client.yml`
+   - Environment name: `npm-production`
+   - Allowed action: `npm publish`
+4. **Create the `npm-production` GitHub Environment** (repo → Settings →
+   Environments → `npm-production`; add required reviewers if you want a manual
+   approval gate before each publish).
+
+## Cutting a release (every time after setup)
+
+1. Bump `version` in `packages/client/package.json` on `main` (strict semver, no
+   `v` prefix) and merge.
+2. Run the **Publish client SDK** workflow (Actions → _Publish client SDK_ →
+   _Run workflow_). It validates the version (tag + npm version must not already
+   exist), builds, `npm publish --provenance` via OIDC, then creates the
+   `client-v<version>` tag + a GitHub release.
+
+Requirements (handled by the workflow): npm CLI ≥ 11.5.1, Node ≥ 22.14
+(workflow pins 24.16.0), `id-token: write`, `registry-url: https://registry.npmjs.org`.

--- a/scripts/validate-client-release.sh
+++ b/scripts/validate-client-release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Gate the @metagraphed/client npm release: run from main, read the version from
+# packages/client/package.json, require strict semver, and refuse if the git tag
+# or the npm version already exists. Mirrors the awesome-claude MCP release gate.
+set -euo pipefail
+
+if [ "${GITHUB_REF:-}" != "refs/heads/main" ]; then
+  echo "::error::@metagraphed/client releases must run from main."
+  exit 1
+fi
+if [ -z "${GITHUB_OUTPUT:-}" ]; then
+  echo "::error::GITHUB_OUTPUT is required."
+  exit 1
+fi
+
+release_version="$(node -p "require('./packages/client/package.json').version")"
+if ! printf '%s' "$release_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "::error::packages/client/package.json version must be strict semver without a v prefix."
+  exit 1
+fi
+
+release_tag="client-v$release_version"
+if git rev-parse "$release_tag" >/dev/null 2>&1; then
+  echo "::error::Release tag already exists: $release_tag"
+  exit 1
+fi
+if npm view "@metagraphed/client@$release_version" version >/dev/null 2>&1; then
+  echo "::error::npm version already exists: @metagraphed/client@$release_version"
+  exit 1
+fi
+
+{
+  echo "version=$release_version"
+  echo "tag=$release_tag"
+} >> "$GITHUB_OUTPUT"
+echo "Releasing @metagraphed/client@$release_version (tag $release_tag)."


### PR DESCRIPTION
## What

Reworks `publish-client.yml` to **tokenless OIDC trusted publishing** — matching your `@heyclaude/mcp` pattern in awesome-claude. **No `NPM_TOKEN`.**

- **validate** job: version gate (`scripts/validate-client-release.sh` — strict semver, refuses if the `client-v<version>` tag or the npm version already exists) + build + `npm pack --dry-run`.
- **publish** job: `environment: npm-production`, `permissions: id-token: write`, `npm publish --access public --provenance --ignore-scripts`, then creates the `client-v<version>` tag + a GitHub release.
- Node `24.16.0` + `registry-url` (npm ≥ 11.5.1 for OIDC). Pinned action SHAs.
- `packages/client/PUBLISHING.md`: the one-time npm-side setup + the per-release flow.

## One-time npm setup (your side — see PUBLISHING.md)

npm requires the package to exist before a Trusted Publisher can be attached, so a new package needs a bootstrap:
1. Create the **`@metagraphed` org** on npmjs.com.
2. Bootstrap so the package exists: `npm trust` (npm 11.10.0+) **or** one bootstrap `npm publish` (one-time; all later releases are tokenless).
3. Add the **Trusted Publisher**: GitHub Actions, `JSONbored/metagraphed`, workflow `publish-client.yml`, environment `npm-production`, action `npm publish`.
4. Create the **`npm-production` GitHub Environment** (optional reviewers for an approval gate).

Then: bump `packages/client/package.json` version → run *Publish client SDK*. `validate:workflows`/`scan:public-safety` green; release script syntax-checked.