### PR TITLE
feat(health): Phase 2 — 2-minute cron prober (D1/KV writes)

### DIFF
--- a/scripts/cloudflare-verify.mjs
+++ b/scripts/cloudflare-verify.mjs
@@ -1,6 +1,11 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { readJson, repoRoot, stableStringify } from "./lib.mjs";
+import {
+  readJson,
+  repoRoot,
+  stableStringify,
+  stripJsonComments,
+} from "./lib.mjs";
 
 const configPath = path.join(repoRoot, "wrangler.jsonc");
 const assetsIgnorePath = path.join(repoRoot, "public/.assetsignore");
@@ -159,11 +164,4 @@ function check(condition, message) {
   if (!condition) {
     errors.push(message);
   }
-}
-
-function stripJsonComments(value) {
-  return value
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|\s)\/\/.*$/gm, "$1")
-    .replace(/,\s*([}\]])/g, "$1");
 }

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -131,6 +131,64 @@ export async function writeJson(filePath, value) {
   await fs.writeFile(filePath, `${stableStringify(value)}\n`, "utf8");
 }
 
+// String-aware JSONC comment stripper. Unlike a naive regex, it never treats
+// `//`, `/*`, or `*/` INSIDE a string literal as a comment delimiter — essential
+// because wrangler.jsonc holds route globs like `"/api/*"` (ends in `/*`) and the
+// cron `"*/2 * * * *"` (contains `*/`); a regex stripper would splice from the
+// former's `/*` to the latter's `*/` and delete the config in between. Also drops
+// trailing commas so JSON.parse accepts the result.
+export function stripJsonComments(value) {
+  let out = "";
+  let inString = false;
+  let inLine = false;
+  let inBlock = false;
+  for (let i = 0; i < value.length; i += 1) {
+    const ch = value[i];
+    const next = value[i + 1];
+    if (inLine) {
+      if (ch === "\n") {
+        inLine = false;
+        out += ch;
+      }
+      continue;
+    }
+    if (inBlock) {
+      if (ch === "*" && next === "/") {
+        inBlock = false;
+        i += 1;
+      }
+      continue;
+    }
+    if (inString) {
+      out += ch;
+      if (ch === "\\") {
+        out += next ?? "";
+        i += 1;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+      out += ch;
+      continue;
+    }
+    if (ch === "/" && next === "/") {
+      inLine = true;
+      i += 1;
+      continue;
+    }
+    if (ch === "/" && next === "*") {
+      inBlock = true;
+      i += 1;
+      continue;
+    }
+    out += ch;
+  }
+  return out.replace(/,\s*([}\]])/g, "$1");
+}
+
 export async function formatRepositoryJson(value) {
   const prettier = await import("prettier");
   return prettier.format(`${stableStringify(value)}\n`, { parser: "json" });

--- a/scripts/worker-deploy-dry-run.mjs
+++ b/scripts/worker-deploy-dry-run.mjs
@@ -1,6 +1,6 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
-import { repoRoot } from "./lib.mjs";
+import { repoRoot, stripJsonComments } from "./lib.mjs";
 
 const configPath = path.join(repoRoot, "wrangler.jsonc");
 const workerPath = path.join(repoRoot, "workers/api.mjs");
@@ -79,11 +79,4 @@ function check(condition, message) {
   if (!condition) {
     errors.push(message);
   }
-}
-
-function stripJsonComments(value) {
-  return value
-    .replace(/\/\*[\s\S]*?\*\//g, "")
-    .replace(/(^|\s)\/\/.*$/gm, "$1")
-    .replace(/,\s*([}\]])/g, "$1");
 }

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -1,0 +1,438 @@
+// Live operational-health cron prober.
+//
+// Runs in the Worker on a 2-minute Cron Trigger (workers/api.mjs `scheduled()`):
+// loads the committed operational-surfaces.json list, probes each surface with
+// the shared isomorphic core (src/health-probe-core.mjs) under bounded
+// concurrency, then writes:
+//   - D1 surface_checks  (append-only time-series → /health/trends)
+//   - D1 surface_status  (upserted latest row + circuit-breaker counter)
+//   - KV health:current  (global + per-subnet operational rollup + 58 rows)
+//   - KV health:rpc-pool (live RPC/WSS endpoint eligibility for the proxy)
+//   - KV health:meta     (last_run_at + counts → freshness + self-monitoring)
+//
+// Everything is injected (db, kv, loadSurfaces, probe, now) so the whole run is
+// unit-testable without a live runtime. Decoupled from the 6h build: a stale
+// structural snapshot can never freeze health again.
+
+import {
+  isUnsafePublicUrl,
+  mapLimit,
+  probeSurface as coreProbeSurface,
+} from "./health-probe-core.mjs";
+
+export const KV_HEALTH_CURRENT = "health:current";
+export const KV_HEALTH_RPC_POOL = "health:rpc-pool";
+export const KV_HEALTH_META = "health:meta";
+export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
+
+const PROBE_CONCURRENCY = 8;
+const HISTORY_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+const RPC_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
+
+const iso = (ms) => (Number.isFinite(ms) ? new Date(ms).toISOString() : null);
+
+// Worker outbound-WebSocket connector for the WSS subtensor probe. Workers open
+// client sockets via fetch(Upgrade: websocket) → response.webSocket, NOT the
+// `new WebSocket()` constructor (which the Node build uses). Resolves a
+// Map<callKey, {ok, result, rpc_error}> matching the core's expectation.
+export function workerWebSocketConnector(fetchImpl = fetch) {
+  return (url, calls, timeoutMs) =>
+    new Promise((resolve, reject) => {
+      const httpUrl = url.replace(/^ws/i, "http");
+      let settled = false;
+      let socket = null;
+      const byId = new Map(calls.map((call, index) => [index + 1, call.key]));
+      const results = new Map();
+      const timer = setTimeout(
+        () => finish(new Error("WSS RPC probe timed out"), "TimeoutError"),
+        timeoutMs,
+      );
+
+      function finish(error, name) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        try {
+          socket?.close();
+        } catch {
+          // ignore close failures
+        }
+        if (error) {
+          if (name) error.name = name;
+          reject(error);
+        } else {
+          resolve(results);
+        }
+      }
+
+      fetchImpl(httpUrl, { headers: { Upgrade: "websocket" } })
+        .then((response) => {
+          socket = response.webSocket;
+          if (!socket) {
+            finish(new Error("server did not accept the WebSocket upgrade"));
+            return;
+          }
+          socket.accept();
+          socket.addEventListener("message", (event) => {
+            try {
+              const raw =
+                typeof event.data === "string"
+                  ? event.data
+                  : new TextDecoder().decode(event.data);
+              const body = JSON.parse(raw);
+              const key = byId.get(body.id);
+              if (!key) return;
+              results.set(key, {
+                ok: !body.error,
+                result: body.result,
+                rpc_error: body.error || null,
+              });
+              if (results.size === calls.length) finish(null);
+            } catch (error) {
+              finish(error);
+            }
+          });
+          socket.addEventListener("error", () =>
+            finish(new Error("WebSocket RPC connection failed")),
+          );
+          socket.addEventListener("close", () => {
+            if (results.size < calls.length) {
+              finish(new Error("WebSocket closed before all responses"));
+            }
+          });
+          for (const [index, call] of calls.entries()) {
+            socket.send(
+              JSON.stringify({
+                jsonrpc: "2.0",
+                id: index + 1,
+                method: call.method,
+                params: call.params,
+              }),
+            );
+          }
+        })
+        .catch((error) => finish(error));
+    });
+}
+
+// Read the committed operational-surfaces.json (dual tier) via the ASSETS
+// binding, falling back to R2. Returns the surfaces array (empty on failure —
+// the run then no-ops rather than throwing).
+export async function loadOperationalSurfaces(env) {
+  // ASSETS first (committed, always present in the deployed Worker).
+  try {
+    if (env.ASSETS?.fetch) {
+      const response = await env.ASSETS.fetch(
+        new Request(`https://assets.local${OPERATIONAL_SURFACES_PATH}`),
+      );
+      if (response.ok) {
+        const body = await response.json();
+        if (Array.isArray(body?.surfaces)) return body.surfaces;
+      }
+    }
+  } catch {
+    // fall through to R2
+  }
+  try {
+    if (env.METAGRAPH_ARCHIVE?.get) {
+      const prefix = env.METAGRAPH_R2_LATEST_PREFIX || "latest/";
+      const key = `${prefix}metagraph/operational-surfaces.json`;
+      const object = await env.METAGRAPH_ARCHIVE.get(key);
+      if (object) {
+        const body = JSON.parse(await object.text());
+        if (Array.isArray(body?.surfaces)) return body.surfaces;
+      }
+    }
+  } catch {
+    // fall through to empty
+  }
+  return [];
+}
+
+function rollupStatus({ ok, degraded, failed, unknown, total }) {
+  if (total === 0 || unknown === total) return "unknown";
+  if (failed === 0 && degraded === 0) return "ok";
+  if (ok > 0 || degraded > 0) return "degraded";
+  return "failed";
+}
+
+function summarizeGroup(rows) {
+  const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
+  let lastChecked = 0;
+  let lastOk = 0;
+  const latencies = [];
+  for (const row of rows) {
+    counts[row.status] = (counts[row.status] || 0) + 1;
+    if (row.checked_at_ms > lastChecked) lastChecked = row.checked_at_ms;
+    if (row.last_ok_ms && row.last_ok_ms > lastOk) lastOk = row.last_ok_ms;
+    if (Number.isFinite(row.latency_ms)) latencies.push(row.latency_ms);
+  }
+  return {
+    status: rollupStatus({ ...counts, total: rows.length }),
+    surface_count: rows.length,
+    ok_count: counts.ok,
+    degraded_count: counts.degraded,
+    failed_count: counts.failed,
+    unknown_count: counts.unknown,
+    last_checked: iso(lastChecked) || null,
+    last_ok: iso(lastOk) || null,
+    avg_latency_ms: latencies.length
+      ? Math.round(latencies.reduce((s, v) => s + v, 0) / latencies.length)
+      : null,
+  };
+}
+
+// Run one full probe sweep and persist results. Returns a small summary object.
+export async function runHealthProber(env, ctx, overrides = {}) {
+  const now = overrides.now || (() => Date.now());
+  const db = overrides.db || env.METAGRAPH_HEALTH_DB;
+  const kv = overrides.kv || env.METAGRAPH_CONTROL;
+  const loadSurfaces =
+    overrides.loadSurfaces || (() => loadOperationalSurfaces(env));
+  const probe = overrides.probeSurface || coreProbeSurface;
+  const probeOptions = overrides.probeOptions || {
+    isUnsafeUrl: overrides.isUnsafeUrl || isUnsafePublicUrl,
+    connect: overrides.connect || workerWebSocketConnector(),
+  };
+  const concurrency = overrides.concurrency || PROBE_CONCURRENCY;
+
+  const runAt = now();
+  const surfaces = await loadSurfaces();
+  if (!surfaces.length) {
+    return { ok: false, reason: "no-operational-surfaces", probed: 0 };
+  }
+
+  // Prior status (last_ok + consecutive_failures) for continuity + the breaker.
+  const priorStatus = new Map();
+  if (db) {
+    try {
+      const ids = surfaces.map((s) => s.surface_id);
+      const placeholders = ids.map(() => "?").join(",");
+      const { results } = await db
+        .prepare(
+          `SELECT surface_id, last_ok, consecutive_failures FROM surface_status WHERE surface_id IN (${placeholders})`,
+        )
+        .bind(...ids)
+        .all();
+      for (const row of results || []) priorStatus.set(row.surface_id, row);
+    } catch {
+      // First run / cold table — treat all as having no prior state.
+    }
+  }
+
+  const probed = await mapLimit(surfaces, concurrency, async (surface) => {
+    const input = {
+      id: surface.surface_id,
+      netuid: surface.netuid,
+      kind: surface.kind,
+      url: surface.url,
+      provider: surface.provider,
+      authority: surface.authority,
+      auth_required: surface.auth_required,
+      public_safe: surface.public_safe,
+      subnet_slug: surface.subnet_slug,
+      subnet_name: surface.subnet_name,
+      probe: surface.probe || { method: "GET", expect: "any" },
+    };
+    let base;
+    try {
+      base = await probe(input, probeOptions);
+    } catch (error) {
+      base = {
+        status: "failed",
+        classification: "unsupported",
+        latency_ms: null,
+        status_code: null,
+        error: error?.message || "probe threw",
+      };
+    }
+    const ok = base.status === "ok";
+    const prior = priorStatus.get(surface.surface_id);
+    const lastOkMs = ok ? runAt : (prior?.last_ok ?? null);
+    const consecutiveFailures = ok ? 0 : (prior?.consecutive_failures ?? 0) + 1;
+    return {
+      surface_id: surface.surface_id,
+      netuid: surface.netuid,
+      kind: surface.kind,
+      provider: surface.provider || null,
+      url: surface.url,
+      status: base.status,
+      classification: base.classification || null,
+      latency_ms: Number.isFinite(base.latency_ms) ? base.latency_ms : null,
+      status_code: Number.isInteger(base.status_code) ? base.status_code : null,
+      archive_support: base.archive_support ?? null,
+      checked_at_ms: runAt,
+      last_ok_ms: lastOkMs,
+      consecutive_failures: consecutiveFailures,
+    };
+  });
+
+  await persistToD1(db, probed, runAt);
+  await persistToKv(kv, probed, runAt);
+
+  const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
+  for (const row of probed) counts[row.status] = (counts[row.status] || 0) + 1;
+  return {
+    ok: true,
+    probed: probed.length,
+    counts,
+    run_at: iso(runAt),
+    duration_ms: now() - runAt,
+  };
+}
+
+async function persistToD1(db, probed, runAt) {
+  if (!db?.prepare) return;
+  try {
+    const checkStmt = db.prepare(
+      `INSERT INTO surface_checks
+       (surface_id, netuid, kind, status, classification, latency_ms, status_code, ok, checked_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const statusStmt = db.prepare(
+      `INSERT INTO surface_status
+       (surface_id, netuid, kind, url, provider, status, classification, latency_ms, status_code, last_checked, last_ok, consecutive_failures, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(surface_id) DO UPDATE SET
+         netuid=excluded.netuid, kind=excluded.kind, url=excluded.url,
+         provider=excluded.provider, status=excluded.status,
+         classification=excluded.classification, latency_ms=excluded.latency_ms,
+         status_code=excluded.status_code, last_checked=excluded.last_checked,
+         last_ok=excluded.last_ok, consecutive_failures=excluded.consecutive_failures,
+         updated_at=excluded.updated_at`,
+    );
+    const statements = [];
+    for (const row of probed) {
+      statements.push(
+        checkStmt.bind(
+          row.surface_id,
+          row.netuid,
+          row.kind,
+          row.status,
+          row.classification,
+          row.latency_ms,
+          row.status_code,
+          row.status === "ok" ? 1 : 0,
+          row.checked_at_ms,
+        ),
+        statusStmt.bind(
+          row.surface_id,
+          row.netuid,
+          row.kind,
+          row.url,
+          row.provider,
+          row.status,
+          row.classification,
+          row.latency_ms,
+          row.status_code,
+          row.checked_at_ms,
+          row.last_ok_ms,
+          row.consecutive_failures,
+          runAt,
+        ),
+      );
+    }
+    await db.batch(statements);
+  } catch {
+    // D1 unavailable / schema cold: KV still gets written so serving stays live.
+  }
+}
+
+async function persistToKv(kv, probed, runAt) {
+  if (!kv?.put) return;
+  const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
+  for (const row of probed) counts[row.status] = (counts[row.status] || 0) + 1;
+
+  const surfaceRows = probed.map((row) => ({
+    surface_id: row.surface_id,
+    netuid: row.netuid,
+    kind: row.kind,
+    provider: row.provider,
+    url: row.url,
+    status: row.status,
+    classification: row.classification,
+    latency_ms: row.latency_ms,
+    status_code: row.status_code,
+    last_checked: iso(row.checked_at_ms),
+    last_ok: iso(row.last_ok_ms),
+  }));
+
+  const byNetuid = new Map();
+  for (const row of probed) {
+    const group = byNetuid.get(row.netuid) || [];
+    group.push(row);
+    byNetuid.set(row.netuid, group);
+  }
+  const subnets = [...byNetuid.entries()]
+    .map(([netuid, rows]) => ({ netuid, ...summarizeGroup(rows) }))
+    .sort((a, b) => a.netuid - b.netuid);
+
+  const current = {
+    schema_version: 1,
+    generated_at: iso(runAt),
+    last_run_at: iso(runAt),
+    source: "live-cron-prober",
+    summary: { surface_count: probed.length, status_counts: counts },
+    subnets,
+    surfaces: surfaceRows,
+  };
+
+  const rpcRows = probed
+    .filter((row) => RPC_KINDS.has(row.kind))
+    .map((row) => ({
+      id: row.surface_id,
+      url: row.url,
+      kind: row.kind,
+      provider: row.provider,
+      status: row.status,
+      classification: row.classification,
+      latency_ms: row.latency_ms,
+      archive_support: row.archive_support,
+      last_ok: iso(row.last_ok_ms),
+      consecutive_failures: row.consecutive_failures,
+      pool_eligible: row.status === "ok",
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
+  const rpcPool = {
+    schema_version: 1,
+    generated_at: iso(runAt),
+    last_run_at: iso(runAt),
+    source: "live-cron-prober",
+    endpoint_count: rpcRows.length,
+    eligible_count: rpcRows.filter((r) => r.pool_eligible).length,
+    endpoints: rpcRows,
+  };
+
+  const meta = {
+    schema_version: 1,
+    last_run_at: iso(runAt),
+    probed_count: probed.length,
+    status_counts: counts,
+    rpc_endpoint_count: rpcRows.length,
+    rpc_eligible_count: rpcPool.eligible_count,
+  };
+
+  await Promise.all([
+    kv.put(KV_HEALTH_CURRENT, JSON.stringify(current)),
+    kv.put(KV_HEALTH_RPC_POOL, JSON.stringify(rpcPool)),
+    kv.put(KV_HEALTH_META, JSON.stringify(meta)),
+  ]);
+}
+
+// Hourly maintenance cron: prune time-series rows older than the retention
+// window so the hot table stays lean.
+export async function pruneHealthHistory(env, overrides = {}) {
+  const now = overrides.now || (() => Date.now());
+  const db = overrides.db || env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return { pruned: false };
+  const cutoff = now() - (overrides.retentionMs || HISTORY_RETENTION_MS);
+  try {
+    const result = await db
+      .prepare(`DELETE FROM surface_checks WHERE checked_at < ?`)
+      .bind(cutoff)
+      .run();
+    return { pruned: true, cutoff, changes: result?.meta?.changes ?? null };
+  } catch {
+    return { pruned: false };
+  }
+}

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  KV_HEALTH_CURRENT,
+  KV_HEALTH_META,
+  KV_HEALTH_RPC_POOL,
+  pruneHealthHistory,
+  runHealthProber,
+} from "../src/health-prober.mjs";
+import { handleScheduled } from "../workers/api.mjs";
+
+// --- mocks --------------------------------------------------------------------
+function makeDb({ priorStatus = [] } = {}) {
+  const calls = { batches: [], runs: [], selects: [] };
+  const bound = (sql, binds) => ({
+    sql,
+    binds,
+    async all() {
+      calls.selects.push({ sql, binds });
+      if (/FROM surface_status WHERE surface_id IN/.test(sql)) {
+        return { results: priorStatus };
+      }
+      return { results: [] };
+    },
+    async run() {
+      calls.runs.push({ sql, binds });
+      return { meta: { changes: 7 } };
+    },
+  });
+  return {
+    calls,
+    prepare(sql) {
+      return { sql, bind: (...binds) => bound(sql, binds) };
+    },
+    async batch(statements) {
+      calls.batches.push(statements);
+      return statements.map(() => ({ success: true }));
+    },
+  };
+}
+
+function makeKv() {
+  const store = new Map();
+  return {
+    store,
+    async put(key, value) {
+      store.set(key, value);
+    },
+    async get(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    json(key) {
+      const raw = store.get(key);
+      return raw ? JSON.parse(raw) : null;
+    },
+  };
+}
+
+const SURFACES = [
+  {
+    surface_id: "sn7-api",
+    netuid: 7,
+    kind: "subnet-api",
+    url: "https://api.example.dev",
+    provider: "acme",
+    authority: "official",
+    auth_required: false,
+    public_safe: true,
+    subnet_slug: "acme",
+    subnet_name: "Acme",
+    probe: { method: "GET", expect: "json" },
+  },
+  {
+    surface_id: "opentensor-finney-rpc",
+    netuid: 0,
+    kind: "subtensor-rpc",
+    url: "https://entrypoint-finney.opentensor.ai",
+    provider: "opentensor",
+    authority: "official",
+    auth_required: false,
+    public_safe: true,
+    subnet_slug: "root",
+    subnet_name: "root",
+    probe: { method: "JSON-RPC", expect: "json" },
+  },
+];
+
+const probeImpl = async (input) =>
+  input.kind === "subtensor-rpc"
+    ? {
+        status: "ok",
+        classification: "live",
+        latency_ms: 42,
+        status_code: 200,
+        archive_support: true,
+      }
+    : {
+        status: "failed",
+        classification: "dead",
+        latency_ms: null,
+        status_code: 404,
+      };
+
+describe("runHealthProber", () => {
+  test("writes D1 batch + the three KV snapshots with correct shapes", async () => {
+    const db = makeDb({
+      priorStatus: [
+        { surface_id: "sn7-api", last_ok: 1000, consecutive_failures: 2 },
+      ],
+    });
+    const kv = makeKv();
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db,
+        kv,
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.probed, 2);
+    assert.deepEqual(result.counts, {
+      ok: 1,
+      degraded: 0,
+      failed: 1,
+      unknown: 0,
+    });
+
+    // One batch with 4 statements (2 surfaces × {check insert, status upsert}).
+    assert.equal(db.calls.batches.length, 1);
+    assert.equal(db.calls.batches[0].length, 4);
+
+    const current = kv.json(KV_HEALTH_CURRENT);
+    assert.equal(current.summary.surface_count, 2);
+    assert.deepEqual(current.summary.status_counts, {
+      ok: 1,
+      degraded: 0,
+      failed: 1,
+      unknown: 0,
+    });
+    assert.equal(current.surfaces.length, 2);
+    // Per-subnet operational rollup, sorted by netuid.
+    assert.deepEqual(
+      current.subnets.map((s) => s.netuid),
+      [0, 7],
+    );
+    assert.equal(current.subnets.find((s) => s.netuid === 0).status, "ok");
+    assert.equal(current.subnets.find((s) => s.netuid === 7).status, "failed");
+
+    // last_ok continuity: the failed surface keeps its prior last_ok (1000).
+    const apiRow = current.surfaces.find((s) => s.surface_id === "sn7-api");
+    assert.equal(apiRow.last_ok, new Date(1000).toISOString());
+    // The ok RPC surface stamps last_ok = run time.
+    const rpcRow = current.surfaces.find(
+      (s) => s.surface_id === "opentensor-finney-rpc",
+    );
+    assert.equal(rpcRow.last_ok, new Date(50000).toISOString());
+
+    // RPC pool snapshot: only the RPC kind, eligible because ok.
+    const pool = kv.json(KV_HEALTH_RPC_POOL);
+    assert.equal(pool.endpoint_count, 1);
+    assert.equal(pool.eligible_count, 1);
+    assert.equal(pool.endpoints[0].pool_eligible, true);
+    assert.equal(pool.endpoints[0].archive_support, true);
+
+    const meta = kv.json(KV_HEALTH_META);
+    assert.equal(meta.probed_count, 2);
+    assert.equal(meta.last_run_at, new Date(50000).toISOString());
+  });
+
+  test("bumps consecutive_failures from prior state for the breaker", async () => {
+    const db = makeDb({
+      priorStatus: [
+        { surface_id: "sn7-api", last_ok: 1000, consecutive_failures: 2 },
+      ],
+    });
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db,
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    // The failed surface's status upsert carries consecutive_failures = 3.
+    const upserts = db.calls.batches[0].filter((s) =>
+      /INSERT INTO surface_status/.test(s.sql),
+    );
+    const apiUpsert = upserts.find((s) => s.binds[0] === "sn7-api");
+    // binds: [surface_id, netuid, kind, url, provider, status, classification,
+    //         latency_ms, status_code, last_checked, last_ok, consec, updated_at]
+    assert.equal(apiUpsert.binds[11], 3);
+  });
+
+  test("no-ops cleanly when there are no operational surfaces", async () => {
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => [],
+      },
+    );
+    assert.equal(result.ok, false);
+    assert.equal(result.reason, "no-operational-surfaces");
+  });
+});
+
+describe("pruneHealthHistory", () => {
+  test("deletes rows older than the retention window", async () => {
+    const db = makeDb();
+    const result = await pruneHealthHistory(
+      {},
+      { now: () => 100_000_000, db, retentionMs: 1000 },
+    );
+    assert.equal(result.pruned, true);
+    assert.equal(result.cutoff, 100_000_000 - 1000);
+    assert.match(db.calls.runs[0].sql, /DELETE FROM surface_checks/);
+    assert.equal(db.calls.runs[0].binds[0], 100_000_000 - 1000);
+  });
+});
+
+describe("handleScheduled dispatch", () => {
+  test("hourly cron prunes; other crons probe", async () => {
+    const db = makeDb();
+    const pruneResult = await handleScheduled(
+      { cron: "0 * * * *" },
+      { METAGRAPH_HEALTH_DB: db },
+    );
+    assert.equal(pruneResult.pruned, true);
+
+    // The 2-minute cron path runs the prober; with an empty env it no-ops.
+    const probeResult = await handleScheduled({ cron: "*/2 * * * *" }, {});
+    assert.equal(probeResult.ok, false);
+    assert.equal(probeResult.reason, "no-operational-surfaces");
+  });
+});

--- a/tests/strip-json-comments.test.mjs
+++ b/tests/strip-json-comments.test.mjs
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { stripJsonComments } from "../scripts/lib.mjs";
+
+describe("stripJsonComments", () => {
+  test("strips line + block comments and trailing commas", () => {
+    const input = `{
+      // a line comment
+      "a": 1, /* inline block */
+      "b": 2,
+    }`;
+    assert.deepEqual(JSON.parse(stripJsonComments(input)), { a: 1, b: 2 });
+  });
+
+  test("preserves comment-like sequences inside string literals", () => {
+    const input = `{ "url": "https://x.dev/a//b", "note": "uses /* and */ and //" }`;
+    assert.deepEqual(JSON.parse(stripJsonComments(input)), {
+      url: "https://x.dev/a//b",
+      note: "uses /* and */ and //",
+    });
+  });
+
+  test("regression: route glob '/api/*' + cron '*/2 * * * *' both survive", () => {
+    // The `/*` ending "/api/*" and the `*/` inside "*/2 * * * *" must NOT be
+    // spliced into a single block comment (the bug that ate the wrangler config).
+    const input = `{
+      "assets": { "run_worker_first": ["/api/*", "/rpc/*", "/metagraph/*"] },
+      "vars": { "FLAG": "true" },
+      "triggers": { "crons": ["*/2 * * * *", "0 * * * *"] }
+    }`;
+    const parsed = JSON.parse(stripJsonComments(input));
+    assert.deepEqual(parsed.assets.run_worker_first, [
+      "/api/*",
+      "/rpc/*",
+      "/metagraph/*",
+    ]);
+    assert.equal(parsed.vars.FLAG, "true");
+    assert.deepEqual(parsed.triggers.crons, ["*/2 * * * *", "0 * * * *"]);
+  });
+
+  test("handles escaped quotes inside strings", () => {
+    const input = `{ "q": "a \\"quoted\\" // not-a-comment" }`;
+    assert.equal(
+      JSON.parse(stripJsonComments(input)).q,
+      'a "quoted" // not-a-comment',
+    );
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -23,6 +23,11 @@ import {
   WEBHOOK_SECRET_HEADER,
   WEBHOOK_SIGNATURE_HEADER,
 } from "../src/webhooks.mjs";
+import { pruneHealthHistory, runHealthProber } from "../src/health-prober.mjs";
+
+// Cron schedule strings (must match wrangler.jsonc `triggers.crons`). The hourly
+// trigger prunes the D1 time-series; every other trigger runs the 2-minute probe.
+const HEALTH_PRUNE_CRON = "0 * * * *";
 
 const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
 
@@ -89,7 +94,21 @@ export default {
   async fetch(request, env, ctx) {
     return handleRequest(request, env, ctx);
   },
+  async scheduled(controller, env, ctx) {
+    return handleScheduled(controller, env, ctx);
+  },
 };
+
+// Cron entrypoint. Cloudflare passes the exact cron string that fired in
+// `controller.cron`; the hourly trigger prunes the time-series, every other
+// trigger (the 2-minute one) runs a full operational-health probe sweep.
+export async function handleScheduled(controller, env = {}, ctx = {}) {
+  const cron = controller?.cron || "";
+  if (cron === HEALTH_PRUNE_CRON) {
+    return pruneHealthHistory(env);
+  }
+  return runHealthProber(env, ctx);
+}
 
 export async function handleRequest(request, env = {}, ctx = {}) {
   const url = new URL(request.url);

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -55,6 +55,12 @@
       "migrations_dir": "migrations",
     },
   ],
+  // Cron prober: every 2 minutes probes the operational surfaces into D1/KV
+  // (served live); the hourly trigger prunes the D1 time-series. Registered
+  // automatically on the next Workers Builds deploy.
+  "triggers": {
+    "crons": ["*/2 * * * *", "0 * * * *"],
+  },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite
   // for enabling METAGRAPH_ENABLE_RPC_PROXY). 100 requests / 60s per client IP;
   // `period` must be 10 or 60. The Worker skips the check when this binding is


### PR DESCRIPTION
## Why
Phase 2 of decoupling operational health from the 6h build. Adds the **live cron prober** that populates D1 + KV every 2 minutes. **Writes only** — serving is untouched (Phase 3 wires the live reads), so deploying this carries no user-facing risk: it just starts filling the store.

## What
- **`src/health-prober.mjs`** — loads `operational-surfaces.json` (ASSETS → R2 fallback), probes all **58** operational surfaces with the shared core under bounded concurrency (8), then writes:
  - **D1** `surface_checks` (append-only time-series) + `surface_status` (upsert; `last_ok` continuity + a `consecutive_failures` breaker counter) in a single `batch()`.
  - **KV** `health:current` (global + per-subnet operational rollup + 58 rows), `health:rpc-pool` (live RPC/WSS eligibility), `health:meta` (`last_run_at` + counts).
  - A **Workers fetch-upgrade WebSocket connector** for the WSS subtensor probe (Workers can't use `new WebSocket()` for outbound), plus an hourly `pruneHealthHistory()`.
- **`workers/api.mjs`** — `scheduled(controller)` dispatching hourly-prune vs 2-min-probe by cron string.
- **`wrangler.jsonc`** — `triggers.crons: ["*/2 * * * *", "0 * * * *"]`.

## Cleanup (root-caused while wiring the cron)
The `worker-deploy-dry-run` + `cloudflare-verify` JSONC strippers used a naive block-comment regex that spliced the `/*` ending the `"/api/*"` route glob to the `*/` inside the new `"*/2 * * * *"` cron — **deleting the config in between** (every wrangler check failed). Replaced both copies with one **shared, string-aware `stripJsonComments()`** in `scripts/lib.mjs` + a regression test.

## Verification
- `npm test` **265/265** (new: `health-prober` 5 mocked-D1/KV; `strip-json-comments` 4).
- `worker:deploy:dry-run` + `cloudflare:verify:dry-run` green (cron triggers + bundle validated).
- Post-merge: I'll confirm the cron fires in prod (D1 rows + `health:meta.last_run_at` advancing every ~2 min).

## Next
Phase 3 wires live serving (`/health`, per-subnet overlay, RPC pool, `/health/trends`) reading KV/D1 with R2 fallback.