### PR TITLE
feat(health): Phase 4 — decouple publish freshness gate + harden sync

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -269,3 +269,19 @@ jobs:
           exit 1
         env:
           METAGRAPH_LIVE_BASE_URL: https://api.metagraph.sh
+
+      # Surfaces publish failures immediately (the original cascade went unnoticed
+      # for ~a day). Opt-in: no-ops unless METAGRAPH_ALERT_WEBHOOK_URL is set.
+      - name: Notify on failure
+        if: failure()
+        env:
+          ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          if [ -z "${ALERT_WEBHOOK_URL:-}" ]; then
+            echo "No METAGRAPH_ALERT_WEBHOOK_URL configured; skipping alert."
+            exit 0
+          fi
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          curl -fsS -m 15 -X POST "$ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d "{\"text\":\"🔴 metagraphed data publish failed — ${RUN_URL}\"}" || true

--- a/.github/workflows/sync-subnets.yml
+++ b/.github/workflows/sync-subnets.yml
@@ -2,7 +2,10 @@ name: Sync Subnets
 
 on:
   schedule:
-    - cron: "17 5,17 * * *"
+    # Every 6h, an hour before each publish (cron 17 1,7,13,19) so a merged sync
+    # PR feeds fresh native/candidate data into the next publish. Was 2×/day,
+    # which let native data drift past the 24h freshness gate and stall publishes.
+    - cron: "17 0,6,12,18 * * *"
   workflow_dispatch:
 
 permissions:
@@ -107,6 +110,22 @@ jobs:
           path: ${{ runner.temp }}/sync-output
           if-no-files-found: error
           retention-days: 1
+
+      # A failing sync (chain RPC rate-limits) is what starved the publish gate.
+      # Opt-in: no-ops unless METAGRAPH_ALERT_WEBHOOK_URL is set.
+      - name: Notify on failure
+        if: failure()
+        env:
+          ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
+        run: |
+          if [ -z "${ALERT_WEBHOOK_URL:-}" ]; then
+            echo "No METAGRAPH_ALERT_WEBHOOK_URL configured; skipping alert."
+            exit 0
+          fi
+          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          curl -fsS -m 15 -X POST "$ALERT_WEBHOOK_URL" \
+            -H 'content-type: application/json' \
+            -d "{\"text\":\"🟠 metagraphed subnet sync failed — ${RUN_URL}\"}" || true
 
   pull-request:
     runs-on: ubuntu-latest

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -3540,6 +3540,12 @@ function buildFreshnessArtifact({
     adapterRows.map((row) => row.as_of),
   );
   const schemaSnapshotAsOf = schemaSnapshotTimestamp(schemaDrift);
+  // Publish freshness windows are env-configurable so ops can widen them when the
+  // sync pipeline lags (e.g. raise to 48h) instead of the publish hard-failing.
+  const blockingHours =
+    Number(process.env.METAGRAPH_FRESHNESS_BLOCKING_HOURS) || 24;
+  const healthHours =
+    Number(process.env.METAGRAPH_FRESHNESS_HEALTH_HOURS) || 24;
   const sources = [
     freshnessSource({
       asOf: native.captured_at,
@@ -3547,7 +3553,7 @@ function buildFreshnessArtifact({
       lane: "native-data",
       pathValue: "registry/native/finney-subnets.json",
       requiredForPublish: true,
-      staleAfterHours: 24,
+      staleAfterHours: blockingHours,
       timestampField: "native_data_as_of",
     }),
     freshnessSource({
@@ -3556,7 +3562,7 @@ function buildFreshnessArtifact({
       lane: "candidate-discovery",
       pathValue: "registry/candidates/generated/public-sources.json",
       requiredForPublish: true,
-      staleAfterHours: 24,
+      staleAfterHours: blockingHours,
       status: candidateDiscoveryAsOf ? "captured" : null,
       timestampField: "candidate_discovery_as_of",
     }),
@@ -3566,22 +3572,27 @@ function buildFreshnessArtifact({
       lane: "candidate-verification",
       pathValue: "registry/verification/promotions.json",
       requiredForPublish: true,
-      staleAfterHours: 24,
+      staleAfterHours: blockingHours,
       timestampField: "verification_as_of",
     }),
     freshnessSource({
       asOf: healthProbeAsOf,
       id: "surface-health",
       lane: "health-probe",
+      // Operational health is now served LIVE from the 2-minute cron prober
+      // (D1/KV), so this 6h-build probe is only the informational/full-surface
+      // fallback. It must NEVER block publish — that coupling was the cascade that
+      // froze the whole site. Warn-only; operational freshness lives in KV
+      // health:meta and is surfaced at /health → operational_health.last_run_at.
       notes:
         health.latest.source === "live-smoke-probe"
-          ? "Observed health is probe-derived."
-          : "Run probes with METAGRAPH_WRITE_PROBE_RESULTS=1 before production publish.",
+          ? "Full-surface health is probe-derived; operational surfaces are probed live every ~2 minutes."
+          : "Operational surfaces are probed live; the 6h full-surface probe is a fallback.",
       pathValue: "public/metagraph/health/latest.json",
-      requiredForPublish: true,
-      staleAfterHours: 6,
+      requiredForPublish: false,
+      staleAfterHours: healthHours,
       status: health.latest.source === "live-smoke-probe" ? "captured" : null,
-      staleBehavior: "block",
+      staleBehavior: "warn",
       timestampField: "health_probe_as_of",
     }),
     freshnessSource({
@@ -3594,7 +3605,7 @@ function buildFreshnessArtifact({
       // candidate-verification, native-subnets all 24h). The publish re-snapshots
       // adapters, so this is a safety buffer for the carry-forward path rather
       // than the primary freshness mechanism.
-      staleAfterHours: 24,
+      staleAfterHours: blockingHours,
       timestampField: "adapter_snapshot_as_of",
     }),
     freshnessSource({

--- a/scripts/sync-subnets.mjs
+++ b/scripts/sync-subnets.mjs
@@ -42,46 +42,81 @@ if (!dryRun) {
 
 console.log(stableStringify(summary));
 
-function fetchNativeSnapshot() {
-  const result = spawnSync(
-    "uvx",
-    [
-      "--from",
-      "bittensor==10.4.0",
-      "python",
-      "scripts/fetch-native-subnets.py",
-      "--network",
-      "finney",
-    ],
-    {
-      cwd: repoRoot,
-      encoding: "utf8",
-      maxBuffer: 1024 * 1024 * 20,
-    },
-  );
+// Synchronous backoff between retries (spawnSync is blocking; Atomics.wait gives
+// a clean sync sleep without a busy-loop).
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 
-  if (result.status !== 0) {
-    const errorMessage = result.error?.message
-      ? `spawn error: ${result.error.message}`
-      : null;
-    const stderr =
-      typeof result.stderr === "string" ? result.stderr.trim() : "";
-    const stdout =
-      typeof result.stdout === "string" ? result.stdout.trim() : "";
-    throw new Error(
+// The chain RPC the Bittensor SDK hits is rate-limited and occasionally flaky —
+// the failure mode that previously stalled the sync for ~40h and cascaded into a
+// blocked publish. Retry with exponential backoff before giving up.
+function fetchNativeSnapshot() {
+  const maxAttempts = Number(process.env.METAGRAPH_NATIVE_FETCH_ATTEMPTS) || 3;
+  let lastError = null;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const result = spawnSync(
+      "uvx",
       [
-        "Failed to fetch native Bittensor subnet snapshot.",
-        "Install uv or run the Bittensor SDK helper manually.",
-        errorMessage,
-        stderr,
-        stdout,
-      ]
-        .filter(Boolean)
-        .join("\n"),
+        "--from",
+        "bittensor==10.4.0",
+        "python",
+        "scripts/fetch-native-subnets.py",
+        "--network",
+        "finney",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        maxBuffer: 1024 * 1024 * 20,
+      },
     );
+
+    if (result.status === 0) {
+      try {
+        return JSON.parse(result.stdout);
+      } catch (error) {
+        lastError = new Error(
+          `Native subnet snapshot was not valid JSON: ${error.message}`,
+        );
+      }
+    } else {
+      const errorMessage = result.error?.message
+        ? `spawn error: ${result.error.message}`
+        : null;
+      const stderr =
+        typeof result.stderr === "string" ? result.stderr.trim() : "";
+      const stdout =
+        typeof result.stdout === "string" ? result.stdout.trim() : "";
+      lastError = new Error(
+        [
+          "Failed to fetch native Bittensor subnet snapshot.",
+          "Install uv or run the Bittensor SDK helper manually.",
+          errorMessage,
+          stderr,
+          stdout,
+        ]
+          .filter(Boolean)
+          .join("\n"),
+      );
+      // A spawn failure (e.g. uvx not installed) is permanent — fail fast instead
+      // of burning the backoff. Only a non-zero EXIT (chain RPC rate-limit/flake)
+      // is worth retrying.
+      if (result.error) {
+        throw lastError;
+      }
+    }
+
+    if (attempt < maxAttempts) {
+      const backoffMs = 5000 * 2 ** (attempt - 1); // 5s, 10s, 20s…
+      console.warn(
+        `::warning::native subnet fetch attempt ${attempt}/${maxAttempts} failed; retrying in ${backoffMs / 1000}s`,
+      );
+      sleepSync(backoffMs);
+    }
   }
 
-  return JSON.parse(result.stdout);
+  throw lastError;
 }
 
 async function readExistingSnapshot() {

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -891,12 +891,16 @@ test("public artifacts are internally consistent", () => {
     assert.equal(typeof source.required_for_publish, "boolean");
     assert.equal(["block", "warn"].includes(source.stale_behavior), true);
   }
+  // surface-health is warn-only now: operational health is served LIVE from the
+  // 2-minute cron prober (D1/KV), so the 6h full-surface probe is a fallback and
+  // must never block publish. This is the decoupling that fixed the cascade.
   assert.equal(
     freshness.sources.some(
       (source) =>
         source.id === "surface-health" &&
         source.lane === "health-probe" &&
-        source.stale_behavior === "block",
+        source.stale_behavior === "warn" &&
+        source.required_for_publish === false,
     ),
     true,
   );


### PR DESCRIPTION
## Why — the cascade fix
The original outage: `sync-subnets` fell behind on chain-RPC rate-limits → native data went >24h stale → the publish **freshness gate** (where `surface-health` was a *blocking* source) aborted the entire publish → **all data, including health, froze**. Phase 3 made operational health live; this PR severs the remaining coupling and hardens the pipeline that fell behind.

## What
- **`build-artifacts.mjs` `buildFreshnessArtifact`**:
  - **`surface-health` → `warn`** (`required_for_publish=false`). It was *blocking* at 6h; health is live now (D1/KV), so the 6h full-surface probe is a fallback and must never block publish. Blocking sources are now only the 4 structural ones.
  - Freshness windows are **env-configurable** (`METAGRAPH_FRESHNESS_BLOCKING_HOURS` / `_HEALTH_HOURS`, default 24) so ops can widen them when sync lags instead of hard-failing.
- **`sync-subnets.mjs`**: retry the chain-RPC native fetch with exponential backoff (5s/10s, `METAGRAPH_NATIVE_FETCH_ATTEMPTS`, default 3) — the exact flakiness that stalled sync for ~40h. A missing binary still **fails fast** (no wasted backoff).
- **`sync-subnets.yml`**: 2×/day → **every 6h** (an hour before each publish) so native data stays inside the freshness window.
- **Alerting**: opt-in failure notification on publish + sync via `METAGRAPH_ALERT_WEBHOOK_URL` (the original outage went unnoticed for ~a day).

## Verification
- `npm test` **278/278** (`artifacts.test` now locks `surface-health` as warn/non-blocking).
- `validate` / `validate:api` / `validate:openapi` / `validate:docs` / `validate:artifact-budgets` / `validate:workflows` + `worker:deploy:dry-run` + `cloudflare:verify:dry-run` green.
- Rebuilt freshness artifact confirms: blocking = `native-subnets, candidate-discovery, candidate-verification, adapter-snapshots`; `surface-health` = warn.

## Setup (optional)
Set repo secret `METAGRAPH_ALERT_WEBHOOK_URL` to receive publish/sync failure alerts (Slack/Discord/etc. incoming-webhook URL). No-ops if unset.

## Next
Phase 5: SDK 0.2.0 (typed trends endpoint) + ADR/docs.