### PR TITLE
Preserve private DNS answers on mixed DoH failures (use Promise.allSettled)

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -132,20 +132,17 @@ export function workerResolvedUrlSafetyGuard({
     if (ipv4Octets(host) || host.includes(":")) {
       return isUnsafeIpAddress(host);
     }
-    try {
-      const answers = (
-        await Promise.all(
-          DNS_RECORD_TYPES.map((type) =>
-            resolveDnsJson(host, type, fetchImpl, dnsJsonEndpoint),
-          ),
-        )
-      ).flat();
-      // Block only on a confirmed private answer (rebinding). No answer / DoH
-      // failure → fail open (handled by the catch below + the literal guard).
-      return answers.some(isUnsafeIpAddress);
-    } catch {
-      return false;
-    }
+    const lookups = await Promise.allSettled(
+      DNS_RECORD_TYPES.map((type) =>
+        resolveDnsJson(host, type, fetchImpl, dnsJsonEndpoint),
+      ),
+    );
+    const answers = lookups.flatMap((lookup) =>
+      lookup.status === "fulfilled" ? lookup.value : [],
+    );
+    // Block on any confirmed private answer (rebinding), even if another RR
+    // lookup failed. No confirmed private answer / DoH failure → fail open.
+    return answers.some(isUnsafeIpAddress);
   };
 }
 

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -60,6 +60,25 @@ describe("workerResolvedUrlSafetyGuard (DNS-aware SSRF)", () => {
     assert.equal(await guard("https://evil.example.com/x"), true);
   });
 
+  test("blocks a private DNS answer when the other RR lookup fails", async () => {
+    const guard = workerResolvedUrlSafetyGuard({
+      fetchImpl: async (url) => {
+        const u = new URL(url);
+        const type = u.searchParams.get("type");
+        if (type === "AAAA") {
+          throw new Error("AAAA lookup timed out");
+        }
+        return {
+          ok: true,
+          async json() {
+            return { Answer: [{ data: "10.1.2.3" }] };
+          },
+        };
+      },
+    });
+    assert.equal(await guard("https://evil.example.com/x"), true);
+  });
+
   test("blocks a private IPv6 AAAA answer", async () => {
     const guard = workerResolvedUrlSafetyGuard({
       fetchImpl: dohFetch({ "v6.example.com": { AAAA: ["fd00::1"] } }),


### PR DESCRIPTION
### Motivation
- The Worker DNS-aware SSRF guard should block when any DNS RR lookup returns a confirmed private IP, but the previous implementation used `Promise.all` which discarded a private answer if the other RR lookup rejected. 
- Ensure the guard still "fails open" on DoH outages but does not allow an attacker to bypass blocking by causing one RR type to fail.

### Description
- Replace `Promise.all` with `Promise.allSettled` when performing A/AAAA DoH lookups in `workerResolvedUrlSafetyGuard` and aggregate only fulfilled results. 
- Return `true` (unsafe) if any fulfilled lookup contains a private IP, and keep the fail-open behavior when no confirmed private answers exist. 
- Add a regression test in `tests/health-prober.test.mjs` that simulates an A record returning `10.1.2.3` while the AAAA lookup throws, asserting the guard blocks the hostname.

### Testing
- Ran targeted tests with `npm test -- tests/health-prober.test.mjs` and the file-specific suite passed (55/55 tests). 
- Ran `npm run lint` and `npx prettier --check src/health-prober.mjs tests/health-prober.test.mjs`, both completed successfully. 
- Ran the full test suite with `npm test`; the overall suite failed due to unrelated preexisting artifact/API fixture errors (missing generated `public/` and `dist/` artifacts), but the targeted DNS guard tests introduced by this change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a3df81980832a9f75d16a24b49edd)