### PR TITLE
test(backend): coverage ~98.7% + CI gate + Discord alert format

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -284,4 +284,4 @@ jobs:
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           curl -fsS -m 15 -X POST "$ALERT_WEBHOOK_URL" \
             -H 'content-type: application/json' \
-            -d "{\"text\":\"🔴 metagraphed data publish failed — ${RUN_URL}\"}" || true
+            -d "{\"content\":\"🔴 metagraphed data publish failed — ${RUN_URL}\"}" || true

--- a/.github/workflows/sync-subnets.yml
+++ b/.github/workflows/sync-subnets.yml
@@ -125,7 +125,7 @@ jobs:
           RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           curl -fsS -m 15 -X POST "$ALERT_WEBHOOK_URL" \
             -H 'content-type: application/json' \
-            -d "{\"text\":\"🟠 metagraphed subnet sync failed — ${RUN_URL}\"}" || true
+            -d "{\"content\":\"🟠 metagraphed subnet sync failed — ${RUN_URL}\"}" || true
 
   pull-request:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -156,9 +156,9 @@ jobs:
         if: steps.route.outputs.mode == 'full'
         run: npm run validate
 
-      - name: Test
+      - name: Test (with coverage gate)
         if: steps.route.outputs.mode == 'full'
-        run: npm test
+        run: npm run test:coverage
 
       - name: Generate R2 manifest
         if: steps.route.outputs.mode == 'full'

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1,0 +1,1064 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import {
+  handleRequest,
+  handleScheduled,
+  proxyWithFailover,
+  weightedPickEndpoint,
+} from "../workers/api.mjs";
+import workerDefault from "../workers/api.mjs";
+
+const req = (path, init) =>
+  new Request(`https://api.metagraph.sh${path}`, init);
+
+// In-memory KV mock matching the Workers KV surface the worker uses.
+function makeKv(entries = {}) {
+  const store = new Map(Object.entries(entries));
+  return {
+    store,
+    async get(key, opts) {
+      if (!store.has(key)) return null;
+      const value = store.get(key);
+      return opts?.type === "json" ? value : JSON.stringify(value);
+    },
+    async put(key, value) {
+      store.set(key, JSON.parse(value));
+    },
+    async delete(key) {
+      store.delete(key);
+    },
+  };
+}
+
+const RPC_POOL = {
+  pools: [
+    {
+      id: "finney-rpc",
+      endpoints: [
+        {
+          id: "fx",
+          provider: "fx",
+          pool_eligible: true,
+          status: "ok",
+          score: 100,
+          url: "https://bittensor-finney.api.onfinality.io/public",
+        },
+      ],
+    },
+  ],
+};
+
+// RPC-proxy env that serves the pool artifact through ASSETS + R2.
+function rpcEnv(overrides = {}) {
+  return {
+    METAGRAPH_ENABLE_RPC_PROXY: "true",
+    ASSETS: {
+      async fetch(request) {
+        const url = new URL(request.url);
+        if (url.pathname === "/metagraph/rpc/pools.json") {
+          return Response.json(RPC_POOL);
+        }
+        return new Response("{}", { status: 404 });
+      },
+    },
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          async json() {
+            return RPC_POOL;
+          },
+        };
+      },
+    },
+    ...overrides,
+  };
+}
+
+function withGlobals({ cache, fetchImpl }, run) {
+  const originalCaches = globalThis.caches;
+  const originalFetch = globalThis.fetch;
+  if (cache !== undefined) globalThis.caches = { default: cache };
+  if (fetchImpl !== undefined) globalThis.fetch = fetchImpl;
+  return Promise.resolve(run()).finally(() => {
+    globalThis.caches = originalCaches;
+    globalThis.fetch = originalFetch;
+  });
+}
+
+const rpcReq = (method, params = [], id = 1) =>
+  req("/rpc/v1/finney", {
+    method: "POST",
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  });
+
+// --- top-level routing edges --------------------------------------------------
+describe("handleRequest routing edges", () => {
+  test("rejects POST to a GET-only route with 405 method_not_allowed", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets", { method: "POST" }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 405);
+    assert.equal((await res.json()).error.code, "method_not_allowed");
+    assert.equal(res.headers.get("allow"), "GET, HEAD, OPTIONS");
+  });
+
+  test("OPTIONS preflight on an api route returns 204", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets", { method: "OPTIONS" }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "GET, HEAD, OPTIONS",
+    );
+  });
+
+  test("OPTIONS preflight on an rpc route advertises POST", async () => {
+    const res = await handleRequest(
+      req("/rpc/v1/finney", { method: "OPTIONS" }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 204);
+    assert.equal(
+      res.headers.get("access-control-allow-methods"),
+      "POST, OPTIONS",
+    );
+  });
+
+  test("falls through to ASSETS for a non-api path", async () => {
+    let assetCalled = false;
+    const env = {
+      ASSETS: {
+        async fetch() {
+          assetCalled = true;
+          return new Response("ok", { status: 200 });
+        },
+      },
+    };
+    const res = await handleRequest(req("/index.html"), env, {});
+    assert.equal(res.status, 200);
+    assert.equal(assetCalled, true);
+  });
+
+  test("returns 404 not_found when no ASSETS binding is configured", async () => {
+    const res = await handleRequest(req("/index.html"), {}, {});
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "not_found");
+  });
+});
+
+// --- slug → netuid resolution -------------------------------------------------
+describe("subnet slug resolution", () => {
+  test("resolves a known slug to its netuid route", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets/allways"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    // allways → netuid 7; should resolve to the subnet detail payload.
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnet.netuid, 7);
+  });
+
+  test("404 subnet_not_found for an unknown slug", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets/this-slug-does-not-exist"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "subnet_not_found");
+  });
+
+  test("404 subnet_not_found for a malformed (undecodable) slug", async () => {
+    // "%E0%A4%A" is an invalid percent-encoding → decodeURIComponent throws
+    // URIError → decodeSlugPathSegment returns null → not_found.
+    const res = await handleRequest(
+      req("/api/v1/subnets/%E0%A4%A"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "subnet_not_found");
+  });
+
+  test("returns not_found when the slug index cannot be loaded (no prior copy)", async () => {
+    // No ASSETS and no R2 → subnets.json cannot be read; lookupSubnetNetuid
+    // returns null on the cold-start path. Use a slug guaranteed not numeric.
+    const env = {
+      ASSETS: {
+        async fetch() {
+          return new Response("nope", { status: 404 });
+        },
+      },
+    };
+    const res = await handleRequest(req("/api/v1/subnets/somename"), env, {});
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "subnet_not_found");
+  });
+});
+
+// --- health readiness ---------------------------------------------------------
+describe("/health readiness", () => {
+  test("405 on a non-GET/HEAD method", async () => {
+    const res = await handleRequest(
+      req("/health", { method: "POST" }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    // POST is not in [GET, HEAD], so the top-level gate returns 405 before
+    // reaching handleHealthRequest. PUT also routes the same way.
+    assert.equal(res.status, 405);
+  });
+
+  test("reports degraded + 503 when the KV latest pointer is stale", async () => {
+    const stale = new Date(Date.now() - 48 * 3_600_000).toISOString();
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "metagraph:latest": { published_at: stale },
+        "health:meta": {
+          last_run_at: new Date().toISOString(),
+          probed_count: 5,
+          status_counts: { ok: 5 },
+        },
+      }),
+    });
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal(res.status, 503);
+    assert.equal(res.headers.get("x-metagraph-health"), "degraded");
+    const body = await res.json();
+    assert.equal(body.status, "degraded");
+    assert.equal(body.freshness.stale, true);
+    assert.equal(body.operational_health.probed_count, 5);
+  });
+
+  test("reports ok + 200 with a fresh pointer", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "metagraph:latest": { published_at: new Date().toISOString() },
+      }),
+    });
+    const res = await handleRequest(req("/health"), env, {});
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).status, "ok");
+  });
+
+  test("HEAD /health returns no body", async () => {
+    const res = await handleRequest(
+      req("/health", { method: "HEAD" }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "");
+  });
+});
+
+// --- raw artifact route -------------------------------------------------------
+describe("raw artifact route", () => {
+  test("serves a raw artifact with source + storage-tier headers", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(req("/metagraph/subnets.json"), env, {});
+    assert.equal(res.status, 200);
+    assert.ok(res.headers.get("x-metagraph-artifact-source"));
+    assert.ok(res.headers.get("x-metagraph-storage-tier"));
+    assert.ok(res.headers.get("etag"));
+  });
+
+  test("304 on a matching if-none-match", async () => {
+    const env = createLocalArtifactEnv();
+    const first = await handleRequest(req("/metagraph/subnets.json"), env, {});
+    const etag = first.headers.get("etag");
+    const res = await handleRequest(
+      req("/metagraph/subnets.json", { headers: { "if-none-match": etag } }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 304);
+  });
+
+  test("404 for a /metagraph/*.json path with no matching contract", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      req("/metagraph/not-a-real-artifact.json"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "not_found");
+  });
+
+  test("propagates the artifact read error when the contract matches but data is missing", async () => {
+    // subnets.json matches a raw-artifact contract; remove both backends so the
+    // read fails and the error is surfaced through the raw route.
+    const env = {
+      ASSETS: {
+        async fetch() {
+          return new Response("nope", { status: 404 });
+        },
+      },
+    };
+    const res = await handleRequest(req("/metagraph/subnets.json"), env, {});
+    assert.equal(res.status, 404);
+    const body = await res.json();
+    assert.equal(body.meta.artifact_path, "/metagraph/subnets.json");
+  });
+});
+
+// --- badge SVG ----------------------------------------------------------------
+describe("badge SVG handler", () => {
+  test("405 when posting to a badge", async () => {
+    const res = await handleRequest(
+      req("/metagraph/health/badges/7.svg", { method: "POST" }),
+      createLocalArtifactEnv(),
+      {},
+    );
+    // POST is not GET/HEAD → top-level gate 405.
+    assert.equal(res.status, 405);
+  });
+
+  test("renders the static badge artifact when no live overlay", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      req("/metagraph/health/badges/7.svg"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /image\/svg\+xml/);
+    const svg = await res.text();
+    assert.match(svg, /<svg/);
+  });
+
+  test("304 on a matching if-none-match for a badge", async () => {
+    const env = createLocalArtifactEnv();
+    const first = await handleRequest(
+      req("/metagraph/health/badges/7.svg"),
+      env,
+      {},
+    );
+    const etag = first.headers.get("etag");
+    const res = await handleRequest(
+      req("/metagraph/health/badges/7.svg", {
+        headers: { "if-none-match": etag },
+      }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 304);
+  });
+
+  test("prefers the live KV overlay status when present", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "health:current": { subnets: [{ netuid: 7, status: "degraded" }] },
+      }),
+    });
+    const res = await handleRequest(
+      req("/metagraph/health/badges/7.svg"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const svg = await res.text();
+    assert.match(svg, /degraded/);
+    // SN7 label rendered from the live overlay branch.
+    assert.match(svg, /SN7/);
+  });
+
+  test("renders a graceful 'unavailable' badge when nothing is available", async () => {
+    const env = {
+      ASSETS: {
+        async fetch() {
+          return new Response("nope", { status: 404 });
+        },
+      },
+    };
+    const res = await handleRequest(
+      req("/metagraph/health/badges/999.svg"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const svg = await res.text();
+    assert.match(svg, /unavailable/);
+    // Graceful fallback uses the short cache profile.
+    assert.match(res.headers.get("cache-control"), /max-age=/);
+  });
+
+  test("HEAD on a badge returns no body", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      req("/metagraph/health/badges/7.svg", { method: "HEAD" }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "");
+  });
+});
+
+// --- live health overlay branches --------------------------------------------
+describe("live health overlay (rpc-endpoints + freshness)", () => {
+  test("/api/v1/rpc/endpoints overlays the live KV rpc pool", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "health:rpc-pool": {
+          last_run_at: "2026-06-11T00:00:00.000Z",
+          generated_at: "2026-06-11T00:00:00.000Z",
+          endpoints: [{ id: "any", status: "ok" }],
+        },
+      }),
+    });
+    const res = await handleRequest(req("/api/v1/rpc/endpoints"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.meta.source, "live-cron-prober");
+  });
+
+  test("/api/v1/freshness overlays the live KV meta", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({
+        "health:meta": { last_run_at: "2026-06-11T00:00:00.000Z" },
+      }),
+    });
+    const res = await handleRequest(req("/api/v1/freshness"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.meta.source, "live-cron-prober");
+  });
+
+  test("/api/v1/health with KV bound but cold serves the static artifact", async () => {
+    // health:current absent → liveHealthOverlay returns null at the `!current`
+    // guard, so the static health summary artifact is served.
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: makeKv({}),
+    });
+    const res = await handleRequest(req("/api/v1/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.notEqual(body.meta.source, "live-cron-prober");
+  });
+
+  test("readHealthKv swallows a throwing KV get (serves static)", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: {
+        async get() {
+          throw new Error("kv blew up");
+        },
+      },
+    });
+    const res = await handleRequest(req("/api/v1/freshness"), env, {});
+    // Live overlay returns null on the KV throw → static artifact served.
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.notEqual(body.meta.source, "live-cron-prober");
+  });
+});
+
+// --- invalid query ------------------------------------------------------------
+describe("invalid query handling", () => {
+  test("400 invalid_query for an unsupported sort field", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?sort=not_a_field"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    const body = await res.json();
+    assert.equal(body.error.code, "invalid_query");
+    assert.equal(body.meta.parameter, "sort");
+  });
+
+  test("400 invalid_query for a bad order value", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?order=sideways"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).meta.parameter, "order");
+  });
+
+  test("paginates with cursor + limit and reports next_cursor", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?limit=2&cursor=0&sort=netuid"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.subnets.length, 2);
+    assert.equal(body.meta.pagination.limit, 2);
+    assert.equal(body.meta.pagination.cursor, 0);
+  });
+
+  test("sorts by a string field (name) descending", async () => {
+    const res = await handleRequest(
+      req("/api/v1/subnets?sort=name&order=desc&limit=3"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    const names = (await res.json()).data.subnets.map((s) => String(s.name));
+    const sorted = [...names].sort((a, b) => b.localeCompare(a));
+    assert.deepEqual(names, sorted);
+  });
+});
+
+// --- 304 on api envelope ------------------------------------------------------
+describe("api envelope 304", () => {
+  test("304 when if-none-match matches the api etag", async () => {
+    const env = createLocalArtifactEnv();
+    const first = await handleRequest(req("/api/v1/subnets"), env, {});
+    const etag = first.headers.get("etag");
+    const res = await handleRequest(
+      req("/api/v1/subnets", { headers: { "if-none-match": etag } }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 304);
+  });
+
+  test("HEAD on an api route returns no body", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      req("/api/v1/subnets", { method: "HEAD" }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "");
+  });
+});
+
+// --- RPC proxy edges ----------------------------------------------------------
+describe("RPC proxy edges", () => {
+  test("405 for a non-POST RPC request", async () => {
+    const res = await handleRequest(
+      req("/rpc/v1/finney", { method: "GET" }),
+      rpcEnv(),
+      {},
+    );
+    assert.equal(res.status, 405);
+    assert.equal((await res.json()).error.code, "method_not_allowed");
+  });
+
+  test("501 when the RPC proxy is disabled", async () => {
+    const res = await handleRequest(
+      rpcReq("system_health"),
+      rpcEnv({ METAGRAPH_ENABLE_RPC_PROXY: "false" }),
+      {},
+    );
+    assert.equal(res.status, 501);
+    assert.equal((await res.json()).error.code, "rpc_proxy_disabled");
+  });
+
+  test("413 when content-length exceeds the body limit", async () => {
+    const res = await handleRequest(
+      req("/rpc/v1/finney", {
+        method: "POST",
+        headers: { "content-length": String(70000) },
+        body: JSON.stringify({ jsonrpc: "2.0", method: "system_health" }),
+      }),
+      rpcEnv(),
+      {},
+    );
+    assert.equal(res.status, 413);
+    assert.equal((await res.json()).error.code, "rpc_body_too_large");
+  });
+
+  test("413 when the decoded body byte length exceeds the limit", async () => {
+    // content-length header omitted/0, but the actual body is oversized.
+    const big = "x".repeat(70000);
+    const res = await handleRequest(
+      req("/rpc/v1/finney", {
+        method: "POST",
+        body: JSON.stringify({ jsonrpc: "2.0", method: "system_health", big }),
+      }),
+      rpcEnv(),
+      {},
+    );
+    assert.equal(res.status, 413);
+    assert.equal((await res.json()).error.code, "rpc_body_too_large");
+  });
+
+  test("400 rpc_invalid_json for a non-JSON body", async () => {
+    const res = await handleRequest(
+      req("/rpc/v1/finney", { method: "POST", body: "{not json" }),
+      rpcEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "rpc_invalid_json");
+  });
+
+  test("400 rpc_invalid_request for an array body", async () => {
+    const res = await handleRequest(
+      req("/rpc/v1/finney", {
+        method: "POST",
+        body: JSON.stringify([{ method: "system_health" }]),
+      }),
+      rpcEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "rpc_invalid_request");
+  });
+
+  test("403 rpc_method_blocked for a denied method", async () => {
+    const res = await handleRequest(
+      rpcReq("author_submitExtrinsic"),
+      rpcEnv(),
+      {},
+    );
+    assert.equal(res.status, 403);
+    assert.equal((await res.json()).error.code, "rpc_method_blocked");
+  });
+
+  test("400 rpc_websocket_unsupported for the /wss route", async () => {
+    const res = await handleRequest(
+      req("/rpc/v1/finney/wss", {
+        method: "POST",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "system_health",
+        }),
+      }),
+      rpcEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "rpc_websocket_unsupported");
+  });
+
+  test("503 rpc_endpoint_unavailable when the pool has no eligible endpoints", async () => {
+    const emptyPool = { pools: [{ id: "finney-rpc", endpoints: [] }] };
+    const env = {
+      METAGRAPH_ENABLE_RPC_PROXY: "true",
+      ASSETS: {
+        async fetch(request) {
+          const url = new URL(request.url);
+          if (url.pathname === "/metagraph/rpc/pools.json") {
+            return Response.json(emptyPool);
+          }
+          return new Response("{}", { status: 404 });
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              return emptyPool;
+            },
+          };
+        },
+      },
+    };
+    const res = await handleRequest(rpcReq("system_health"), env, {});
+    assert.equal(res.status, 503);
+    assert.equal((await res.json()).error.code, "rpc_endpoint_unavailable");
+  });
+
+  test("502 rpc_endpoint_unsafe when the only eligible endpoint URL is unsafe", async () => {
+    const unsafePool = {
+      pools: [
+        {
+          id: "finney-rpc",
+          endpoints: [
+            {
+              id: "evil",
+              provider: "evil",
+              pool_eligible: true,
+              status: "ok",
+              url: "https://evil.example.com/rpc",
+            },
+          ],
+        },
+      ],
+    };
+    const env = {
+      METAGRAPH_ENABLE_RPC_PROXY: "true",
+      ASSETS: {
+        async fetch(request) {
+          const url = new URL(request.url);
+          if (url.pathname === "/metagraph/rpc/pools.json") {
+            return Response.json(unsafePool);
+          }
+          return new Response("{}", { status: 404 });
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              return unsafePool;
+            },
+          };
+        },
+      },
+    };
+    const res = await handleRequest(rpcReq("system_health"), env, {});
+    assert.equal(res.status, 502);
+    assert.equal((await res.json()).error.code, "rpc_endpoint_unsafe");
+  });
+
+  test("propagates a pool-artifact read failure", async () => {
+    const env = {
+      METAGRAPH_ENABLE_RPC_PROXY: "true",
+      ASSETS: {
+        async fetch() {
+          return new Response("nope", { status: 404 });
+        },
+      },
+    };
+    const res = await handleRequest(rpcReq("system_health"), env, {});
+    // pools.json is r2-tier; with no R2 binding the read fails.
+    assert.notEqual(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.meta.artifact_path, "/metagraph/rpc/pools.json");
+  });
+
+  test("rate-limited with a limiter that allows passes through", async () => {
+    const env = rpcEnv({
+      RPC_RATE_LIMITER: {
+        async limit() {
+          return { success: true };
+        },
+      },
+    });
+    await withGlobals(
+      {
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({ jsonrpc: "2.0", id: 1, result: { peers: 1 } }),
+            { status: 200 },
+          ),
+      },
+      async () => {
+        const res = await handleRequest(rpcReq("system_health"), env, {});
+        assert.equal(res.status, 200);
+      },
+    );
+  });
+
+  test("cache miss with a non-200 upstream returns the status + miss header", async () => {
+    const cache = {
+      async match() {
+        return undefined;
+      },
+      async put() {},
+    };
+    await withGlobals(
+      {
+        cache,
+        fetchImpl: async () =>
+          new Response(JSON.stringify({ jsonrpc: "2.0", error: { code: 1 } }), {
+            status: 400,
+          }),
+      },
+      async () => {
+        // chain_getBlockHash with a numeric arg is cacheable, so cacheKey is set;
+        // an upstream 400 is fatal and short-circuits at the status!==200 branch.
+        const res = await handleRequest(
+          rpcReq("chain_getBlockHash", [5]),
+          rpcEnv(),
+          {},
+        );
+        assert.equal(res.status, 400);
+        assert.equal(res.headers.get("x-metagraph-rpc-cache"), "miss");
+      },
+    );
+  });
+
+  test("malformed cached entry is treated as a miss and re-fetched", async () => {
+    const store = new Map();
+    const cache = {
+      async match(r) {
+        const hit = store.get(r.url);
+        return hit ? hit.clone() : undefined;
+      },
+      async put(r, resp) {
+        store.set(r.url, resp);
+      },
+    };
+    let fetchCount = 0;
+    await withGlobals(
+      {
+        cache,
+        fetchImpl: async () => {
+          fetchCount += 1;
+          return new Response(
+            JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0xabc" }),
+            { status: 200 },
+          );
+        },
+      },
+      async () => {
+        // Seed a garbage cache entry by intercepting the first match() call so
+        // the malformed-hit branch (JSON.parse throw → treated as a miss) runs.
+        let firstMatch = true;
+        cache.match = async () => {
+          if (firstMatch) {
+            firstMatch = false;
+            return new Response("not json at all");
+          }
+          return undefined;
+        };
+        const waits = [];
+        const ctx = { waitUntil: (p) => waits.push(p) };
+        const res = await handleRequest(
+          rpcReq("chain_getBlockHash", [9]),
+          rpcEnv(),
+          ctx,
+        );
+        await Promise.all(waits);
+        assert.equal(res.status, 200);
+        // Malformed hit was discarded → upstream fetched.
+        assert.equal(fetchCount, 1);
+        assert.equal(res.headers.get("x-metagraph-rpc-cache"), "miss");
+      },
+    );
+  });
+});
+
+// --- proxyWithFailover tee() inspection branch -------------------------------
+describe("proxyWithFailover tee inspection", () => {
+  const SAFE_A = "https://bittensor-finney.api.onfinality.io/public";
+  const SAFE_B = "https://bittensor-public.nodies.app/rpc";
+  const ep = (id, url) => ({
+    id,
+    url,
+    provider: "fixture",
+    pool_eligible: true,
+    score: 100,
+    status: "ok",
+  });
+
+  test("a 2xx upstream whose body is a node-internal error fails over via tee()", async () => {
+    // A streaming body that yields a transient JSON-RPC error; because it has a
+    // real .body.tee(), the inspect-and-classify tee branch runs and classifies
+    // it transient (-32603) → fail over to the next endpoint.
+    const healthMap = new Map();
+    let calls = 0;
+    const fetchFn = async (url) => {
+      calls += 1;
+      if (url === SAFE_A) {
+        return new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            error: { code: -32603, message: "internal" },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: "ok" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    };
+    const res = await proxyWithFailover([ep("a", SAFE_A), ep("b", SAFE_B)], {
+      bodyText: "{}",
+      poolId: "finney-rpc",
+      fetchFn,
+      healthMap,
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "b");
+    assert.equal(calls, 2);
+    assert.equal(healthMap.get("a").fails, 1);
+  });
+
+  test("a successful 2xx upstream with a real tee()-able body streams through", async () => {
+    const fetchFn = async () =>
+      new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { peers: 3 } }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    const res = await proxyWithFailover([ep("a", SAFE_A)], {
+      bodyText: "{}",
+      poolId: "finney-rpc",
+      fetchFn,
+      healthMap: new Map(),
+    });
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).result.peers, 3);
+  });
+});
+
+// --- R2 timeout → static fallback --------------------------------------------
+describe("R2 timeout and static fallback", () => {
+  test("falls back to static assets when R2 times out and fallback is enabled", async () => {
+    let assetHit = false;
+    const env = {
+      METAGRAPH_ALLOW_R2_STATIC_FALLBACK: "true",
+      METAGRAPH_R2_TIMEOUT_MS: "10",
+      METAGRAPH_DISABLE_REQUEST_LOGS: "true",
+      ASSETS: {
+        async fetch(request) {
+          const url = new URL(request.url);
+          if (url.pathname === "/metagraph/rpc-endpoints.json") {
+            assetHit = true;
+            return Response.json({
+              schema_version: 1,
+              endpoints: [],
+            });
+          }
+          return new Response("nope", { status: 404 });
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          // Never resolve → triggers the withTimeout race rejection.
+          return new Promise(() => {});
+        },
+      },
+    };
+    const res = await handleRequest(req("/api/v1/rpc/endpoints"), env, {});
+    assert.equal(res.status, 200);
+    assert.equal(assetHit, true);
+    assert.equal(res.headers.get("x-metagraph-cache-profile") !== null, true);
+  });
+
+  test("returns 504 r2_timeout when fallback is disabled", async () => {
+    const env = {
+      METAGRAPH_R2_TIMEOUT_MS: "10",
+      ASSETS: {
+        async fetch() {
+          return new Response("nope", { status: 404 });
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return new Promise(() => {});
+        },
+      },
+    };
+    const res = await handleRequest(req("/api/v1/rpc/endpoints"), env, {});
+    assert.equal(res.status, 504);
+    assert.equal((await res.json()).error.code, "r2_timeout");
+  });
+});
+
+// --- handleHealthTrends D1 throw ---------------------------------------------
+describe("health trends D1 error handling", () => {
+  test("returns a schema-stable empty payload when D1 throws", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          return {
+            bind() {
+              return {
+                async all() {
+                  throw new Error("d1 down");
+                },
+              };
+            },
+          };
+        },
+      },
+    });
+    const res = await handleRequest(
+      req("/api/v1/subnets/0/health/trends"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, 0);
+    assert.equal(body.data.windows["7d"].uptime_ratio, null);
+  });
+});
+
+// --- readAsset with no ASSETS binding ----------------------------------------
+describe("readAsset missing binding", () => {
+  test("dual-tier read falls back to R2 when ASSETS is unbound", async () => {
+    // subnets.json is dual-tier: readAsset returns asset_binding_missing (404),
+    // then readR2 serves it.
+    const env = {
+      METAGRAPH_R2_LATEST_PREFIX: "latest/",
+      METAGRAPH_ARCHIVE: createLocalArtifactEnv().METAGRAPH_ARCHIVE,
+    };
+    const res = await handleRequest(req("/api/v1/subnets"), env, {});
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("x-metagraph-cache-profile") !== null, true);
+  });
+});
+
+// --- weightedPickEndpoint fallthrough ----------------------------------------
+describe("weightedPickEndpoint", () => {
+  test("returns the last endpoint when the cursor never goes negative", () => {
+    // randomFn returns ~1 so cursor = total; subtracting each weight never goes
+    // below zero until the loop ends → fallthrough returns the last endpoint.
+    const endpoints = [
+      { id: "a", score: 1 },
+      { id: "b", score: 1 },
+    ];
+    const picked = weightedPickEndpoint(endpoints, () => 0.999999999);
+    assert.equal(picked.id, "b");
+  });
+
+  test("single-endpoint shortcut", () => {
+    assert.equal(weightedPickEndpoint([{ id: "solo" }]).id, "solo");
+  });
+});
+
+// --- scheduled handler --------------------------------------------------------
+describe("handleScheduled", () => {
+  test("the hourly prune cron prunes the time-series", async () => {
+    // No D1 binding → pruneHealthHistory is a no-op but the branch is taken.
+    const result = await handleScheduled({ cron: "0 * * * *" }, {}, {});
+    assert.ok(result === undefined || typeof result === "object");
+  });
+
+  test("any other cron runs the health prober", async () => {
+    // No bindings → runHealthProber should not throw with an empty env.
+    const result = await handleScheduled(
+      { cron: "*/2 * * * *" },
+      {},
+      { waitUntil() {} },
+    );
+    assert.ok(result === undefined || typeof result === "object");
+  });
+
+  test("the default export wires fetch + scheduled", async () => {
+    const res = await workerDefault.fetch(
+      req("/api/v1/subnets"),
+      createLocalArtifactEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    await workerDefault.scheduled({ cron: "0 * * * *" }, {}, {});
+  });
+});
+
+// --- logEvent disabled --------------------------------------------------------
+describe("logEvent", () => {
+  test("R2 timeout with logs disabled still produces a 504 (no log spam)", async () => {
+    const env = {
+      METAGRAPH_DISABLE_REQUEST_LOGS: "true",
+      METAGRAPH_R2_TIMEOUT_MS: "10",
+      ASSETS: {
+        async fetch() {
+          return new Response("nope", { status: 404 });
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return new Promise(() => {});
+        },
+      },
+    };
+    const res = await handleRequest(req("/api/v1/rpc/endpoints"), env, {});
+    assert.equal(res.status, 504);
+  });
+});

--- a/tests/coverage-fill.test.mjs
+++ b/tests/coverage-fill.test.mjs
@@ -1,0 +1,420 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { describe, test } from "vitest";
+import {
+  artifactDirectoryPath,
+  listJsonFiles,
+  listJsonFilesRecursive,
+  netuidFromEvidenceSubject,
+  publishedAt,
+  readArtifactJson,
+  selectReviewableReadmeLinks,
+} from "../scripts/lib.mjs";
+import { schemaDetailArtifactRelativePath } from "../src/artifact-storage.mjs";
+import {
+  extractSingleProvider,
+  validateCandidateForSubmission,
+  validateProviderForSubmission,
+} from "../scripts/submission-policy.mjs";
+
+const native = {
+  subnets: [
+    { netuid: 7, name: "Allways" },
+    { netuid: 74, name: "Gittensor" },
+  ],
+};
+const providers = [{ id: "allways" }, { id: "gittensor" }];
+
+const baseCandidate = {
+  schema_version: 1,
+  id: "candidate-one",
+  netuid: 7,
+  state: "schema-valid",
+  name: "Candidate one",
+  kind: "docs",
+  url: "https://docs.all-ways.io/path",
+  source_url: "https://docs.all-ways.io/source",
+  source_type: "community-pr-intake",
+  source_tier: "community-docs",
+  confidence: "medium",
+  provider: "allways",
+  auth_required: false,
+  public_safe: true,
+};
+
+const validSubmissionDocument = {
+  submission: {
+    submitted_by: "jsonbored",
+    submitted_by_url: "https://github.com/jsonbored",
+  },
+};
+
+describe("artifact-storage schema detail guards", () => {
+  test("rejects schema detail paths containing a backslash segment", () => {
+    assert.equal(
+      schemaDetailArtifactRelativePath("schemas/sn-7\\openapi.json"),
+      null,
+    );
+    assert.equal(
+      schemaDetailArtifactRelativePath("/metagraph/schemas/a\\b.json"),
+      null,
+    );
+  });
+});
+
+describe("submission-policy provider extraction and validation", () => {
+  test("extractSingleProvider rejects non-object documents", () => {
+    assert.deepEqual(extractSingleProvider(null), {
+      provider: null,
+      errors: [
+        {
+          category: "unsupported-shape",
+          message: "provider submission document must be a JSON object",
+        },
+      ],
+    });
+    assert.equal(extractSingleProvider("string").errors.length, 1);
+  });
+
+  test("extractSingleProvider flags bad schema_version and missing provider", () => {
+    const extracted = extractSingleProvider({
+      schema_version: 2,
+      provider: null,
+    });
+    assert.equal(extracted.provider, null);
+    assert.equal(extracted.errors.length, 2);
+    assert.equal(
+      extracted.errors.some((error) =>
+        error.message.includes("schema_version must be 1"),
+      ),
+      true,
+    );
+    assert.equal(
+      extracted.errors.some((error) =>
+        error.message.includes("must include provider"),
+      ),
+      true,
+    );
+  });
+
+  test("extractSingleProvider returns a well-formed provider", () => {
+    const extracted = extractSingleProvider({
+      schema_version: 1,
+      provider: { id: "example-operator" },
+    });
+    assert.equal(extracted.errors.length, 0);
+    assert.deepEqual(extracted.provider, { id: "example-operator" });
+  });
+
+  test("validateProviderForSubmission requires a provider object", () => {
+    const result = validateProviderForSubmission({
+      provider: null,
+      providers,
+    });
+    assert.equal(result.errors[0].category, "unsupported-shape");
+    assert.equal(result.errors[0].message, "provider is required");
+    assert.deepEqual(result.manual_reasons, [
+      "provider profile submissions require review",
+    ]);
+  });
+
+  test("validateProviderForSubmission flags every malformed provider field", () => {
+    const result = validateProviderForSubmission({
+      provider: {
+        schema_version: 2,
+        id: "Bad ID",
+        name: "   ",
+        kind: "made-up",
+        website_url: "http://127.0.0.1",
+        docs_url: "http://10.0.0.1",
+        github_url: "http://169.254.169.254",
+        team_url: "http://192.168.0.1",
+        contact_url: "ftp://example.com",
+        authority: "official",
+        notes: "legacy notes",
+      },
+      document: { submission: {} },
+      submitter: null,
+      providers,
+    });
+    const messages = result.errors.map((error) => error.message);
+    assert.equal(messages.includes("provider schema_version must be 1"), true);
+    assert.equal(
+      messages.includes("provider id must be a lowercase slug"),
+      true,
+    );
+    assert.equal(messages.includes("provider name is required"), true);
+    assert.equal(messages.includes("provider kind is unsupported"), true);
+    assert.equal(
+      messages.includes("provider website_url is missing, invalid, or unsafe"),
+      true,
+    );
+    assert.equal(
+      messages.includes("provider docs_url is invalid or unsafe"),
+      true,
+    );
+    assert.equal(
+      messages.includes("provider github_url is invalid or unsafe"),
+      true,
+    );
+    assert.equal(
+      messages.includes("provider team_url is invalid or unsafe"),
+      true,
+    );
+    assert.equal(
+      messages.includes("provider contact_url is invalid or unsafe"),
+      true,
+    );
+    assert.equal(
+      messages.includes(
+        "community provider submissions can only use community or provider-claimed authority",
+      ),
+      true,
+    );
+    assert.equal(
+      messages.includes(
+        "community provider submissions must use public_notes, not notes",
+      ),
+      true,
+    );
+  });
+
+  test("validateProviderForSubmission warns on normalizable URLs and reviews existing providers", () => {
+    const result = validateProviderForSubmission({
+      provider: {
+        schema_version: 1,
+        id: "allways",
+        name: "Allways",
+        kind: "subnet-team",
+        website_url: "https://all-ways.io/",
+        docs_url: "docs.all-ways.io/path/",
+        authority: "provider-claimed",
+      },
+      document: validSubmissionDocument,
+      submitter: "jsonbored",
+      providers,
+    });
+    assert.equal(result.errors.length, 0);
+    assert.equal(
+      result.warnings.some((warning) =>
+        warning.includes("docs_url will be normalized"),
+      ),
+      true,
+    );
+    assert.equal(
+      result.manual_reasons.includes(
+        "existing provider profile updates require review",
+      ),
+      true,
+    );
+  });
+});
+
+describe("submission-policy candidate schema shape branches", () => {
+  test("flags non-string text fields, source_type and verification shape", () => {
+    const result = validateCandidateForSubmission({
+      candidate: {
+        ...baseCandidate,
+        source_type: 7,
+        rate_limit_notes: 5,
+        review_notes: { not: "a string" },
+        verification: ["not", "an", "object"],
+      },
+      document: validSubmissionDocument,
+      submitter: "jsonbored",
+      native,
+      providers,
+    });
+    const messages = result.errors.map((error) => error.message);
+    assert.equal(
+      messages.includes("candidate source_type must be a string"),
+      true,
+    );
+    assert.equal(
+      messages.includes("candidate rate_limit_notes must be a string"),
+      true,
+    );
+    assert.equal(
+      messages.includes("candidate review_notes must be a string"),
+      true,
+    );
+    assert.equal(
+      messages.includes("candidate verification must be an object"),
+      true,
+    );
+  });
+
+  test("flags malformed verification metadata inside a verification object", () => {
+    const result = validateCandidateForSubmission({
+      candidate: {
+        ...baseCandidate,
+        verification: {
+          classification: "not-a-real-classification",
+          verified_at: 12345,
+        },
+      },
+      document: validSubmissionDocument,
+      submitter: "jsonbored",
+      native,
+      providers,
+    });
+    const messages = result.errors.map((error) => error.message);
+    assert.equal(
+      messages.includes("candidate verification classification is unsupported"),
+      true,
+    );
+    assert.equal(
+      messages.includes("candidate verification verified_at must be a string"),
+      true,
+    );
+  });
+
+  test("accepts a well-formed verification object", () => {
+    const result = validateCandidateForSubmission({
+      candidate: {
+        ...baseCandidate,
+        verification: {
+          classification: "live",
+          verified_at: "1970-01-01T00:00:00.000Z",
+        },
+      },
+      document: validSubmissionDocument,
+      submitter: "jsonbored",
+      native,
+      providers,
+    });
+    assert.equal(
+      result.errors.some((error) =>
+        error.message.startsWith("candidate verification"),
+      ),
+      false,
+    );
+  });
+
+  test("treats a null verification as absent", () => {
+    const result = validateCandidateForSubmission({
+      candidate: { ...baseCandidate, verification: null },
+      document: validSubmissionDocument,
+      submitter: "jsonbored",
+      native,
+      providers,
+    });
+    assert.equal(
+      result.errors.some((error) =>
+        error.message.startsWith("candidate verification"),
+      ),
+      false,
+    );
+  });
+});
+
+describe("lib evidence-subject and artifact helpers", () => {
+  test("netuidFromEvidenceSubject parses subnet, sn-, and unknown subjects", () => {
+    assert.equal(netuidFromEvidenceSubject("subnet:5"), 5);
+    assert.equal(netuidFromEvidenceSubject("candidate:community-sn-42-x"), 42);
+    assert.equal(netuidFromEvidenceSubject("provider:unscoped"), null);
+    assert.equal(netuidFromEvidenceSubject(""), null);
+    assert.equal(netuidFromEvidenceSubject(null), null);
+  });
+
+  test("readArtifactJson reads a committed dual-tier artifact", async () => {
+    const contracts = await readArtifactJson("contracts.json");
+    assert.equal(typeof contracts, "object");
+    assert.equal(contracts.primary_domain, "api.metagraph.sh");
+  });
+
+  test("artifactDirectoryPath falls back to the public tree when unstaged", () => {
+    const directory = artifactDirectoryPath("definitely-not-staged-xyz/");
+    assert.equal(directory.includes("public/metagraph"), true);
+    assert.equal(directory.endsWith("definitely-not-staged-xyz"), true);
+  });
+
+  test("publishedAt returns the configured publish timestamp", () => {
+    const previous = process.env.METAGRAPH_PUBLISHED_AT;
+    try {
+      process.env.METAGRAPH_PUBLISHED_AT = "  2026-06-10T00:00:00.000Z  ";
+      assert.equal(publishedAt(), "2026-06-10T00:00:00.000Z");
+      process.env.METAGRAPH_PUBLISHED_AT = "   ";
+      assert.equal(publishedAt(), null);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.METAGRAPH_PUBLISHED_AT;
+      } else {
+        process.env.METAGRAPH_PUBLISHED_AT = previous;
+      }
+    }
+  });
+});
+
+describe("lib JSON directory listing error propagation", () => {
+  test("listJsonFiles and listJsonFilesRecursive rethrow non-ENOENT errors", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "metagraphed-listerr-"));
+    const filePath = path.join(dir, "not-a-directory.json");
+    try {
+      await writeFile(filePath, "{}", "utf8");
+      // Reading a file as a directory raises ENOTDIR (not ENOENT), which must
+      // propagate rather than being swallowed as "no files".
+      await assert.rejects(listJsonFiles(filePath), (error) => {
+        assert.equal(error.code, "ENOTDIR");
+        return true;
+      });
+      await assert.rejects(listJsonFilesRecursive(filePath), (error) => {
+        assert.equal(error.code, "ENOTDIR");
+        return true;
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("lib README link selection limits", () => {
+  test("respects per-kind caps and the overall link limit", () => {
+    const links = [
+      {
+        classification: { kind: "website", label: "site" },
+        label: "Example one",
+        url: "https://exampleproject.ai/",
+      },
+      {
+        classification: { kind: "website", label: "site" },
+        label: "Example two",
+        url: "https://app.exampleproject.ai/",
+      },
+      {
+        classification: { kind: "docs", label: "docs" },
+        label: "Example docs",
+        url: "https://docs.exampleproject.ai/install",
+      },
+    ];
+
+    const selected = selectReviewableReadmeLinks(links, {
+      repo: { owner: "ExampleProject", repo: "subnet" },
+    });
+    // website kind cap is 1, so only the first website survives; docs adds one.
+    assert.deepEqual(
+      selected.map((link) => link.url),
+      ["https://exampleproject.ai/", "https://docs.exampleproject.ai/install"],
+    );
+
+    const capped = selectReviewableReadmeLinks(
+      [
+        {
+          classification: { kind: "docs", label: "docs" },
+          label: "First docs",
+          url: "https://docs.exampleproject.ai/a",
+        },
+        {
+          classification: { kind: "website", label: "site" },
+          label: "Site",
+          url: "https://exampleproject.ai/",
+        },
+      ],
+      { limit: 1, repo: { owner: "ExampleProject", repo: "subnet" } },
+    );
+    assert.equal(capped.length, 1);
+    assert.equal(capped[0].url, "https://docs.exampleproject.ai/a");
+  });
+});

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -1,12 +1,19 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  acceptHeader,
   classifyProbe,
   classifyRpcProbe,
   contentMismatch,
   isUnsafePublicUrl,
   mapLimit,
+  nodeWebSocketConnector,
+  normalizeJsonRpcResult,
+  parseBlockNumber,
+  probeSubtensorHttp,
+  probeSubtensorWss,
   probeSurface,
+  probeUrl,
   statusForClassification,
   summarizeRpcProbe,
 } from "../src/health-probe-core.mjs";
@@ -16,6 +23,7 @@ function fakeResponse({
   status = 200,
   contentType = "application/json",
   body = "{}",
+  location = null,
 } = {}) {
   return {
     ok: status >= 200 && status < 300,
@@ -23,6 +31,7 @@ function fakeResponse({
     headers: {
       get(name) {
         if (name === "content-type") return contentType;
+        if (name === "location") return location;
         return null;
       },
     },
@@ -31,6 +40,11 @@ function fakeResponse({
       return body;
     },
   };
+}
+
+// Build a valid JSON-RPC response body for the subtensor probe methods.
+function rpcBody(id, result) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
 }
 
 describe("isUnsafePublicUrl", () => {
@@ -234,5 +248,1140 @@ describe("probeSurface (injected fetch)", () => {
     assert.deepEqual(calls, ["HEAD", "GET"]);
     assert.equal(base.status, "ok");
     assert.equal(base.method_tested, "GET");
+  });
+});
+
+describe("acceptHeader", () => {
+  test("maps expect kinds to Accept values", () => {
+    assert.equal(acceptHeader("json"), "application/json");
+    assert.equal(acceptHeader("html"), "text/html,application/xhtml+xml");
+    assert.equal(acceptHeader("sse"), "text/event-stream");
+    assert.equal(acceptHeader("anything-else"), "*/*");
+    assert.equal(acceptHeader(undefined), "*/*");
+  });
+});
+
+describe("probeUrl", () => {
+  const opts = (fetchImpl, isUnsafeUrl = async () => false) => ({
+    fetchImpl,
+    isUnsafeUrl,
+  });
+
+  test("success: 200 returns ok + content_type + status_code", async () => {
+    const probe = await probeUrl(
+      "https://x.dev/a",
+      "GET",
+      "*/*",
+      5000,
+      opts(async () =>
+        fakeResponse({ status: 200, contentType: "application/json" }),
+      ),
+    );
+    assert.equal(probe.ok, true);
+    assert.equal(probe.status_code, 200);
+    assert.equal(probe.content_type, "application/json");
+    assert.equal(probe.method_tested, "GET");
+    assert.equal(typeof probe.verified_at, "string");
+  });
+
+  test("non-ok: 404 returns ok=false with status_code", async () => {
+    const probe = await probeUrl(
+      "https://x.dev/missing",
+      "GET",
+      "*/*",
+      5000,
+      opts(async () => fakeResponse({ status: 404, contentType: "text/html" })),
+    );
+    assert.equal(probe.ok, false);
+    assert.equal(probe.status_code, 404);
+  });
+
+  test("missing content-type returns null", async () => {
+    const probe = await probeUrl(
+      "https://x.dev/a",
+      "GET",
+      "*/*",
+      5000,
+      opts(async () => fakeResponse({ status: 200, contentType: null })),
+    );
+    assert.equal(probe.content_type, null);
+  });
+
+  test("unsafe initial URL short-circuits before any fetch", async () => {
+    let fetched = false;
+    const probe = await probeUrl("http://localhost/x", "GET", "*/*", 5000, {
+      isUnsafeUrl: async () => true,
+      fetchImpl: async () => {
+        fetched = true;
+        return fakeResponse();
+      },
+    });
+    assert.equal(fetched, false);
+    assert.equal(probe.ok, false);
+    assert.equal(probe.unsafe_url, true);
+    assert.equal(probe.error, "unsafe URL");
+    assert.equal(probe.method_tested, "GET");
+  });
+
+  test("redirect 301 to safe target recurses and sums latency", async () => {
+    const urls = [];
+    const probe = await probeUrl("https://x.dev/old", "GET", "*/*", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url) => {
+        urls.push(url);
+        if (url === "https://x.dev/old") {
+          return fakeResponse({
+            status: 301,
+            location: "https://x.dev/new",
+            contentType: "text/html",
+          });
+        }
+        return fakeResponse({ status: 200, contentType: "application/json" });
+      },
+    });
+    assert.deepEqual(urls, ["https://x.dev/old", "https://x.dev/new"]);
+    assert.equal(probe.ok, true);
+    assert.equal(probe.status_code, 200);
+    assert.equal(probe.redirect_target, "https://x.dev/new");
+    assert.ok(typeof probe.latency_ms === "number");
+  });
+
+  test("redirect 302 with relative Location resolves against base", async () => {
+    const urls = [];
+    const probe = await probeUrl("https://x.dev/a/b", "GET", "*/*", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url) => {
+        urls.push(url);
+        if (url === "https://x.dev/a/b") {
+          return fakeResponse({ status: 302, location: "/c" });
+        }
+        return fakeResponse({ status: 200, contentType: "application/json" });
+      },
+    });
+    assert.deepEqual(urls, ["https://x.dev/a/b", "https://x.dev/c"]);
+    assert.equal(probe.ok, true);
+    assert.equal(probe.redirect_target, "https://x.dev/c");
+  });
+
+  test("redirect to unsafe target is blocked (private_redirect_blocked)", async () => {
+    const probe = await probeUrl("https://x.dev/old", "GET", "*/*", 5000, {
+      // safe for the initial URL, unsafe for the redirect target
+      isUnsafeUrl: async (u) => u.includes("169.254"),
+      fetchImpl: async () =>
+        fakeResponse({ status: 301, location: "http://169.254.169.254/meta" }),
+    });
+    assert.equal(probe.ok, false);
+    assert.equal(probe.private_redirect_blocked, true);
+    assert.equal(probe.error, "redirect target is unsafe");
+    assert.equal(probe.redirect_target, "http://169.254.169.254/meta");
+    assert.equal(probe.status_code, 301);
+  });
+
+  test("redirect without Location header is treated as a normal response", async () => {
+    const probe = await probeUrl(
+      "https://x.dev/old",
+      "GET",
+      "*/*",
+      5000,
+      opts(async () => fakeResponse({ status: 301, location: null })),
+    );
+    // No location -> falls through to the normal (non-redirect) return path.
+    assert.equal(probe.status_code, 301);
+    assert.equal(probe.ok, false);
+    assert.equal(probe.redirect_target, undefined);
+  });
+
+  test("redirectCount cap (>5) stops recursing and returns the redirect verbatim", async () => {
+    let calls = 0;
+    const probe = await probeUrl(
+      "https://x.dev/loop",
+      "GET",
+      "*/*",
+      5000,
+      {
+        isUnsafeUrl: async () => false,
+        fetchImpl: async () => {
+          calls += 1;
+          return fakeResponse({
+            status: 301,
+            location: "https://x.dev/loop",
+            contentType: "text/html",
+          });
+        },
+      },
+      5, // already at the cap -> redirectCount < 5 is false
+    );
+    assert.equal(calls, 1);
+    assert.equal(probe.status_code, 301);
+    assert.equal(probe.ok, false);
+  });
+
+  test("AbortError / timeout is caught and reported with error_class", async () => {
+    const probe = await probeUrl(
+      "https://x.dev/slow",
+      "GET",
+      "*/*",
+      5000,
+      opts(async () => {
+        const err = new Error("The operation was aborted");
+        err.name = "AbortError";
+        throw err;
+      }),
+    );
+    assert.equal(probe.ok, false);
+    assert.equal(probe.error_class, "AbortError");
+    assert.equal(probe.error, "The operation was aborted");
+    assert.equal(
+      classifyProbe(probe, { probe: { expect: "html" } }),
+      "timeout",
+    );
+  });
+});
+
+describe("probeSubtensorHttp / jsonRpcHttp (HTTP RPC)", () => {
+  test("unsafe URL short-circuits", async () => {
+    let fetched = false;
+    const probe = await probeSubtensorHttp("http://10.0.0.1:9944", 5000, {
+      isUnsafeUrl: async () => true,
+      fetchImpl: async () => {
+        fetched = true;
+        return fakeResponse();
+      },
+    });
+    assert.equal(fetched, false);
+    assert.equal(probe.unsafe_url, true);
+    assert.equal(probe.error, "unsafe URL");
+  });
+
+  test("full success path: live RPC with archive support + method count", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_url, init) => {
+        const req = JSON.parse(init.body);
+        switch (req.method) {
+          case "chain_getHeader":
+            return fakeResponse({
+              status: 200,
+              body: rpcBody(req.id, { number: "0x1a2b" }),
+            });
+          case "system_health":
+            return fakeResponse({
+              status: 200,
+              body: rpcBody(req.id, { peers: 4, isSyncing: false }),
+            });
+          case "rpc_methods":
+            return fakeResponse({
+              status: 200,
+              body: rpcBody(req.id, { methods: ["a", "b", "c"] }),
+            });
+          case "chain_getBlockHash":
+            return fakeResponse({
+              status: 200,
+              body: rpcBody(req.id, "0xdeadbeef"),
+            });
+          default:
+            return fakeResponse({ status: 200, body: rpcBody(req.id, null) });
+        }
+      },
+    });
+    assert.equal(classifyRpcProbe(probe), "live");
+    assert.equal(probe.archive_support, true);
+    assert.equal(probe.latest_block, 0x1a2b);
+    assert.equal(probe.rpc_method_count, 3);
+    assert.deepEqual(probe.methods_supported, {
+      chain_getHeader: true,
+      system_health: true,
+      rpc_methods: true,
+      chain_getBlockHash: true,
+    });
+    assert.equal(probe.method_results.chain_getHeader.ok, true);
+  });
+
+  test("archive NOT detected when block-hash result is not a hex string", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_url, init) => {
+        const req = JSON.parse(init.body);
+        if (req.method === "chain_getBlockHash") {
+          return fakeResponse({ status: 200, body: rpcBody(req.id, null) });
+        }
+        return fakeResponse({
+          status: 200,
+          body: rpcBody(req.id, { number: "0x1" }),
+        });
+      },
+    });
+    assert.equal(probe.archive_support, false);
+    assert.equal(probe.methods_supported.chain_getBlockHash, true);
+  });
+
+  test("transport error on first method exits the loop early", async () => {
+    let callCount = 0;
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () => {
+        callCount += 1;
+        const err = new Error("connect ECONNREFUSED");
+        err.name = "FetchError";
+        throw err;
+      },
+    });
+    // Only the first SUBTENSOR_PROBE_CALLS entry should have been attempted.
+    assert.equal(callCount, 1);
+    assert.equal(probe.transport_error, true);
+    assert.equal(probe.error_class, "FetchError");
+    assert.equal(probe.method_results.chain_getHeader.ok, false);
+    // archive_support is omitted entirely in the transport-error branch.
+    assert.equal(probe.archive_support, undefined);
+  });
+
+  test("non-JSON response is a transport error (response was not JSON)", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () =>
+        fakeResponse({
+          status: 200,
+          contentType: "text/html",
+          body: "<html>not json</html>",
+        }),
+    });
+    assert.equal(probe.transport_error, true);
+    assert.equal(probe.error, "response was not JSON");
+    assert.equal(probe.content_type, "text/html");
+    assert.equal(probe.status_code, 200);
+  });
+
+  test("rpc error body marks the method not-ok and surfaces the message", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_url, init) => {
+        const req = JSON.parse(init.body);
+        return fakeResponse({
+          status: 200,
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: req.id,
+            error: { code: -32601, message: "Method not found" },
+          }),
+        });
+      },
+    });
+    // ok && !body.error -> false, so chain_getHeader is not ok.
+    assert.equal(probe.method_results.chain_getHeader.ok, false);
+    assert.equal(
+      probe.method_results.chain_getHeader.error,
+      "Method not found",
+    );
+    assert.equal(probe.method_results.chain_getHeader.code, -32601);
+    assert.equal(classifyRpcProbe(probe), "transient");
+  });
+
+  test("redirect to unsafe target during RPC is a transport error", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async (u) => u.includes("127.0.0.1"),
+      fetchImpl: async () =>
+        fakeResponse({
+          status: 308,
+          location: "http://127.0.0.1:9944",
+        }),
+    });
+    assert.equal(probe.transport_error, true);
+    assert.equal(probe.private_redirect_blocked, true);
+    // new URL("http://127.0.0.1:9944", base).toString() adds a trailing slash.
+    assert.equal(probe.redirect_target, "http://127.0.0.1:9944/");
+    assert.equal(probe.status_code, 308);
+  });
+
+  test("redirect to a SAFE target falls through and parses body", async () => {
+    // Location present + safe target: the if-body is skipped and the response
+    // is parsed normally (exercises the safe-redirect branch of jsonRpcHttp).
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_url, init) => {
+        const req = JSON.parse(init.body);
+        return fakeResponse({
+          status: 302,
+          location: "https://rpc-2.dev",
+          body: rpcBody(req.id, null),
+        });
+      },
+    });
+    // 302 is not >= 500 / 429 / 401-403, body parsed, no error -> evaluated.
+    assert.equal(probe.method_results.chain_getHeader.ok, false);
+    assert.equal(probe.status_code, 302);
+  });
+});
+
+describe("probeSubtensorWss", () => {
+  test("unsafe URL short-circuits", async () => {
+    const probe = await probeSubtensorWss("ws://localhost:9944", 5000, {
+      isUnsafeUrl: async () => true,
+      connect: async () => new Map(),
+    });
+    assert.equal(probe.unsafe_url, true);
+    assert.equal(probe.error, "unsafe URL");
+  });
+
+  test("no connector available -> UnsupportedRuntime", async () => {
+    const probe = await probeSubtensorWss("wss://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+    });
+    assert.equal(probe.error_class, "UnsupportedRuntime");
+    assert.match(probe.error, /no WebSocket connector/);
+  });
+
+  test("connector resolving a full Map -> live summary", async () => {
+    const probe = await probeSubtensorWss("wss://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      connect: async () =>
+        new Map([
+          ["chain_getHeader", { ok: true, result: { number: "0x20" } }],
+          ["system_health", { ok: true, result: { peers: 2 } }],
+          ["rpc_methods", { ok: true, result: { methods: ["x", "y"] } }],
+          ["archive_probe", { ok: true, result: "0xabc" }],
+        ]),
+    });
+    assert.equal(classifyRpcProbe(probe), "live");
+    assert.equal(probe.latest_block, 0x20);
+    assert.equal(probe.archive_support, true);
+    assert.equal(probe.rpc_method_count, 2);
+  });
+
+  test("connector resolving a partial Map fills missing keys", async () => {
+    const probe = await probeSubtensorWss("wss://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      connect: async () =>
+        new Map([["chain_getHeader", { ok: true, result: { number: "0x1" } }]]),
+    });
+    // archive_probe etc. become { error: "missing response" } -> ok=false.
+    assert.equal(probe.methods_supported.system_health, false);
+    assert.equal(probe.method_results.archive_probe.error, "missing response");
+  });
+
+  test("connector that throws is caught and reported", async () => {
+    const probe = await probeSubtensorWss("wss://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      connect: async () => {
+        const err = new Error("WebSocket RPC probe timed out");
+        err.name = "TimeoutError";
+        throw err;
+      },
+    });
+    assert.equal(probe.error, "WebSocket RPC probe timed out");
+    assert.equal(probe.error_class, "TimeoutError");
+    assert.deepEqual(probe.method_results, {});
+    assert.equal(classifyRpcProbe(probe), "timeout");
+  });
+});
+
+describe("nodeWebSocketConnector", () => {
+  // Fake WebSocket: stores handlers added via addEventListener and exposes a way
+  // to drive open/message/error events synchronously from the test.
+  class FakeSocket {
+    constructor(url) {
+      this.url = url;
+      this.sent = [];
+      this.closed = false;
+      this.handlers = {};
+      FakeSocket.last = this;
+    }
+    addEventListener(type, fn) {
+      this.handlers[type] = fn;
+    }
+    send(data) {
+      this.sent.push(data);
+    }
+    close() {
+      this.closed = true;
+    }
+    fire(type, event) {
+      this.handlers[type]?.(event);
+    }
+  }
+
+  const calls = [
+    { key: "chain_getHeader", method: "chain_getHeader", params: [] },
+    { key: "system_health", method: "system_health", params: [] },
+  ];
+
+  test("missing WebSocket global rejects", async () => {
+    // Pass null (not undefined) so the default-param fallback to
+    // globalThis.WebSocket does not kick in: typeof null !== "function".
+    const connect = nodeWebSocketConnector(null);
+    await assert.rejects(
+      () => connect("wss://rpc.dev", calls, 5000),
+      /WebSocket global is unavailable/,
+    );
+  });
+
+  test("open sends every call, message resolves when all ids arrive", async () => {
+    const connect = nodeWebSocketConnector(FakeSocket);
+    const promise = connect("wss://rpc.dev", calls, 5000);
+    const socket = FakeSocket.last;
+
+    socket.fire("open");
+    assert.equal(socket.sent.length, 2);
+    const sent0 = JSON.parse(socket.sent[0]);
+    assert.equal(sent0.method, "chain_getHeader");
+    assert.equal(sent0.id, 1);
+
+    // First response: not yet complete.
+    socket.fire("message", {
+      data: JSON.stringify({ id: 1, result: { number: "0x1" } }),
+    });
+    // Unknown id is ignored (no key) -> still pending.
+    socket.fire("message", { data: JSON.stringify({ id: 99, result: {} }) });
+    // Final response completes the set.
+    socket.fire("message", {
+      data: JSON.stringify({ id: 2, result: { peers: 1 } }),
+    });
+
+    const results = await promise;
+    assert.equal(results.size, 2);
+    assert.equal(results.get("chain_getHeader").ok, true);
+    assert.equal(results.get("system_health").ok, true);
+    assert.equal(socket.closed, true);
+  });
+
+  test("rpc error in a message sets ok=false but still resolves", async () => {
+    const connect = nodeWebSocketConnector(FakeSocket);
+    const promise = connect("wss://rpc.dev", calls, 5000);
+    const socket = FakeSocket.last;
+    socket.fire("open");
+    socket.fire("message", {
+      data: JSON.stringify({ id: 1, error: { code: -1, message: "boom" } }),
+    });
+    socket.fire("message", {
+      data: JSON.stringify({ id: 2, result: { peers: 0 } }),
+    });
+    const results = await promise;
+    assert.equal(results.get("chain_getHeader").ok, false);
+    assert.equal(results.get("chain_getHeader").rpc_error.message, "boom");
+  });
+
+  test("malformed message JSON rejects and closes the socket", async () => {
+    const connect = nodeWebSocketConnector(FakeSocket);
+    const promise = connect("wss://rpc.dev", calls, 5000);
+    const socket = FakeSocket.last;
+    socket.fire("open");
+    socket.fire("message", { data: "{not-json" });
+    await assert.rejects(() => promise);
+    assert.equal(socket.closed, true);
+  });
+
+  test("error event rejects the connection", async () => {
+    const connect = nodeWebSocketConnector(FakeSocket);
+    const promise = connect("wss://rpc.dev", calls, 5000);
+    const socket = FakeSocket.last;
+    socket.fire("error", {});
+    await assert.rejects(() => promise, /WebSocket RPC connection failed/);
+  });
+
+  test("timeout rejects with a TimeoutError and closes the socket", async () => {
+    const connect = nodeWebSocketConnector(FakeSocket);
+    // 0ms timeout fires on the next macrotask before any message arrives.
+    const promise = connect("wss://rpc.dev", calls, 0);
+    const socket = FakeSocket.last;
+    await assert.rejects(promise, (err) => {
+      assert.equal(err.name, "TimeoutError");
+      assert.match(err.message, /timed out/);
+      return true;
+    });
+    assert.equal(socket.closed, true);
+  });
+
+  test("timeout swallows a close() that throws", async () => {
+    class ThrowingCloseSocket extends FakeSocket {
+      close() {
+        throw new Error("close failed");
+      }
+    }
+    const connect = nodeWebSocketConnector(ThrowingCloseSocket);
+    const promise = connect("wss://rpc.dev", calls, 0);
+    await assert.rejects(promise, /timed out/);
+  });
+
+  test("default WebSocketImpl uses globalThis.WebSocket", async () => {
+    const original = globalThis.WebSocket;
+    globalThis.WebSocket = FakeSocket;
+    try {
+      const connect = nodeWebSocketConnector();
+      const promise = connect("wss://rpc.dev", calls, 5000);
+      const socket = FakeSocket.last;
+      socket.fire("open");
+      socket.fire("message", {
+        data: JSON.stringify({ id: 1, result: { number: "0x1" } }),
+      });
+      socket.fire("message", {
+        data: JSON.stringify({ id: 2, result: { peers: 1 } }),
+      });
+      const results = await promise;
+      assert.equal(results.size, 2);
+    } finally {
+      globalThis.WebSocket = original;
+    }
+  });
+});
+
+describe("normalizeJsonRpcResult", () => {
+  test("header result captures raw_header.number", () => {
+    const n = normalizeJsonRpcResult({ ok: true, result: { number: "0x10" } });
+    assert.equal(n.ok, true);
+    assert.deepEqual(n.raw_header, { number: "0x10" });
+    assert.equal(n.result_type, "object");
+    assert.equal(n.result_present, true);
+  });
+
+  test("array result -> result_type array + rpc_method_count", () => {
+    const n = normalizeJsonRpcResult({
+      ok: true,
+      result: { methods: ["a", "b"] },
+    });
+    assert.equal(n.rpc_method_count, 2);
+  });
+
+  test("hex string result sets raw_hex_result_present", () => {
+    const n = normalizeJsonRpcResult({ ok: true, result: "0xabc" });
+    assert.equal(n.result_type, "string");
+    assert.equal(n.raw_hex_result_present, true);
+  });
+
+  test("plain array result -> result_type array, no header", () => {
+    const n = normalizeJsonRpcResult({ ok: true, result: [1, 2, 3] });
+    assert.equal(n.result_type, "array");
+    assert.equal(n.raw_header, undefined);
+  });
+
+  test("null result -> result_type null, not present", () => {
+    const n = normalizeJsonRpcResult({ ok: false, result: null });
+    assert.equal(n.result_type, "null");
+    assert.equal(n.result_present, false);
+  });
+
+  test("undefined result -> result_type undefined, not present", () => {
+    const n = normalizeJsonRpcResult({ ok: false });
+    assert.equal(n.result_type, "undefined");
+    assert.equal(n.result_present, false);
+  });
+
+  test("rpc_error message + code are surfaced", () => {
+    const n = normalizeJsonRpcResult({
+      ok: false,
+      rpc_error: { code: -32000, message: "server error" },
+    });
+    assert.equal(n.error, "server error");
+    assert.equal(n.code, -32000);
+  });
+
+  test("plain error string is surfaced", () => {
+    const n = normalizeJsonRpcResult({ error: "missing response" });
+    assert.equal(n.error, "missing response");
+    assert.equal(n.ok, false);
+  });
+});
+
+describe("parseBlockNumber", () => {
+  test("hex string is parsed base-16", () => {
+    assert.equal(parseBlockNumber({ number: "0xff" }), 255);
+  });
+  test("decimal string is parsed base-10", () => {
+    assert.equal(parseBlockNumber({ number: "1024" }), 1024);
+  });
+  test("number passes through", () => {
+    assert.equal(parseBlockNumber({ number: 42 }), 42);
+  });
+  test("non-object header returns null", () => {
+    assert.equal(parseBlockNumber(null), null);
+    assert.equal(parseBlockNumber(undefined), null);
+    assert.equal(parseBlockNumber("nope"), null);
+  });
+  test("non-string/number number field returns null", () => {
+    assert.equal(parseBlockNumber({ number: { nested: true } }), null);
+    assert.equal(parseBlockNumber({}), null);
+  });
+});
+
+describe("contentMismatch (remaining branches)", () => {
+  test("json expect: text/plain at a .json path is tolerated", () => {
+    assert.equal(
+      contentMismatch(
+        { content_type: "text/plain" },
+        { url: "https://x.dev/file.JSON", probe: { expect: "json" } },
+      ),
+      false,
+    );
+  });
+  test("json expect: non-json content is a mismatch", () => {
+    assert.equal(
+      contentMismatch(
+        { content_type: "text/html" },
+        { url: "https://x.dev/data.json", probe: { expect: "json" } },
+      ),
+      true,
+    );
+  });
+  test("html expect: non-html is a mismatch, html is fine", () => {
+    const surface = { url: "https://x.dev", probe: { expect: "html" } };
+    assert.equal(
+      contentMismatch({ content_type: "application/json" }, surface),
+      true,
+    );
+    assert.equal(
+      contentMismatch({ content_type: "text/html" }, surface),
+      false,
+    );
+  });
+  test("sse expect: non-sse is a mismatch, event-stream is fine", () => {
+    const surface = { url: "https://x.dev/stream", probe: { expect: "sse" } };
+    assert.equal(contentMismatch({ content_type: "text/html" }, surface), true);
+    assert.equal(
+      contentMismatch({ content_type: "text/event-stream" }, surface),
+      false,
+    );
+  });
+  test("unknown expect kind is never a mismatch", () => {
+    assert.equal(
+      contentMismatch(
+        { content_type: "text/plain" },
+        { url: "https://x.dev", probe: { expect: "data" } },
+      ),
+      false,
+    );
+  });
+});
+
+describe("classifyProbe / classifyRpcProbe (remaining branches)", () => {
+  test("classifyProbe: private_redirect_blocked -> unsafe", () => {
+    assert.equal(
+      classifyProbe({ private_redirect_blocked: true }, { probe: {} }),
+      "unsafe",
+    );
+  });
+  test("classifyProbe: 410 -> dead, 401 -> auth-required", () => {
+    const s = { probe: { expect: "html" } };
+    assert.equal(classifyProbe({ status_code: 410 }, s), "dead");
+    assert.equal(classifyProbe({ status_code: 401 }, s), "auth-required");
+  });
+  test("classifyProbe: not-ok, no special status -> unsupported", () => {
+    assert.equal(
+      classifyProbe(
+        { ok: false, status_code: 200 },
+        { probe: { expect: "html" } },
+      ),
+      "unsupported",
+    );
+  });
+  test("classifyRpcProbe: unsafe / rate-limited / auth-required / transient", () => {
+    assert.equal(classifyRpcProbe({ unsafe_url: true }), "unsafe");
+    assert.equal(
+      classifyRpcProbe({ private_redirect_blocked: true }),
+      "unsafe",
+    );
+    assert.equal(classifyRpcProbe({ error_class: "AbortError" }), "timeout");
+    assert.equal(classifyRpcProbe({ status_code: 429 }), "rate-limited");
+    assert.equal(classifyRpcProbe({ status_code: 401 }), "auth-required");
+    assert.equal(classifyRpcProbe({ status_code: 500 }), "transient");
+    assert.equal(classifyRpcProbe({ error: "boom" }), "unsupported");
+    assert.equal(classifyRpcProbe({ method_results: {} }), "transient");
+  });
+});
+
+describe("statusForClassification (remaining branches)", () => {
+  test("content-mismatch downgrades for registry-observed", () => {
+    assert.equal(
+      statusForClassification("content-mismatch", {
+        authority: "registry-observed",
+      }),
+      "degraded",
+    );
+  });
+  test("unsupported with official authority stays failed", () => {
+    assert.equal(
+      statusForClassification("unsupported", { authority: "official" }),
+      "failed",
+    );
+  });
+  test("redirected -> ok, rate-limited -> degraded", () => {
+    assert.equal(statusForClassification("redirected"), "ok");
+    assert.equal(statusForClassification("rate-limited"), "degraded");
+  });
+  test("null surface with dead -> failed", () => {
+    assert.equal(statusForClassification("dead"), "failed");
+  });
+});
+
+describe("probeSurface (RPC kinds)", () => {
+  const wssSurface = {
+    id: "sn0-wss",
+    netuid: 0,
+    kind: "subtensor-wss",
+    url: "wss://rpc.dev",
+    provider: "opentensor",
+    auth_required: false,
+    public_safe: true,
+    subnet_name: "Root",
+    subnet_slug: "root",
+    probe: { enabled: true, method: "WSS", expect: "json", timeout_ms: 4000 },
+  };
+
+  test("subtensor-wss live path threads through probeSurface", async () => {
+    const row = await probeSurface(wssSurface, {
+      isUnsafeUrl: async () => false,
+      connect: async () =>
+        new Map([
+          ["chain_getHeader", { ok: true, result: { number: "0x5" } }],
+          ["system_health", { ok: true, result: { peers: 3 } }],
+          ["rpc_methods", { ok: true, result: { methods: ["a"] } }],
+          ["archive_probe", { ok: true, result: "0xfeed" }],
+        ]),
+    });
+    assert.equal(row.classification, "live");
+    assert.equal(row.status, "ok");
+    assert.equal(row.kind, "subtensor-wss");
+    assert.equal(row.latest_block, 5);
+    assert.equal(row.archive_support, true);
+    assert.equal(row.surface_id, "sn0-wss");
+  });
+
+  test("subtensor-wss unsafe URL -> unsafe/failed with fallback timeout", async () => {
+    const noTimeout = {
+      ...wssSurface,
+      probe: { ...wssSurface.probe, timeout_ms: undefined },
+    };
+    const row = await probeSurface(noTimeout, {
+      isUnsafeUrl: async () => true,
+      connect: async () => new Map(),
+    });
+    assert.equal(row.classification, "unsafe");
+    assert.equal(row.status, "failed");
+    assert.equal(row.private_redirect_blocked, false);
+  });
+
+  test("subtensor-rpc transport error -> transient/degraded", async () => {
+    const rpcSurface = {
+      ...wssSurface,
+      id: "sn0-rpc",
+      kind: "subtensor-rpc",
+      url: "https://rpc.dev",
+      probe: {
+        enabled: true,
+        method: "POST",
+        expect: "json",
+        timeout_ms: undefined,
+      },
+    };
+    const row = await probeSurface(rpcSurface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () => {
+        const err = new Error("ECONNRESET");
+        err.name = "FetchError";
+        throw err;
+      },
+    });
+    assert.equal(row.kind, "subtensor-rpc");
+    assert.equal(row.error_class, "FetchError");
+    // transport_error -> classifyRpcProbe sees probe.error -> "unsupported".
+    assert.equal(row.classification, "unsupported");
+    assert.equal(row.archive_support, undefined);
+  });
+});
+
+describe("probeSurface (non-RPC remaining branches)", () => {
+  const surface = {
+    id: "sn7-html",
+    netuid: 7,
+    kind: "website",
+    url: "https://x.dev/",
+    provider: "acme",
+    auth_required: false,
+    public_safe: true,
+    subnet_name: "Acme",
+    subnet_slug: "acme",
+    probe: {
+      enabled: true,
+      method: "GET",
+      expect: "html",
+      timeout_ms: undefined,
+    },
+  };
+
+  test("default timeout (8000) used when timeout_ms omitted; html live", async () => {
+    const row = await probeSurface(surface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () =>
+        fakeResponse({ status: 200, contentType: "text/html" }),
+    });
+    assert.equal(row.classification, "live");
+    assert.equal(row.status, "ok");
+  });
+
+  test("HEAD 200 (no fallback) keeps method HEAD", async () => {
+    const headSurface = {
+      ...surface,
+      probe: { ...surface.probe, method: "HEAD" },
+    };
+    const calls = [];
+    const row = await probeSurface(headSurface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_u, init) => {
+        calls.push(init.method);
+        return fakeResponse({ status: 200, contentType: "text/html" });
+      },
+    });
+    assert.deepEqual(calls, ["HEAD"]);
+    assert.equal(row.method_tested, "HEAD");
+  });
+
+  test("non-HEAD 405 does NOT fall back to GET", async () => {
+    const calls = [];
+    const row = await probeSurface(surface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_u, init) => {
+        calls.push(init.method);
+        return fakeResponse({ status: 405, contentType: "text/html" });
+      },
+    });
+    assert.deepEqual(calls, ["GET"]);
+    assert.equal(row.status_code, 405);
+  });
+});
+
+// A fetch mock that honours the AbortController signal so the timeout timer's
+// abort() callback actually fires (covers the setTimeout(() => abort()) lines).
+function abortableFetch() {
+  return (_url, init) =>
+    new Promise((_resolve, reject) => {
+      const signal = init.signal;
+      if (signal.aborted) {
+        const err = new Error("This operation was aborted");
+        err.name = "AbortError";
+        reject(err);
+        return;
+      }
+      signal.addEventListener("abort", () => {
+        const err = new Error("This operation was aborted");
+        err.name = "AbortError";
+        reject(err);
+      });
+    });
+}
+
+describe("timeout abort timer callbacks", () => {
+  test("probeUrl: 0ms timeout fires controller.abort() -> AbortError", async () => {
+    const probe = await probeUrl("https://x.dev/slow", "GET", "*/*", 0, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: abortableFetch(),
+    });
+    assert.equal(probe.ok, false);
+    assert.equal(probe.error_class, "AbortError");
+    assert.equal(
+      classifyProbe(probe, { probe: { expect: "html" } }),
+      "timeout",
+    );
+  });
+
+  test("probeSubtensorHttp: 0ms timeout aborts the RPC fetch", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 0, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: abortableFetch(),
+    });
+    assert.equal(probe.transport_error, true);
+    assert.equal(probe.error_class, "AbortError");
+    assert.equal(classifyRpcProbe(probe), "timeout");
+  });
+});
+
+describe("isUnsafePublicUrl / isJsonContentType (remaining branches)", () => {
+  test("empty hostname is unsafe (host falsy branch)", () => {
+    // A URL whose hostname parses to an empty string.
+    assert.equal(isUnsafePublicUrl("https://"), true);
+    assert.equal(isUnsafePublicUrl("http://[::1]/x"), true);
+  });
+  test("trailing-dot + bracketed-IPv6 hosts are normalized", () => {
+    // Public host with a trailing dot -> stripped, still safe.
+    assert.equal(isUnsafePublicUrl("https://example.com./x"), false);
+  });
+});
+
+describe("contentMismatch with null content_type", () => {
+  test("json expect + null content_type is a mismatch (|| '' branch)", () => {
+    assert.equal(
+      contentMismatch(
+        { content_type: null },
+        { url: "https://x.dev/data.json", probe: { expect: "json" } },
+      ),
+      true,
+    );
+  });
+  test("html expect + null content_type is a mismatch", () => {
+    assert.equal(
+      contentMismatch(
+        { content_type: null },
+        { url: "https://x.dev", probe: { expect: "html" } },
+      ),
+      true,
+    );
+  });
+  test("sse expect + null content_type is a mismatch", () => {
+    assert.equal(
+      contentMismatch(
+        { content_type: null },
+        { url: "https://x.dev", probe: { expect: "sse" } },
+      ),
+      true,
+    );
+  });
+});
+
+describe("jsonRpcHttp non-JSON with empty content-type", () => {
+  test("non-JSON body + missing content-type -> content_type null", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () =>
+        fakeResponse({ status: 200, contentType: null, body: "<<garbage" }),
+    });
+    assert.equal(probe.transport_error, true);
+    assert.equal(probe.error, "response was not JSON");
+    assert.equal(probe.content_type, null);
+  });
+});
+
+describe("probeSurface non-RPC redirect_target passthrough", () => {
+  test("redirected response surfaces redirect_target (|| null else-branch)", async () => {
+    const surface = {
+      id: "x",
+      netuid: 1,
+      kind: "website",
+      url: "https://x.dev/old",
+      provider: "p",
+      auth_required: false,
+      public_safe: true,
+      subnet_name: "n",
+      subnet_slug: "s",
+      probe: { method: "GET", expect: "html" },
+    };
+    const row = await probeSurface(surface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (url) =>
+        url === "https://x.dev/old"
+          ? fakeResponse({ status: 301, location: "https://x.dev/new" })
+          : fakeResponse({ status: 200, contentType: "text/html" }),
+    });
+    assert.equal(row.redirect_target, "https://x.dev/new");
+    assert.equal(row.classification, "redirected");
+    assert.equal(row.status, "ok");
+  });
+
+  test("non-RPC timeout: missing status_code defaults to null", async () => {
+    const surface = {
+      id: "x",
+      netuid: 1,
+      kind: "website",
+      url: "https://x.dev/",
+      provider: "p",
+      auth_required: false,
+      public_safe: true,
+      subnet_name: "n",
+      subnet_slug: "s",
+      probe: { method: "GET", expect: "html" },
+    };
+    const row = await probeSurface(surface, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () => {
+        const err = new Error("aborted");
+        err.name = "AbortError";
+        throw err;
+      },
+    });
+    // AbortError path on probeUrl omits status_code -> defaults to null.
+    assert.equal(row.status_code, null);
+    assert.equal(row.classification, "timeout");
+    assert.equal(row.status, "degraded");
+  });
+});
+
+describe("jsonRpcHttp empty/headerless body branches", () => {
+  test("empty body text -> body null, missing content-type -> null", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async () =>
+        fakeResponse({ status: 200, contentType: null, body: "" }),
+    });
+    // text === "" -> body = null; response.ok && !null?.error -> ok true.
+    assert.equal(probe.content_type, null);
+    assert.equal(probe.method_results.chain_getHeader.ok, true);
+    assert.equal(probe.method_results.chain_getHeader.result_present, false);
+  });
+
+  test("non-ok HTTP status with valid JSON -> method not ok", async () => {
+    const probe = await probeSubtensorHttp("https://rpc.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_u, init) => {
+        const req = JSON.parse(init.body);
+        return fakeResponse({ status: 502, body: rpcBody(req.id, null) });
+      },
+    });
+    // status_code 502 -> classifyRpcProbe transient.
+    assert.equal(probe.method_results.chain_getHeader.ok, false);
+    assert.equal(probe.status_code, 502);
+    assert.equal(classifyRpcProbe(probe), "transient");
+  });
+});
+
+describe("probeSurface field-default branches", () => {
+  test("RPC row uses fallbackVerifiedAt when probe omits verified_at", async () => {
+    // A connector that resolves an empty Map -> summarizeRpcProbe still sets
+    // verified_at, so to hit the fallback we make probeSubtensorWss throw
+    // synchronously is hard; instead verify the non-RPC redirect_target/null
+    // content_type defaults below. Here we assert verified_at is always a string.
+    const row = await probeSurface(
+      {
+        id: "x",
+        netuid: 1,
+        kind: "subtensor-wss",
+        url: "wss://rpc.dev",
+        provider: "p",
+        auth_required: false,
+        public_safe: true,
+        subnet_name: "n",
+        subnet_slug: "s",
+        probe: { method: "WSS", expect: "json" },
+      },
+      {
+        isUnsafeUrl: async () => false,
+        connect: async () =>
+          new Map([
+            ["chain_getHeader", { ok: true, result: { number: "0x1" } }],
+            ["system_health", { ok: true }],
+            ["rpc_methods", { ok: true, result: { methods: [] } }],
+            ["archive_probe", { ok: false }],
+          ]),
+      },
+    );
+    assert.equal(typeof row.verified_at, "string");
+    assert.equal(typeof row.last_checked, "string");
+  });
+
+  test("non-RPC row: null content_type + null redirect_target defaults", async () => {
+    const row = await probeSurface(
+      {
+        id: "x",
+        netuid: 1,
+        kind: "website",
+        url: "https://x.dev/",
+        provider: "p",
+        auth_required: false,
+        public_safe: true,
+        subnet_name: "n",
+        subnet_slug: "s",
+        probe: { method: "GET", expect: "html" },
+      },
+      {
+        isUnsafeUrl: async () => false,
+        fetchImpl: async () => fakeResponse({ status: 200, contentType: null }),
+      },
+    );
+    assert.equal(row.content_type, null);
+    assert.equal(row.redirect_target, null);
   });
 });

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -4,8 +4,11 @@ import {
   KV_HEALTH_CURRENT,
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
+  loadOperationalSurfaces,
+  OPERATIONAL_SURFACES_PATH,
   pruneHealthHistory,
   runHealthProber,
+  workerWebSocketConnector,
 } from "../src/health-prober.mjs";
 import { handleScheduled } from "../workers/api.mjs";
 
@@ -55,6 +58,49 @@ function makeKv() {
     },
   };
 }
+
+// A fake Worker-style client WebSocket. Listeners are captured so a test can
+// drive message/error/close events deterministically after send() runs.
+function makeFakeWebSocket() {
+  const listeners = { message: [], error: [], close: [] };
+  const sent = [];
+  return {
+    sent,
+    listeners,
+    accepted: false,
+    closed: false,
+    accept() {
+      this.accepted = true;
+    },
+    addEventListener(type, fn) {
+      (listeners[type] ||= []).push(fn);
+    },
+    send(payload) {
+      sent.push(payload);
+    },
+    close() {
+      this.closed = true;
+    },
+    emit(type, event) {
+      for (const fn of listeners[type] || []) fn(event);
+    },
+  };
+}
+
+// A fetchImpl that hands back the given webSocket (or rejects/omits it) and
+// records the URL it was called with so the ws:→http: rewrite is checkable.
+function makeFetchImpl({ webSocket, reject, calls = [] } = {}) {
+  return (url, init) => {
+    calls.push({ url, init });
+    if (reject) return Promise.reject(reject);
+    return Promise.resolve({ webSocket });
+  };
+}
+
+const RPC_CALLS = [
+  { key: "a", method: "chain_getHeader", params: [] },
+  { key: "b", method: "system_chain", params: [] },
+];
 
 const SURFACES = [
   {
@@ -244,5 +290,832 @@ describe("handleScheduled dispatch", () => {
     const probeResult = await handleScheduled({ cron: "*/2 * * * *" }, {});
     assert.equal(probeResult.ok, false);
     assert.equal(probeResult.reason, "no-operational-surfaces");
+  });
+});
+
+describe("workerWebSocketConnector", () => {
+  test("rewrites ws:→http:, accepts, sends every call, resolves on all replies", async () => {
+    const socket = makeFakeWebSocket();
+    const calls = [];
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket, calls }),
+    );
+    const promise = connect("wss://node.example/rpc", RPC_CALLS, 1000);
+
+    // ws→http rewrite + Upgrade header.
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].url, "https://node.example/rpc");
+    assert.equal(calls[0].init.headers.Upgrade, "websocket");
+
+    // Wait for the fetch().then() to run so accept()/send() have happened.
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(socket.accepted, true);
+    assert.equal(socket.sent.length, 2);
+    const firstSent = JSON.parse(socket.sent[0]);
+    assert.equal(firstSent.jsonrpc, "2.0");
+    assert.equal(firstSent.id, 1);
+    assert.equal(firstSent.method, "chain_getHeader");
+
+    // Reply to both ids → resolve. One reply carries an rpc error.
+    socket.emit("message", {
+      data: JSON.stringify({ id: 1, result: { number: "0x1" } }),
+    });
+    socket.emit("message", {
+      data: JSON.stringify({ id: 2, error: { code: -32000, message: "boom" } }),
+    });
+
+    const results = await promise;
+    assert.equal(results.get("a").ok, true);
+    assert.deepEqual(results.get("a").result, { number: "0x1" });
+    assert.equal(results.get("b").ok, false);
+    assert.deepEqual(results.get("b").rpc_error, {
+      code: -32000,
+      message: "boom",
+    });
+    assert.equal(socket.closed, true);
+  });
+
+  test("decodes binary (ArrayBuffer) message data via TextDecoder", async () => {
+    const socket = makeFakeWebSocket();
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket }),
+    );
+    const promise = connect("ws://node.example", [RPC_CALLS[0]], 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    const bytes = new TextEncoder().encode(JSON.stringify({ id: 1, result: 9 }));
+    socket.emit("message", { data: bytes });
+    const results = await promise;
+    assert.equal(results.get("a").result, 9);
+  });
+
+  test("ignores replies with an unknown id without resolving early", async () => {
+    const socket = makeFakeWebSocket();
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket }),
+    );
+    const promise = connect("wss://node.example", RPC_CALLS, 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    // id 99 is not in the byId map → ignored, run not yet complete.
+    socket.emit("message", { data: JSON.stringify({ id: 99, result: 1 }) });
+    socket.emit("message", { data: JSON.stringify({ id: 1, result: 1 }) });
+    socket.emit("message", { data: JSON.stringify({ id: 2, result: 2 }) });
+    const results = await promise;
+    assert.equal(results.size, 2);
+  });
+
+  test("rejects when a message body is malformed JSON", async () => {
+    const socket = makeFakeWebSocket();
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket }),
+    );
+    const promise = connect("wss://node.example", RPC_CALLS, 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    socket.emit("message", { data: "{not json" });
+    await assert.rejects(promise, /Unexpected|JSON/i);
+  });
+
+  test("rejects on the 'error' event", async () => {
+    const socket = makeFakeWebSocket();
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket }),
+    );
+    const promise = connect("wss://node.example", RPC_CALLS, 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    socket.emit("error", {});
+    await assert.rejects(promise, /WebSocket RPC connection failed/);
+  });
+
+  test("rejects when closed before all responses arrive", async () => {
+    const socket = makeFakeWebSocket();
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket }),
+    );
+    const promise = connect("wss://node.example", RPC_CALLS, 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    socket.emit("message", { data: JSON.stringify({ id: 1, result: 1 }) });
+    socket.emit("close", {});
+    await assert.rejects(promise, /WebSocket closed before all responses/);
+  });
+
+  test("does not reject on close once all responses already arrived", async () => {
+    const socket = makeFakeWebSocket();
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket }),
+    );
+    const promise = connect("wss://node.example", RPC_CALLS, 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    socket.emit("message", { data: JSON.stringify({ id: 1, result: 1 }) });
+    socket.emit("message", { data: JSON.stringify({ id: 2, result: 2 }) });
+    await promise; // resolved by the second message
+    // A trailing close after settle is a no-op (settled guard).
+    socket.emit("close", {});
+    socket.emit("error", {});
+    const results = await promise;
+    assert.equal(results.size, 2);
+  });
+
+  test("rejects with a TimeoutError when no responses arrive in time", async () => {
+    const socket = makeFakeWebSocket();
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket }),
+    );
+    const promise = connect("wss://node.example", RPC_CALLS, 5);
+    await assert.rejects(promise, (err) => {
+      assert.equal(err.name, "TimeoutError");
+      assert.match(err.message, /WSS RPC probe timed out/);
+      return true;
+    });
+  });
+
+  test("rejects when the response carries no .webSocket", async () => {
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: undefined }),
+    );
+    await assert.rejects(
+      connect("wss://node.example", RPC_CALLS, 1000),
+      /server did not accept the WebSocket upgrade/,
+    );
+  });
+
+  test("rejects when fetchImpl itself rejects (catch path)", async () => {
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ reject: new Error("connect refused") }),
+    );
+    await assert.rejects(
+      connect("wss://node.example", RPC_CALLS, 1000),
+      /connect refused/,
+    );
+  });
+
+  test("swallows a throwing socket.close() during finish", async () => {
+    const socket = makeFakeWebSocket();
+    socket.close = () => {
+      throw new Error("close blew up");
+    };
+    const connect = workerWebSocketConnector(
+      makeFetchImpl({ webSocket: socket }),
+    );
+    const promise = connect("wss://node.example", [RPC_CALLS[0]], 1000);
+    await Promise.resolve();
+    await Promise.resolve();
+    socket.emit("message", { data: JSON.stringify({ id: 1, result: 1 }) });
+    const results = await promise; // resolves despite close() throwing
+    assert.equal(results.get("a").result, 1);
+  });
+
+  test("defaults fetchImpl to global fetch when none is passed", () => {
+    // Construction alone exercises the default-parameter branch.
+    const connect = workerWebSocketConnector();
+    assert.equal(typeof connect, "function");
+  });
+});
+
+describe("loadOperationalSurfaces", () => {
+  const surfacesBody = { surfaces: [{ surface_id: "x", netuid: 1 }] };
+
+  test("returns surfaces from the ASSETS binding on success", async () => {
+    let requested = null;
+    const env = {
+      ASSETS: {
+        fetch: async (req) => {
+          requested = req.url;
+          return { ok: true, json: async () => surfacesBody };
+        },
+      },
+    };
+    const surfaces = await loadOperationalSurfaces(env);
+    assert.deepEqual(surfaces, surfacesBody.surfaces);
+    assert.match(requested, new RegExp(OPERATIONAL_SURFACES_PATH));
+  });
+
+  test("falls back to R2 when ASSETS.fetch throws", async () => {
+    const env = {
+      ASSETS: {
+        fetch: async () => {
+          throw new Error("assets down");
+        },
+      },
+      METAGRAPH_R2_LATEST_PREFIX: "live/",
+      METAGRAPH_ARCHIVE: {
+        get: async (key) => {
+          assert.equal(key, "live/metagraph/operational-surfaces.json");
+          return { text: async () => JSON.stringify(surfacesBody) };
+        },
+      },
+    };
+    const surfaces = await loadOperationalSurfaces(env);
+    assert.deepEqual(surfaces, surfacesBody.surfaces);
+  });
+
+  test("falls back to R2 with the default prefix when none is configured", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        get: async (key) => {
+          assert.equal(key, "latest/metagraph/operational-surfaces.json");
+          return { text: async () => JSON.stringify(surfacesBody) };
+        },
+      },
+    };
+    const surfaces = await loadOperationalSurfaces(env);
+    assert.deepEqual(surfaces, surfacesBody.surfaces);
+  });
+
+  test("returns [] when ASSETS responds non-ok and there is no R2", async () => {
+    const env = { ASSETS: { fetch: async () => ({ ok: false }) } };
+    assert.deepEqual(await loadOperationalSurfaces(env), []);
+  });
+
+  test("returns [] when the ASSETS body has no surfaces array", async () => {
+    const env = {
+      ASSETS: { fetch: async () => ({ ok: true, json: async () => ({}) }) },
+    };
+    assert.deepEqual(await loadOperationalSurfaces(env), []);
+  });
+
+  test("returns [] when R2 returns a null object", async () => {
+    const env = { METAGRAPH_ARCHIVE: { get: async () => null } };
+    assert.deepEqual(await loadOperationalSurfaces(env), []);
+  });
+
+  test("returns [] when R2 .text() yields a body without a surfaces array", async () => {
+    const env = {
+      METAGRAPH_ARCHIVE: {
+        get: async () => ({ text: async () => JSON.stringify({ nope: 1 }) }),
+      },
+    };
+    assert.deepEqual(await loadOperationalSurfaces(env), []);
+  });
+
+  test("returns [] when both ASSETS and R2 throw", async () => {
+    const env = {
+      ASSETS: {
+        fetch: async () => {
+          throw new Error("assets down");
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        get: async () => {
+          throw new Error("r2 down");
+        },
+      },
+    };
+    assert.deepEqual(await loadOperationalSurfaces(env), []);
+  });
+
+  test("returns [] for an empty env (no bindings present)", async () => {
+    assert.deepEqual(await loadOperationalSurfaces({}), []);
+  });
+});
+
+describe("runHealthProber edge paths", () => {
+  test("uses the real workerWebSocketConnector path when no probeOptions are given", async () => {
+    // Drive the default probeOptions branch: probeSurface still injected so no
+    // real network is hit, but probeOptions falls through to the connector.
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        // probeOptions intentionally omitted → exercises the default branch.
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.probed, 2);
+  });
+
+  test("catches a probe that throws → failed/unsupported row", async () => {
+    const kv = makeKv();
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 7000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [SURFACES[0]],
+        probeSurface: async () => {
+          throw new Error("kaboom");
+        },
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.deepEqual(result.counts, {
+      ok: 0,
+      degraded: 0,
+      failed: 1,
+      unknown: 0,
+    });
+    const current = kv.json(KV_HEALTH_CURRENT);
+    const row = current.surfaces[0];
+    assert.equal(row.status, "failed");
+    assert.equal(row.classification, "unsupported");
+    assert.equal(row.latency_ms, null);
+    assert.equal(row.status_code, null);
+  });
+
+  test("falls back to a default error message when a probe throws without one", async () => {
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 7000,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => [SURFACES[0]],
+        // Throw a non-Error so error?.message is undefined.
+        probeSurface: async () => {
+          throw "string failure";
+        },
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.counts.failed, 1);
+  });
+
+  test("catches a throwing priorStatus SELECT and treats all as cold", async () => {
+    const db = makeDb();
+    // Make the prior-status SELECT blow up; the run should still complete.
+    db.prepare = (sql) => ({
+      sql,
+      bind: () => ({
+        async all() {
+          if (/FROM surface_status WHERE surface_id IN/.test(sql)) {
+            throw new Error("cold table");
+          }
+          return { results: [] };
+        },
+        async run() {
+          return { meta: { changes: 0 } };
+        },
+      }),
+    });
+    db.batch = async () => [];
+    const kv = makeKv();
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 9000,
+        db,
+        kv,
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    // With no prior state, the failed surface starts its breaker at 1.
+    const current = kv.json(KV_HEALTH_CURRENT);
+    assert.equal(current.surfaces.length, 2);
+  });
+
+  test("runs with db absent (KV-only) and kv absent (D1-only)", async () => {
+    // db absent → skips the prior SELECT + persistToD1; KV still written.
+    const kv = makeKv();
+    const kvOnly = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db: null,
+        kv,
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(kvOnly.ok, true);
+    assert.ok(kv.json(KV_HEALTH_CURRENT));
+
+    // kv absent → persistToKv no-ops; D1 still written.
+    const db = makeDb();
+    const d1Only = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db,
+        kv: null,
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(d1Only.ok, true);
+    assert.equal(db.calls.batches.length, 1);
+  });
+
+  test("handles a SELECT with no results key and a surface without a provider", async () => {
+    // db.prepare(...).all() returns an object without a `results` key →
+    // exercises the `results || []` fallback in the prior-status loop. The
+    // surface has no provider → exercises the `surface.provider || null` branch.
+    const db = makeDb();
+    db.prepare = (sql) => ({
+      sql,
+      bind: () => ({
+        async all() {
+          return {}; // no `results` key
+        },
+      }),
+    });
+    db.batch = async () => [];
+    const kv = makeKv();
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db,
+        kv,
+        loadSurfaces: async () => [
+          {
+            surface_id: "no-provider",
+            netuid: 9,
+            kind: "subnet-api",
+            url: "https://np.dev",
+            // provider intentionally omitted
+          },
+        ],
+        probeSurface: async () => ({
+          status: "ok",
+          classification: "live",
+          latency_ms: 5,
+        }),
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    const current = kv.json(KV_HEALTH_CURRENT);
+    assert.equal(current.surfaces[0].provider, null);
+  });
+
+  test("respects a custom concurrency override", async () => {
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db: makeDb(),
+        kv: makeKv(),
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+        concurrency: 1,
+      },
+    );
+    assert.equal(result.probed, 2);
+  });
+});
+
+describe("persistToD1 via runHealthProber", () => {
+  test("no-ops when db has no .prepare", async () => {
+    const kv = makeKv();
+    // db is a truthy object without .prepare → prior SELECT skipped (guarded by
+    // db truthiness then .prepare access), persistToD1 returns immediately.
+    const db = { batch: async () => [] };
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db,
+        kv,
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.ok(kv.json(KV_HEALTH_CURRENT));
+  });
+
+  test("swallows a throwing db.batch so KV still gets written", async () => {
+    const db = makeDb();
+    db.batch = async () => {
+      throw new Error("batch failed");
+    };
+    const kv = makeKv();
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db,
+        kv,
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    // KV write happened despite the D1 batch throwing.
+    assert.ok(kv.json(KV_HEALTH_CURRENT));
+  });
+});
+
+describe("persistToKv via runHealthProber", () => {
+  test("no-ops when kv has no .put", async () => {
+    const db = makeDb();
+    // kv truthy but missing .put → persistToKv returns early.
+    const result = await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 1,
+        db,
+        kv: { get: async () => null },
+        loadSurfaces: async () => SURFACES,
+        probeSurface: probeImpl,
+        probeOptions: {},
+      },
+    );
+    assert.equal(result.ok, true);
+    // D1 still got its batch.
+    assert.equal(db.calls.batches.length, 1);
+  });
+
+  test("builds the rpc-pool snapshot from RPC-kind rows incl. eligible_count", async () => {
+    // Two RPC-kind surfaces: one ok (eligible), one failed (ineligible), plus a
+    // non-RPC api surface that must be excluded from the pool.
+    const surfaces = [
+      {
+        surface_id: "rpc-ok",
+        netuid: 0,
+        kind: "subtensor-rpc",
+        url: "https://a.rpc",
+        provider: "p1",
+      },
+      {
+        surface_id: "rpc-bad",
+        netuid: 0,
+        kind: "subtensor-wss",
+        url: "wss://b.rpc",
+        provider: "p2",
+      },
+      {
+        surface_id: "api-x",
+        netuid: 5,
+        kind: "subnet-api",
+        url: "https://x.api",
+        provider: "p3",
+      },
+    ];
+    const probe = async (input) =>
+      input.id === "rpc-ok"
+        ? {
+            status: "ok",
+            classification: "live",
+            latency_ms: 10,
+            archive_support: true,
+          }
+        : { status: "failed", classification: "dead", latency_ms: null };
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 2000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => surfaces,
+        probeSurface: probe,
+        probeOptions: {},
+      },
+    );
+    const pool = kv.json(KV_HEALTH_RPC_POOL);
+    // Only the two RPC-kind surfaces, sorted by id (rpc-bad < rpc-ok).
+    assert.equal(pool.endpoint_count, 2);
+    assert.equal(pool.eligible_count, 1);
+    assert.deepEqual(
+      pool.endpoints.map((e) => e.id),
+      ["rpc-bad", "rpc-ok"],
+    );
+    assert.equal(
+      pool.endpoints.find((e) => e.id === "rpc-ok").pool_eligible,
+      true,
+    );
+    assert.equal(
+      pool.endpoints.find((e) => e.id === "rpc-bad").pool_eligible,
+      false,
+    );
+
+    const meta = kv.json(KV_HEALTH_META);
+    assert.equal(meta.rpc_endpoint_count, 2);
+    assert.equal(meta.rpc_eligible_count, 1);
+  });
+});
+
+describe("summarizeGroup / rollupStatus via per-subnet rollup", () => {
+  function buildSurface(id, netuid, kind = "subnet-api") {
+    return {
+      surface_id: id,
+      netuid,
+      kind,
+      url: `https://${id}.dev`,
+      provider: "p",
+    };
+  }
+
+  test("all-unknown subnet rolls up to unknown with null aggregates", async () => {
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 5000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [
+          buildSurface("u1", 11),
+          buildSurface("u2", 11),
+        ],
+        // Both unknown, no latency, no last_ok.
+        probeSurface: async () => ({
+          status: "unknown",
+          classification: null,
+          latency_ms: null,
+        }),
+        probeOptions: {},
+      },
+    );
+    const current = kv.json(KV_HEALTH_CURRENT);
+    const subnet = current.subnets.find((s) => s.netuid === 11);
+    assert.equal(subnet.status, "unknown");
+    assert.equal(subnet.unknown_count, 2);
+    assert.equal(subnet.avg_latency_ms, null);
+    // No surface ever went ok → lastOk stays at the 0 epoch sentinel (iso(0)),
+    // which is truthy so the `|| null` fallback does not fire.
+    assert.equal(subnet.last_ok, new Date(0).toISOString());
+    assert.equal(subnet.last_checked, new Date(5000).toISOString());
+  });
+
+  test("mixed ok+failed subnet rolls up to degraded with avg latency", async () => {
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 6000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [
+          buildSurface("m-ok", 22),
+          buildSurface("m-bad", 22),
+        ],
+        probeSurface: async (input) =>
+          input.id === "m-ok"
+            ? { status: "ok", classification: "live", latency_ms: 100 }
+            : { status: "failed", classification: "dead", latency_ms: 300 },
+        probeOptions: {},
+      },
+    );
+    const current = kv.json(KV_HEALTH_CURRENT);
+    const subnet = current.subnets.find((s) => s.netuid === 22);
+    // ok>0 with a failure present → degraded.
+    assert.equal(subnet.status, "degraded");
+    assert.equal(subnet.ok_count, 1);
+    assert.equal(subnet.failed_count, 1);
+    // Average of 100 and 300.
+    assert.equal(subnet.avg_latency_ms, 200);
+    assert.equal(subnet.last_ok, new Date(6000).toISOString());
+  });
+
+  test("all-failed subnet rolls up to failed", async () => {
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 8000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [
+          buildSurface("f1", 33),
+          buildSurface("f2", 33),
+        ],
+        probeSurface: async () => ({
+          status: "failed",
+          classification: "dead",
+          latency_ms: null,
+        }),
+        probeOptions: {},
+      },
+    );
+    const current = kv.json(KV_HEALTH_CURRENT);
+    const subnet = current.subnets.find((s) => s.netuid === 33);
+    // No ok, no degraded, all failed → failed.
+    assert.equal(subnet.status, "failed");
+    assert.equal(subnet.failed_count, 2);
+  });
+
+  test("all-ok subnet rolls up to ok", async () => {
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 9000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [buildSurface("g1", 44)],
+        probeSurface: async () => ({
+          status: "ok",
+          classification: "live",
+          latency_ms: 50,
+        }),
+        probeOptions: {},
+      },
+    );
+    const current = kv.json(KV_HEALTH_CURRENT);
+    const subnet = current.subnets.find((s) => s.netuid === 44);
+    assert.equal(subnet.status, "ok");
+  });
+
+  test("degraded-only subnet (no failures) rolls up to degraded", async () => {
+    const kv = makeKv();
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 9500,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => [buildSurface("d1", 55)],
+        probeSurface: async () => ({
+          status: "degraded",
+          classification: "slow",
+          latency_ms: 900,
+        }),
+        probeOptions: {},
+      },
+    );
+    const current = kv.json(KV_HEALTH_CURRENT);
+    const subnet = current.subnets.find((s) => s.netuid === 55);
+    // failed === 0 but degraded > 0 → degraded (not ok).
+    assert.equal(subnet.status, "degraded");
+    assert.equal(subnet.degraded_count, 1);
+  });
+});
+
+describe("pruneHealthHistory edge paths", () => {
+  test("returns {pruned:false} when db is absent", async () => {
+    assert.deepEqual(await pruneHealthHistory({}, { db: null }), {
+      pruned: false,
+    });
+  });
+
+  test("returns {pruned:false} when db lacks .prepare", async () => {
+    assert.deepEqual(await pruneHealthHistory({}, { db: {} }), {
+      pruned: false,
+    });
+  });
+
+  test("returns {pruned:true,changes} on success using env binding + default retention", async () => {
+    const db = makeDb();
+    const result = await pruneHealthHistory(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => 1_000_000_000_000 },
+    );
+    assert.equal(result.pruned, true);
+    assert.equal(result.changes, 7);
+    // Default 30-day retention window applied.
+    assert.equal(result.cutoff, 1_000_000_000_000 - 30 * 24 * 60 * 60 * 1000);
+  });
+
+  test("returns {pruned:false} when prepare/run throws", async () => {
+    const db = {
+      prepare() {
+        throw new Error("prepare exploded");
+      },
+    };
+    assert.deepEqual(await pruneHealthHistory({}, { db }), { pruned: false });
+  });
+
+  test("returns null changes when run() yields no meta", async () => {
+    const db = {
+      prepare: (sql) => ({
+        sql,
+        bind: () => ({
+          async run() {
+            return {}; // no .meta
+          },
+        }),
+      }),
+    };
+    const result = await pruneHealthHistory({}, { now: () => 0, db });
+    assert.equal(result.pruned, true);
+    assert.equal(result.changes, null);
   });
 });

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1,13 +1,16 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  OPERATIONAL_KINDS,
   buildGlobalHealth,
   formatTrends,
   mergeFreshness,
   mergeRpcEndpoints,
   overlayRpcPoolEligibility,
   overlaySubnetHealth,
+  parseLive,
   subnetBadgeStatus,
+  summarizeRows,
 } from "../src/health-serving.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
@@ -210,6 +213,415 @@ describe("subnetBadgeStatus", () => {
     const live = { subnets: [{ netuid: 7, status: "degraded" }] };
     assert.equal(subnetBadgeStatus(live, 7).status, "degraded");
     assert.equal(subnetBadgeStatus(live, 9), null);
+  });
+});
+
+describe("parseLive", () => {
+  test("null/undefined/empty → null", () => {
+    assert.equal(parseLive(null), null);
+    assert.equal(parseLive(undefined), null);
+    assert.equal(parseLive(""), null);
+  });
+  test("already-an-object passes through unchanged", () => {
+    const obj = { a: 1 };
+    assert.equal(parseLive(obj), obj);
+  });
+  test("valid JSON string parses", () => {
+    assert.deepEqual(parseLive('{"a":1}'), { a: 1 });
+  });
+  test("malformed JSON string → null", () => {
+    assert.equal(parseLive("{not json"), null);
+  });
+});
+
+describe("summarizeRows / rollupStatus", () => {
+  const row = (status, extra = {}) => ({ status, ...extra });
+
+  test("empty rows → unknown status, null aggregates", () => {
+    const out = summarizeRows([]);
+    assert.equal(out.status, "unknown");
+    assert.equal(out.surface_count, 0);
+    assert.equal(out.last_checked, null);
+    assert.equal(out.last_ok, null);
+    assert.equal(out.avg_latency_ms, null);
+  });
+  test("all-unknown → unknown", () => {
+    assert.equal(summarizeRows([row("unknown"), row("unknown")]).status, "unknown");
+  });
+  test("all-ok → ok", () => {
+    assert.equal(summarizeRows([row("ok"), row("ok")]).status, "ok");
+  });
+  test("ok + failed mix → degraded", () => {
+    assert.equal(summarizeRows([row("ok"), row("failed")]).status, "degraded");
+  });
+  test("ok + degraded mix → degraded", () => {
+    assert.equal(summarizeRows([row("ok"), row("degraded")]).status, "degraded");
+  });
+  test("degraded + failed (no ok) → degraded (right-hand OR operand)", () => {
+    // ok=0 so the `(counts.ok||0)>0` left operand is false; degraded>0 carries it.
+    assert.equal(
+      summarizeRows([row("degraded"), row("failed")]).status,
+      "degraded",
+    );
+  });
+  test("all-failed (no ok, no degraded) → failed", () => {
+    const out = summarizeRows([row("failed"), row("failed")]);
+    assert.equal(out.status, "failed");
+    assert.equal(out.failed_count, 2);
+  });
+  test("unrecognized status key initializes its own count (|| 0 branch)", () => {
+    // A status outside the known keys exercises the `counts[row.status] || 0`
+    // default-init branch in summarizeRows. With no failed/degraded counts,
+    // rollupStatus reports "ok".
+    const out = summarizeRows([row("weird"), row("weird")]);
+    assert.equal(out.status, "ok");
+    assert.equal(out.failed_count, 0);
+    assert.equal(out.ok_count, 0);
+  });
+  test("aggregates latency (rounded), latest last_checked/last_ok", () => {
+    const out = summarizeRows([
+      row("ok", {
+        latency_ms: 10,
+        last_checked: "2026-06-11T00:00:00.000Z",
+        last_ok: "2026-06-11T00:00:00.000Z",
+      }),
+      row("ok", {
+        latency_ms: 25,
+        last_checked: "2026-06-11T00:05:00.000Z",
+        last_ok: "2026-06-10T23:00:00.000Z",
+      }),
+      // Non-finite latency is skipped from the average.
+      row("ok", { latency_ms: null, last_checked: null, last_ok: null }),
+    ]);
+    assert.equal(out.avg_latency_ms, 18); // round((10+25)/2)
+    assert.equal(out.last_checked, "2026-06-11T00:05:00.000Z"); // latest
+    assert.equal(out.last_ok, "2026-06-11T00:00:00.000Z"); // latest non-null
+  });
+});
+
+describe("OPERATIONAL_KINDS export", () => {
+  test("is a Set of the operational surface kinds", () => {
+    assert.ok(OPERATIONAL_KINDS instanceof Set);
+    assert.ok(OPERATIONAL_KINDS.has("subtensor-rpc"));
+    assert.ok(OPERATIONAL_KINDS.has("data-artifact"));
+    assert.equal(OPERATIONAL_KINDS.has("docs"), false);
+  });
+});
+
+describe("overlaySubnetHealth (additional paths)", () => {
+  test("null/empty live → null (no surfaces array)", () => {
+    assert.equal(overlaySubnetHealth({ surfaces: [] }, null, 7), null);
+    assert.equal(overlaySubnetHealth({ surfaces: [] }, {}, 7), null);
+    assert.equal(
+      overlaySubnetHealth({ surfaces: [] }, { surfaces: "nope" }, 7),
+      null,
+    );
+  });
+
+  test("no live rows for the netuid AND no static artifact → null", () => {
+    const live = {
+      surfaces: [{ surface_id: "x", netuid: 99, status: "ok" }],
+    };
+    assert.equal(overlaySubnetHealth(null, live, 7), null);
+  });
+
+  test("static null but live present → builds from live only", () => {
+    const live = {
+      last_run_at: "2026-06-11T00:00:00.000Z",
+      surfaces: [
+        {
+          surface_id: "sn7-rpc",
+          netuid: 7,
+          kind: "subtensor-rpc",
+          provider: "prov",
+          url: "https://rpc",
+          status: "ok",
+          classification: "live",
+          latency_ms: 30,
+          status_code: 200,
+          last_checked: "2026-06-11T00:00:00.000Z",
+          last_ok: "2026-06-11T00:00:00.000Z",
+        },
+      ],
+    };
+    const out = overlaySubnetHealth(null, live, 7);
+    assert.equal(out.netuid, 7);
+    assert.equal(out.schema_version, 1); // default when no static
+    assert.equal(out.surfaces.length, 1);
+    const pushed = out.surfaces[0];
+    assert.equal(pushed.surface_id, "sn7-rpc");
+    assert.equal(pushed.kind, "subtensor-rpc");
+    assert.equal(pushed.provider, "prov");
+    assert.equal(pushed.url, "https://rpc");
+    assert.equal(pushed.status_code, 200);
+    assert.equal(pushed.observed_by, "live-cron-prober");
+    assert.equal(out.summary.status, "ok");
+  });
+
+  test("static artifact without a surfaces array → treated as empty, live pushed", () => {
+    const live = {
+      last_run_at: null,
+      surfaces: [
+        { surface_id: "sn7-rpc", netuid: 7, kind: "subtensor-rpc", status: "ok" },
+      ],
+    };
+    const out = overlaySubnetHealth({ schema_version: 2 }, live, 7);
+    assert.equal(out.schema_version, 2);
+    assert.equal(out.surfaces.length, 1);
+    assert.equal(out.surfaces[0].observed_by, "live-cron-prober");
+    assert.equal(out.operational_observed_at, null); // last_run_at falsy → null
+  });
+
+  test("live surfaces NOT in static get pushed as new operational surfaces", () => {
+    const staticArtifact = {
+      schema_version: 1,
+      contract_version: "cv",
+      generated_at: "ga",
+      slug: "acme",
+      name: "Acme",
+      surfaces: [
+        { surface_id: "sn7-api", kind: "subnet-api", status: "failed" },
+      ],
+    };
+    const live = {
+      last_run_at: "2026-06-11T00:00:00.000Z",
+      surfaces: [
+        // Matches an existing static surface (replace branch).
+        {
+          surface_id: "sn7-api",
+          netuid: 7,
+          kind: "subnet-api",
+          status: "ok",
+          latency_ms: 10,
+        },
+        // Brand new operational surface (push branch).
+        {
+          surface_id: "sn7-new",
+          netuid: 7,
+          kind: "sse",
+          provider: "p2",
+          url: "https://sse",
+          status: "ok",
+          classification: "live",
+          latency_ms: 20,
+          status_code: 200,
+          last_checked: "2026-06-11T00:00:00.000Z",
+          last_ok: "2026-06-11T00:00:00.000Z",
+        },
+        // Different netuid → ignored entirely.
+        { surface_id: "other", netuid: 99, kind: "sse", status: "failed" },
+      ],
+    };
+    const out = overlaySubnetHealth(staticArtifact, live, 7);
+    assert.equal(out.contract_version, "cv");
+    assert.equal(out.generated_at, "ga");
+    assert.equal(out.slug, "acme");
+    assert.equal(out.name, "Acme");
+    const ids = out.surfaces.map((s) => s.surface_id).sort();
+    assert.deepEqual(ids, ["sn7-api", "sn7-new"]);
+    const pushed = out.surfaces.find((s) => s.surface_id === "sn7-new");
+    assert.equal(pushed.observed_by, "live-cron-prober");
+    assert.equal(pushed.netuid, 7);
+    assert.equal(out.summary.status, "ok");
+    assert.equal(out.summary.ok_count, 2);
+  });
+});
+
+describe("buildGlobalHealth (additional paths)", () => {
+  test("null live → null", () => {
+    assert.equal(buildGlobalHealth(null, {}), null);
+  });
+  test("live without a summary → null", () => {
+    assert.equal(buildGlobalHealth({ generated_at: "g" }, {}), null);
+  });
+  test("defaults subnets to [] and falls back last_run_at to null", () => {
+    const out = buildGlobalHealth(
+      { generated_at: "g", summary: { status: "ok" } },
+      null,
+    );
+    assert.deepEqual(out.subnets, []);
+    assert.equal(out.operational_observed_at, null);
+    assert.equal(out.contract_version, undefined);
+  });
+});
+
+describe("subnetBadgeStatus (additional paths)", () => {
+  test("null live → null", () => {
+    assert.equal(subnetBadgeStatus(null, 7), null);
+  });
+  test("live without subnets array → null", () => {
+    assert.equal(subnetBadgeStatus({ subnets: "nope" }, 7), null);
+  });
+});
+
+describe("mergeRpcEndpoints (additional paths)", () => {
+  test("null live or live without endpoints array → null", () => {
+    assert.equal(mergeRpcEndpoints({ endpoints: [] }, null), null);
+    assert.equal(mergeRpcEndpoints({ endpoints: [] }, {}), null);
+    assert.equal(
+      mergeRpcEndpoints({ endpoints: [] }, { endpoints: "nope" }),
+      null,
+    );
+  });
+
+  test("archive_support falls back to the static value when live omits it", () => {
+    const stat = {
+      schema_version: 3,
+      contract_version: "cv",
+      endpoints: [
+        { id: "a", status: "ok", archive_support: true, pool_eligible: true },
+      ],
+    };
+    const live = {
+      last_run_at: "r",
+      generated_at: "g",
+      endpoints: [
+        // archive_support undefined → keep static true; last_ok null → use last_run_at.
+        {
+          id: "a",
+          status: "ok",
+          classification: "live",
+          latency_ms: 5,
+          last_ok: null,
+          pool_eligible: true,
+        },
+      ],
+    };
+    const out = mergeRpcEndpoints(stat, live);
+    assert.equal(out.schema_version, 3);
+    assert.equal(out.contract_version, "cv");
+    const a = out.endpoints.find((e) => e.id === "a");
+    assert.equal(a.archive_support, true); // fallback to static
+    assert.equal(a.health_source, "live-cron-prober");
+    assert.equal(a.health_stale, false);
+    assert.equal(a.observed_at, "r"); // last_ok null → last_run_at
+  });
+
+  test("static WITHOUT an endpoints array → uses the live endpoint pool directly", () => {
+    const live = {
+      last_run_at: "r",
+      generated_at: "g",
+      endpoints: [{ id: "x", status: "ok" }],
+    };
+    const out = mergeRpcEndpoints({ schema_version: 1 }, live);
+    assert.deepEqual(out.endpoints, live.endpoints);
+    assert.equal(out.source, "live-cron-prober");
+    assert.equal(out.operational_observed_at, "r");
+  });
+
+  test("static null entirely → defaults + live endpoints", () => {
+    const live = {
+      last_run_at: null,
+      generated_at: "g",
+      endpoints: [{ id: "x", status: "ok" }],
+    };
+    const out = mergeRpcEndpoints(null, live);
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.contract_version, undefined);
+    assert.equal(out.operational_observed_at, null);
+    assert.deepEqual(out.endpoints, live.endpoints);
+  });
+});
+
+describe("overlayRpcPoolEligibility (additional paths)", () => {
+  test("null pool → returned unchanged (null)", () => {
+    assert.equal(overlayRpcPoolEligibility(null, { endpoints: [] }), null);
+  });
+  test("live without endpoints array → pool unchanged", () => {
+    const pool = { endpoints: [{ id: "a", pool_eligible: true }] };
+    assert.equal(overlayRpcPoolEligibility(pool, { endpoints: "nope" }), pool);
+    assert.equal(overlayRpcPoolEligibility(pool, {}), pool);
+  });
+
+  test("endpoint with no live match stays unchanged; latency fallback used", () => {
+    const pool = {
+      endpoints: [
+        { id: "a", pool_eligible: true, latency_ms: 11 },
+        { id: "no-live", pool_eligible: true, latency_ms: 99 },
+      ],
+    };
+    const live = {
+      endpoints: [
+        // status ok → not sustained-down even if a stray failure count exists;
+        // latency_ms missing → fall back to endpoint.latency_ms.
+        { id: "a", status: "ok", consecutive_failures: 5 },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(pool, live);
+    const a = out.endpoints.find((e) => e.id === "a");
+    assert.equal(a.pool_eligible, true); // status ok ⇒ not sustainedDown
+    assert.equal(a.latency_ms, 11); // fallback to endpoint.latency_ms
+    assert.equal(a.health_source, "live-cron-prober");
+    const noLive = out.endpoints.find((e) => e.id === "no-live");
+    assert.equal(noLive.latency_ms, 99);
+    assert.equal(noLive.health_source, undefined); // untouched
+  });
+
+  test("pool without an endpoints array → maps over [] (no throw)", () => {
+    const out = overlayRpcPoolEligibility({ id: "p" }, { endpoints: [] });
+    assert.deepEqual(out.endpoints, []);
+    assert.equal(out.id, "p");
+  });
+
+  test("sustained-down endpoint with explicit live latency drops eligibility", () => {
+    const pool = { endpoints: [{ id: "a", pool_eligible: true, latency_ms: 5 }] };
+    const live = {
+      endpoints: [
+        { id: "a", status: "failed", consecutive_failures: 2, latency_ms: 70 },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(pool, live);
+    const a = out.endpoints.find((e) => e.id === "a");
+    assert.equal(a.pool_eligible, false);
+    assert.equal(a.latency_ms, 70); // explicit live latency wins
+  });
+});
+
+describe("mergeFreshness (additional paths)", () => {
+  test("null live meta or null static → null", () => {
+    assert.equal(mergeFreshness({ sources: [] }, null), null);
+    assert.equal(mergeFreshness(null, { last_run_at: "r" }), null);
+  });
+
+  test("sources NOT an array → passed through verbatim", () => {
+    const stat = { sources: "nope", summary: { a: 1 } };
+    const out = mergeFreshness(stat, { last_run_at: "r" });
+    assert.equal(out.sources, "nope");
+    assert.equal(out.summary.health_probe_as_of, "r");
+    assert.equal(out.summary.operational_probe_as_of, "r");
+    assert.equal(out.summary.a, 1); // preserves existing summary keys
+  });
+});
+
+describe("formatTrends (additional paths)", () => {
+  test("surfaces are sorted by surface_id; null avg_latency passes through", () => {
+    const out = formatTrends({
+      netuid: 7,
+      observedAt: "r",
+      windows: {
+        "7d": [
+          { surface_id: "z", total: 10, ok_count: 5, avg_latency_ms: null },
+          { surface_id: "a", total: 4, ok_count: 1, avg_latency_ms: 12.6 },
+          // total 0 → uptime_ratio null for that surface.
+          { surface_id: "m", total: 0, ok_count: 0, avg_latency_ms: 9 },
+        ],
+      },
+    });
+    const w = out.windows["7d"];
+    assert.deepEqual(
+      w.surfaces.map((s) => s.surface_id),
+      ["a", "m", "z"],
+    );
+    assert.equal(w.surfaces.find((s) => s.surface_id === "z").avg_latency_ms, null);
+    assert.equal(w.surfaces.find((s) => s.surface_id === "a").avg_latency_ms, 13);
+    assert.equal(w.surfaces.find((s) => s.surface_id === "m").uptime_ratio, null);
+    assert.equal(w.samples, 14);
+    assert.equal(w.uptime_ratio, Number((6 / 14).toFixed(4)));
+  });
+
+  test("observedAt omitted → null", () => {
+    const out = formatTrends({ netuid: 1, windows: { "7d": [] } });
+    assert.equal(out.observed_at, null);
   });
 });
 

--- a/tests/webhooks-core.test.mjs
+++ b/tests/webhooks-core.test.mjs
@@ -1,0 +1,618 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  buildChangeEvent,
+  deliverChangeEvent,
+  dispatchChangeEvent,
+  eventMatchesFilters,
+  isPublicWebhookAddress,
+  isPublicWebhookUrl,
+  isResolvedPublicWebhookUrl,
+  normalizeFilters,
+  publicSubscriptionView,
+  signPayload,
+  timingSafeEqual,
+  validateSubscriptionInput,
+} from "../src/webhooks.mjs";
+
+// --- isPublicWebhookAddress ---------------------------------------------------
+describe("isPublicWebhookAddress", () => {
+  test("empty / falsy host → false", () => {
+    assert.equal(isPublicWebhookAddress(""), false);
+    assert.equal(isPublicWebhookAddress(null), false);
+    assert.equal(isPublicWebhookAddress(undefined), false);
+  });
+
+  test("loopback / link-local / unique-local / mapped IPv6 → false", () => {
+    assert.equal(isPublicWebhookAddress("::1"), false);
+    assert.equal(isPublicWebhookAddress("::"), false);
+    assert.equal(isPublicWebhookAddress("fe80::1"), false);
+    assert.equal(isPublicWebhookAddress("fc00::1"), false);
+    assert.equal(isPublicWebhookAddress("fd12::1"), false);
+    assert.equal(isPublicWebhookAddress("::ffff:10.0.0.1"), false);
+  });
+
+  test("public IPv6 → true", () => {
+    assert.equal(isPublicWebhookAddress("2606:4700:4700::1111"), true);
+  });
+
+  test("private IPv4 literals → false", () => {
+    assert.equal(isPublicWebhookAddress("10.0.0.1"), false);
+    assert.equal(isPublicWebhookAddress("127.0.0.1"), false);
+    assert.equal(isPublicWebhookAddress("169.254.1.1"), false);
+    assert.equal(isPublicWebhookAddress("192.168.1.1"), false);
+    assert.equal(isPublicWebhookAddress("172.16.0.1"), false);
+    assert.equal(isPublicWebhookAddress("100.64.0.1"), false);
+  });
+
+  test("public IPv4 literal → true", () => {
+    assert.equal(isPublicWebhookAddress("8.8.8.8"), true);
+  });
+
+  test("a bare hostname (not an IP literal) → false", () => {
+    assert.equal(isPublicWebhookAddress("example.com"), false);
+  });
+});
+
+// --- isPublicWebhookUrl -------------------------------------------------------
+describe("isPublicWebhookUrl", () => {
+  test("rejects an unparseable URL", () => {
+    assert.equal(isPublicWebhookUrl("not a url"), false);
+  });
+
+  test("rejects non-https, credentials, non-default port", () => {
+    assert.equal(isPublicWebhookUrl("http://example.com/x"), false);
+    assert.equal(isPublicWebhookUrl("https://user:pass@example.com/x"), false);
+    assert.equal(isPublicWebhookUrl("https://example.com:8443/x"), false);
+  });
+
+  test("allows the explicit default 443 port", () => {
+    assert.equal(isPublicWebhookUrl("https://example.com:443/x"), true);
+  });
+
+  test("rejects localhost / internal / local suffixes and bare labels", () => {
+    assert.equal(isPublicWebhookUrl("https://localhost/x"), false);
+    assert.equal(isPublicWebhookUrl("https://api.localhost/x"), false);
+    assert.equal(isPublicWebhookUrl("https://svc.internal/x"), false);
+    assert.equal(isPublicWebhookUrl("https://printer.local/x"), false);
+    assert.equal(isPublicWebhookUrl("https://router/x"), false);
+  });
+
+  test("rejects a private IPv4 literal host", () => {
+    assert.equal(isPublicWebhookUrl("https://169.254.169.254/x"), false);
+  });
+
+  test("allows a public IPv4 literal host", () => {
+    assert.equal(isPublicWebhookUrl("https://8.8.8.8/x"), true);
+  });
+
+  test("allows a registrable hostname with a dot", () => {
+    assert.equal(isPublicWebhookUrl("https://hooks.example.com/mg"), true);
+  });
+});
+
+// --- isResolvedPublicWebhookUrl ----------------------------------------------
+describe("isResolvedPublicWebhookUrl", () => {
+  test("short-circuits false for a non-public URL", async () => {
+    assert.equal(
+      await isResolvedPublicWebhookUrl("http://example.com/x"),
+      false,
+    );
+  });
+
+  test("returns true with no resolver injected", async () => {
+    assert.equal(
+      await isResolvedPublicWebhookUrl("https://hooks.example.com/mg"),
+      true,
+    );
+  });
+
+  test("an IP-literal host is checked directly (resolver ignored)", async () => {
+    assert.equal(
+      await isResolvedPublicWebhookUrl("https://8.8.8.8/x", async () => [
+        "10.0.0.1",
+      ]),
+      true,
+    );
+    assert.equal(
+      await isResolvedPublicWebhookUrl("https://127.0.0.1/x", async () => [
+        "8.8.8.8",
+      ]),
+      false,
+    );
+  });
+
+  test("returns false when the resolver throws", async () => {
+    assert.equal(
+      await isResolvedPublicWebhookUrl("https://hooks.example.com/mg", () => {
+        throw new Error("dns boom");
+      }),
+      false,
+    );
+  });
+
+  test("requires every resolved address to be public", async () => {
+    assert.equal(
+      await isResolvedPublicWebhookUrl(
+        "https://hooks.example.com/mg",
+        async () => ["8.8.8.8", "1.1.1.1"],
+      ),
+      true,
+    );
+    assert.equal(
+      await isResolvedPublicWebhookUrl(
+        "https://hooks.example.com/mg",
+        async () => ["8.8.8.8", "10.0.0.1"],
+      ),
+      false,
+    );
+    assert.equal(
+      await isResolvedPublicWebhookUrl(
+        "https://hooks.example.com/mg",
+        async () => [],
+      ),
+      false,
+    );
+  });
+});
+
+// --- normalizeFilters / validateSubscriptionInput ----------------------------
+describe("normalizeFilters", () => {
+  test("undefined / null → {}", () => {
+    assert.deepEqual(normalizeFilters(undefined), {});
+    assert.deepEqual(normalizeFilters(null), {});
+  });
+
+  test("non-object or array → null", () => {
+    assert.equal(normalizeFilters(5), null);
+    assert.equal(normalizeFilters([1, 2]), null);
+  });
+
+  test("rejects too many netuids", () => {
+    const netuids = Array.from({ length: 65 }, (_, i) => i);
+    assert.equal(normalizeFilters({ netuids }), null);
+  });
+
+  test("rejects non-array / out-of-range netuids", () => {
+    assert.equal(normalizeFilters({ netuids: "nope" }), null);
+    assert.equal(normalizeFilters({ netuids: [-1] }), null);
+    assert.equal(normalizeFilters({ netuids: [70000] }), null);
+    assert.equal(normalizeFilters({ netuids: [1.5] }), null);
+  });
+
+  test("dedupes + sorts netuids", () => {
+    assert.deepEqual(normalizeFilters({ netuids: [7, 1, 7] }), {
+      netuids: [1, 7],
+    });
+  });
+
+  test("rejects too many kinds", () => {
+    const kinds = Array.from({ length: 9 }, () => "subnets");
+    assert.equal(normalizeFilters({ kinds }), null);
+  });
+
+  test("rejects a non-array / invalid kind", () => {
+    assert.equal(normalizeFilters({ kinds: "subnets" }), null);
+    assert.equal(normalizeFilters({ kinds: ["nope"] }), null);
+    assert.equal(normalizeFilters({ kinds: [5] }), null);
+  });
+
+  test("dedupes + sorts kinds", () => {
+    assert.deepEqual(
+      normalizeFilters({ kinds: ["subnets", "artifacts", "subnets"] }),
+      { kinds: ["artifacts", "subnets"] },
+    );
+  });
+});
+
+describe("validateSubscriptionInput", () => {
+  test("rejects a non-object input", () => {
+    assert.equal(validateSubscriptionInput(null).ok, false);
+    assert.equal(validateSubscriptionInput([]).ok, false);
+    assert.equal(validateSubscriptionInput(5).ok, false);
+  });
+
+  test("rejects a non-string / non-public url", () => {
+    assert.equal(validateSubscriptionInput({ url: 5 }).ok, false);
+    assert.equal(
+      validateSubscriptionInput({ url: "http://example.com/x" }).ok,
+      false,
+    );
+  });
+
+  test("rejects invalid filters", () => {
+    const out = validateSubscriptionInput({
+      url: "https://hooks.example.com/x",
+      filters: { netuids: "bad" },
+    });
+    assert.equal(out.ok, false);
+    assert.match(out.error, /filters/);
+  });
+
+  test("rejects a too-short / too-long / non-string secret", () => {
+    assert.equal(
+      validateSubscriptionInput({
+        url: "https://hooks.example.com/x",
+        secret: "short",
+      }).ok,
+      false,
+    );
+    assert.equal(
+      validateSubscriptionInput({
+        url: "https://hooks.example.com/x",
+        secret: "x".repeat(257),
+      }).ok,
+      false,
+    );
+    assert.equal(
+      validateSubscriptionInput({
+        url: "https://hooks.example.com/x",
+        secret: 12345,
+      }).ok,
+      false,
+    );
+  });
+
+  test("accepts a valid subscription with a secret + filters", () => {
+    const out = validateSubscriptionInput({
+      url: "https://hooks.example.com/x",
+      filters: { netuids: [7], kinds: ["subnets"] },
+      secret: "a-sixteen-char!!",
+    });
+    assert.equal(out.ok, true);
+    assert.deepEqual(out.value.filters, { netuids: [7], kinds: ["subnets"] });
+    assert.equal(out.value.secret, "a-sixteen-char!!");
+  });
+});
+
+// --- buildChangeEvent / eventMatchesFilters ----------------------------------
+describe("buildChangeEvent + eventMatchesFilters", () => {
+  const event = buildChangeEvent({
+    changelog: {
+      generated_at: "g",
+      contract_version: "v1",
+      artifacts: {
+        added: ["/metagraph/subnets/7.json", { path: "/metagraph/x.json" }],
+        modified: [],
+        removed: [],
+      },
+      subnets: {
+        added: [{ netuid: 7 }],
+        removed: [3],
+        renamed: [{ netuid: 11 }],
+      },
+    },
+    pointer: { published_at: "p" },
+  });
+
+  test("derives change kinds, affected netuids, and summary", () => {
+    assert.equal(event.published_at, "p");
+    assert.deepEqual(event.change_kinds.sort(), ["artifacts", "subnets"]);
+    assert.deepEqual(event.affected_netuids, [3, 7, 11]);
+    assert.equal(event.summary.artifacts.added, 2);
+    assert.equal(event.summary.subnets.renamed, 1);
+  });
+
+  test("empty changelog → no kinds, empty netuids", () => {
+    const empty = buildChangeEvent({});
+    assert.deepEqual(empty.change_kinds, []);
+    assert.deepEqual(empty.affected_netuids, []);
+    assert.equal(empty.contract_version, null);
+  });
+
+  test("no filters → matches everything", () => {
+    assert.equal(eventMatchesFilters(event, undefined), true);
+    assert.equal(eventMatchesFilters(event, {}), true);
+  });
+
+  test("kind filter: matches only when a kind overlaps", () => {
+    assert.equal(eventMatchesFilters(event, { kinds: ["subnets"] }), true);
+    const artifactsOnly = buildChangeEvent({
+      changelog: { artifacts: { added: ["/metagraph/x.json"] } },
+    });
+    assert.equal(
+      eventMatchesFilters(artifactsOnly, { kinds: ["subnets"] }),
+      false,
+    );
+  });
+
+  test("netuid filter: matches only on an affected netuid", () => {
+    assert.equal(eventMatchesFilters(event, { netuids: [7] }), true);
+    assert.equal(eventMatchesFilters(event, { netuids: [99] }), false);
+  });
+});
+
+// --- signPayload / timingSafeEqual -------------------------------------------
+describe("signPayload + timingSafeEqual", () => {
+  test("signing is deterministic for the same secret + body", async () => {
+    const a = await signPayload("secret", "hello");
+    const b = await signPayload("secret", "hello");
+    assert.equal(a, b);
+    assert.match(a, /^[0-9a-f]{64}$/);
+  });
+
+  test("a different secret yields a different signature", async () => {
+    const a = await signPayload("secret-a", "hello");
+    const b = await signPayload("secret-b", "hello");
+    assert.notEqual(a, b);
+  });
+
+  test("timingSafeEqual matches equal strings and rejects mismatches", () => {
+    assert.equal(timingSafeEqual("abc", "abc"), true);
+    assert.equal(timingSafeEqual("abc", "abd"), false);
+    assert.equal(timingSafeEqual("abc", "abcd"), false);
+  });
+});
+
+// --- publicSubscriptionView --------------------------------------------------
+describe("publicSubscriptionView", () => {
+  test("null / non-object → null", () => {
+    assert.equal(publicSubscriptionView(null), null);
+    assert.equal(publicSubscriptionView("nope"), null);
+  });
+
+  test("strips the secret and defaults active true", () => {
+    const view = publicSubscriptionView({
+      id: "x",
+      url: "https://h.example.com",
+      secret: "s",
+    });
+    assert.equal(view.secret, undefined);
+    assert.equal(view.active, true);
+    assert.deepEqual(view.filters, {});
+    assert.equal(view.created_at, null);
+  });
+
+  test("active false is preserved", () => {
+    assert.equal(
+      publicSubscriptionView({ id: "x", active: false }).active,
+      false,
+    );
+  });
+});
+
+// --- deliverChangeEvent ------------------------------------------------------
+describe("deliverChangeEvent", () => {
+  const event = buildChangeEvent({
+    changelog: { subnets: { added: [{ netuid: 7 }] } },
+    pointer: { published_at: "p" },
+  });
+  const base = {
+    id: "sub-1",
+    url: "https://hooks.example.com/mg",
+    secret: "a-sixteen-char!!",
+  };
+
+  test("skips an invalid subscription (no url)", async () => {
+    const out = await deliverChangeEvent({
+      subscription: { id: "x" },
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+    });
+    assert.equal(out.status, "skipped");
+    assert.equal(out.reason, "invalid");
+  });
+
+  test("skips a null subscription", async () => {
+    const out = await deliverChangeEvent({
+      subscription: null,
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+    });
+    assert.equal(out.status, "skipped");
+    assert.equal(out.id, null);
+  });
+
+  test("skips an unsafe url", async () => {
+    const out = await deliverChangeEvent({
+      subscription: { ...base, url: "http://example.com/x" },
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+    });
+    assert.equal(out.status, "skipped");
+    assert.equal(out.reason, "unsafe-url");
+  });
+
+  test("reports filtered on a filter mismatch", async () => {
+    const out = await deliverChangeEvent({
+      subscription: { ...base, filters: { netuids: [99] } },
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+    });
+    assert.equal(out.status, "filtered");
+  });
+
+  test("skips when no secret is set", async () => {
+    const out = await deliverChangeEvent({
+      subscription: { id: "x", url: base.url },
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+    });
+    assert.equal(out.status, "skipped");
+    assert.equal(out.reason, "no-secret");
+  });
+
+  test("skips when DNS resolves to a private address", async () => {
+    const out = await deliverChangeEvent({
+      subscription: base,
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+      resolveHostnames: async () => ["10.0.0.1"],
+    });
+    assert.equal(out.status, "skipped");
+    assert.equal(out.reason, "unsafe-url");
+  });
+
+  test("delivers on a 2xx with the current timestamp from now()", async () => {
+    let seenHeaders;
+    const out = await deliverChangeEvent({
+      subscription: base,
+      event,
+      now: () => "2026-06-11T00:00:00.000Z",
+      fetchFn: async (_url, init) => {
+        seenHeaders = init.headers;
+        return new Response(null, { status: 204 });
+      },
+    });
+    assert.equal(out.status, "delivered");
+    assert.equal(out.status_code, 204);
+    assert.equal(out.attempts, 1);
+    assert.equal(
+      seenHeaders["x-metagraph-timestamp"],
+      "2026-06-11T00:00:00.000Z",
+    );
+    assert.match(seenHeaders["x-metagraph-signature"], /^[0-9a-f]{64}$/);
+  });
+
+  test("uses the epoch timestamp when now() is not a function", async () => {
+    let seenHeaders;
+    await deliverChangeEvent({
+      subscription: base,
+      event,
+      fetchFn: async (_url, init) => {
+        seenHeaders = init.headers;
+        return new Response("", { status: 200 });
+      },
+    });
+    assert.equal(
+      seenHeaders["x-metagraph-timestamp"],
+      new Date(0).toISOString(),
+    );
+  });
+
+  test("fails (no retry) on a 3xx redirect", async () => {
+    const out = await deliverChangeEvent({
+      subscription: base,
+      event,
+      fetchFn: async () => new Response("", { status: 302 }),
+    });
+    assert.equal(out.status, "failed");
+    assert.equal(out.reason, "redirect-not-followed");
+    assert.equal(out.attempts, 1);
+  });
+
+  test("fails (no retry) on a deterministic 4xx", async () => {
+    let calls = 0;
+    const out = await deliverChangeEvent({
+      subscription: base,
+      event,
+      fetchFn: async () => {
+        calls += 1;
+        return new Response("", { status: 404 });
+      },
+    });
+    assert.equal(out.status, "failed");
+    assert.equal(out.reason, "http-404");
+    assert.equal(calls, 1);
+  });
+
+  test("retries 5xx up to maxAttempts then fails", async () => {
+    let calls = 0;
+    const out = await deliverChangeEvent({
+      subscription: base,
+      event,
+      maxAttempts: 3,
+      fetchFn: async () => {
+        calls += 1;
+        return new Response("", { status: 503 });
+      },
+    });
+    assert.equal(out.status, "failed");
+    assert.equal(out.reason, "http-503");
+    assert.equal(out.attempts, 3);
+    assert.equal(calls, 3);
+  });
+
+  test("retries 429 then succeeds", async () => {
+    let calls = 0;
+    const out = await deliverChangeEvent({
+      subscription: base,
+      event,
+      fetchFn: async () => {
+        calls += 1;
+        return calls < 2
+          ? new Response("", { status: 429 })
+          : new Response("", { status: 200 });
+      },
+    });
+    assert.equal(out.status, "delivered");
+    assert.equal(out.attempts, 2);
+  });
+
+  test("classifies a TimeoutError vs a generic network error", async () => {
+    const timeoutOut = await deliverChangeEvent({
+      subscription: base,
+      event,
+      maxAttempts: 1,
+      fetchFn: async () => {
+        const err = new Error("timed out");
+        err.name = "TimeoutError";
+        throw err;
+      },
+    });
+    assert.equal(timeoutOut.status, "failed");
+    assert.equal(timeoutOut.reason, "timeout");
+
+    const networkOut = await deliverChangeEvent({
+      subscription: base,
+      event,
+      maxAttempts: 1,
+      fetchFn: async () => {
+        throw new Error("connection reset");
+      },
+    });
+    assert.equal(networkOut.status, "failed");
+    assert.equal(networkOut.reason, "network-error");
+  });
+});
+
+// --- dispatchChangeEvent -----------------------------------------------------
+describe("dispatchChangeEvent", () => {
+  const event = buildChangeEvent({
+    changelog: { subnets: { added: [{ netuid: 7 }] } },
+  });
+
+  test("fans out over many subscriptions, one result each", async () => {
+    const subs = Array.from({ length: 5 }, (_, i) => ({
+      id: `sub-${i}`,
+      url: "https://hooks.example.com/mg",
+      secret: "a-sixteen-char!!",
+    }));
+    const results = await dispatchChangeEvent({
+      subscriptions: subs,
+      event,
+      concurrency: 2,
+      fetchFn: async () => new Response("", { status: 200 }),
+    });
+    assert.equal(results.length, 5);
+    assert.ok(results.every((r) => r.status === "delivered"));
+  });
+
+  test("empty subscription list → empty results (no throw)", async () => {
+    const results = await dispatchChangeEvent({
+      subscriptions: [],
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+    });
+    assert.deepEqual(results, []);
+  });
+
+  test("a bad endpoint cannot sink the batch", async () => {
+    const results = await dispatchChangeEvent({
+      subscriptions: [
+        {
+          id: "ok",
+          url: "https://hooks.example.com/mg",
+          secret: "a-sixteen-char!!",
+        },
+        { id: "bad", url: "http://example.com/x", secret: "a-sixteen-char!!" },
+      ],
+      event,
+      fetchFn: async () => new Response("", { status: 200 }),
+    });
+    assert.equal(results.length, 2);
+    const byId = Object.fromEntries(results.map((r) => [r.id, r.status]));
+    assert.equal(byId.ok, "delivered");
+    assert.equal(byId.bad, "skipped");
+  });
+});

--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -237,3 +237,147 @@ describe("SSE change feed", () => {
     assert.ok(Array.isArray(event.affected_netuids));
   });
 });
+
+describe("webhook route edge cases", () => {
+  test("404 for an unknown webhook sub-route", async () => {
+    const res = await handleRequest(
+      req("/api/v1/webhooks/not-subscriptions"),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "not_found");
+  });
+
+  test("405 for an unsupported method on the collection root", async () => {
+    // PUT has an id-less collection path but is neither POST (create) nor a
+    // GET/DELETE on an id, so it hits the method_not_allowed tail.
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", { method: "PATCH" }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 405);
+    assert.equal((await res.json()).error.code, "method_not_allowed");
+    assert.match(res.headers.get("allow"), /POST, GET, DELETE/);
+  });
+
+  test("413 when the content-length header exceeds the body limit", async () => {
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": String(9000),
+          "x-metagraph-webhook-subscription-token": SUBSCRIPTION_TOKEN,
+        },
+        body: JSON.stringify({ url: "https://hooks.example.com/mg" }),
+      }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 413);
+    assert.equal((await res.json()).error.code, "payload_too_large");
+  });
+
+  test("413 when the decoded body byte length exceeds the limit", async () => {
+    // content-length omitted, but the JSON payload itself is oversized.
+    const body = JSON.stringify({
+      url: "https://hooks.example.com/mg",
+      pad: "x".repeat(9000),
+    });
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-metagraph-webhook-subscription-token": SUBSCRIPTION_TOKEN,
+        },
+        body,
+      }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 413);
+    assert.equal((await res.json()).error.code, "payload_too_large");
+  });
+
+  test("503 when KV put fails during creation", async () => {
+    const kv = makeKv();
+    kv.put = async () => {
+      throw new Error("kv put down");
+    };
+    const res = await postSub(envWith(kv), {
+      url: "https://hooks.example.com/mg",
+    });
+    assert.equal(res.status, 503);
+    assert.equal((await res.json()).error.code, "webhooks_unavailable");
+  });
+
+  test("400 invalid_subscription_id on GET with a malformed id", async () => {
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions/not-a-uuid"),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_subscription_id");
+  });
+
+  test("400 invalid_subscription_id on DELETE with a malformed id", async () => {
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions/not-a-uuid", { method: "DELETE" }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_subscription_id");
+  });
+
+  test("404 on DELETE of an unknown subscription id", async () => {
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions/00000000-0000-4000-8000-000000000000", {
+        method: "DELETE",
+        headers: { "x-metagraph-webhook-secret": "whatever" },
+      }),
+      envWith(makeKv()),
+      {},
+    );
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "subscription_not_found");
+  });
+
+  test("503 when KV delete fails", async () => {
+    const kv = makeKv();
+    const created = await (
+      await postSub(envWith(kv), { url: "https://hooks.example.com/mg" })
+    ).json();
+    kv.delete = async () => {
+      throw new Error("kv delete down");
+    };
+    const res = await handleRequest(
+      req(`/api/v1/webhooks/subscriptions/${created.data.id}`, {
+        method: "DELETE",
+        headers: { "x-metagraph-webhook-secret": created.data.secret },
+      }),
+      envWith(kv),
+      {},
+    );
+    assert.equal(res.status, 503);
+    assert.equal((await res.json()).error.code, "webhooks_unavailable");
+  });
+
+  test("readWebhookSubscription swallows a throwing KV get → 404", async () => {
+    const kv = makeKv();
+    kv.get = async () => {
+      throw new Error("kv get down");
+    };
+    const res = await handleRequest(
+      req("/api/v1/webhooks/subscriptions/00000000-0000-4000-8000-000000000000"),
+      envWith(kv),
+      {},
+    );
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "subscription_not_found");
+  });
+});

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -12,11 +12,14 @@ export default defineConfig({
         "workers/**/*.mjs",
         "scripts/{artifact-budgets,lib,openapi-components,submission-notifications,submission-policy}.mjs",
       ],
+      // Locked in after the coverage push (global ~98.7% stmts/lines, 92.7%
+      // branches). Gates below the achieved level so coverage can't silently
+      // regress past the 97%+ bar.
       thresholds: {
-        branches: 85,
-        functions: 95,
-        lines: 97,
-        statements: 97,
+        branches: 90,
+        functions: 97,
+        lines: 98,
+        statements: 98,
       },
     },
   },


### PR DESCRIPTION
## Coverage → ~98.7% (gated in CI)
Backend statement/line coverage raised from ~87% to **98.69% stmts / 98.7% lines / 99.35% funcs / 92.67% branches**, every measured module ≥97%:

| Module | Before | After |
|---|---|---|
| `src/health-probe-core.mjs` | 44% | **99.6%** |
| `src/health-prober.mjs` | 63% | **100%** |
| `src/health-serving.mjs` | 83% | **100%** |
| `workers/api.mjs` | 93.6% | **97.8%** |
| `src/webhooks.mjs` | 93.4% | **99%** |
| `src/artifact-storage.mjs` | 97% | **100%** |
| `scripts/lib.mjs` / `submission-policy.mjs` | 96.6% / 93.7% | **98.4% / 98.6%** |

**579 tests** (was 278), all passing, **no source changes** (tests only). Thresholds raised to 98/98/97/90 and the CI Test step now runs `npm run test:coverage`, so coverage is enforced on every PR.

## Alerting
Converted the publish/sync failure-alert payloads to **Discord format** (`{"content":...}`); the `METAGRAPH_ALERT_WEBHOOK_URL` secret is set (a test message was delivered). Failures now ping Discord with a run link.