### PR TITLE
feat(health): Phase 1 — probe core, operational-surfaces, D1 (live-health foundations)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -11,4 +11,5 @@ registry/candidates/generated
 registry/subnets/generated
 registry/verification
 registry/adapters/latest
+migrations
 tmp

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -63,6 +63,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/rpc/pools.json`: endpoint pool scoring for future read-only routing.
 - `/metagraph/endpoint-pools.json`: generalized endpoint pool scoring for future read-only routing.
 - `/metagraph/endpoint-incidents.json`: probe-derived endpoint incident summary and active endpoint failures.
+- `/metagraph/operational-surfaces.json`: operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the 2-minute Cloudflare cron health prober; the prober's input list, served from the committed assets.
 - `/metagraph/schema-drift.json`: OpenAPI snapshot/drift status.
 - `/metagraph/schemas/index.json`: captured machine-readable schema index.
 - `/metagraph/schemas/{surface_id}.json`: captured machine-readable OpenAPI/Swagger schema snapshot detail. R2-backed.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1401,6 +1401,33 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        OperationalSurfacesArtifact: components["schemas"]["ArtifactBase"] & ({
+            kinds: string[];
+            surface_count: number;
+            surfaces: ({
+                auth_required?: boolean;
+                authority?: string;
+                kind: string;
+                netuid: number;
+                probe: {
+                    expect: string;
+                    method: string;
+                    timeout_ms?: number | null;
+                } & {
+                    [key: string]: unknown;
+                };
+                provider?: string;
+                public_safe?: boolean;
+                subnet_name?: string;
+                subnet_slug?: string;
+                surface_id: string;
+                url: string;
+            } & {
+                [key: string]: unknown;
+            })[];
+        } & {
+            [key: string]: unknown;
+        });
         PaginationMeta: {
             collection: string;
             cursor: number;

--- a/migrations/0001_health.sql
+++ b/migrations/0001_health.sql
@@ -1,0 +1,47 @@
+-- Live operational-health store (Phase 1).
+--
+-- Written every 2 minutes by the Cloudflare cron prober (src/health-prober.mjs)
+-- and read live by the serving layer (workers/api.mjs). Decoupled from the 6h
+-- build pipeline: a stale structural snapshot can never freeze health again.
+--
+-- `surface_checks` is the append-only time-series (powers /health/trends and is
+-- pruned by the hourly cron). `surface_status` is the upserted latest row per
+-- surface (powers live serving + the cross-isolate circuit-breaker counter).
+
+CREATE TABLE IF NOT EXISTS surface_checks (
+  surface_id     TEXT    NOT NULL,
+  netuid         INTEGER NOT NULL,
+  kind           TEXT    NOT NULL,
+  status         TEXT    NOT NULL,            -- ok | degraded | failed | unknown
+  classification TEXT,
+  latency_ms     INTEGER,
+  status_code    INTEGER,
+  ok             INTEGER NOT NULL DEFAULT 0,  -- 1 when status = 'ok', else 0
+  checked_at     INTEGER NOT NULL             -- epoch milliseconds
+);
+
+CREATE INDEX IF NOT EXISTS idx_surface_checks_surface_time
+  ON surface_checks (surface_id, checked_at);
+CREATE INDEX IF NOT EXISTS idx_surface_checks_netuid_time
+  ON surface_checks (netuid, checked_at);
+CREATE INDEX IF NOT EXISTS idx_surface_checks_time
+  ON surface_checks (checked_at);
+
+CREATE TABLE IF NOT EXISTS surface_status (
+  surface_id           TEXT PRIMARY KEY,
+  netuid               INTEGER NOT NULL,
+  kind                 TEXT    NOT NULL,
+  url                  TEXT,
+  provider             TEXT,
+  status               TEXT    NOT NULL,
+  classification       TEXT,
+  latency_ms           INTEGER,
+  status_code          INTEGER,
+  last_checked         INTEGER,               -- epoch milliseconds
+  last_ok              INTEGER,               -- epoch milliseconds
+  consecutive_failures INTEGER NOT NULL DEFAULT 0,
+  updated_at           INTEGER NOT NULL       -- epoch milliseconds
+);
+
+CREATE INDEX IF NOT EXISTS idx_surface_status_netuid
+  ON surface_status (netuid);

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -296,6 +296,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "operational-surfaces",
+      "path": "/metagraph/operational-surfaces.json",
+      "schema_ref": "#/components/schemas/OperationalSurfacesArtifact",
+      "storage_tier": "dual"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",
       "schema_ref": "#/components/schemas/SchemaDriftArtifact",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -381,6 +381,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the cron health prober; input list for the 2-minute scheduled prober.",
+      "id": "operational-surfaces",
+      "path": "/metagraph/operational-surfaces.json",
+      "schema_ref": "#/components/schemas/OperationalSurfacesArtifact",
+      "storage_tier": "dual"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "OpenAPI schema snapshot/drift status.",
       "id": "schema-drift",
       "path": "/metagraph/schema-drift.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2567,6 +2567,103 @@
         ],
         "type": "object"
       },
+      "OperationalSurfacesArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "kinds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "surfaces": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "auth_required": {
+                      "type": "boolean"
+                    },
+                    "authority": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "probe": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "expect": {
+                          "type": "string"
+                        },
+                        "method": {
+                          "type": "string"
+                        },
+                        "timeout_ms": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "method",
+                        "expect"
+                      ],
+                      "type": "object"
+                    },
+                    "provider": {
+                      "type": "string"
+                    },
+                    "public_safe": {
+                      "type": "boolean"
+                    },
+                    "subnet_name": {
+                      "type": "string"
+                    },
+                    "subnet_slug": {
+                      "type": "string"
+                    },
+                    "surface_id": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "surface_id",
+                    "netuid",
+                    "kind",
+                    "url",
+                    "probe"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "surface_count",
+              "kinds",
+              "surfaces"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "PaginationMeta": {
         "additionalProperties": false,
         "properties": {

--- a/public/metagraph/operational-surfaces.json
+++ b/public/metagraph/operational-surfaces.json
@@ -1,0 +1,1002 @@
+{
+  "contract_version": "2026-06-06.1",
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "kinds": [
+    "archive",
+    "data-artifact",
+    "sse",
+    "subnet-api",
+    "subtensor-rpc",
+    "subtensor-wss"
+  ],
+  "schema_version": 1,
+  "surface_count": 58,
+  "surfaces": [
+    {
+      "auth_required": false,
+      "authority": "community",
+      "kind": "subtensor-rpc",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "JSON-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "nodies",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "nodies-finney-rpc",
+      "url": "https://bittensor-public.nodies.app"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subtensor-rpc",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "JSON-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "onfinality",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "onfinality-finney-rpc",
+      "url": "https://bittensor-finney.api.onfinality.io/public"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subtensor-wss",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "WSS-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "onfinality",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "onfinality-finney-wss",
+      "url": "wss://bittensor-finney.api.onfinality.io/public-ws"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subtensor-rpc",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "JSON-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "opentensor-archive-rpc",
+      "url": "https://archive.chain.opentensor.ai"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subtensor-wss",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "WSS-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "opentensor-archive-wss",
+      "url": "wss://archive.chain.opentensor.ai:443"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subtensor-rpc",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "JSON-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "opentensor-finney-rpc",
+      "url": "https://entrypoint-finney.opentensor.ai"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subtensor-wss",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "WSS-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "opentensor-finney-wss",
+      "url": "wss://entrypoint-finney.opentensor.ai:443"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subtensor-rpc",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "JSON-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "opentensor-lite-rpc",
+      "url": "https://lite.chain.opentensor.ai"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subtensor-wss",
+      "netuid": 0,
+      "probe": {
+        "expect": "json",
+        "method": "WSS-RPC",
+        "timeout_ms": 12000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "root",
+      "subnet_slug": "root",
+      "surface_id": "opentensor-lite-wss",
+      "url": "wss://lite.chain.opentensor.ai:443"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 6,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "subnet_name": "Numinous",
+      "subnet_slug": "numinous",
+      "surface_id": "sn-6-numinous-api-health",
+      "url": "https://api.numinouslabs.io/api/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 6,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "numinous",
+      "public_safe": true,
+      "subnet_name": "Numinous",
+      "subnet_slug": "numinous",
+      "surface_id": "sn-6-numinous-leaderboard",
+      "url": "https://api.numinouslabs.io/api/v1/leaderboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-api-health",
+      "url": "https://api.all-ways.io/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-crown",
+      "url": "https://api.all-ways.io/crown"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-events-latest",
+      "url": "https://api.all-ways.io/events/latest"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-miners",
+      "url": "https://api.all-ways.io/miners"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-miners-leaderboard",
+      "url": "https://api.all-ways.io/miners/leaderboard"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-miners-reliability",
+      "url": "https://api.all-ways.io/miners/reliability"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-network-overview",
+      "url": "https://api.all-ways.io/network/overview"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-protocol-chain-state",
+      "url": "https://api.all-ways.io/protocol/chain-state"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-protocol-constants",
+      "url": "https://api.all-ways.io/protocol/constants"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "sse",
+      "netuid": 7,
+      "probe": {
+        "expect": "sse",
+        "method": "GET",
+        "timeout_ms": 5000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "allways-sse",
+      "url": "https://api.all-ways.io/sse"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "subnet-api",
+      "netuid": 7,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "allways",
+      "public_safe": true,
+      "subnet_name": "Allways",
+      "subnet_slug": "allways",
+      "surface_id": "community-sn-7-subnet-api-api-all-ways-io",
+      "url": "https://api.all-ways.io/swaps"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 23,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "trishool",
+      "public_safe": true,
+      "subnet_name": "Trishool",
+      "subnet_slug": "sn-23",
+      "surface_id": "sn-23-trishool-api-root",
+      "url": "https://api.trishool.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 24,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "silx-labs",
+      "public_safe": true,
+      "subnet_name": "Quasar",
+      "subnet_slug": "sn-24",
+      "surface_id": "sn-24-quasar-base-model",
+      "url": "https://huggingface.co/silx-ai/Quasar-3B-A1B-Preview"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 24,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "silx-labs",
+      "public_safe": true,
+      "subnet_name": "Quasar",
+      "subnet_slug": "sn-24",
+      "surface_id": "sn-24-quasar-launch-teacher",
+      "url": "https://huggingface.co/Qwen/Qwen3.5-4B"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "data-artifact",
+      "netuid": 24,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "silx-labs",
+      "public_safe": true,
+      "subnet_name": "Quasar",
+      "subnet_slug": "sn-24",
+      "surface_id": "sn-24-website-link-silxinc-com-data-artifact-3",
+      "url": "https://silxinc.com/blog/silx-ai-partners-with-adaption-labs"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 29,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "coldint",
+      "public_safe": true,
+      "subnet_name": "Coldint",
+      "subnet_slug": "sn-29",
+      "surface_id": "sn-29-coldint-fineweb-dataset",
+      "url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 33,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "readyai",
+      "public_safe": true,
+      "subnet_name": "ReadyAI",
+      "subnet_slug": "sn-33",
+      "surface_id": "sn-33-readyai-hf-dataset",
+      "url": "https://huggingface.co/datasets/ReadyAi/5000-podcast-conversations-with-metadata-and-embedding-dataset"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 33,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "readyai",
+      "public_safe": true,
+      "subnet_name": "ReadyAI",
+      "subnet_slug": "sn-33",
+      "surface_id": "sn-33-readyai-llms-data-repo",
+      "url": "https://github.com/afterpartyai/llms_txt_store"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 47,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "evolai",
+      "public_safe": true,
+      "subnet_name": "EvolAI",
+      "subnet_slug": "sn-47",
+      "surface_id": "sn-47-evolai-universal-qa-dataset",
+      "url": "https://huggingface.co/datasets/evolai/universal_qa"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "subnet-api",
+      "netuid": 51,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "lium.io",
+      "subnet_slug": "sn-51",
+      "surface_id": "sn-51-website-common-api",
+      "url": "https://lium.io/api"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 56,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gradients",
+      "public_safe": true,
+      "subnet_name": "Gradients",
+      "subnet_slug": "gradients",
+      "surface_id": "sn-56-gradients-last-boss-battle",
+      "url": "https://api.gradients.io/v1/performance/last-boss-battle"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 56,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gradients",
+      "public_safe": true,
+      "subnet_name": "Gradients",
+      "subnet_slug": "gradients",
+      "surface_id": "sn-56-gradients-latest-tournament-weights",
+      "url": "https://api.gradients.io/v1/performance/latest-tournament-weights"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "data-artifact",
+      "netuid": 56,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "gradients",
+      "public_safe": true,
+      "subnet_name": "Gradients",
+      "subnet_slug": "gradients",
+      "surface_id": "sn-56-gradients-models",
+      "url": "https://www.gradients.io/app/my-models"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "subnet-api",
+      "netuid": 56,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "gradients",
+      "public_safe": true,
+      "subnet_name": "Gradients",
+      "subnet_slug": "gradients",
+      "surface_id": "sn-56-gradients-weight-projection-static",
+      "url": "https://api.gradients.io/v1/performance/weight-projection-static"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "subnet-api",
+      "netuid": 58,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "tensorplex-subnet-docs",
+      "public_safe": true,
+      "subnet_name": "Handshake58",
+      "subnet_slug": "sn-58",
+      "surface_id": "sn-58-github-readme-handshake58-hs58-subnet-api-2",
+      "url": "https://handshake58.com/api/drain/signing"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 58,
+      "probe": {
+        "expect": "json",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "handshake58",
+      "public_safe": true,
+      "subnet_name": "Handshake58",
+      "subnet_slug": "sn-58",
+      "surface_id": "sn-58-handshake58-provider-directory-api",
+      "url": "https://handshake58.com/api/mcp/providers"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 58,
+      "probe": {
+        "expect": "json",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "handshake58",
+      "public_safe": true,
+      "subnet_name": "Handshake58",
+      "subnet_slug": "sn-58",
+      "surface_id": "sn-58-handshake58-skills-api",
+      "url": "https://handshake58.com/api/skills?status=published"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "subnet-api",
+      "netuid": 59,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "Babelbit",
+      "subnet_slug": "sn-59",
+      "surface_id": "sn-59-github-readme-babelbit-babelbit-subnet-subnet-api-1",
+      "url": "https://api.babelbit.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 64,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "subnet_name": "Chutes",
+      "subnet_slug": "sn-64",
+      "surface_id": "sn-64-chutes-pricing-api",
+      "url": "https://api.chutes.ai/pricing"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "data-artifact",
+      "netuid": 64,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "subnet_name": "Chutes",
+      "subnet_slug": "sn-64",
+      "surface_id": "sn-64-website-link-chutes-ai-data-artifact-5",
+      "url": "https://chutes.ai/app?type=llm"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "data-artifact",
+      "netuid": 64,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "chutes",
+      "public_safe": true,
+      "subnet_name": "Chutes",
+      "subnet_slug": "sn-64",
+      "surface_id": "sn-64-website-link-chutes-ai-data-artifact-6",
+      "url": "https://chutes.ai/app?type=diffusion"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 66,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "unarbos",
+      "public_safe": true,
+      "subnet_name": "ninja",
+      "subnet_slug": "sn-66",
+      "surface_id": "sn-66-ninja-health",
+      "url": "https://ninja.arbos.life/health"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "data-artifact",
+      "netuid": 68,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "NOVA",
+      "subnet_slug": "sn-68",
+      "surface_id": "sn-68-website-link-www-metanova-labs-ai-data-artifact-4",
+      "url": "https://www.metanova-labs.ai/models"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "data-artifact",
+      "netuid": 70,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "NexisGen",
+      "subnet_slug": "sn-70",
+      "surface_id": "sn-70-website-link-nexisgen-ai-data-artifact-5",
+      "url": "https://nexisgen.ai/commission"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 72,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "natix",
+      "public_safe": true,
+      "subnet_name": "StreetVision by NATIX",
+      "subnet_slug": "sn-72",
+      "surface_id": "sn-72-natix-huggingface",
+      "url": "https://huggingface.co/natix-network-org"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "data-artifact",
+      "netuid": 74,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": null
+      },
+      "provider": "gittensor",
+      "public_safe": true,
+      "subnet_name": "Gittensor",
+      "subnet_slug": "gittensor",
+      "surface_id": "gittensor-master-repositories",
+      "url": "https://raw.githubusercontent.com/entrius/gittensor/main/gittensor/validator/weights/master_repositories.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 79,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "taos-im",
+      "public_safe": true,
+      "subnet_name": "MVTRX",
+      "subnet_slug": "sn-79",
+      "surface_id": "sn-79-mvtrx-paper",
+      "url": "https://simulate.trading/taos-im-paper"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 88,
+      "probe": {
+        "expect": "html",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "mobiusfund",
+      "public_safe": true,
+      "subnet_name": "Investing",
+      "subnet_slug": "sn-88",
+      "surface_id": "sn-88-investing-assets",
+      "url": "https://api.investing88.ai/assets"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "kind": "data-artifact",
+      "netuid": 95,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "actual-computer",
+      "public_safe": true,
+      "subnet_name": "Actual",
+      "subnet_slug": "actual",
+      "surface_id": "sn-95-actual-model-registry",
+      "url": "https://models.actual.inc/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "subnet-api",
+      "netuid": 96,
+      "probe": {
+        "expect": "json",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "verathos",
+      "public_safe": true,
+      "subnet_name": "Verathos",
+      "subnet_slug": "sn-96",
+      "surface_id": "sn-96-verathos-models-api",
+      "url": "https://api.verathos.ai/v1/models"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "subnet-api",
+      "netuid": 107,
+      "probe": {
+        "expect": "any",
+        "method": "GET",
+        "timeout_ms": 10000
+      },
+      "provider": "opentensor",
+      "public_safe": true,
+      "subnet_name": "Minos",
+      "subnet_slug": "sn-107",
+      "surface_id": "sn-107-github-readme-minos-protocol-minos-subnet-subnet-api-1",
+      "url": "https://api.theminos.ai/"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 109,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "academia",
+      "public_safe": true,
+      "subnet_name": "Academia",
+      "subnet_slug": "sn-109",
+      "surface_id": "sn-109-academia-archives",
+      "url": "https://github.com/fx-integral/academia-archives"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 110,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "green-compute",
+      "public_safe": true,
+      "subnet_name": "Green Compute",
+      "subnet_slug": "sn-110",
+      "surface_id": "sn-110-green-compute-models",
+      "url": "https://www.green-compute.com/models"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "data-artifact",
+      "netuid": 110,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "green-compute",
+      "public_safe": true,
+      "subnet_name": "Green Compute",
+      "subnet_slug": "sn-110",
+      "surface_id": "sn-110-website-link-www-green-compute-com-data-artifact-10",
+      "url": "https://www.green-compute.com/models?prefill=Qwen%2FQwen2.5-7B-Instruct"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "data-artifact",
+      "netuid": 110,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "green-compute",
+      "public_safe": true,
+      "subnet_name": "Green Compute",
+      "subnet_slug": "sn-110",
+      "surface_id": "sn-110-website-link-www-green-compute-com-data-artifact-9",
+      "url": "https://www.green-compute.com/models?prefill=meta-llama%2FMeta-Llama-3.1-8B-Instruct"
+    },
+    {
+      "auth_required": false,
+      "authority": "official",
+      "kind": "data-artifact",
+      "netuid": 114,
+      "probe": {
+        "expect": "html",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "soma",
+      "public_safe": true,
+      "subnet_name": "SOMA",
+      "subnet_slug": "sn-114",
+      "surface_id": "sn-114-soma-mcp",
+      "url": "https://thesoma.ai/mcp"
+    },
+    {
+      "auth_required": false,
+      "authority": "registry-observed",
+      "kind": "data-artifact",
+      "netuid": 118,
+      "probe": {
+        "expect": "any",
+        "method": "HEAD",
+        "timeout_ms": 10000
+      },
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "subnet_name": "Ditto",
+      "subnet_slug": "sn-118",
+      "surface_id": "sn-118-website-link-heyditto-ai-data-artifact-3",
+      "url": "https://heyditto.ai/ditto-vs-frontier-open-models"
+    }
+  ]
+}

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1401,6 +1401,33 @@ export interface components {
         } & {
             [key: string]: unknown;
         };
+        OperationalSurfacesArtifact: components["schemas"]["ArtifactBase"] & ({
+            kinds: string[];
+            surface_count: number;
+            surfaces: ({
+                auth_required?: boolean;
+                authority?: string;
+                kind: string;
+                netuid: number;
+                probe: {
+                    expect: string;
+                    method: string;
+                    timeout_ms?: number | null;
+                } & {
+                    [key: string]: unknown;
+                };
+                provider?: string;
+                public_safe?: boolean;
+                subnet_name?: string;
+                subnet_slug?: string;
+                surface_id: string;
+                url: string;
+            } & {
+                [key: string]: unknown;
+            })[];
+        } & {
+            [key: string]: unknown;
+        });
         PaginationMeta: {
             collection: string;
             cursor: number;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -2545,6 +2545,103 @@
         ],
         "type": "object"
       },
+      "OperationalSurfacesArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "kinds": {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              "surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "surfaces": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "auth_required": {
+                      "type": "boolean"
+                    },
+                    "authority": {
+                      "type": "string"
+                    },
+                    "kind": {
+                      "type": "string"
+                    },
+                    "netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "probe": {
+                      "additionalProperties": true,
+                      "properties": {
+                        "expect": {
+                          "type": "string"
+                        },
+                        "method": {
+                          "type": "string"
+                        },
+                        "timeout_ms": {
+                          "type": [
+                            "integer",
+                            "null"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "method",
+                        "expect"
+                      ],
+                      "type": "object"
+                    },
+                    "provider": {
+                      "type": "string"
+                    },
+                    "public_safe": {
+                      "type": "boolean"
+                    },
+                    "subnet_name": {
+                      "type": "string"
+                    },
+                    "subnet_slug": {
+                      "type": "string"
+                    },
+                    "surface_id": {
+                      "type": "string"
+                    },
+                    "url": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "surface_id",
+                    "netuid",
+                    "kind",
+                    "url",
+                    "probe"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            },
+            "required": [
+              "surface_count",
+              "kinds",
+              "surfaces"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "PaginationMeta": {
         "additionalProperties": false,
         "properties": {

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -488,6 +488,55 @@
       },
       "ReviewQueueArtifact": {
         "$ref": "#/components/schemas/CandidatesArtifact"
+      },
+      "OperationalSurfacesArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "type": "object",
+            "required": ["surface_count", "kinds", "surfaces"],
+            "properties": {
+              "surface_count": { "type": "integer", "minimum": 0 },
+              "kinds": {
+                "type": "array",
+                "items": { "type": "string" }
+              },
+              "surfaces": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": ["surface_id", "netuid", "kind", "url", "probe"],
+                  "properties": {
+                    "surface_id": { "type": "string" },
+                    "netuid": { "type": "integer", "minimum": 0 },
+                    "subnet_slug": { "type": "string" },
+                    "subnet_name": { "type": "string" },
+                    "kind": { "type": "string" },
+                    "provider": { "type": "string" },
+                    "authority": { "type": "string" },
+                    "url": { "type": "string" },
+                    "auth_required": { "type": "boolean" },
+                    "public_safe": { "type": "boolean" },
+                    "probe": {
+                      "type": "object",
+                      "required": ["method", "expect"],
+                      "properties": {
+                        "method": { "type": "string" },
+                        "expect": { "type": "string" },
+                        "timeout_ms": { "type": ["integer", "null"] }
+                      },
+                      "additionalProperties": true
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            },
+            "additionalProperties": true
+          }
+        ]
       }
     }
   }

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { promises as fs } from "node:fs";
 import { promisify } from "node:util";
 import path from "node:path";
+import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
 import {
   buildEndpointResourceArtifact,
   buildEvidenceSubjectNetuidIndex,
@@ -895,6 +896,49 @@ await writeJson(artifactFile("registry-summary.json"), {
       renamed: (changelogArtifact.subnets?.renamed || []).length,
     },
   },
+});
+
+// Operational-surfaces list — the input for the 2-minute Cloudflare cron health
+// prober (src/health-prober.mjs). Deterministic, committed (git-tier), and read
+// by the Worker at runtime via the ASSETS binding. Only probe-enabled,
+// public-safe, operational-kind surfaces; everything else stays on this 6h build.
+const operationalKindSet = new Set(OPERATIONAL_SURFACE_KINDS);
+const operationalSurfaces = surfaces
+  .filter(
+    (surface) =>
+      surface.probe?.enabled &&
+      surface.public_safe &&
+      operationalKindSet.has(surface.kind),
+  )
+  .map((surface) => ({
+    surface_id: surface.id,
+    netuid: surface.netuid,
+    subnet_slug: surface.subnet_slug,
+    subnet_name: surface.subnet_name,
+    kind: surface.kind,
+    provider: surface.provider,
+    authority: surface.authority,
+    url: surface.url,
+    auth_required: Boolean(surface.auth_required),
+    public_safe: Boolean(surface.public_safe),
+    probe: {
+      method: surface.probe.method,
+      expect: surface.probe.expect,
+      timeout_ms: Number.isInteger(surface.probe.timeout_ms)
+        ? surface.probe.timeout_ms
+        : null,
+    },
+  }))
+  .sort(
+    (a, b) => a.netuid - b.netuid || a.surface_id.localeCompare(b.surface_id),
+  );
+await writeJson(artifactFile("operational-surfaces.json"), {
+  schema_version: 1,
+  contract_version: contractVersion,
+  generated_at: generatedAt,
+  surface_count: operationalSurfaces.length,
+  kinds: [...OPERATIONAL_SURFACE_KINDS].sort(),
+  surfaces: operationalSurfaces,
 });
 
 const artifactSizesBeforeR2 = await collectArtifactSizes({

--- a/scripts/probes-smoke.mjs
+++ b/scripts/probes-smoke.mjs
@@ -7,7 +7,6 @@ import {
   buildRpcEndpointArtifact,
   buildTimestamp,
   flattenSurfaces,
-  isJsonContentType,
   artifactDirectoryPath,
   artifactOutputPath,
   loadProviders,
@@ -16,6 +15,11 @@ import {
   repoRoot,
   writeJson,
 } from "./lib.mjs";
+import {
+  mapLimit,
+  nodeWebSocketConnector,
+  probeSurface as coreProbeSurface,
+} from "../src/health-probe-core.mjs";
 
 const contractVersion = "2026-06-06.1";
 const subnets = await loadSubnets();
@@ -26,43 +30,22 @@ const surfaces = allSurfaces.filter(
 );
 const startedAt = Date.now();
 const priorHistory = await loadPriorHistory();
-const subtensorProbeCalls = [
-  { key: "chain_getHeader", method: "chain_getHeader", params: [] },
-  { key: "system_health", method: "system_health", params: [] },
-  { key: "rpc_methods", method: "rpc_methods", params: [] },
-  { key: "archive_probe", method: "chain_getBlockHash", params: [1] },
-];
+
+// Probe primitives now live in the isomorphic core (src/health-probe-core.mjs),
+// shared with the Worker cron prober. The Node build injects the DNS-aware SSRF
+// guard + the global-WebSocket connector; this thin wrapper layers the daily
+// history-derived fields (last_ok, uptime_sample_ratio) the build artifacts need.
+const probeOptions = {
+  isUnsafeUrl: isUnsafeResolvedUrl,
+  connect: nodeWebSocketConnector(),
+};
 
 async function probeSurface(surface) {
-  if (["subtensor-rpc", "subtensor-wss"].includes(surface.kind)) {
-    return probeSubtensorSurface(surface);
-  }
-
-  const timeoutMs = surface.probe.timeout_ms || 8000;
-  let probe = await probeUrl(
-    surface.url,
-    surface.probe.method,
-    acceptHeader(surface.probe.expect),
-    timeoutMs,
-  );
-  if (
-    !probe.ok &&
-    surface.probe.method === "HEAD" &&
-    [400, 403, 405].includes(probe.status_code)
-  ) {
-    probe = await probeUrl(
-      surface.url,
-      "GET",
-      acceptHeader(surface.probe.expect),
-      timeoutMs,
-    );
-  }
-  const classification = classifyProbe(probe, surface);
-  const status = statusForClassification(classification, surface);
+  const base = await coreProbeSurface(surface, probeOptions);
   const history = priorHistory.get(surface.id) || [];
   const lastOk =
-    status === "ok"
-      ? probe.verified_at
+    base.status === "ok"
+      ? base.verified_at
       : latestString(
           history
             .filter((entry) => entry.status === "ok")
@@ -70,586 +53,20 @@ async function probeSurface(surface) {
         );
   const historyWithCurrent = [
     ...history,
-    { status, verified_at: probe.verified_at },
+    { status: base.status, verified_at: base.verified_at },
   ];
-
   return {
-    auth_required: surface.auth_required,
-    classification,
-    content_type: probe.content_type || null,
-    error: probe.error || null,
-    error_class: probe.error_class || null,
-    kind: surface.kind,
-    last_checked: probe.verified_at,
+    ...base,
     last_ok: lastOk,
-    latency_ms: probe.latency_ms,
-    method_tested: probe.method_tested,
-    netuid: surface.netuid,
-    private_redirect_blocked: probe.private_redirect_blocked || false,
-    provider: surface.provider,
-    public_safe: surface.public_safe,
-    redirect_target: probe.redirect_target || null,
-    status,
-    status_code: probe.status_code || null,
-    subnet_name: surface.subnet_name,
-    subnet_slug: surface.subnet_slug,
-    surface_id: surface.id,
     uptime_sample_ratio: uptimeRatio(historyWithCurrent),
-    url: surface.url,
-    verified_at: probe.verified_at,
   };
 }
 
-async function probeSubtensorSurface(surface) {
-  const timeoutMs = surface.probe.timeout_ms || 12000;
-  const startedAt = new Date().toISOString();
-  const probe =
-    surface.kind === "subtensor-wss"
-      ? await probeSubtensorWss(surface.url, timeoutMs)
-      : await probeSubtensorHttp(surface.url, timeoutMs);
-  const classification = classifyRpcProbe(probe);
-  const status = statusForClassification(classification, surface);
-  const history = priorHistory.get(surface.id) || [];
-  const verifiedAt = probe.verified_at || startedAt;
-  const lastOk =
-    status === "ok"
-      ? verifiedAt
-      : latestString(
-          history
-            .filter((entry) => entry.status === "ok")
-            .map((entry) => entry.verified_at),
-        );
-  const historyWithCurrent = [...history, { status, verified_at: verifiedAt }];
-
-  return {
-    archive_support: probe.archive_support,
-    auth_required: surface.auth_required,
-    classification,
-    content_type: probe.content_type || null,
-    error: probe.error || null,
-    error_class: probe.error_class || null,
-    kind: surface.kind,
-    last_checked: verifiedAt,
-    last_ok: lastOk,
-    latency_ms: probe.latency_ms,
-    latest_block: probe.latest_block,
-    method_results: probe.method_results,
-    method_tested: surface.probe.method,
-    methods_supported: probe.methods_supported,
-    netuid: surface.netuid,
-    private_redirect_blocked: probe.private_redirect_blocked || false,
-    provider: surface.provider,
-    public_safe: surface.public_safe,
-    redirect_target: probe.redirect_target || null,
-    rpc_method_count: probe.rpc_method_count,
-    status,
-    status_code: probe.status_code || null,
-    subnet_name: surface.subnet_name,
-    subnet_slug: surface.subnet_slug,
-    surface_id: surface.id,
-    uptime_sample_ratio: uptimeRatio(historyWithCurrent),
-    url: surface.url,
-    verified_at: verifiedAt,
-  };
-}
-
-async function probeUrl(url, method, accept, timeoutMs, redirectCount = 0) {
-  if (await isUnsafeResolvedUrl(url)) {
-    return {
-      ok: false,
-      error: "unsafe URL",
-      latency_ms: 0,
-      method_tested: method,
-      unsafe_url: true,
-      verified_at: new Date().toISOString(),
-    };
-  }
-
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  const started = performance.now();
-
-  try {
-    const response = await fetch(url, {
-      method,
-      headers: {
-        accept,
-        "user-agent": "metagraphed-smoke-probe/0.0",
-      },
-      redirect: "manual",
-      signal: controller.signal,
-    });
-
-    const latencyMs = Math.round(performance.now() - started);
-    const location = response.headers.get("location");
-    if (
-      [301, 302, 303, 307, 308].includes(response.status) &&
-      location &&
-      redirectCount < 5
-    ) {
-      const redirectTarget = new URL(location, url).toString();
-      if (await isUnsafeResolvedUrl(redirectTarget)) {
-        await response.body?.cancel();
-        return {
-          ok: false,
-          error: "redirect target is unsafe",
-          latency_ms: latencyMs,
-          method_tested: method,
-          private_redirect_blocked: true,
-          redirect_target: redirectTarget,
-          status_code: response.status,
-          verified_at: new Date().toISOString(),
-        };
-      }
-      await response.body?.cancel();
-      const redirected = await probeUrl(
-        redirectTarget,
-        method,
-        accept,
-        timeoutMs,
-        redirectCount + 1,
-      );
-      return {
-        ...redirected,
-        latency_ms: latencyMs + (redirected.latency_ms || 0),
-        redirect_target: redirected.redirect_target || redirectTarget,
-      };
-    }
-
-    const contentType = response.headers.get("content-type") || "";
-    await response.body?.cancel();
-    return {
-      ok: response.ok,
-      content_type: contentType || null,
-      latency_ms: latencyMs,
-      method_tested: method,
-      status_code: response.status,
-      verified_at: new Date().toISOString(),
-    };
-  } catch (error) {
-    return {
-      ok: false,
-      error: error.message,
-      error_class: error.name,
-      latency_ms: Math.round(performance.now() - started),
-      method_tested: method,
-      verified_at: new Date().toISOString(),
-    };
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-function classifyProbe(probe, surface) {
-  if (probe.unsafe_url || probe.private_redirect_blocked) {
-    return "unsafe";
-  }
-  if (probe.error_class === "AbortError") {
-    return "timeout";
-  }
-  if (probe.status_code === 429) {
-    return "rate-limited";
-  }
-  if ([401, 403].includes(probe.status_code)) {
-    return "auth-required";
-  }
-  if ([404, 410].includes(probe.status_code)) {
-    return "dead";
-  }
-  if (probe.status_code >= 500) {
-    return "transient";
-  }
-  if (probe.ok && contentMismatch(probe, surface)) {
-    return "content-mismatch";
-  }
-  if (probe.ok && probe.redirect_target) {
-    return "redirected";
-  }
-  if (probe.ok) {
-    return "live";
-  }
-  return "unsupported";
-}
-
-function classifyRpcProbe(probe) {
-  if (probe.unsafe_url || probe.private_redirect_blocked) {
-    return "unsafe";
-  }
-  if (
-    probe.error_class === "AbortError" ||
-    probe.error_class === "TimeoutError"
-  ) {
-    return "timeout";
-  }
-  if (probe.status_code === 429) {
-    return "rate-limited";
-  }
-  if ([401, 403].includes(probe.status_code)) {
-    return "auth-required";
-  }
-  if (probe.status_code >= 500) {
-    return "transient";
-  }
-  if (probe.error) {
-    return "unsupported";
-  }
-  if (
-    probe.method_results?.chain_getHeader?.ok &&
-    probe.method_results?.system_health?.ok
-  ) {
-    return "live";
-  }
-  if (probe.method_results?.chain_getHeader?.ok) {
-    return "unsupported";
-  }
-  return "transient";
-}
-
-function contentMismatch(probe, surface) {
-  if (surface.probe.expect === "json") {
-    if (
-      String(probe.content_type || "")
-        .toLowerCase()
-        .includes("text/plain") &&
-      (new URL(surface.url).pathname.toLowerCase().endsWith(".json") ||
-        new URL(surface.url).hostname === "raw.githubusercontent.com")
-    ) {
-      return false;
-    }
-    return !isJsonContentType(probe.content_type);
-  }
-  if (surface.probe.expect === "html") {
-    return !String(probe.content_type || "")
-      .toLowerCase()
-      .includes("html");
-  }
-  if (surface.probe.expect === "sse") {
-    return !String(probe.content_type || "")
-      .toLowerCase()
-      .includes("text/event-stream");
-  }
-  return false;
-}
-
-function statusForClassification(classification, surface = null) {
-  if (["live", "redirected"].includes(classification)) {
-    return "ok";
-  }
-  if (
-    ["rate-limited", "auth-required", "transient", "timeout"].includes(
-      classification,
-    )
-  ) {
-    return "degraded";
-  }
-  if (
-    ["unsupported", "dead", "content-mismatch"].includes(classification) &&
-    ["registry-observed", "community"].includes(surface?.authority)
-  ) {
-    return "degraded";
-  }
-  return "failed";
-}
-
-async function probeSubtensorHttp(url, timeoutMs) {
-  if (await isUnsafeResolvedUrl(url)) {
-    return {
-      unsafe_url: true,
-      error: "unsafe URL",
-      latency_ms: 0,
-      verified_at: new Date().toISOString(),
-    };
-  }
-
-  const started = performance.now();
-  const methodResults = {};
-  let statusCode = null;
-  let contentType = null;
-  for (const [index, call] of subtensorProbeCalls.entries()) {
-    const response = await jsonRpcHttp(
-      url,
-      call.method,
-      call.params,
-      index + 1,
-      timeoutMs,
-    );
-    statusCode = response.status_code || statusCode;
-    contentType = response.content_type || contentType;
-    methodResults[call.key] = normalizeJsonRpcResult(response);
-    if (response.transport_error) {
-      return {
-        ...response,
-        content_type: contentType,
-        latency_ms: Math.round(performance.now() - started),
-        method_results: methodResults,
-        status_code: statusCode,
-        verified_at: new Date().toISOString(),
-      };
-    }
-  }
-
-  return summarizeRpcProbe({
-    content_type: contentType,
-    latency_ms: Math.round(performance.now() - started),
-    method_results: methodResults,
-    status_code: statusCode,
-    verified_at: new Date().toISOString(),
-  });
-}
-
-async function probeSubtensorWss(url, timeoutMs) {
-  if (await isUnsafeResolvedUrl(url)) {
-    return {
-      unsafe_url: true,
-      error: "unsafe URL",
-      latency_ms: 0,
-      verified_at: new Date().toISOString(),
-    };
-  }
-
-  if (typeof WebSocket !== "function") {
-    return {
-      error: "WebSocket global is unavailable in this Node.js runtime",
-      error_class: "UnsupportedRuntime",
-      latency_ms: 0,
-      verified_at: new Date().toISOString(),
-    };
-  }
-
-  const started = performance.now();
-  const methodResults = {};
-
-  try {
-    const rawResults = await jsonRpcWss(url, subtensorProbeCalls, timeoutMs);
-    for (const call of subtensorProbeCalls) {
-      methodResults[call.key] = normalizeJsonRpcResult(
-        rawResults.get(call.key) || { error: "missing response" },
-      );
-    }
-    return summarizeRpcProbe({
-      latency_ms: Math.round(performance.now() - started),
-      method_results: methodResults,
-      verified_at: new Date().toISOString(),
-    });
-  } catch (error) {
-    return {
-      error: error.message,
-      error_class: error.name,
-      latency_ms: Math.round(performance.now() - started),
-      method_results: methodResults,
-      verified_at: new Date().toISOString(),
-    };
-  }
-}
-
-async function jsonRpcHttp(url, method, params, id, timeoutMs) {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), timeoutMs);
-  try {
-    const response = await fetch(url, {
-      method: "POST",
-      headers: {
-        accept: "application/json",
-        "content-type": "application/json",
-        "user-agent": "metagraphed-subtensor-rpc-probe/0.0",
-      },
-      body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
-      redirect: "manual",
-      signal: controller.signal,
-    });
-
-    const location = response.headers.get("location");
-    if ([301, 302, 303, 307, 308].includes(response.status) && location) {
-      const redirectTarget = new URL(location, url).toString();
-      if (await isUnsafeResolvedUrl(redirectTarget)) {
-        await response.body?.cancel();
-        return {
-          transport_error: true,
-          private_redirect_blocked: true,
-          redirect_target: redirectTarget,
-          status_code: response.status,
-          error: "redirect target is unsafe",
-        };
-      }
-    }
-
-    const contentType = response.headers.get("content-type") || "";
-    const text = await response.text();
-    let body = null;
-    try {
-      body = text ? JSON.parse(text) : null;
-    } catch {
-      return {
-        transport_error: true,
-        content_type: contentType || null,
-        status_code: response.status,
-        error: "response was not JSON",
-      };
-    }
-
-    return {
-      content_type: contentType || null,
-      ok: response.ok && !body?.error,
-      result: body?.result,
-      rpc_error: body?.error || null,
-      status_code: response.status,
-    };
-  } catch (error) {
-    return {
-      transport_error: true,
-      error: error.message,
-      error_class: error.name,
-    };
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
-async function jsonRpcWss(url, calls, timeoutMs) {
-  return new Promise((resolve, reject) => {
-    const socket = new WebSocket(url);
-    const byId = new Map(calls.map((call, index) => [index + 1, call.key]));
-    const results = new Map();
-    const timer = setTimeout(() => {
-      try {
-        socket.close();
-      } catch {
-        // Ignore close failures after timeout.
-      }
-      const error = new Error("WebSocket RPC probe timed out");
-      error.name = "TimeoutError";
-      reject(error);
-    }, timeoutMs);
-
-    socket.addEventListener("open", () => {
-      calls.forEach((call, index) => {
-        socket.send(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            id: index + 1,
-            method: call.method,
-            params: call.params,
-          }),
-        );
-      });
-    });
-
-    socket.addEventListener("message", (event) => {
-      try {
-        const body = JSON.parse(String(event.data));
-        const key = byId.get(body.id);
-        if (!key) {
-          return;
-        }
-        results.set(key, {
-          ok: !body.error,
-          result: body.result,
-          rpc_error: body.error || null,
-        });
-        if (results.size === calls.length) {
-          clearTimeout(timer);
-          socket.close();
-          resolve(results);
-        }
-      } catch (error) {
-        clearTimeout(timer);
-        try {
-          socket.close();
-        } catch {
-          // Ignore close failures after parse failure.
-        }
-        reject(error);
-      }
-    });
-
-    socket.addEventListener("error", () => {
-      clearTimeout(timer);
-      reject(new Error("WebSocket RPC connection failed"));
-    });
-  });
-}
-
-function normalizeJsonRpcResult(response) {
-  const normalized = {
-    ok: Boolean(response.ok),
-    error: response.error || response.rpc_error?.message || null,
-    code: response.rpc_error?.code || null,
-    result_type:
-      response.result === null
-        ? "null"
-        : Array.isArray(response.result)
-          ? "array"
-          : typeof response.result,
-    result_present: response.result !== null && response.result !== undefined,
-  };
-  if (
-    response.result &&
-    typeof response.result === "object" &&
-    !Array.isArray(response.result) &&
-    response.result.number
-  ) {
-    normalized.raw_header = { number: response.result.number };
-  }
-  if (response.result && Array.isArray(response.result.methods)) {
-    normalized.rpc_method_count = response.result.methods.length;
-  }
-  if (typeof response.result === "string" && response.result.startsWith("0x")) {
-    normalized.raw_hex_result_present = true;
-  }
-  return normalized;
-}
-
-function summarizeRpcProbe(probe) {
-  const header = probe.method_results.chain_getHeader;
-  const methods = probe.method_results.rpc_methods;
-  const archiveProbe = probe.method_results.archive_probe;
-  const latestBlock = parseBlockNumber(header?.raw_header);
-  return {
-    ...probe,
-    archive_support: Boolean(
-      archiveProbe?.ok && archiveProbe.raw_hex_result_present,
-    ),
-    latest_block: latestBlock,
-    methods_supported: {
-      chain_getHeader: Boolean(probe.method_results.chain_getHeader?.ok),
-      system_health: Boolean(probe.method_results.system_health?.ok),
-      rpc_methods: Boolean(probe.method_results.rpc_methods?.ok),
-      chain_getBlockHash: Boolean(probe.method_results.archive_probe?.ok),
-    },
-    rpc_method_count: methods?.rpc_method_count ?? null,
-  };
-}
-
-function parseBlockNumber(header) {
-  if (!header || typeof header !== "object") {
-    return null;
-  }
-  const value = header.number;
-  if (typeof value === "number") {
-    return value;
-  }
-  if (typeof value === "string") {
-    return value.startsWith("0x")
-      ? Number.parseInt(value, 16)
-      : Number.parseInt(value, 10);
-  }
-  return null;
-}
-
-function acceptHeader(expect) {
-  switch (expect) {
-    case "json":
-      return "application/json";
-    case "html":
-      return "text/html,application/xhtml+xml";
-    case "sse":
-      return "text/event-stream";
-    default:
-      return "*/*";
-  }
-}
-
-const results = await mapLimit(surfaces, 16, probeSurface);
+const results = (await mapLimit(surfaces, 16, probeSurface)).sort(
+  (a, b) =>
+    a.subnet_slug.localeCompare(b.subnet_slug) ||
+    a.surface_id.localeCompare(b.surface_id),
+);
 const artifact = buildHealthArtifacts(results, {
   generatedAt: buildTimestamp(),
   source: "live-smoke-probe",
@@ -1035,26 +452,6 @@ function badgeColor(status) {
       failed: "red",
       unknown: "lightgrey",
     }[status] || "lightgrey"
-  );
-}
-
-async function mapLimit(items, limit, mapper) {
-  const queue = [...items];
-  const results = [];
-  const workers = Array.from(
-    { length: Math.min(limit, queue.length) },
-    async () => {
-      while (queue.length > 0) {
-        const item = queue.shift();
-        results.push(await mapper(item));
-      }
-    },
-  );
-  await Promise.all(workers);
-  return results.sort(
-    (a, b) =>
-      a.subnet_slug.localeCompare(b.subnet_slug) ||
-      a.surface_id.localeCompare(b.surface_id),
   );
 }
 

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -74,6 +74,10 @@ const DUAL_PATTERNS = [
   /^r2-manifest\.json$/,
   /^contracts\.json$/,
   /^coverage\.json$/,
+  // Operational-surfaces list: low-churn (changes only when the registry gains
+  // operational surfaces), read by the Worker cron prober at runtime via ASSETS.
+  // Committed + mirrored to R2 like the other small contract digests.
+  /^operational-surfaces\.json$/,
   /^openapi\.json$/,
   /^schemas\/index\.json$/,
   // subnets.json (124 KB) stays committed: the changelog diffs it against the

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -775,6 +775,12 @@ export const PUBLIC_ARTIFACTS = [
     "EndpointIncidentsArtifact",
   ),
   artifact(
+    "operational-surfaces",
+    "/metagraph/operational-surfaces.json",
+    "Operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the cron health prober; input list for the 2-minute scheduled prober.",
+    "OperationalSurfacesArtifact",
+  ),
+  artifact(
     "schema-drift",
     "/metagraph/schema-drift.json",
     "OpenAPI schema snapshot/drift status.",

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -1,0 +1,721 @@
+// Pure, isomorphic surface-probing primitives shared by the Node 6h build
+// (scripts/probes-smoke.mjs) and the Cloudflare cron prober (src/health-prober.mjs,
+// wired through workers/api.mjs `scheduled()`).
+//
+// NO module-level I/O: `fetch`, the SSRF guard, and the WebSocket connector are
+// INJECTED so every branch is unit-testable and the code runs unchanged on the
+// Workers runtime and Node 22 (both expose fetch, AbortController, performance,
+// URL, TextEncoder). The classification + scoring logic is lifted verbatim from
+// the historical build so artifacts stay byte-stable after the extraction
+// (writeJson sorts keys via stableStringify, so only VALUES must match).
+
+export const SUBTENSOR_PROBE_CALLS = [
+  { key: "chain_getHeader", method: "chain_getHeader", params: [] },
+  { key: "system_health", method: "system_health", params: [] },
+  { key: "rpc_methods", method: "rpc_methods", params: [] },
+  { key: "archive_probe", method: "chain_getBlockHash", params: [1] },
+];
+
+// Surface kinds whose health changes minute-to-minute and is worth probing live
+// (the 2-minute cron prober). Everything else — docs, website, source-repo,
+// dashboard, openapi, sdk, example, repo-registry — stays on the slower 6h build.
+// This is the single source of truth: scripts/build-artifacts.mjs emits the
+// operational-surfaces.json list from it, and the Worker prober consumes that list.
+export const OPERATIONAL_SURFACE_KINDS = [
+  "subtensor-rpc",
+  "subtensor-wss",
+  "archive",
+  "subnet-api",
+  "sse",
+  "data-artifact",
+];
+
+// --- URL safety: isomorphic literal SSRF guard --------------------------------
+// Best-effort default used by the Worker (which cannot resolve DNS). The Node
+// build injects the stronger DNS-aware `isUnsafeResolvedUrl` from scripts/lib.mjs.
+// Operational surfaces are already curated `public_safe`, so this is defense in
+// depth, not the primary control.
+const UNSAFE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /\.localhost$/i,
+  /\.local$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^0\./,
+  /^::1$/,
+  /^::$/,
+  /^fe80:/i,
+  /^fc00:/i,
+  /^fd/i,
+];
+
+export function isUnsafePublicUrl(value) {
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:", "ws:", "wss:"].includes(url.protocol)) {
+      return true;
+    }
+    const host = String(url.hostname || "")
+      .trim()
+      .toLowerCase()
+      .replace(/^\[(.*)\]$/, "$1")
+      .replace(/\.$/, "");
+    if (!host) {
+      return true;
+    }
+    // 172.16.0.0 – 172.31.255.255 (private range).
+    if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) {
+      return true;
+    }
+    return UNSAFE_HOST_PATTERNS.some((pattern) => pattern.test(host));
+  } catch {
+    return true;
+  }
+}
+
+export function isJsonContentType(value) {
+  return String(value || "")
+    .toLowerCase()
+    .includes("json");
+}
+
+export function acceptHeader(expect) {
+  switch (expect) {
+    case "json":
+      return "application/json";
+    case "html":
+      return "text/html,application/xhtml+xml";
+    case "sse":
+      return "text/event-stream";
+    default:
+      return "*/*";
+  }
+}
+
+// --- HTTP(S) probe ------------------------------------------------------------
+export async function probeUrl(
+  url,
+  method,
+  accept,
+  timeoutMs,
+  options = {},
+  redirectCount = 0,
+) {
+  const { isUnsafeUrl = isUnsafePublicUrl, fetchImpl = fetch } = options;
+
+  if (await isUnsafeUrl(url)) {
+    return {
+      ok: false,
+      error: "unsafe URL",
+      latency_ms: 0,
+      method_tested: method,
+      unsafe_url: true,
+      verified_at: new Date().toISOString(),
+    };
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const started = performance.now();
+
+  try {
+    const response = await fetchImpl(url, {
+      method,
+      headers: {
+        accept,
+        "user-agent": "metagraphed-smoke-probe/0.0",
+      },
+      redirect: "manual",
+      signal: controller.signal,
+    });
+
+    const latencyMs = Math.round(performance.now() - started);
+    const location = response.headers.get("location");
+    if (
+      [301, 302, 303, 307, 308].includes(response.status) &&
+      location &&
+      redirectCount < 5
+    ) {
+      const redirectTarget = new URL(location, url).toString();
+      if (await isUnsafeUrl(redirectTarget)) {
+        await response.body?.cancel();
+        return {
+          ok: false,
+          error: "redirect target is unsafe",
+          latency_ms: latencyMs,
+          method_tested: method,
+          private_redirect_blocked: true,
+          redirect_target: redirectTarget,
+          status_code: response.status,
+          verified_at: new Date().toISOString(),
+        };
+      }
+      await response.body?.cancel();
+      const redirected = await probeUrl(
+        redirectTarget,
+        method,
+        accept,
+        timeoutMs,
+        options,
+        redirectCount + 1,
+      );
+      return {
+        ...redirected,
+        latency_ms: latencyMs + (redirected.latency_ms || 0),
+        redirect_target: redirected.redirect_target || redirectTarget,
+      };
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    await response.body?.cancel();
+    return {
+      ok: response.ok,
+      content_type: contentType || null,
+      latency_ms: latencyMs,
+      method_tested: method,
+      status_code: response.status,
+      verified_at: new Date().toISOString(),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message,
+      error_class: error.name,
+      latency_ms: Math.round(performance.now() - started),
+      method_tested: method,
+      verified_at: new Date().toISOString(),
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export function classifyProbe(probe, surface) {
+  if (probe.unsafe_url || probe.private_redirect_blocked) {
+    return "unsafe";
+  }
+  if (probe.error_class === "AbortError") {
+    return "timeout";
+  }
+  if (probe.status_code === 429) {
+    return "rate-limited";
+  }
+  if ([401, 403].includes(probe.status_code)) {
+    return "auth-required";
+  }
+  if ([404, 410].includes(probe.status_code)) {
+    return "dead";
+  }
+  if (probe.status_code >= 500) {
+    return "transient";
+  }
+  if (probe.ok && contentMismatch(probe, surface)) {
+    return "content-mismatch";
+  }
+  if (probe.ok && probe.redirect_target) {
+    return "redirected";
+  }
+  if (probe.ok) {
+    return "live";
+  }
+  return "unsupported";
+}
+
+export function classifyRpcProbe(probe) {
+  if (probe.unsafe_url || probe.private_redirect_blocked) {
+    return "unsafe";
+  }
+  if (
+    probe.error_class === "AbortError" ||
+    probe.error_class === "TimeoutError"
+  ) {
+    return "timeout";
+  }
+  if (probe.status_code === 429) {
+    return "rate-limited";
+  }
+  if ([401, 403].includes(probe.status_code)) {
+    return "auth-required";
+  }
+  if (probe.status_code >= 500) {
+    return "transient";
+  }
+  if (probe.error) {
+    return "unsupported";
+  }
+  if (
+    probe.method_results?.chain_getHeader?.ok &&
+    probe.method_results?.system_health?.ok
+  ) {
+    return "live";
+  }
+  if (probe.method_results?.chain_getHeader?.ok) {
+    return "unsupported";
+  }
+  return "transient";
+}
+
+export function contentMismatch(probe, surface) {
+  if (surface.probe.expect === "json") {
+    if (
+      String(probe.content_type || "")
+        .toLowerCase()
+        .includes("text/plain") &&
+      (new URL(surface.url).pathname.toLowerCase().endsWith(".json") ||
+        new URL(surface.url).hostname === "raw.githubusercontent.com")
+    ) {
+      return false;
+    }
+    return !isJsonContentType(probe.content_type);
+  }
+  if (surface.probe.expect === "html") {
+    return !String(probe.content_type || "")
+      .toLowerCase()
+      .includes("html");
+  }
+  if (surface.probe.expect === "sse") {
+    return !String(probe.content_type || "")
+      .toLowerCase()
+      .includes("text/event-stream");
+  }
+  return false;
+}
+
+export function statusForClassification(classification, surface = null) {
+  if (["live", "redirected"].includes(classification)) {
+    return "ok";
+  }
+  if (
+    ["rate-limited", "auth-required", "transient", "timeout"].includes(
+      classification,
+    )
+  ) {
+    return "degraded";
+  }
+  if (
+    ["unsupported", "dead", "content-mismatch"].includes(classification) &&
+    ["registry-observed", "community"].includes(surface?.authority)
+  ) {
+    return "degraded";
+  }
+  return "failed";
+}
+
+// --- Subtensor JSON-RPC probes (HTTP + WSS) -----------------------------------
+export async function probeSubtensorHttp(url, timeoutMs, options = {}) {
+  const { isUnsafeUrl = isUnsafePublicUrl, fetchImpl = fetch } = options;
+  if (await isUnsafeUrl(url)) {
+    return {
+      unsafe_url: true,
+      error: "unsafe URL",
+      latency_ms: 0,
+      verified_at: new Date().toISOString(),
+    };
+  }
+
+  const started = performance.now();
+  const methodResults = {};
+  let statusCode = null;
+  let contentType = null;
+  for (const [index, call] of SUBTENSOR_PROBE_CALLS.entries()) {
+    const response = await jsonRpcHttp(
+      url,
+      call.method,
+      call.params,
+      index + 1,
+      timeoutMs,
+      { fetchImpl, isUnsafeUrl },
+    );
+    statusCode = response.status_code || statusCode;
+    contentType = response.content_type || contentType;
+    methodResults[call.key] = normalizeJsonRpcResult(response);
+    if (response.transport_error) {
+      return {
+        ...response,
+        content_type: contentType,
+        latency_ms: Math.round(performance.now() - started),
+        method_results: methodResults,
+        status_code: statusCode,
+        verified_at: new Date().toISOString(),
+      };
+    }
+  }
+
+  return summarizeRpcProbe({
+    content_type: contentType,
+    latency_ms: Math.round(performance.now() - started),
+    method_results: methodResults,
+    status_code: statusCode,
+    verified_at: new Date().toISOString(),
+  });
+}
+
+async function jsonRpcHttp(url, method, params, id, timeoutMs, options = {}) {
+  const { isUnsafeUrl = isUnsafePublicUrl, fetchImpl = fetch } = options;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        accept: "application/json",
+        "content-type": "application/json",
+        "user-agent": "metagraphed-subtensor-rpc-probe/0.0",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+      redirect: "manual",
+      signal: controller.signal,
+    });
+
+    const location = response.headers.get("location");
+    if ([301, 302, 303, 307, 308].includes(response.status) && location) {
+      const redirectTarget = new URL(location, url).toString();
+      if (await isUnsafeUrl(redirectTarget)) {
+        await response.body?.cancel();
+        return {
+          transport_error: true,
+          private_redirect_blocked: true,
+          redirect_target: redirectTarget,
+          status_code: response.status,
+          error: "redirect target is unsafe",
+        };
+      }
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    const text = await response.text();
+    let body = null;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      return {
+        transport_error: true,
+        content_type: contentType || null,
+        status_code: response.status,
+        error: "response was not JSON",
+      };
+    }
+
+    return {
+      content_type: contentType || null,
+      ok: response.ok && !body?.error,
+      result: body?.result,
+      rpc_error: body?.error || null,
+      status_code: response.status,
+    };
+  } catch (error) {
+    return {
+      transport_error: true,
+      error: error.message,
+      error_class: error.name,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// WSS probe. The connector is injected because the runtimes differ: Node uses
+// the global `WebSocket` constructor; the Worker opens an outbound socket via
+// `fetch(url, { headers: { Upgrade: "websocket" } })` → `response.webSocket`.
+// `connect(url, calls, timeoutMs)` resolves a Map<callKey, {ok, result, rpc_error}>.
+export async function probeSubtensorWss(url, timeoutMs, options = {}) {
+  const { isUnsafeUrl = isUnsafePublicUrl, connect } = options;
+  if (await isUnsafeUrl(url)) {
+    return {
+      unsafe_url: true,
+      error: "unsafe URL",
+      latency_ms: 0,
+      verified_at: new Date().toISOString(),
+    };
+  }
+
+  if (typeof connect !== "function") {
+    return {
+      error: "no WebSocket connector available in this runtime",
+      error_class: "UnsupportedRuntime",
+      latency_ms: 0,
+      verified_at: new Date().toISOString(),
+    };
+  }
+
+  const started = performance.now();
+  const methodResults = {};
+  try {
+    const rawResults = await connect(url, SUBTENSOR_PROBE_CALLS, timeoutMs);
+    for (const call of SUBTENSOR_PROBE_CALLS) {
+      methodResults[call.key] = normalizeJsonRpcResult(
+        rawResults.get(call.key) || { error: "missing response" },
+      );
+    }
+    return summarizeRpcProbe({
+      latency_ms: Math.round(performance.now() - started),
+      method_results: methodResults,
+      verified_at: new Date().toISOString(),
+    });
+  } catch (error) {
+    return {
+      error: error.message,
+      error_class: error.name,
+      latency_ms: Math.round(performance.now() - started),
+      method_results: methodResults,
+      verified_at: new Date().toISOString(),
+    };
+  }
+}
+
+// Node WebSocket connector (uses the global `WebSocket`, Node 22+). The Worker
+// supplies its own fetch-upgrade connector in src/health-prober.mjs.
+export function nodeWebSocketConnector(WebSocketImpl = globalThis.WebSocket) {
+  return (url, calls, timeoutMs) =>
+    new Promise((resolve, reject) => {
+      if (typeof WebSocketImpl !== "function") {
+        reject(new Error("WebSocket global is unavailable in this runtime"));
+        return;
+      }
+      const socket = new WebSocketImpl(url);
+      const byId = new Map(calls.map((call, index) => [index + 1, call.key]));
+      const results = new Map();
+      const timer = setTimeout(() => {
+        try {
+          socket.close();
+        } catch {
+          // Ignore close failures after timeout.
+        }
+        const error = new Error("WebSocket RPC probe timed out");
+        error.name = "TimeoutError";
+        reject(error);
+      }, timeoutMs);
+
+      socket.addEventListener("open", () => {
+        calls.forEach((call, index) => {
+          socket.send(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: index + 1,
+              method: call.method,
+              params: call.params,
+            }),
+          );
+        });
+      });
+
+      socket.addEventListener("message", (event) => {
+        try {
+          const body = JSON.parse(String(event.data));
+          const key = byId.get(body.id);
+          if (!key) {
+            return;
+          }
+          results.set(key, {
+            ok: !body.error,
+            result: body.result,
+            rpc_error: body.error || null,
+          });
+          if (results.size === calls.length) {
+            clearTimeout(timer);
+            socket.close();
+            resolve(results);
+          }
+        } catch (error) {
+          clearTimeout(timer);
+          try {
+            socket.close();
+          } catch {
+            // Ignore close failures after parse failure.
+          }
+          reject(error);
+        }
+      });
+
+      socket.addEventListener("error", () => {
+        clearTimeout(timer);
+        reject(new Error("WebSocket RPC connection failed"));
+      });
+    });
+}
+
+export function normalizeJsonRpcResult(response) {
+  const normalized = {
+    ok: Boolean(response.ok),
+    error: response.error || response.rpc_error?.message || null,
+    code: response.rpc_error?.code || null,
+    result_type:
+      response.result === null
+        ? "null"
+        : Array.isArray(response.result)
+          ? "array"
+          : typeof response.result,
+    result_present: response.result !== null && response.result !== undefined,
+  };
+  if (
+    response.result &&
+    typeof response.result === "object" &&
+    !Array.isArray(response.result) &&
+    response.result.number
+  ) {
+    normalized.raw_header = { number: response.result.number };
+  }
+  if (response.result && Array.isArray(response.result.methods)) {
+    normalized.rpc_method_count = response.result.methods.length;
+  }
+  if (typeof response.result === "string" && response.result.startsWith("0x")) {
+    normalized.raw_hex_result_present = true;
+  }
+  return normalized;
+}
+
+export function summarizeRpcProbe(probe) {
+  const header = probe.method_results.chain_getHeader;
+  const methods = probe.method_results.rpc_methods;
+  const archiveProbe = probe.method_results.archive_probe;
+  const latestBlock = parseBlockNumber(header?.raw_header);
+  return {
+    ...probe,
+    archive_support: Boolean(
+      archiveProbe?.ok && archiveProbe.raw_hex_result_present,
+    ),
+    latest_block: latestBlock,
+    methods_supported: {
+      chain_getHeader: Boolean(probe.method_results.chain_getHeader?.ok),
+      system_health: Boolean(probe.method_results.system_health?.ok),
+      rpc_methods: Boolean(probe.method_results.rpc_methods?.ok),
+      chain_getBlockHash: Boolean(probe.method_results.archive_probe?.ok),
+    },
+    rpc_method_count: methods?.rpc_method_count ?? null,
+  };
+}
+
+export function parseBlockNumber(header) {
+  if (!header || typeof header !== "object") {
+    return null;
+  }
+  const value = header.number;
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "string") {
+    return value.startsWith("0x")
+      ? Number.parseInt(value, 16)
+      : Number.parseInt(value, 10);
+  }
+  return null;
+}
+
+// Bounded-concurrency map. Preserves INPUT order in the returned array (callers
+// that need a different order sort afterwards). Used by both the Node build and
+// the Worker cron prober to respect the runtime's simultaneous-connection cap.
+export async function mapLimit(items, limit, mapper) {
+  const results = new Array(items.length);
+  let cursor = 0;
+  const workerCount = Math.max(1, Math.min(limit, items.length));
+  const workers = Array.from({ length: workerCount }, async () => {
+    while (cursor < items.length) {
+      const index = cursor;
+      cursor += 1;
+      results[index] = await mapper(items[index], index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+// --- Top-level: probe one surface → common probe-derived row ------------------
+// Returns the fields both callers share. It does NOT compute `last_ok` or
+// `uptime_sample_ratio` (history/store-derived): the Node build computes those
+// from its daily history files; the Worker computes them from D1 `surface_status`.
+export async function probeSurface(surface, options = {}) {
+  const isRpc = ["subtensor-rpc", "subtensor-wss"].includes(surface.kind);
+  if (isRpc) {
+    const timeoutMs = surface.probe.timeout_ms || 12000;
+    const fallbackVerifiedAt = new Date().toISOString();
+    const probe =
+      surface.kind === "subtensor-wss"
+        ? await probeSubtensorWss(surface.url, timeoutMs, options)
+        : await probeSubtensorHttp(surface.url, timeoutMs, options);
+    const classification = classifyRpcProbe(probe);
+    const status = statusForClassification(classification, surface);
+    const verifiedAt = probe.verified_at || fallbackVerifiedAt;
+    // NOTE: pass probe fields through verbatim (no `?? null`). In the
+    // transport-error case the RPC probe omits archive_support/latest_block/
+    // methods_supported/rpc_method_count entirely; preserving `undefined` keeps
+    // the Node build's stableStringify output byte-identical (undefined keys are
+    // dropped). The Worker coerces to null at the D1 column boundary.
+    return {
+      archive_support: probe.archive_support,
+      auth_required: surface.auth_required,
+      classification,
+      content_type: probe.content_type || null,
+      error: probe.error || null,
+      error_class: probe.error_class || null,
+      kind: surface.kind,
+      last_checked: verifiedAt,
+      latency_ms: probe.latency_ms,
+      latest_block: probe.latest_block,
+      method_results: probe.method_results,
+      method_tested: surface.probe.method,
+      methods_supported: probe.methods_supported,
+      netuid: surface.netuid,
+      private_redirect_blocked: probe.private_redirect_blocked || false,
+      provider: surface.provider,
+      public_safe: surface.public_safe,
+      redirect_target: probe.redirect_target || null,
+      rpc_method_count: probe.rpc_method_count,
+      status,
+      status_code: probe.status_code || null,
+      subnet_name: surface.subnet_name,
+      subnet_slug: surface.subnet_slug,
+      surface_id: surface.id,
+      url: surface.url,
+      verified_at: verifiedAt,
+    };
+  }
+
+  const timeoutMs = surface.probe.timeout_ms || 8000;
+  let probe = await probeUrl(
+    surface.url,
+    surface.probe.method,
+    acceptHeader(surface.probe.expect),
+    timeoutMs,
+    options,
+  );
+  if (
+    !probe.ok &&
+    surface.probe.method === "HEAD" &&
+    [400, 403, 405].includes(probe.status_code)
+  ) {
+    probe = await probeUrl(
+      surface.url,
+      "GET",
+      acceptHeader(surface.probe.expect),
+      timeoutMs,
+      options,
+    );
+  }
+  const classification = classifyProbe(probe, surface);
+  const status = statusForClassification(classification, surface);
+  return {
+    auth_required: surface.auth_required,
+    classification,
+    content_type: probe.content_type || null,
+    error: probe.error || null,
+    error_class: probe.error_class || null,
+    kind: surface.kind,
+    last_checked: probe.verified_at,
+    latency_ms: probe.latency_ms,
+    method_tested: probe.method_tested,
+    netuid: surface.netuid,
+    private_redirect_blocked: probe.private_redirect_blocked || false,
+    provider: surface.provider,
+    public_safe: surface.public_safe,
+    redirect_target: probe.redirect_target || null,
+    status,
+    status_code: probe.status_code || null,
+    subnet_name: surface.subnet_name,
+    subnet_slug: surface.subnet_slug,
+    surface_id: surface.id,
+    url: surface.url,
+    verified_at: probe.verified_at,
+  };
+}

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  classifyProbe,
+  classifyRpcProbe,
+  contentMismatch,
+  isUnsafePublicUrl,
+  mapLimit,
+  probeSurface,
+  statusForClassification,
+  summarizeRpcProbe,
+} from "../src/health-probe-core.mjs";
+
+// Minimal Response-like stub for an injected fetch.
+function fakeResponse({
+  status = 200,
+  contentType = "application/json",
+  body = "{}",
+} = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get(name) {
+        if (name === "content-type") return contentType;
+        return null;
+      },
+    },
+    body: { cancel: async () => {} },
+    async text() {
+      return body;
+    },
+  };
+}
+
+describe("isUnsafePublicUrl", () => {
+  test("blocks private/loopback/link-local + non-http schemes", () => {
+    for (const url of [
+      "http://localhost/x",
+      "http://127.0.0.1/x",
+      "http://10.1.2.3/x",
+      "http://192.168.0.1/x",
+      "http://169.254.169.254/latest",
+      "http://172.16.0.1/x",
+      "http://172.31.255.255/x",
+      "https://service.local/x",
+      "ftp://example.com/x",
+      "file:///etc/passwd",
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), true, url);
+    }
+  });
+
+  test("allows public http(s)/ws(s)", () => {
+    for (const url of [
+      "https://entrypoint-finney.opentensor.ai",
+      "http://example.com/api",
+      "wss://lite.chain.opentensor.ai:443",
+      "https://172.15.0.1/x", // just outside the private 172.16-31 range
+    ]) {
+      assert.equal(isUnsafePublicUrl(url), false, url);
+    }
+  });
+});
+
+describe("classifyProbe", () => {
+  const htmlSurface = { url: "https://x.dev", probe: { expect: "html" } };
+  const jsonSurface = {
+    url: "https://x.dev/data.json",
+    probe: { expect: "json" },
+  };
+
+  test("maps status codes + content to classifications", () => {
+    assert.equal(
+      classifyProbe({ error_class: "AbortError" }, htmlSurface),
+      "timeout",
+    );
+    assert.equal(
+      classifyProbe({ status_code: 429 }, htmlSurface),
+      "rate-limited",
+    );
+    assert.equal(
+      classifyProbe({ status_code: 403 }, htmlSurface),
+      "auth-required",
+    );
+    assert.equal(classifyProbe({ status_code: 404 }, htmlSurface), "dead");
+    assert.equal(classifyProbe({ status_code: 503 }, htmlSurface), "transient");
+    assert.equal(
+      classifyProbe({ ok: true, content_type: "text/html" }, htmlSurface),
+      "live",
+    );
+    assert.equal(
+      classifyProbe({ ok: true, content_type: "text/html" }, jsonSurface),
+      "content-mismatch",
+    );
+    assert.equal(
+      classifyProbe(
+        {
+          ok: true,
+          content_type: "application/json",
+          redirect_target: "https://y",
+        },
+        jsonSurface,
+      ),
+      "redirected",
+    );
+    assert.equal(classifyProbe({ unsafe_url: true }, htmlSurface), "unsafe");
+  });
+
+  test("content-mismatch tolerates text/plain JSON from raw.githubusercontent.com", () => {
+    const raw = {
+      url: "https://raw.githubusercontent.com/o/r/main/x.json",
+      probe: { expect: "json" },
+    };
+    assert.equal(
+      contentMismatch({ content_type: "text/plain; charset=utf-8" }, raw),
+      false,
+    );
+  });
+});
+
+describe("classifyRpcProbe + statusForClassification", () => {
+  test("live requires header + system_health", () => {
+    assert.equal(
+      classifyRpcProbe({
+        method_results: {
+          chain_getHeader: { ok: true },
+          system_health: { ok: true },
+        },
+      }),
+      "live",
+    );
+    assert.equal(
+      classifyRpcProbe({ method_results: { chain_getHeader: { ok: true } } }),
+      "unsupported",
+    );
+    assert.equal(classifyRpcProbe({ error_class: "TimeoutError" }), "timeout");
+  });
+
+  test("status downgrades for community/registry-observed authorities", () => {
+    assert.equal(statusForClassification("live"), "ok");
+    assert.equal(statusForClassification("timeout"), "degraded");
+    assert.equal(
+      statusForClassification("dead", { authority: "official" }),
+      "failed",
+    );
+    assert.equal(
+      statusForClassification("dead", { authority: "community" }),
+      "degraded",
+    );
+  });
+});
+
+describe("summarizeRpcProbe", () => {
+  test("derives archive_support, methods_supported, latest_block", () => {
+    const summary = summarizeRpcProbe({
+      method_results: {
+        chain_getHeader: { ok: true, raw_header: { number: "0x10" } },
+        system_health: { ok: true },
+        rpc_methods: { ok: true, rpc_method_count: 42 },
+        archive_probe: { ok: true, raw_hex_result_present: true },
+      },
+    });
+    assert.equal(summary.archive_support, true);
+    assert.equal(summary.latest_block, 16);
+    assert.equal(summary.rpc_method_count, 42);
+    assert.deepEqual(summary.methods_supported, {
+      chain_getHeader: true,
+      system_health: true,
+      rpc_methods: true,
+      chain_getBlockHash: true,
+    });
+  });
+});
+
+describe("mapLimit", () => {
+  test("preserves input order and bounds concurrency", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const out = await mapLimit([1, 2, 3, 4, 5], 2, async (n) => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((r) => setTimeout(r, 1));
+      inFlight -= 1;
+      return n * 10;
+    });
+    assert.deepEqual(out, [10, 20, 30, 40, 50]);
+    assert.ok(maxInFlight <= 2, `maxInFlight=${maxInFlight}`);
+  });
+});
+
+describe("probeSurface (injected fetch)", () => {
+  const surface = {
+    id: "sn7-api",
+    netuid: 7,
+    kind: "subnet-api",
+    url: "https://api.example.dev/health",
+    provider: "acme",
+    auth_required: false,
+    public_safe: true,
+    subnet_name: "Acme",
+    subnet_slug: "acme",
+    probe: { enabled: true, method: "GET", expect: "json", timeout_ms: 5000 },
+  };
+
+  test("a 200 JSON response is live/ok", async () => {
+    const base = await probeSurface(surface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () =>
+        fakeResponse({ status: 200, contentType: "application/json" }),
+    });
+    assert.equal(base.status, "ok");
+    assert.equal(base.classification, "live");
+    assert.equal(base.surface_id, "sn7-api");
+    assert.equal(base.netuid, 7);
+    assert.equal(typeof base.last_checked, "string");
+  });
+
+  test("HEAD 405 falls back to GET", async () => {
+    const calls = [];
+    const headSurface = {
+      ...surface,
+      probe: { ...surface.probe, method: "HEAD" },
+    };
+    const base = await probeSurface(headSurface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_url, init) => {
+        calls.push(init.method);
+        return init.method === "HEAD"
+          ? fakeResponse({ status: 405, contentType: "text/plain" })
+          : fakeResponse({ status: 200, contentType: "application/json" });
+      },
+    });
+    assert.deepEqual(calls, ["HEAD", "GET"]);
+    assert.equal(base.status, "ok");
+    assert.equal(base.method_tested, "GET");
+  });
+});

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -31,9 +31,7 @@
     "METAGRAPH_ENABLE_RPC_PROXY": "true",
     "METAGRAPH_R2_LATEST_PREFIX": "latest/",
   },
-  "routes": [
-    { "pattern": "api.metagraph.sh", "custom_domain": true },
-  ],
+  "routes": [{ "pattern": "api.metagraph.sh", "custom_domain": true }],
   "kv_namespaces": [
     {
       "binding": "METAGRAPH_CONTROL",
@@ -44,6 +42,17 @@
     {
       "binding": "METAGRAPH_ARCHIVE",
       "bucket_name": "metagraphed-artifacts",
+    },
+  ],
+  // Live operational-health store. Written every 2 minutes by the cron prober
+  // (src/health-prober.mjs) and read live by the serving layer — decoupled from
+  // the 6h build so a stale structural snapshot never freezes health.
+  "d1_databases": [
+    {
+      "binding": "METAGRAPH_HEALTH_DB",
+      "database_name": "metagraphed-health",
+      "database_id": "fcb0b856-1829-46a3-a2f1-c1ba3a9a1915",
+      "migrations_dir": "migrations",
     },
   ],
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite


### PR DESCRIPTION
## Why

Operational health (RPC/WSS chain nodes, subnet APIs, SSE) is currently baked into **static R2 artifacts refreshed only every 6h**, and is *structurally coupled* to the slow structural pipeline: `surface-health` is a **blocking** publish gate, refreshed solely by `sync-subnets.yml` (2×/day). When the native-chain snapshot goes >24h stale, the freshness gate aborts the **entire** publish — freezing health too. A 6h-old "endpoint is up" is operationally useless.

This is **Phase 1 of 5** re-architecting operational health onto a **2-minute Cloudflare cron prober → D1/KV → served live**, decoupled from the build. See the plan for the full arc. **This PR is foundations only — no behavior change; serving is untouched.**

## What's in this PR

- **`src/health-probe-core.mjs`** — pure, isomorphic probe primitives (HTTP/JSON-RPC/WSS probing, classification, bounded-concurrency `mapLimit`) shared by the Node build and the upcoming Worker cron prober. `fetch`, the SSRF guard, and the WebSocket connector are **injected**, so it runs unchanged on the Workers runtime and Node 22.
- **`scripts/probes-smoke.mjs`** — refactored to import the core (≈615 lines of duplicated probe logic removed). Logic moved **verbatim**; `writeJson` sorts keys via `stableStringify`, so the 6h build output stays **byte-identical**.
- **`operational-surfaces.json`** — new committed (git-tier) artifact listing the **58 operational surfaces** (5 RPC + 4 WSS + 25 subnet-api + 1 SSE + 23 data-artifact) the prober consumes. New `OperationalSurfacesArtifact` schema + contract route registration + docs.
- **D1 `metagraphed-health`** (`fcb0b856…`) + `migrations/0001_health.sql` — `surface_checks` (append-only time-series → powers `/health/trends`) + `surface_status` (upserted latest row + cross-isolate circuit-breaker counter). Bound as `METAGRAPH_HEALTH_DB`. Migration applied to remote + local.

## Verification

- `npm test` — **256/256** (incl. new `tests/health-probe-core.test.mjs`, 10 tests locking previously-uncovered classification logic).
- `validate` + `validate:schemas/api/openapi/types/artifact-budgets/docs/workflows` — all green.
- `worker:deploy:dry-run` — green (validates the new D1 binding in `wrangler.jsonc`).
- Subset-commit discipline: committed deterministic contract artifacts (operational-surfaces, openapi, types, api-index, contracts, bundled schema); restored changelog/build-summary/r2-manifest to main.

## Next phases
2. Cron prober (`scheduled()` → D1/KV writes). 3. Serve live + `/health/trends`. 4. Decouple the freshness gate + harden `sync-subnets`. 5. SDK 0.2.0 + docs/ADR.