### PR TITLE
fix(ci): remove self-deadlocking concurrency in publish-client

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -51,9 +51,6 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    concurrency:
-      group: client-package-release
-      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
The publish job and the workflow shared the same concurrency group `client-package-release`, so the job deadlocked on the group held by its own run — failing instantly with 0 steps (why the 0.2.0 OIDC publish never executed). The workflow-level concurrency already serializes releases.

`validate:workflows` green.