### PR TITLE
feat(health): Phase 5 — typed trends endpoint + SDK 0.2.0 + ADR

### DIFF
--- a/docs/adr/0002-live-operational-health.md
+++ b/docs/adr/0002-live-operational-health.md
@@ -1,0 +1,78 @@
+# ADR 0002 — Live operational health (2-minute cron prober → D1/KV → served live)
+
+- **Status:** Accepted — implemented (Phases 1–5, PRs #252–#257).
+- **Date:** 2026-06-10
+- **Relates to:** ADR 0001 (R2-only data artifacts, 6h scheduled publish).
+
+## Context
+
+The backend served **all** health from the same 6h batch as structural data:
+`scripts/probes-smoke.mjs` probed ~1,140 surfaces during `sync-subnets.yml`
+(2×/day), and the results were baked into static R2 artifacts. Two problems:
+
+1. **Staleness.** Operational health (RPC/WSS chain nodes, subnet APIs, SSE) was
+   only as fresh as the last successful 6h publish — a 6h-old "endpoint is up" is
+   operationally useless.
+2. **Coupling cascade.** `surface-health` was a **blocking** publish-freshness
+   source, and the publish gate also blocks on `native-subnets`. When
+   `sync-subnets` fell behind on chain-RPC rate-limits, native data went >24h
+   stale → the freshness gate aborted the **entire** publish → **all data,
+   including health, froze** for ~a day before anyone noticed.
+
+Operational health and structural data have fundamentally different freshness
+needs, but shared one pipeline.
+
+## Decision
+
+Split the two data classes. Keep slow/structural data on the 6h build. Move the
+**~49–58 operational surfaces** (`subtensor-rpc`, `subtensor-wss`, `archive`,
+`subnet-api`, `sse`, `data-artifact`) onto a **dedicated live pipeline**:
+
+```
+EVERY 2 MIN (Cloudflare Cron Trigger, workers/api.mjs scheduled())
+  load operational-surfaces.json (committed) → probe with the shared isomorphic
+  core (src/health-probe-core.mjs) under bounded concurrency →
+    D1 surface_checks  (append-only time-series → /health/trends)
+    D1 surface_status  (latest row + circuit-breaker counter)
+    KV health:current / health:rpc-pool / health:meta  (hot snapshots)
+
+SERVING (workers/api.mjs): /api/v1/health, /subnets/{n}/health, badges,
+  /rpc/endpoints + the RPC proxy pool, and /freshness OVERLAY the live snapshot
+  onto the static artifact, falling back to static when the snapshot is cold.
+  NEW /api/v1/subnets/{n}/health/trends reads D1 directly.
+```
+
+Key properties:
+
+- **Isomorphic probe core.** `src/health-probe-core.mjs` holds the probe +
+  classification logic, shared verbatim by the Node 6h build and the Worker cron
+  (fetch / SSRF guard / WebSocket connector injected). WSS is probed from the
+  Worker via `fetch(Upgrade: websocket)` (Workers have no `new WebSocket()` for
+  outbound).
+- **Fallback everywhere.** Every live read returns null/unchanged when KV/D1 is
+  cold and the caller serves the static artifact — zero-downtime, regression-proof
+  rollout; the live path engages automatically once the cron warms KV.
+- **Decoupled gate.** `surface-health` is now **warn-only** (`required_for_publish
+= false`); operational health can never block publish again. The structural
+  freshness windows are env-configurable (`METAGRAPH_FRESHNESS_BLOCKING_HOURS`).
+- **Hardened sync.** The chain-RPC native fetch retries with backoff
+  (`METAGRAPH_NATIVE_FETCH_ATTEMPTS`); `sync-subnets` runs every 6h; publish/sync
+  failures alert via `METAGRAPH_ALERT_WEBHOOK_URL`.
+
+## Why not alternatives
+
+- **Real-time per-request probing** — a Worker can't crawl hundreds of
+  third-party endpoints per request (rate limits, latency, subrequest caps).
+- **Durable Object / Queue prober** — overkill at ~58 endpoints; one 2-minute
+  cron with bounded concurrency sits far under the 30s CPU / 15-min duration /
+  10k-subrequest limits. Revisit if per-endpoint staggered scheduling is needed.
+- **Probe everything live** — the ~1,091 docs/website/repo surfaces rarely change
+  and stay on the 6h build; only operational surfaces need minute-level freshness.
+
+## Outcome
+
+Operational health is fresh to **~2 minutes** (was 6h). `/health` reports
+`operational_health.last_run_at` for monitoring. D1 time-series powers
+`/health/trends` (7d/30d uptime + latency). The cascade is structurally
+impossible: health no longer depends on the publish, the freshness gate, or
+`sync-subnets`. Cost stays within free/cheap Cloudflare limits (cron + D1 + KV).

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -161,10 +161,16 @@ curl -s https://api.metagraph.sh/api/v1/subnets/7/profile | jq '.data'
 # Search across the registry
 curl -s 'https://api.metagraph.sh/api/v1/search?q=gittensor' | jq '.data'
 
-# Probe-derived health for a subnet + its embeddable badge
+# Operational health for a subnet + its embeddable badge. Operational surfaces
+# (RPC/WSS/subnet-api/SSE) are probed LIVE every ~2 minutes (D1/KV) and overlaid
+# on the 6h static artifact; read freshness from meta.operational_observed_at.
 curl -s https://api.metagraph.sh/api/v1/subnets/7/health | jq '.data'
 #   <img src="https://api.metagraph.sh/metagraph/health/badges/7.svg">
 
-# Worker readiness (not part of /api/v1)
+# 7d/30d uptime + latency trends for a subnet's operational surfaces (D1-backed)
+curl -s https://api.metagraph.sh/api/v1/subnets/7/health/trends | jq '.data.windows'
+
+# Worker readiness (not part of /api/v1); operational_health.last_run_at shows the
+# cron prober's last sweep.
 curl -s https://api.metagraph.sh/health | jq
 ```

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -64,6 +64,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/endpoint-pools.json`: generalized endpoint pool scoring for future read-only routing.
 - `/metagraph/endpoint-incidents.json`: probe-derived endpoint incident summary and active endpoint failures.
 - `/metagraph/operational-surfaces.json`: operational surfaces (RPC/WSS/subnet-api/SSE/data-artifact) probed live by the 2-minute Cloudflare cron health prober; the prober's input list, served from the committed assets.
+- `/metagraph/health/trends/{netuid}.json`: schema for the computed 7d/30d uptime + latency trends served live from D1 at `GET /api/v1/subnets/{netuid}/health/trends` (no static file is written).
 - `/metagraph/schema-drift.json`: OpenAPI snapshot/drift status.
 - `/metagraph/schemas/index.json`: captured machine-readable schema index.
 - `/metagraph/schemas/{surface_id}.json`: captured machine-readable OpenAPI/Swagger schema snapshot detail. R2-backed.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -701,6 +701,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/health/trends": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1). */
+        get: operations["subnetHealthTrends"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/subnets/{netuid}/overview": {
         parameters: {
             query?: never;
@@ -1376,6 +1393,30 @@ export interface components {
             /** Format: uri */
             url: string;
             verified_at?: string | null;
+        };
+        HealthTrendsArtifact: {
+            netuid: number;
+            observed_at?: string | null;
+            schema_version: number;
+            source: string;
+            windows: {
+                [key: string]: {
+                    samples: number;
+                    surfaces: ({
+                        avg_latency_ms: number | null;
+                        samples: number;
+                        surface_id: string;
+                        uptime_ratio: number | null;
+                    } & {
+                        [key: string]: unknown;
+                    })[];
+                    uptime_ratio: number | null;
+                } & {
+                    [key: string]: unknown;
+                };
+            };
+        } & {
+            [key: string]: unknown;
         };
         JsonObject: {
             [key: string]: unknown;
@@ -5536,6 +5577,76 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthSubnetArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetHealthTrends: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["HealthTrendsArtifact"];
                     };
                 };
             };

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jsonbored/metagraphed",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
   "license": "MIT",
   "type": "module",

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -268,6 +268,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "health-trends",
+      "path": "/metagraph/health/trends/{netuid}.json",
+      "schema_ref": "#/components/schemas/HealthTrendsArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
       "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
@@ -3167,6 +3174,18 @@
           }
         }
       ]
+    },
+    {
+      "artifact_path": "/metagraph/health/trends/{netuid}.json",
+      "cache": "short",
+      "description": "Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1).",
+      "id": "subnet-health-trends",
+      "method": "GET",
+      "path": "/api/v1/subnets/{netuid}/health/trends",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": []
     },
     {
       "artifact_path": "/metagraph/freshness.json",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -345,6 +345,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Computed 7d/30d uptime + latency trends for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
+      "id": "health-trends",
+      "path": "/metagraph/health/trends/{netuid}.json",
+      "schema_ref": "#/components/schemas/HealthTrendsArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Bittensor base-layer RPC endpoint registry and probe status.",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2525,6 +2525,92 @@
         ],
         "type": "object"
       },
+      "HealthTrendsArtifact": {
+        "additionalProperties": true,
+        "properties": {
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "windows": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "properties": {
+                "samples": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "surfaces": {
+                  "items": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "avg_latency_ms": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "samples": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "surface_id": {
+                        "type": "string"
+                      },
+                      "uptime_ratio": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "surface_id",
+                      "samples",
+                      "uptime_ratio",
+                      "avg_latency_ms"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "uptime_ratio": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "samples",
+                "uptime_ratio",
+                "surfaces"
+              ],
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "source",
+          "windows"
+        ],
+        "type": "object"
+      },
       "JsonObject": {
         "additionalProperties": true,
         "type": "object"
@@ -14132,6 +14218,105 @@
           }
         },
         "summary": "Fetch health detail for one subnet.",
+        "tags": [
+          "health",
+          "subnets"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}/health/trends": {
+      "get": {
+        "operationId": "subnetHealthTrends",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/HealthTrendsArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1).",
         "tags": [
           "health",
           "subnets"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -701,6 +701,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/health/trends": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1). */
+        get: operations["subnetHealthTrends"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/subnets/{netuid}/overview": {
         parameters: {
             query?: never;
@@ -1376,6 +1393,30 @@ export interface components {
             /** Format: uri */
             url: string;
             verified_at?: string | null;
+        };
+        HealthTrendsArtifact: {
+            netuid: number;
+            observed_at?: string | null;
+            schema_version: number;
+            source: string;
+            windows: {
+                [key: string]: {
+                    samples: number;
+                    surfaces: ({
+                        avg_latency_ms: number | null;
+                        samples: number;
+                        surface_id: string;
+                        uptime_ratio: number | null;
+                    } & {
+                        [key: string]: unknown;
+                    })[];
+                    uptime_ratio: number | null;
+                } & {
+                    [key: string]: unknown;
+                };
+            };
+        } & {
+            [key: string]: unknown;
         };
         JsonObject: {
             [key: string]: unknown;
@@ -5536,6 +5577,76 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthSubnetArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetHealthTrends: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["HealthTrendsArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -2503,6 +2503,92 @@
         ],
         "type": "object"
       },
+      "HealthTrendsArtifact": {
+        "additionalProperties": true,
+        "properties": {
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "windows": {
+            "additionalProperties": {
+              "additionalProperties": true,
+              "properties": {
+                "samples": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "surfaces": {
+                  "items": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "avg_latency_ms": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "samples": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "surface_id": {
+                        "type": "string"
+                      },
+                      "uptime_ratio": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "surface_id",
+                      "samples",
+                      "uptime_ratio",
+                      "avg_latency_ms"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "uptime_ratio": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "samples",
+                "uptime_ratio",
+                "surfaces"
+              ],
+              "type": "object"
+            },
+            "type": "object"
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "source",
+          "windows"
+        ],
+        "type": "object"
+      },
       "JsonObject": {
         "additionalProperties": true,
         "type": "object"

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -398,6 +398,48 @@
             "additionalProperties": true
           }
         ]
+      },
+      "HealthTrendsArtifact": {
+        "type": "object",
+        "required": ["schema_version", "netuid", "source", "windows"],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "netuid": { "type": "integer", "minimum": 0 },
+          "observed_at": { "type": ["string", "null"] },
+          "source": { "type": "string" },
+          "windows": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "required": ["samples", "uptime_ratio", "surfaces"],
+              "properties": {
+                "samples": { "type": "integer", "minimum": 0 },
+                "uptime_ratio": { "type": ["number", "null"] },
+                "surfaces": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": [
+                      "surface_id",
+                      "samples",
+                      "uptime_ratio",
+                      "avg_latency_ms"
+                    ],
+                    "properties": {
+                      "surface_id": { "type": "string" },
+                      "samples": { "type": "integer", "minimum": 0 },
+                      "uptime_ratio": { "type": ["number", "null"] },
+                      "avg_latency_ms": { "type": ["integer", "null"] }
+                    },
+                    "additionalProperties": true
+                  }
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
       }
     }
   }

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -36,6 +36,14 @@ const checks = [
   ],
   ["/api/v1/subnets/7", (body) => assert.equal(body.data.subnet.netuid, 7)],
   [
+    "/api/v1/subnets/7/health/trends",
+    (body) => {
+      assert.equal(body.data.netuid, 7);
+      assert.equal(typeof body.data.windows, "object");
+      assert.equal(typeof body.data.windows["7d"].samples, "number");
+    },
+  ],
+  [
     "/api/v1/profiles?profile_level=adapter-backed",
     (body) =>
       assert.equal(

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -17,6 +17,11 @@ import {
   artifactStorageTierForPath,
 } from "../src/artifact-storage.mjs";
 
+// Artifacts whose schema describes a live-computed API response with no static
+// file on disk (served from D1/KV). Their schema is exercised by validate-api's
+// per-route response validation, not by validating files here.
+const COMPUTED_ARTIFACTS = new Set(["health-trends"]);
+
 const ajv = new Ajv2020({
   allErrors: true,
   allowUnionTypes: true,
@@ -105,7 +110,7 @@ console.log("JSON Schema validation passed.");
 async function artifactValidationTargets() {
   const targets = [];
   for (const artifact of PUBLIC_ARTIFACTS) {
-    if (!artifact.schema_ref) {
+    if (!artifact.schema_ref || COMPUTED_ARTIFACTS.has(artifact.id)) {
       continue;
     }
 

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -21,6 +21,10 @@ const R2_ONLY_PATTERNS = [
   /^health\/latest\.json$/,
   /^health\/summary\.json$/,
   /^health\/subnets\/(?:\d+|\{netuid\})\.json$/,
+  // Health trends are computed live from D1 by the Worker, never written as a
+  // file. Marked R2-only so the contract maps a schema to the route without the
+  // build expecting a committed/staged artifact.
+  /^health\/trends\/(?:\d+|\{netuid\})\.json$/,
   /^metagraph\/latest\.json$/,
   /^profiles\/(?:\d+|\{netuid\})\.json$/,
   /^providers\/[^/]+\.json$/,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -751,6 +751,12 @@ export const PUBLIC_ARTIFACTS = [
     "HealthBadgeArtifact",
   ),
   artifact(
+    "health-trends",
+    "/metagraph/health/trends/{netuid}.json",
+    "Computed 7d/30d uptime + latency trends for one subnet's operational surfaces. Served live from D1 at /api/v1/subnets/{netuid}/health/trends (no static file).",
+    "HealthTrendsArtifact",
+  ),
+  artifact(
     "rpc-endpoints",
     "/metagraph/rpc-endpoints.json",
     "Bittensor base-layer RPC endpoint registry and probe status.",
@@ -1174,6 +1180,17 @@ export const API_ROUTES = [
     "short",
     ["health", "subnets"],
     listQuery("health-surfaces", { exclude: ["netuid"] }),
+    [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+  ),
+  route(
+    "subnet-health-trends",
+    "GET",
+    "/api/v1/subnets/{netuid}/health/trends",
+    "/metagraph/health/trends/{netuid}.json",
+    "Fetch 7d/30d uptime and latency trends for one subnet's operational surfaces (computed live from D1).",
+    "short",
+    ["health", "subnets"],
+    [],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -523,7 +523,7 @@ async function handleHealthTrends(request, env, netuid) {
     {
       data,
       meta: {
-        artifact_path: null,
+        artifact_path: `/metagraph/health/trends/${netuid}.json`,
         cache: "short",
         contract_version: contractVersion(env),
         generated_at: data.observed_at,


### PR DESCRIPTION
## Why
Final phase: make the live trends endpoint a **typed, contracted** part of the API (so it lands in the published SDK), ship **SDK 0.2.0** through the new OIDC trusted-publishing pipeline, and document the architecture.

## What
- **Contract**: `HealthTrendsArtifact` schema (`06-health`) + `health-trends` artifact + `subnet-health-trends` route → `GET /api/v1/subnets/{netuid}/health/trends` is now in `openapi.json` + the generated TS client. The artifact is R2-only/**fileless** (computed live from D1): `validate-schemas` skips it (no file to validate; its schema is exercised by `validate-api`'s per-route response check).
- **SDK** `packages/client` → **0.2.0** (typed trends; the first release through OIDC trusted publishing).
- **Docs**: **ADR 0002** (live operational health), `api-stability.md` trends example + live-health notes, `backend-artifact-contracts.md` entry.

## Verification
- `validate` / `validate:api` (**46 routes**) / `validate:openapi` / `validate:schemas` / `validate:types` / `validate:docs` / `validate:artifact-budgets` / `validate:workflows` + `worker:deploy:dry-run` + `cloudflare:verify:dry-run` — all green.
- `npm test` **278/278**.
- Confirmed `/api/v1/subnets/{netuid}/health/trends` is in `generated/metagraphed-api.d.ts`.

## After merge
Run the **Publish client SDK** workflow → publishes `@jsonbored/metagraphed@0.2.0` tokenless (`--provenance`), validating the OIDC trusted-publishing setup end-to-end.