### PR TITLE
security: isolate OIDC publish job (#251) + DNS-aware prober SSRF guard (#255)

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -36,12 +36,30 @@ jobs:
       - name: Validate release version
         run: bash scripts/validate-client-release.sh
 
-      - name: Build + pack dry-run
+      # Build + pack happen in THIS unprivileged job (no id-token). The privileged
+      # publish job below never runs npm install/build, so a compromised build
+      # dependency can't reach the OIDC token (codex #251).
+      - name: Build package tarball
         working-directory: packages/client
         run: |
+          set -euo pipefail
           npm install --no-audit --no-fund
           npm run build
-          npm pack --dry-run
+          npm pack --pack-destination "$RUNNER_TEMP"
+          count=$(find "$RUNNER_TEMP" -maxdepth 1 -type f -name "*.tgz" | wc -l | tr -d ' ')
+          if [ "$count" != "1" ]; then
+            echo "Expected exactly one tarball, found $count" >&2
+            find "$RUNNER_TEMP" -maxdepth 1 -type f -name "*.tgz" -print >&2
+            exit 1
+          fi
+
+      - name: Upload package tarball
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: client-package-tarball
+          path: ${{ runner.temp }}/*.tgz
+          if-no-files-found: error
+          retention-days: 7
 
   publish:
     runs-on: ubuntu-latest
@@ -68,17 +86,28 @@ jobs:
         id: release
         run: bash scripts/validate-client-release.sh
 
-      - name: Build
-        working-directory: packages/client
-        run: |
-          npm install --no-audit --no-fund
-          npm run build
+      # Pull the tarball built by the unprivileged validate job — this job never
+      # runs npm install/build, so no third-party code executes while the OIDC
+      # token is available (codex #251).
+      - name: Download package tarball
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: client-package-tarball
+          path: ${{ runner.temp }}/client-package
 
       - name: Publish to npm (OIDC trusted publishing)
-        working-directory: packages/client
         env:
           NPM_CONFIG_PROVENANCE: "true"
-        run: npm publish --access public --provenance --ignore-scripts
+        run: |
+          set -euo pipefail
+          count=$(find "$RUNNER_TEMP/client-package" -maxdepth 1 -type f -name "*.tgz" | wc -l | tr -d ' ')
+          if [ "$count" != "1" ]; then
+            echo "Expected exactly one tarball, found $count" >&2
+            find "$RUNNER_TEMP/client-package" -maxdepth 1 -type f -name "*.tgz" -print >&2
+            exit 1
+          fi
+          tarball=$(find "$RUNNER_TEMP/client-package" -maxdepth 1 -type f -name "*.tgz" -print -quit)
+          npm publish "$tarball" --access public --provenance --ignore-scripts
 
       - name: Tag + GitHub release
         env:

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -28,8 +28,126 @@ export const OPERATIONAL_SURFACES_PATH = "/metagraph/operational-surfaces.json";
 const PROBE_CONCURRENCY = 8;
 const HISTORY_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 const RPC_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
+const DNS_JSON_ENDPOINT = "https://cloudflare-dns.com/dns-query";
+const DNS_RECORD_TYPES = ["A", "AAAA"];
+const DNS_TIMEOUT_MS = 4000;
 
 const iso = (ms) => (Number.isFinite(ms) ? new Date(ms).toISOString() : null);
+
+// --- DNS-aware SSRF guard for the Worker prober (codex #255) -------------------
+// The literal `isUnsafePublicUrl` guard can't see DNS rebinding (a public-looking
+// hostname that resolves to a private IP). Workers have no node:dns, so we verify
+// answers via Cloudflare DNS-over-HTTPS immediately before the probe. Policy:
+// block on a DETECTED private answer (real rebinding), but fail OPEN on a DoH
+// timeout/error/no-answer — operational surfaces are a curated, public_safe,
+// PR-reviewed allowlist that already passed the literal guard, so a DoH blip must
+// never falsely mark all health unsafe.
+function normalizedHostname(value) {
+  return String(value || "")
+    .trim()
+    .toLowerCase()
+    .replace(/^\[(.*)\]$/, "$1")
+    .replace(/\.$/, "");
+}
+
+function ipv4Octets(value) {
+  const parts = String(value || "").split(".");
+  if (parts.length !== 4) return null;
+  const octets = parts.map((part) => {
+    if (!/^\d+$/.test(part)) return null;
+    const n = Number(part);
+    return Number.isInteger(n) && n >= 0 && n <= 255 ? n : null;
+  });
+  return octets.every((n) => n !== null) ? octets : null;
+}
+
+function isUnsafeIpAddress(value) {
+  const host = normalizedHostname(value);
+  const v4 = ipv4Octets(host);
+  if (v4) {
+    const [a, b, c, d] = v4;
+    return (
+      a === 0 ||
+      a === 10 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      a === 127 ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 0 && c === 0) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      a >= 224 ||
+      (a === 255 && b === 255 && c === 255 && d === 255)
+    );
+  }
+  return (
+    host === "::" ||
+    host === "::1" ||
+    host.startsWith("100:") ||
+    host.startsWith("64:ff9b:1:") ||
+    host.startsWith("fc") ||
+    host.startsWith("fd") ||
+    /^fe[89ab][0-9a-f]:/i.test(host) ||
+    host.startsWith("ff")
+  );
+}
+
+function dnsAddressAnswers(body) {
+  if (!body || typeof body !== "object" || !Array.isArray(body.Answer)) {
+    return [];
+  }
+  return body.Answer.map((answer) => String(answer?.data || "").trim()).filter(
+    (data) => ipv4Octets(data) || normalizedHostname(data).includes(":"),
+  );
+}
+
+async function resolveDnsJson(host, recordType, fetchImpl, endpoint) {
+  const query = new URL(endpoint);
+  query.searchParams.set("name", host);
+  query.searchParams.set("type", recordType);
+  const response = await fetchImpl(query.toString(), {
+    headers: { accept: "application/dns-json" },
+    signal: AbortSignal.timeout(DNS_TIMEOUT_MS),
+  });
+  if (!response?.ok) {
+    return [];
+  }
+  return dnsAddressAnswers(await response.json());
+}
+
+export function workerResolvedUrlSafetyGuard({
+  fetchImpl = fetch,
+  dnsJsonEndpoint = DNS_JSON_ENDPOINT,
+} = {}) {
+  return async function isUnsafeWorkerResolvedUrl(value) {
+    if (isUnsafePublicUrl(value)) {
+      return true;
+    }
+    let host;
+    try {
+      host = normalizedHostname(new URL(value).hostname);
+    } catch {
+      return true;
+    }
+    if (ipv4Octets(host) || host.includes(":")) {
+      return isUnsafeIpAddress(host);
+    }
+    try {
+      const answers = (
+        await Promise.all(
+          DNS_RECORD_TYPES.map((type) =>
+            resolveDnsJson(host, type, fetchImpl, dnsJsonEndpoint),
+          ),
+        )
+      ).flat();
+      // Block only on a confirmed private answer (rebinding). No answer / DoH
+      // failure → fail open (handled by the catch below + the literal guard).
+      return answers.some(isUnsafeIpAddress);
+    } catch {
+      return false;
+    }
+  };
+}
 
 // Worker outbound-WebSocket connector for the WSS subtensor probe. Workers open
 // client sockets via fetch(Upgrade: websocket) → response.webSocket, NOT the
@@ -191,7 +309,11 @@ export async function runHealthProber(env, ctx, overrides = {}) {
     overrides.loadSurfaces || (() => loadOperationalSurfaces(env));
   const probe = overrides.probeSurface || coreProbeSurface;
   const probeOptions = overrides.probeOptions || {
-    isUnsafeUrl: overrides.isUnsafeUrl || isUnsafePublicUrl,
+    // DNS-aware SSRF guard (resolves via DoH; fail-open on DoH error). Falls back
+    // to the isomorphic literal guard when an override is supplied (tests).
+    isUnsafeUrl:
+      overrides.isUnsafeUrl ||
+      workerResolvedUrlSafetyGuard({ fetchImpl: overrides.safetyFetch }),
     connect: overrides.connect || workerWebSocketConnector(),
   };
   const concurrency = overrides.concurrency || PROBE_CONCURRENCY;

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -8,9 +8,93 @@ import {
   OPERATIONAL_SURFACES_PATH,
   pruneHealthHistory,
   runHealthProber,
+  workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
 } from "../src/health-prober.mjs";
 import { handleScheduled } from "../workers/api.mjs";
+
+describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
+  // DoH JSON mock: maps host → { A: [...], AAAA: [...] }.
+  const dohFetch = (records) => async (url) => {
+    const u = new URL(url);
+    const name = u.searchParams.get("name");
+    const type = u.searchParams.get("type");
+    const data = records[name]?.[type] || [];
+    return {
+      ok: true,
+      async json() {
+        return { Answer: data.map((d) => ({ data: d })) };
+      },
+    };
+  };
+
+  test("literal guard still blocks private literals + bad schemes", async () => {
+    const guard = workerResolvedUrlSafetyGuard({ fetchImpl: dohFetch({}) });
+    assert.equal(await guard("http://10.0.0.1/x"), true);
+    assert.equal(await guard("ftp://example.com"), true);
+    assert.equal(await guard("not a url"), true);
+  });
+
+  test("IP-literal hosts are checked directly without DNS", async () => {
+    let called = false;
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: async () => {
+        called = true;
+        return {
+          ok: true,
+          async json() {
+            return {};
+          },
+        };
+      },
+    });
+    // 8.8.8.8 is public, passes the literal guard, and is an IP literal.
+    assert.equal(await guard("https://8.8.8.8/x"), false);
+    assert.equal(called, false);
+  });
+
+  test("blocks a public hostname that resolves to a private IP (rebinding)", async () => {
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: dohFetch({ "evil.example.com": { A: ["10.1.2.3"] } }),
+    });
+    assert.equal(await guard("https://evil.example.com/x"), true);
+  });
+
+  test("blocks a private IPv6 AAAA answer", async () => {
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: dohFetch({ "v6.example.com": { AAAA: ["fd00::1"] } }),
+    });
+    assert.equal(await guard("https://v6.example.com/x"), true);
+  });
+
+  test("allows a hostname that resolves to a public IP", async () => {
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: dohFetch({ "ok.example.com": { A: ["93.184.216.34"] } }),
+    });
+    assert.equal(await guard("https://ok.example.com/x"), false);
+  });
+
+  test("fails OPEN on a DoH error (does not block all health)", async () => {
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: async () => {
+        throw new Error("DoH unreachable");
+      },
+    });
+    assert.equal(await guard("https://ok.example.com/x"), false);
+  });
+
+  test("fails OPEN on no DNS answer / non-ok DoH", async () => {
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: async () => ({
+        ok: false,
+        async json() {
+          return {};
+        },
+      }),
+    });
+    assert.equal(await guard("https://unknown.example.com/x"), false);
+  });
+});
 
 // --- mocks --------------------------------------------------------------------
 function makeDb({ priorStatus = [] } = {}) {
@@ -344,7 +428,9 @@ describe("workerWebSocketConnector", () => {
     const promise = connect("ws://node.example", [RPC_CALLS[0]], 1000);
     await Promise.resolve();
     await Promise.resolve();
-    const bytes = new TextEncoder().encode(JSON.stringify({ id: 1, result: 9 }));
+    const bytes = new TextEncoder().encode(
+      JSON.stringify({ id: 1, result: 9 }),
+    );
     socket.emit("message", { data: bytes });
     const results = await promise;
     assert.equal(results.get("a").result, 9);


### PR DESCRIPTION
Adopts two codex security findings (#251, #255), re-implemented on current `main` (the original PRs were stale against pre-OIDC / pre-coverage code).

## #251 — OIDC publish-job isolation
Build + `npm pack` run in the **unprivileged** validate job → tarball uploaded as an artifact. The `id-token: write` publish job **downloads the tarball** and runs `npm publish <tarball> --provenance --ignore-scripts` with **no npm install/build** — so a compromised build dependency can't reach the OIDC token. Validated locally (pack → `publish --dry-run` from the tarball works).

## #255 — DNS-aware prober SSRF guard
The literal hostname guard can't catch DNS rebinding (public hostname → private IP). Workers have no `node:dns`, so `workerResolvedUrlSafetyGuard` verifies answers via **Cloudflare DoH** right before probing. **Robustness improvement** over the original: blocks only on a *confirmed* private answer and **fails open** on DoH timeout/error/no-answer (4s timeout) — operational surfaces are a curated, public_safe, PR-reviewed allowlist that already passed the literal guard, so a DoH blip must never falsely mark all health unsafe.

## Verify
- +7 guard tests (rebinding A/AAAA, IP-literal short-circuit, fail-open paths). **586/586**, coverage gate green (98.6%).
- `validate:workflows` green; tarball-publish flow dry-run validated locally.

Closes #251, closes #255.