### PR TITLE
fix(health): resolve cron prober DNS before outbound probes

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -31,8 +31,9 @@ export const OPERATIONAL_SURFACE_KINDS = [
 ];
 
 // --- URL safety: isomorphic literal SSRF guard --------------------------------
-// Best-effort default used by the Worker (which cannot resolve DNS). The Node
-// build injects the stronger DNS-aware `isUnsafeResolvedUrl` from scripts/lib.mjs.
+// Best-effort fallback for tests/injected runtimes. The Node build injects the
+// stronger DNS-aware `isUnsafeResolvedUrl` from scripts/lib.mjs, and the Worker
+// cron prober injects a DNS-over-HTTPS guard from src/health-prober.mjs.
 // Operational surfaces are already curated `public_safe`, so this is defense in
 // depth, not the primary control.
 const UNSAFE_HOST_PATTERNS = [

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -25,6 +25,121 @@ export const KV_HEALTH_RPC_POOL = "health:rpc-pool";
 export const KV_HEALTH_META = "health:meta";
 export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
 
+const DNS_JSON_ENDPOINT = "https://cloudflare-dns.com/dns-query";
+const DNS_RECORD_TYPES = ["A", "AAAA"];
+
+function normalizedHostname(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[(.*)\]$/, "$1")
+    .replace(/\.$/, "");
+}
+
+function ipv4Octets(value) {
+  const parts = String(value || "").split(".");
+  if (parts.length !== 4) return null;
+  const octets = parts.map((part) => {
+    if (!/^\d+$/.test(part)) return null;
+    const n = Number(part);
+    return Number.isInteger(n) && n >= 0 && n <= 255 ? n : null;
+  });
+  return octets.every((n) => n !== null) ? octets : null;
+}
+
+function isUnsafeIpAddress(value) {
+  const host = normalizedHostname(value);
+  const v4 = ipv4Octets(host);
+  if (v4) {
+    const [a, b, c, d] = v4;
+    return (
+      a === 0 ||
+      a === 10 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      a === 127 ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 0 && c === 0) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      a >= 224 ||
+      (a === 255 && b === 255 && c === 255 && d === 255)
+    );
+  }
+
+  // Compact IPv6 denylist matching the ranges used by the Node build guard:
+  // unspecified/loopback, discard-only, IPv4/IPv6 translation, unique-local,
+  // link-local, and multicast. DNS answers are already canonical IP literals.
+  return (
+    host === "::" ||
+    host === "::1" ||
+    host === "0:0:0:0:0:0:0:0" ||
+    host === "0:0:0:0:0:0:0:1" ||
+    host === "100::" ||
+    host.startsWith("100:0:") ||
+    host.startsWith("64:ff9b:1:") ||
+    host.startsWith("fc") ||
+    host.startsWith("fd") ||
+    /^fe[89ab][0-9a-f]:/i.test(host) ||
+    host.startsWith("ff")
+  );
+}
+
+function dnsAddressAnswers(body) {
+  if (!body || typeof body !== "object" || !Array.isArray(body.Answer)) {
+    return [];
+  }
+  return body.Answer.map((answer) => String(answer?.data || "").trim()).filter(
+    (data) => ipv4Octets(data) || normalizedHostname(data).includes(":"),
+  );
+}
+
+async function resolveDnsJson(host, recordType, fetchImpl, endpoint) {
+  const query = new URL(endpoint);
+  query.searchParams.set("name", host);
+  query.searchParams.set("type", recordType);
+  const response = await fetchImpl(query.toString(), {
+    headers: { accept: "application/dns-json" },
+  });
+  if (!response?.ok) {
+    return [];
+  }
+  return dnsAddressAnswers(await response.json());
+}
+
+export function workerResolvedUrlSafetyGuard({
+  fetchImpl = fetch,
+  dnsJsonEndpoint = DNS_JSON_ENDPOINT,
+} = {}) {
+  return async function isUnsafeWorkerResolvedUrl(value) {
+    if (isUnsafePublicUrl(value)) {
+      return true;
+    }
+
+    const url = new URL(value);
+    const host = normalizedHostname(url.hostname);
+    if (ipv4Octets(host) || host.includes(":")) {
+      return isUnsafeIpAddress(host);
+    }
+
+    try {
+      const answers = (
+        await Promise.all(
+          DNS_RECORD_TYPES.map((type) =>
+            resolveDnsJson(host, type, fetchImpl, dnsJsonEndpoint),
+          ),
+        )
+      ).flat();
+
+      // Fail closed if the Worker cannot verify a public A/AAAA answer
+      // immediately before the outbound probe.
+      return answers.length === 0 || answers.some(isUnsafeIpAddress);
+    } catch {
+      return true;
+    }
+  };
+}
+
 const PROBE_CONCURRENCY = 8;
 const HISTORY_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const RPC_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
@@ -190,8 +305,11 @@ export async function runHealthProber(env, ctx, overrides = {}) {
   const loadSurfaces =
     overrides.loadSurfaces || (() => loadOperationalSurfaces(env));
   const probe = overrides.probeSurface || coreProbeSurface;
+  const isUnsafeUrl =
+    overrides.isUnsafeUrl ||
+    workerResolvedUrlSafetyGuard({ fetchImpl: overrides.safetyFetch });
   const probeOptions = overrides.probeOptions || {
-    isUnsafeUrl: overrides.isUnsafeUrl || isUnsafePublicUrl,
+    isUnsafeUrl,
     connect: overrides.connect || workerWebSocketConnector(),
   };
   const concurrency = overrides.concurrency || PROBE_CONCURRENCY;

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -6,6 +6,7 @@ import {
   KV_HEALTH_RPC_POOL,
   pruneHealthHistory,
   runHealthProber,
+  workerResolvedUrlSafetyGuard,
 } from "../src/health-prober.mjs";
 import { handleScheduled } from "../workers/api.mjs";
 
@@ -100,6 +101,60 @@ const probeImpl = async (input) =>
         latency_ms: null,
         status_code: 404,
       };
+
+describe("workerResolvedUrlSafetyGuard", () => {
+  test("blocks public-looking hostnames that resolve to private DNS answers", async () => {
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: async (url) => {
+        const recordType = new URL(url).searchParams.get("type");
+        return {
+          ok: true,
+          async json() {
+            return recordType === "A"
+              ? { Answer: [{ type: 1, data: "127.0.0.1" }] }
+              : { Answer: [] };
+          },
+        };
+      },
+    });
+
+    assert.equal(
+      await guard("https://metagraphed-rebind-poc.example/private"),
+      true,
+    );
+  });
+
+  test("allows public hostnames only after public DNS answers are verified", async () => {
+    const seen = [];
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: async (url) => {
+        seen.push(new URL(url).searchParams.get("type"));
+        return {
+          ok: true,
+          async json() {
+            return { Answer: [{ type: 1, data: "93.184.216.34" }] };
+          },
+        };
+      },
+    });
+
+    assert.equal(await guard("https://example.com/api"), false);
+    assert.deepEqual(seen.sort(), ["A", "AAAA"]);
+  });
+
+  test("fails closed when DNS verification has no A/AAAA answers", async () => {
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: async () => ({
+        ok: true,
+        async json() {
+          return { Answer: [] };
+        },
+      }),
+    });
+
+    assert.equal(await guard("https://example.com/api"), true);
+  });
+});
 
 describe("runHealthProber", () => {
   test("writes D1 batch + the three KV snapshots with correct shapes", async () => {


### PR DESCRIPTION
### Motivation
- The Cloudflare cron prober used a literal-hostname-only guard (`isUnsafePublicUrl`) which allowed DNS-rebound public hostnames to resolve to private/internal IPs at probe time, creating a recurring SSRF primitive from the deployed Worker.
- The 2-minute scheduled handler activates the prober in production, so the default Worker safety path must verify DNS answers immediately before outbound fetch/WebSocket probes.

### Description
- Add a DNS-over-HTTPS based Worker safety guard `workerResolvedUrlSafetyGuard` to `src/health-prober.mjs` that resolves A/AAAA records, filters to address answers, blocks private/link-local/loopback/reserved IP answers, and fails closed when verification fails or no addresses are returned.
- Wire the new guard into the prober default `probeOptions` used by `runHealthProber`, while preserving the ability to inject overrides for tests and other callers.
- Add small helper functions (`normalizedHostname`, `ipv4Octets`, `isUnsafeIpAddress`, `dnsAddressAnswers`, `resolveDnsJson`) in `src/health-prober.mjs` used by the DNS guard.
- Document that the literal hostname guard in `src/health-probe-core.mjs` is a fallback for non-DNS-capable runtimes and add regression tests in `tests/health-prober.test.mjs` covering DNS-rebound private answers, verified public answers, and no-answer fail-closed behavior.

### Testing
- Ran targeted unit tests with `npm test -- --run tests/health-prober.test.mjs tests/health-probe-core.test.mjs` and they passed (2 test files, 18 tests total).
- Ran `npm run lint` which succeeded on the modified files.
- Ran the full `npm test` suite which failed due to missing generated public artifacts (unrelated ENOENT / 404 failures in artifact/API tests in this checkout), so those failures are not caused by these changes.
- `npm run format:check` previously reported a pre-existing formatting warning in `docs/adr/0001-r2-only-data-artifacts.md` that was not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a0080df18832a872e679c7b98010a)