### PR TITLE
fix(ci): isolate npm trusted publish job

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -36,12 +36,27 @@ jobs:
       - name: Validate release version
         run: bash scripts/validate-client-release.sh
 
-      - name: Build + pack dry-run
+      - name: Build package tarball
         working-directory: packages/client
         run: |
+          set -euo pipefail
           npm install --no-audit --no-fund
           npm run build
-          npm pack --dry-run
+          npm pack --pack-destination "$RUNNER_TEMP"
+          tarball_count=$(find "$RUNNER_TEMP" -maxdepth 1 -type f -name "*.tgz" | wc -l | tr -d ' ')
+          if [ "$tarball_count" != "1" ]; then
+            echo "Expected exactly one package tarball, found $tarball_count" >&2
+            find "$RUNNER_TEMP" -maxdepth 1 -type f -name "*.tgz" -print >&2
+            exit 1
+          fi
+
+      - name: Upload package tarball
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: client-package-tarball
+          path: ${{ runner.temp }}/*.tgz
+          if-no-files-found: error
+          retention-days: 7
 
   publish:
     runs-on: ubuntu-latest
@@ -71,17 +86,25 @@ jobs:
         id: release
         run: bash scripts/validate-client-release.sh
 
-      - name: Build
-        working-directory: packages/client
-        run: |
-          npm install --no-audit --no-fund
-          npm run build
+      - name: Download package tarball
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: client-package-tarball
+          path: ${{ runner.temp }}/client-package
 
       - name: Publish to npm (OIDC trusted publishing)
-        working-directory: packages/client
         env:
           NPM_CONFIG_PROVENANCE: "true"
-        run: npm publish --access public --provenance --ignore-scripts
+        run: |
+          set -euo pipefail
+          tarball_count=$(find "$RUNNER_TEMP/client-package" -maxdepth 1 -type f -name "*.tgz" | wc -l | tr -d ' ')
+          if [ "$tarball_count" != "1" ]; then
+            echo "Expected exactly one package tarball, found $tarball_count" >&2
+            find "$RUNNER_TEMP/client-package" -maxdepth 1 -type f -name "*.tgz" -print >&2
+            exit 1
+          fi
+          tarball=$(find "$RUNNER_TEMP/client-package" -maxdepth 1 -type f -name "*.tgz" -print -quit)
+          npm publish "$tarball" --access public --provenance --ignore-scripts
 
       - name: Tag + GitHub release
         env:

--- a/packages/client/PUBLISHING.md
+++ b/packages/client/PUBLISHING.md
@@ -37,8 +37,11 @@ Trusted Publisher, so a brand-new package needs one bootstrap step:
    `v` prefix) and merge.
 2. Run the **Publish client SDK** workflow (Actions → _Publish client SDK_ →
    _Run workflow_). It validates the version (tag + npm version must not already
-   exist), builds, `npm publish --provenance` via OIDC, then creates the
-   `client-v<version>` tag + a GitHub release.
+   exist), builds and packs the SDK in an unprivileged validation job, then the
+   `npm-production` job downloads that exact tarball and runs
+   `npm publish --provenance` via OIDC before creating the `client-v<version>`
+   tag + a GitHub release.
 
 Requirements (handled by the workflow): npm CLI ≥ 11.5.1, Node ≥ 22.14
-(workflow pins 24.16.0), `id-token: write`, `registry-url: https://registry.npmjs.org`.
+(workflow pins 24.16.0), `id-token: write` only on the tarball-publishing job,
+`registry-url: https://registry.npmjs.org`.


### PR DESCRIPTION
### Motivation
- The current publish workflow granted `id-token: write` to a job that also runs `npm install` and `npm run build`, exposing OIDC tokens to dependency lifecycle scripts. 
- A compromised dependency or build tool could use that token to publish a malicious tarball with trusted provenance. 
- The goal is to separate unprivileged build steps from the OIDC-enabled publish step so only a prebuilt tarball is published.

### Description
- Changed `.github/workflows/publish-client.yml` `validate` job to build the client, run `npm pack --pack-destination "$RUNNER_TEMP"`, verify exactly one `.tgz`, and upload it with `actions/upload-artifact` as `client-package-tarball`.
- Modified the `publish` job to `download` the `client-package-tarball`, verify a single tarball in the artifact directory, and run `npm publish <tarball> --access public --provenance --ignore-scripts` without running `npm install` or `npm run build` in the OIDC-enabled job.
- Updated `packages/client/PUBLISHING.md` to document the separated build/pack (unprivileged) and tarball-only OIDC publish flow and note that `id-token: write` applies only to the tarball-publishing job.

### Testing
- Ran YAML syntax check with `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/publish-client.yml")'`, which succeeded. 
- Ran `git diff --check` which reported no whitespace or diff errors. 
- Executed `bash scripts/validate-client-release.sh`, which failed as expected because the script requires running on `main`. 
- Attempted `cd packages/client && npm run build` to validate local pack behavior, which failed due to `tsup` not being available in the local environment (dev dependencies were not installed), so full local build could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29ec279da8832aad4965b6dd5f9766)