### PR TITLE
feat(health): Phase 3 — serve live operational health + /health/trends

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -1,0 +1,284 @@
+// Live operational-health serving helpers.
+//
+// Pure functions that overlay the 2-minute cron snapshot (KV health:current /
+// health:rpc-pool / health:meta, written by src/health-prober.mjs) onto the 6h
+// static artifacts. Every helper returns null when the live store is cold/absent
+// so the caller (workers/api.mjs) falls back to the static artifact — keeping
+// serving zero-downtime and regression-proof. No I/O here: callers pass parsed
+// objects + D1 rows in.
+
+const OPERATIONAL_KINDS = new Set([
+  "subtensor-rpc",
+  "subtensor-wss",
+  "archive",
+  "subnet-api",
+  "sse",
+  "data-artifact",
+]);
+
+export function parseLive(raw) {
+  if (!raw) return null;
+  if (typeof raw === "object") return raw;
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function rollupStatus(counts, total) {
+  if (total === 0 || counts.unknown === total) return "unknown";
+  if ((counts.failed || 0) === 0 && (counts.degraded || 0) === 0) return "ok";
+  if ((counts.ok || 0) > 0 || (counts.degraded || 0) > 0) return "degraded";
+  return "failed";
+}
+
+function latestIso(values) {
+  let best = null;
+  for (const value of values) {
+    if (value && (!best || value > best)) best = value;
+  }
+  return best;
+}
+
+// Summarize a set of serving rows ({status, latency_ms, last_checked, last_ok}).
+export function summarizeRows(rows) {
+  const counts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
+  const latencies = [];
+  for (const row of rows) {
+    counts[row.status] = (counts[row.status] || 0) + 1;
+    if (Number.isFinite(row.latency_ms)) latencies.push(row.latency_ms);
+  }
+  return {
+    status: rollupStatus(counts, rows.length),
+    surface_count: rows.length,
+    ok_count: counts.ok,
+    degraded_count: counts.degraded,
+    failed_count: counts.failed,
+    unknown_count: counts.unknown,
+    last_checked: latestIso(rows.map((r) => r.last_checked)),
+    last_ok: latestIso(rows.map((r) => r.last_ok)),
+    avg_latency_ms: latencies.length
+      ? Math.round(latencies.reduce((s, v) => s + v, 0) / latencies.length)
+      : null,
+  };
+}
+
+// Per-subnet overlay: replace the static artifact's operational surfaces with the
+// fresh live rows (matched by surface_id), keep informational surfaces static,
+// recompute the summary. Returns null when there is no live snapshot.
+export function overlaySubnetHealth(staticArtifact, liveCurrent, netuid) {
+  if (!liveCurrent || !Array.isArray(liveCurrent.surfaces)) return null;
+  const liveById = new Map();
+  for (const row of liveCurrent.surfaces) {
+    if (row.netuid === netuid) liveById.set(row.surface_id, row);
+  }
+  if (liveById.size === 0 && !staticArtifact) return null;
+
+  const staticSurfaces = Array.isArray(staticArtifact?.surfaces)
+    ? staticArtifact.surfaces
+    : [];
+  const seen = new Set();
+  const merged = staticSurfaces.map((surface) => {
+    const live = liveById.get(surface.surface_id);
+    if (!live) return surface;
+    seen.add(surface.surface_id);
+    return {
+      ...surface,
+      status: live.status,
+      classification: live.classification,
+      latency_ms: live.latency_ms,
+      status_code: live.status_code,
+      last_checked: live.last_checked,
+      last_ok: live.last_ok,
+      observed_by: "live-cron-prober",
+    };
+  });
+  // Live operational surfaces not (yet) in the static artifact.
+  for (const [id, live] of liveById) {
+    if (seen.has(id)) continue;
+    merged.push({
+      surface_id: id,
+      netuid,
+      kind: live.kind,
+      provider: live.provider,
+      url: live.url,
+      status: live.status,
+      classification: live.classification,
+      latency_ms: live.latency_ms,
+      status_code: live.status_code,
+      last_checked: live.last_checked,
+      last_ok: live.last_ok,
+      observed_by: "live-cron-prober",
+    });
+  }
+
+  return {
+    schema_version: staticArtifact?.schema_version ?? 1,
+    contract_version: staticArtifact?.contract_version,
+    generated_at: staticArtifact?.generated_at,
+    netuid,
+    slug: staticArtifact?.slug,
+    name: staticArtifact?.name,
+    summary: summarizeRows(merged),
+    operational_observed_at: liveCurrent.last_run_at || null,
+    surfaces: merged,
+  };
+}
+
+// Global operational health (fresh): the live per-subnet operational rollup +
+// global counts. Returns null when the snapshot is cold so the caller serves the
+// static summary (and labels the source correctly).
+export function buildGlobalHealth(liveCurrent, staticSummary) {
+  if (!liveCurrent || !liveCurrent.summary) {
+    return null;
+  }
+  return {
+    schema_version: 1,
+    contract_version: staticSummary?.contract_version,
+    generated_at: liveCurrent.generated_at,
+    source: "live-cron-prober",
+    scope: "operational",
+    operational_observed_at: liveCurrent.last_run_at || null,
+    global: liveCurrent.summary,
+    subnets: liveCurrent.subnets || [],
+  };
+}
+
+// Per-subnet status for badges (overlaid). Returns {status, ...} or null.
+export function subnetBadgeStatus(liveCurrent, netuid) {
+  if (!liveCurrent || !Array.isArray(liveCurrent.subnets)) return null;
+  return liveCurrent.subnets.find((entry) => entry.netuid === netuid) || null;
+}
+
+// Overlay live RPC/WSS health onto the static rpc-endpoints artifact.
+export function mergeRpcEndpoints(staticArtifact, liveRpcPool) {
+  if (!liveRpcPool || !Array.isArray(liveRpcPool.endpoints)) return null;
+  const liveById = new Map(liveRpcPool.endpoints.map((e) => [e.id, e]));
+  const endpoints = Array.isArray(staticArtifact?.endpoints)
+    ? staticArtifact.endpoints.map((endpoint) => {
+        const live = liveById.get(endpoint.id);
+        if (!live) return endpoint;
+        return {
+          ...endpoint,
+          status: live.status,
+          classification: live.classification,
+          latency_ms: live.latency_ms,
+          archive_support: live.archive_support ?? endpoint.archive_support,
+          health_source: "live-cron-prober",
+          health_stale: false,
+          observed_at: live.last_ok || liveRpcPool.last_run_at,
+          pool_eligible: live.pool_eligible,
+        };
+      })
+    : liveRpcPool.endpoints;
+  return {
+    schema_version: staticArtifact?.schema_version ?? 1,
+    contract_version: staticArtifact?.contract_version,
+    generated_at: liveRpcPool.generated_at,
+    source: "live-cron-prober",
+    operational_observed_at: liveRpcPool.last_run_at || null,
+    endpoints,
+  };
+}
+
+// Overlay live RPC health onto the static proxy pool: an endpoint stays eligible
+// only if the static policy (auth/safety/scoring) AND current health agree. To
+// avoid over-reacting to a single transient probe, an endpoint is dropped only
+// after 2+ consecutive failed prober runs (~4 min sustained down); the in-isolate
+// circuit breaker handles instantaneous per-request failures. Returns the pool
+// unchanged when there is no live snapshot.
+export function overlayRpcPoolEligibility(pool, liveRpcPool) {
+  if (!pool || !liveRpcPool || !Array.isArray(liveRpcPool.endpoints)) {
+    return pool;
+  }
+  const liveById = new Map(liveRpcPool.endpoints.map((e) => [e.id, e]));
+  return {
+    ...pool,
+    endpoints: (pool.endpoints || []).map((endpoint) => {
+      const live = liveById.get(endpoint.id);
+      if (!live) return endpoint;
+      const sustainedDown =
+        live.status !== "ok" && (live.consecutive_failures || 0) >= 2;
+      return {
+        ...endpoint,
+        status: live.status,
+        latency_ms: live.latency_ms ?? endpoint.latency_ms,
+        health_source: "live-cron-prober",
+        pool_eligible: Boolean(endpoint.pool_eligible) && !sustainedDown,
+      };
+    }),
+  };
+}
+
+// Set the live health-probe freshness onto the static freshness artifact.
+export function mergeFreshness(staticFreshness, liveMeta) {
+  if (!liveMeta || !staticFreshness) return null;
+  const sources = Array.isArray(staticFreshness.sources)
+    ? staticFreshness.sources.map((source) =>
+        source.id === "surface-health"
+          ? {
+              ...source,
+              as_of: liveMeta.last_run_at,
+              timestamp: liveMeta.last_run_at,
+              status: "current",
+              stale_behavior: "warn",
+              notes: "Operational surfaces are probed live every ~2 minutes.",
+            }
+          : source,
+      )
+    : staticFreshness.sources;
+  return {
+    ...staticFreshness,
+    sources,
+    summary: {
+      ...staticFreshness.summary,
+      health_probe_as_of: liveMeta.last_run_at,
+      operational_probe_as_of: liveMeta.last_run_at,
+    },
+  };
+}
+
+// Format D1 GROUP BY aggregates into a trends payload. `windows` maps a label to
+// an array of per-surface aggregate rows {surface_id, total, ok_count, avg_latency_ms}.
+export function formatTrends({ netuid, observedAt, windows }) {
+  const formatWindow = (rows) => {
+    let total = 0;
+    let okCount = 0;
+    const perSurface = [];
+    for (const row of rows) {
+      const rowTotal = Number(row.total) || 0;
+      const rowOk = Number(row.ok_count) || 0;
+      total += rowTotal;
+      okCount += rowOk;
+      perSurface.push({
+        surface_id: row.surface_id,
+        samples: rowTotal,
+        uptime_ratio: rowTotal ? Number((rowOk / rowTotal).toFixed(4)) : null,
+        avg_latency_ms:
+          row.avg_latency_ms == null
+            ? null
+            : Math.round(Number(row.avg_latency_ms)),
+      });
+    }
+    perSurface.sort((a, b) => a.surface_id.localeCompare(b.surface_id));
+    return {
+      samples: total,
+      uptime_ratio: total ? Number((okCount / total).toFixed(4)) : null,
+      surfaces: perSurface,
+    };
+  };
+  const windowsOut = {};
+  for (const [label, rows] of Object.entries(windows)) {
+    windowsOut[label] = formatWindow(rows);
+  }
+  return {
+    schema_version: 1,
+    netuid,
+    observed_at: observedAt || null,
+    source: "live-cron-prober",
+    windows: windowsOut,
+  };
+}
+
+export { OPERATIONAL_KINDS };

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildGlobalHealth,
+  formatTrends,
+  mergeFreshness,
+  mergeRpcEndpoints,
+  overlayRpcPoolEligibility,
+  overlaySubnetHealth,
+  subnetBadgeStatus,
+} from "../src/health-serving.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import { handleRequest } from "../workers/api.mjs";
+
+describe("overlaySubnetHealth", () => {
+  test("replaces operational surfaces with live rows; keeps informational static", () => {
+    const staticArtifact = {
+      schema_version: 1,
+      netuid: 7,
+      slug: "acme",
+      name: "Acme",
+      summary: { status: "failed" },
+      surfaces: [
+        {
+          surface_id: "sn7-api",
+          kind: "subnet-api",
+          status: "failed",
+          last_checked: "old",
+        },
+        {
+          surface_id: "sn7-docs",
+          kind: "docs",
+          status: "ok",
+          last_checked: "old",
+        },
+      ],
+    };
+    const liveCurrent = {
+      last_run_at: "2026-06-11T00:00:00.000Z",
+      surfaces: [
+        {
+          surface_id: "sn7-api",
+          netuid: 7,
+          kind: "subnet-api",
+          status: "ok",
+          classification: "live",
+          latency_ms: 50,
+          last_checked: "2026-06-11T00:00:00.000Z",
+          last_ok: "2026-06-11T00:00:00.000Z",
+        },
+      ],
+    };
+    const merged = overlaySubnetHealth(staticArtifact, liveCurrent, 7);
+    const api = merged.surfaces.find((s) => s.surface_id === "sn7-api");
+    const docs = merged.surfaces.find((s) => s.surface_id === "sn7-docs");
+    assert.equal(api.status, "ok"); // overlaid live
+    assert.equal(api.observed_by, "live-cron-prober");
+    assert.equal(docs.status, "ok"); // static, untouched
+    assert.equal(merged.summary.status, "ok"); // recomputed over merged set
+    assert.equal(merged.summary.ok_count, 2);
+    assert.equal(merged.operational_observed_at, "2026-06-11T00:00:00.000Z");
+  });
+
+  test("returns null with no live snapshot (caller falls back to static)", () => {
+    assert.equal(overlaySubnetHealth({ surfaces: [] }, null, 7), null);
+  });
+});
+
+describe("buildGlobalHealth", () => {
+  test("serves the live operational summary when present", () => {
+    const live = {
+      generated_at: "g",
+      last_run_at: "r",
+      summary: { surface_count: 2, status_counts: { ok: 2 } },
+      subnets: [{ netuid: 7, status: "ok" }],
+    };
+    const out = buildGlobalHealth(live, { contract_version: "v" });
+    assert.equal(out.scope, "operational");
+    assert.equal(out.source, "live-cron-prober");
+    assert.deepEqual(out.subnets, [{ netuid: 7, status: "ok" }]);
+  });
+
+  test("returns null when cold so the caller serves static", () => {
+    assert.equal(buildGlobalHealth(null, { subnets: [] }), null);
+  });
+});
+
+describe("mergeRpcEndpoints", () => {
+  test("overlays live status/eligibility by id", () => {
+    const stat = {
+      endpoints: [
+        { id: "a", status: "ok", pool_eligible: true },
+        { id: "b", status: "ok", pool_eligible: true },
+      ],
+    };
+    const live = {
+      last_run_at: "r",
+      generated_at: "g",
+      endpoints: [
+        {
+          id: "a",
+          status: "failed",
+          classification: "dead",
+          latency_ms: null,
+          pool_eligible: false,
+        },
+      ],
+    };
+    const merged = mergeRpcEndpoints(stat, live);
+    assert.equal(merged.endpoints.find((e) => e.id === "a").status, "failed");
+    assert.equal(
+      merged.endpoints.find((e) => e.id === "a").pool_eligible,
+      false,
+    );
+    assert.equal(merged.endpoints.find((e) => e.id === "b").status, "ok"); // no live → static
+  });
+});
+
+describe("overlayRpcPoolEligibility", () => {
+  const pool = {
+    id: "finney-rpc",
+    endpoints: [
+      { id: "a", url: "https://a", pool_eligible: true },
+      { id: "b", url: "https://b", pool_eligible: true },
+    ],
+  };
+  test("drops endpoints only after 2+ consecutive failures", () => {
+    const live = {
+      endpoints: [
+        { id: "a", status: "failed", consecutive_failures: 1 }, // transient → stays
+        { id: "b", status: "failed", consecutive_failures: 3 }, // sustained → drop
+      ],
+    };
+    const out = overlayRpcPoolEligibility(pool, live);
+    assert.equal(out.endpoints.find((e) => e.id === "a").pool_eligible, true);
+    assert.equal(out.endpoints.find((e) => e.id === "b").pool_eligible, false);
+  });
+  test("returns the static pool unchanged when live is cold", () => {
+    assert.equal(overlayRpcPoolEligibility(pool, null), pool);
+  });
+});
+
+describe("mergeFreshness", () => {
+  test("marks surface-health current + warn from live meta", () => {
+    const stat = {
+      sources: [
+        {
+          id: "surface-health",
+          as_of: null,
+          status: "missing",
+          stale_behavior: "block",
+        },
+        {
+          id: "native-subnets",
+          as_of: "x",
+          status: "captured",
+          stale_behavior: "block",
+        },
+      ],
+      summary: {},
+    };
+    const out = mergeFreshness(stat, {
+      last_run_at: "2026-06-11T00:00:00.000Z",
+    });
+    const sh = out.sources.find((s) => s.id === "surface-health");
+    assert.equal(sh.as_of, "2026-06-11T00:00:00.000Z");
+    assert.equal(sh.status, "current");
+    assert.equal(sh.stale_behavior, "warn");
+    // Other blocking sources are untouched.
+    assert.equal(
+      out.sources.find((s) => s.id === "native-subnets").stale_behavior,
+      "block",
+    );
+    assert.equal(out.summary.health_probe_as_of, "2026-06-11T00:00:00.000Z");
+  });
+});
+
+describe("formatTrends", () => {
+  test("computes uptime_ratio + avg latency per window", () => {
+    const out = formatTrends({
+      netuid: 7,
+      observedAt: "r",
+      windows: {
+        "7d": [
+          { surface_id: "a", total: 100, ok_count: 95, avg_latency_ms: 50.4 },
+        ],
+        "30d": [
+          { surface_id: "a", total: 400, ok_count: 380, avg_latency_ms: 60.9 },
+        ],
+      },
+    });
+    assert.equal(out.windows["7d"].uptime_ratio, 0.95);
+    assert.equal(out.windows["7d"].surfaces[0].avg_latency_ms, 50);
+    assert.equal(out.windows["30d"].uptime_ratio, 0.95);
+    assert.equal(out.netuid, 7);
+  });
+  test("empty windows yield null ratios (D1 cold)", () => {
+    const out = formatTrends({
+      netuid: 7,
+      observedAt: null,
+      windows: { "7d": [], "30d": [] },
+    });
+    assert.equal(out.windows["7d"].uptime_ratio, null);
+    assert.equal(out.windows["7d"].samples, 0);
+  });
+});
+
+describe("subnetBadgeStatus", () => {
+  test("finds the subnet rollup", () => {
+    const live = { subnets: [{ netuid: 7, status: "degraded" }] };
+    assert.equal(subnetBadgeStatus(live, 7).status, "degraded");
+    assert.equal(subnetBadgeStatus(live, 9), null);
+  });
+});
+
+// --- Worker integration: the LIVE path (mock KV + D1) -------------------------
+function kvWith(entries) {
+  return {
+    async get(key, opts) {
+      if (!(key in entries)) return null;
+      return opts?.type === "json"
+        ? entries[key]
+        : JSON.stringify(entries[key]);
+    },
+  };
+}
+function d1With(rows) {
+  return {
+    prepare() {
+      return {
+        bind() {
+          return {
+            async all() {
+              return { results: rows };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+const req = (path) => new Request(`https://api.metagraph.sh${path}`);
+
+describe("worker live health serving", () => {
+  test("/api/v1/health serves the live operational summary from KV", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: kvWith({
+        "health:current": {
+          generated_at: "2026-06-11T00:00:00.000Z",
+          last_run_at: "2026-06-11T00:00:00.000Z",
+          summary: {
+            surface_count: 58,
+            status_counts: { ok: 57, degraded: 1 },
+          },
+          subnets: [{ netuid: 0, status: "ok" }],
+        },
+      }),
+    });
+    const res = await handleRequest(req("/api/v1/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.meta.source, "live-cron-prober");
+    assert.equal(body.data.scope, "operational");
+    assert.equal(body.meta.operational_observed_at, "2026-06-11T00:00:00.000Z");
+  });
+
+  test("/api/v1/subnets/0/health/trends queries D1", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_HEALTH_DB: d1With([
+        { surface_id: "rpc-a", total: 100, ok_count: 99, avg_latency_ms: 42 },
+      ]),
+      METAGRAPH_CONTROL: kvWith({
+        "health:meta": { last_run_at: "2026-06-11T00:00:00.000Z" },
+      }),
+    });
+    const res = await handleRequest(
+      req("/api/v1/subnets/0/health/trends"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, 0);
+    assert.equal(body.data.windows["7d"].uptime_ratio, 0.99);
+    assert.equal(body.data.source, "live-cron-prober");
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -23,11 +23,30 @@ import {
   WEBHOOK_SECRET_HEADER,
   WEBHOOK_SIGNATURE_HEADER,
 } from "../src/webhooks.mjs";
-import { pruneHealthHistory, runHealthProber } from "../src/health-prober.mjs";
+import {
+  KV_HEALTH_CURRENT,
+  KV_HEALTH_META,
+  KV_HEALTH_RPC_POOL,
+  pruneHealthHistory,
+  runHealthProber,
+} from "../src/health-prober.mjs";
+import {
+  buildGlobalHealth,
+  formatTrends,
+  mergeFreshness,
+  mergeRpcEndpoints,
+  overlayRpcPoolEligibility,
+  overlaySubnetHealth,
+  subnetBadgeStatus,
+} from "../src/health-serving.mjs";
 
 // Cron schedule strings (must match wrangler.jsonc `triggers.crons`). The hourly
 // trigger prunes the D1 time-series; every other trigger runs the 2-minute probe.
 const HEALTH_PRUNE_CRON = "0 * * * *";
+// Trend windows for /api/v1/subnets/{netuid}/health/trends.
+const HEALTH_TREND_WINDOWS = { "7d": 7, "30d": 30 };
+const TRENDS_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/health\/trends$/;
+const DAY_MS = 24 * 60 * 60 * 1000;
 
 const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
 
@@ -157,6 +176,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         { slug: resolved.slug },
       );
     }
+    // D1-backed health trends (slug-aware after resolution). Special-handled
+    // rather than artifact-backed, like /api/v1/events.
+    const trendsMatch = TRENDS_PATH_PATTERN.exec(resolved.url.pathname);
+    if (trendsMatch) {
+      return handleHealthTrends(request, env, Number(trendsMatch[1]));
+    }
     return handleApiRequest(request, env, resolved.url);
   }
 
@@ -231,6 +256,13 @@ const BADGE_COLOR_HEX = {
   lightgrey: "#9f9f9f",
   grey: "#555",
 };
+// Shields-style color for a health status (matches the build's badgeColor).
+const BADGE_STATUS_COLOR = {
+  ok: "brightgreen",
+  degraded: "yellow",
+  failed: "red",
+  unknown: "lightgrey",
+};
 
 async function handleBadgeSvgRequest(request, env, url) {
   if (request.method !== "GET" && request.method !== "HEAD") {
@@ -247,10 +279,27 @@ async function handleBadgeSvgRequest(request, env, url) {
     env,
     `/metagraph/health/badges/${netuid}.json`,
   );
-  const available = artifact.ok && artifact.data;
-  const badge = available
-    ? artifact.data
-    : { label: `SN${netuid}`, message: "unavailable", color: "lightgrey" };
+  // Live overlay: prefer the fresh operational status from the 2-min cron
+  // snapshot; fall back to the static badge artifact, then to "unavailable".
+  const liveCurrent = await readHealthKv(env, KV_HEALTH_CURRENT);
+  const liveStatus = subnetBadgeStatus(liveCurrent, Number(netuid));
+  const available = Boolean(liveStatus || (artifact.ok && artifact.data));
+  let badge;
+  if (liveStatus) {
+    badge = {
+      label: `SN${netuid}`,
+      message: liveStatus.status,
+      color: BADGE_STATUS_COLOR[liveStatus.status] || "lightgrey",
+    };
+  } else if (artifact.ok && artifact.data) {
+    badge = artifact.data;
+  } else {
+    badge = {
+      label: `SN${netuid}`,
+      message: "unavailable",
+      color: "lightgrey",
+    };
+  }
   const svg = renderBadgeSvg(
     badge.label || `SN${netuid}`,
     badge.message || "unknown",
@@ -378,14 +427,27 @@ async function handleApiRequest(request, env, url) {
   }
 
   const artifact = await readArtifact(env, matched.artifactPath);
-  if (!artifact.ok) {
+
+  // Live operational-health overlay (Phase 3): for health/rpc routes, overlay
+  // the fresh 2-minute cron snapshot (KV/D1) onto the static artifact. Falls back
+  // to the static artifact when the snapshot is cold/unbound — zero regression.
+  const live = await liveHealthOverlay(
+    env,
+    matched,
+    artifact.ok ? artifact.data : null,
+  );
+
+  if (!artifact.ok && !live) {
     return errorResponse(artifact.code, artifact.message, artifact.status, {
       artifact_path: matched.artifactPath,
     });
   }
 
+  const baseData = live ? live.data : artifact.data;
+  const baseSource = live ? "live-cron-prober" : artifact.source;
+
   const transformed = applyQueryFilters(
-    artifact.data,
+    baseData,
     url,
     matched.queryCollection,
     matched.queryFilterNames,
@@ -404,16 +466,72 @@ async function handleApiRequest(request, env, url) {
         artifact_path: matched.artifactPath,
         cache: matched.cache,
         contract_version: contractVersion(env),
-        generated_at: artifact.data?.generated_at || null,
+        generated_at: baseData?.generated_at || null,
         // Real publish time from the KV latest pointer; null until a publish has
         // populated it. Unlike generated_at (a deterministic content marker),
         // this is safe to render as a human "last updated" timestamp.
         published_at: await publishedAt(env),
-        source: artifact.source,
+        source: baseSource,
+        ...(baseData?.operational_observed_at
+          ? { operational_observed_at: baseData.operational_observed_at }
+          : {}),
         ...transformed.meta,
       },
     },
     matched.cache,
+  );
+}
+
+// D1-backed 7d/30d uptime + latency trends for one subnet's operational
+// surfaces. Returns a schema-stable empty payload when D1 is unbound/cold so it
+// never errors (mirrors the live-overlay fall-back philosophy).
+async function handleHealthTrends(request, env, netuid) {
+  const db = env.METAGRAPH_HEALTH_DB;
+  const nowMs = Date.now();
+  const windows = {};
+  for (const [label, days] of Object.entries(HEALTH_TREND_WINDOWS)) {
+    let rows = [];
+    if (db?.prepare) {
+      try {
+        const result = await db
+          .prepare(
+            `SELECT surface_id,
+                    COUNT(*) AS total,
+                    SUM(ok) AS ok_count,
+                    AVG(latency_ms) AS avg_latency_ms
+             FROM surface_checks
+             WHERE netuid = ? AND checked_at >= ?
+             GROUP BY surface_id`,
+          )
+          .bind(netuid, nowMs - days * DAY_MS)
+          .all();
+        rows = result?.results || [];
+      } catch {
+        rows = [];
+      }
+    }
+    windows[label] = rows;
+  }
+  const meta = await readHealthKv(env, KV_HEALTH_META);
+  const data = formatTrends({
+    netuid,
+    observedAt: meta?.last_run_at || null,
+    windows,
+  });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: {
+        artifact_path: null,
+        cache: "short",
+        contract_version: contractVersion(env),
+        generated_at: data.observed_at,
+        published_at: await publishedAt(env),
+        source: "live-cron-prober",
+      },
+    },
+    "short",
   );
 }
 
@@ -540,9 +658,14 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     );
   }
   const poolId = "finney-rpc";
-  const pool = (poolArtifact.data.pools || []).find(
+  const staticPool = (poolArtifact.data.pools || []).find(
     (candidate) => candidate.id === poolId,
   );
+  // Overlay the 2-minute cron health so the proxy avoids sustained-down endpoints
+  // (the in-isolate breaker still handles instantaneous failures). Falls back to
+  // the static pool when the live snapshot is cold.
+  const liveRpcPool = await readHealthKv(env, KV_HEALTH_RPC_POOL);
+  const pool = overlayRpcPoolEligibility(staticPool, liveRpcPool);
   const { endpoints: candidates, unsafeEndpoint } = orderSafeRpcEndpoints(pool);
   if (!candidates.length) {
     if (unsafeEndpoint) {
@@ -955,6 +1078,7 @@ function matchRoute(pathname) {
     }
     const params = match.groups || {};
     return {
+      id: candidate.id,
       artifactPath: candidate.artifactPath(params),
       cache: candidate.cache,
       params,
@@ -1018,6 +1142,7 @@ async function handleHealthRequest(request, env) {
     assets: Boolean(env.ASSETS?.fetch),
     r2: Boolean(env.METAGRAPH_ARCHIVE?.get),
     kv: Boolean(env.METAGRAPH_CONTROL?.get),
+    health_db: Boolean(env.METAGRAPH_HEALTH_DB?.prepare),
   };
 
   // Data freshness — the scheduled refresh (ADR 0001) advances the KV `latest`
@@ -1038,6 +1163,15 @@ async function handleHealthRequest(request, env) {
     : null;
   const stale = ageHours !== null && ageHours > maxAgeHours;
 
+  // Operational-health freshness — the 2-minute cron prober's last run. Reported
+  // for observability (a stuck prober shows a growing age); does not gate the
+  // HTTP status here (Phase 4 wires alerting). Null until the first cron run.
+  const meta = bindings.kv ? await readHealthKv(env, KV_HEALTH_META) : null;
+  const opRunAtMs = meta?.last_run_at ? Date.parse(meta.last_run_at) : NaN;
+  const opAgeMinutes = Number.isFinite(opRunAtMs)
+    ? (Date.now() - opRunAtMs) / 60_000
+    : null;
+
   const body = JSON.stringify({
     status: stale ? "degraded" : "ok",
     service: "metagraphed",
@@ -1049,6 +1183,13 @@ async function handleHealthRequest(request, env) {
       age_hours: ageHours === null ? null : Math.round(ageHours * 100) / 100,
       max_age_hours: maxAgeHours,
       stale,
+    },
+    operational_health: {
+      last_run_at: meta?.last_run_at || null,
+      age_minutes:
+        opAgeMinutes === null ? null : Math.round(opAgeMinutes * 100) / 100,
+      probed_count: meta?.probed_count ?? null,
+      status_counts: meta?.status_counts ?? null,
     },
   });
 
@@ -1455,6 +1596,53 @@ async function latestPointer(env) {
     });
   } catch {
     return null;
+  }
+}
+
+// Read a live health snapshot written by the cron prober (KV health:* keys).
+// Returns null when KV is unbound or the key is cold so callers fall back to the
+// static artifact.
+async function readHealthKv(env, key) {
+  if (!env.METAGRAPH_CONTROL?.get) {
+    return null;
+  }
+  try {
+    return await env.METAGRAPH_CONTROL.get(key, { type: "json" });
+  } catch {
+    return null;
+  }
+}
+
+// Overlay the 2-minute cron snapshot onto a static health/rpc artifact. Returns
+// { data } when a live snapshot is available, else null (caller serves static).
+async function liveHealthOverlay(env, matched, staticData) {
+  switch (matched.id) {
+    case "health": {
+      const current = await readHealthKv(env, KV_HEALTH_CURRENT);
+      if (!current) return null;
+      return { data: buildGlobalHealth(current, staticData) };
+    }
+    case "subnet-health": {
+      const current = await readHealthKv(env, KV_HEALTH_CURRENT);
+      const data = overlaySubnetHealth(
+        staticData,
+        current,
+        Number(matched.params.netuid),
+      );
+      return data ? { data } : null;
+    }
+    case "rpc-endpoints": {
+      const pool = await readHealthKv(env, KV_HEALTH_RPC_POOL);
+      const data = mergeRpcEndpoints(staticData, pool);
+      return data ? { data } : null;
+    }
+    case "freshness": {
+      const meta = await readHealthKv(env, KV_HEALTH_META);
+      const data = mergeFreshness(staticData, meta);
+      return data ? { data } : null;
+    }
+    default:
+      return null;
   }
 }
 


### PR DESCRIPTION
## Why
Phase 3 makes operational health **fresh** for consumers. The 2-minute cron (Phase 2) fills KV/D1; this PR serves that data, overlaying it onto the static artifacts with a **fallback when the snapshot is cold** — so it's zero-regression and the live path engages automatically.

## What
- **`src/health-serving.mjs`** — pure overlay/merge helpers (all return null/unchanged when live is absent):
  - `overlaySubnetHealth` — static surfaces with operational ones replaced by live rows, summary recomputed.
  - `buildGlobalHealth` — fresh operational global + per-subnet rollup.
  - `mergeRpcEndpoints` / `overlayRpcPoolEligibility` — live RPC/WSS status + pool eligibility.
  - `mergeFreshness` — sets `surface-health` current/warn from the live run.
  - `formatTrends` — 7d/30d uptime + avg latency.
- **`workers/api.mjs`**:
  - `handleApiRequest` overlays `health` / `subnet-health` / `rpc-endpoints` / `freshness` (static fallback, correct `source`).
  - Badges prefer the fresh operational status.
  - **RPC proxy** avoids endpoints the prober found *sustained-down* (2+ consecutive fails); the in-isolate breaker still handles instantaneous failures.
  - `/health` reports the D1 binding + operational `last_run_at` + counts.
  - **NEW** `GET /api/v1/subnets/{netuid}/health/trends` — D1-backed, slug-aware, empty-but-valid when D1 is cold.

## Verification
- `npm test` **278/278** (+13 health-serving incl. worker-integration over a mock KV/D1 live path).
- `validate` / `validate:api` / `validate:openapi` / `validate:docs` + `worker:deploy:dry-run` green.
- In CI (`createLocalArtifactEnv`, no KV/D1) every overlay falls back to static → no regression.
- Post-merge: I'll curl the live endpoints and confirm `last_checked` advances within ~2 min + trends returns data.

## Notes
- `/health/trends` is special-handled (like `/api/v1/events`) rather than artifact-backed; OpenAPI/SDK typing for it lands in Phase 5.
- Next: Phase 4 decouples the publish freshness gate (the cascade fix) + hardens `sync-subnets` + adds alerting.