### PR TITLE
fix(ci): isolate npm publish token

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -17,7 +17,41 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+
+      - name: Install and build @metagraphed/client
+        working-directory: packages/client
+        run: |
+          npm ci --no-audit --no-fund
+          npm run build
+
+      - name: Upload client package
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: metagraphed-client-package
+          path: |
+            packages/client/dist
+            packages/client/README.md
+            packages/client/package.json
+          if-no-files-found: error
+          retention-days: 1
+
   publish:
+    needs: build
+    if: github.event_name == 'release' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -34,10 +68,14 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
-      - name: Build and publish @metagraphed/client
+      - name: Download built client package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: metagraphed-client-package
+          path: packages/client
+
+      - name: Publish @metagraphed/client
         working-directory: packages/client
-        run: |
-          npm install --no-audit --no-fund
-          npm publish --access public --provenance
+        run: npm publish --access public --provenance --ignore-scripts
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
### Motivation
- Prevent accidental disclosure of `NODE_AUTH_TOKEN` to dependency install or package lifecycle scripts during publish. 
- Ensure build tooling and third-party install scripts run in a tokenless, non-provenance context and only the final publish step holds the publish secret. 
- Limit manual publish entry points so secret-bearing runs are restricted to release events and `main` branch triggers. 

### Description
- Split the single `publish` job into a `build` job and a dependent `publish` job in `.github/workflows/publish-client.yml`. 
- The `build` job runs `npm ci` and `npm run build` in `packages/client` without any `NODE_AUTH_TOKEN` and uploads only the publishable artifacts using `actions/upload-artifact`. 
- The `publish` job downloads the pre-built artifacts with `actions/download-artifact`, runs `npm publish --ignore-scripts` to avoid executing lifecycle scripts, and exposes `NODE_AUTH_TOKEN` only for the publish command. 
- Added an `if` guard so manual `workflow_dispatch` publishes only run on `refs/heads/main` while preserving release-triggered publishes, and kept `id-token: write` limited to the final publish job. 

### Testing
- Ran workflow validation with `npm run validate:workflows` which printed "Validated 7 workflow file(s)." and exited successfully. 
- Ran repository build with `npm run build` which completed artifact generation and client codegen steps successfully. 
- Produced a client package preview with `cd packages/client && npm pack --dry-run --ignore-scripts` which produced `metagraphed-client-0.1.0.tgz` successfully. 
- Attempted to run `cd packages/client && npm run build` but the client build failed because `tsup` could not be fetched from the registry (403 Forbidden), so local dev-tooling install failed and prevented a full local build of the client package.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29e33313ac832a8949072a8ed4075b)