### PR TITLE
fix(health): preserve RPC endpoint artifact contract

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -153,29 +153,32 @@ export function subnetBadgeStatus(liveCurrent, netuid) {
 
 // Overlay live RPC/WSS health onto the static rpc-endpoints artifact.
 export function mergeRpcEndpoints(staticArtifact, liveRpcPool) {
-  if (!liveRpcPool || !Array.isArray(liveRpcPool.endpoints)) return null;
+  if (
+    !staticArtifact ||
+    !Array.isArray(staticArtifact.endpoints) ||
+    !liveRpcPool ||
+    !Array.isArray(liveRpcPool.endpoints)
+  ) {
+    return null;
+  }
   const liveById = new Map(liveRpcPool.endpoints.map((e) => [e.id, e]));
-  const endpoints = Array.isArray(staticArtifact?.endpoints)
-    ? staticArtifact.endpoints.map((endpoint) => {
-        const live = liveById.get(endpoint.id);
-        if (!live) return endpoint;
-        return {
-          ...endpoint,
-          status: live.status,
-          classification: live.classification,
-          latency_ms: live.latency_ms,
-          archive_support: live.archive_support ?? endpoint.archive_support,
-          health_source: "live-cron-prober",
-          health_stale: false,
-          observed_at: live.last_ok || liveRpcPool.last_run_at,
-          pool_eligible: live.pool_eligible,
-        };
-      })
-    : liveRpcPool.endpoints;
+  const endpoints = staticArtifact.endpoints.map((endpoint) => {
+    const live = liveById.get(endpoint.id);
+    if (!live) return endpoint;
+    return {
+      ...endpoint,
+      status: live.status,
+      classification: live.classification,
+      latency_ms: live.latency_ms,
+      archive_support: live.archive_support ?? endpoint.archive_support,
+      health_source: "probe-derived",
+      health_stale: false,
+      observed_at: live.last_ok || liveRpcPool.last_run_at,
+    };
+  });
   return {
-    schema_version: staticArtifact?.schema_version ?? 1,
-    contract_version: staticArtifact?.contract_version,
-    generated_at: liveRpcPool.generated_at,
+    ...staticArtifact,
+    generated_at: liveRpcPool.generated_at ?? staticArtifact.generated_at,
     source: "live-cron-prober",
     operational_observed_at: liveRpcPool.last_run_at || null,
     endpoints,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -89,11 +89,14 @@ describe("buildGlobalHealth", () => {
 });
 
 describe("mergeRpcEndpoints", () => {
-  test("overlays live status/eligibility by id", () => {
+  test("overlays live status by id while preserving the artifact contract", () => {
     const stat = {
+      schema_version: 1,
+      generated_at: "old",
+      summary: { total: 2 },
       endpoints: [
-        { id: "a", status: "ok", pool_eligible: true },
-        { id: "b", status: "ok", pool_eligible: true },
+        { id: "a", status: "ok", health_source: "probe-derived" },
+        { id: "b", status: "ok", health_source: "probe-derived" },
       ],
     };
     const live = {
@@ -110,11 +113,13 @@ describe("mergeRpcEndpoints", () => {
       ],
     };
     const merged = mergeRpcEndpoints(stat, live);
-    assert.equal(merged.endpoints.find((e) => e.id === "a").status, "failed");
-    assert.equal(
-      merged.endpoints.find((e) => e.id === "a").pool_eligible,
-      false,
-    );
+    const a = merged.endpoints.find((e) => e.id === "a");
+    assert.equal(a.status, "failed");
+    assert.equal(a.health_source, "probe-derived");
+    assert.equal(a.pool_eligible, undefined);
+    assert.deepEqual(merged.summary, { total: 2 });
+    assert.equal(merged.generated_at, "g");
+    assert.equal(merged.operational_observed_at, "r");
     assert.equal(merged.endpoints.find((e) => e.id === "b").status, "ok"); // no live → static
   });
 });
@@ -468,9 +473,9 @@ describe("mergeRpcEndpoints (additional paths)", () => {
     const stat = {
       schema_version: 3,
       contract_version: "cv",
-      endpoints: [
-        { id: "a", status: "ok", archive_support: true, pool_eligible: true },
-      ],
+      generated_at: "old",
+      summary: { total: 1 },
+      endpoints: [{ id: "a", status: "ok", archive_support: true }],
     };
     const live = {
       last_run_at: "r",
@@ -492,34 +497,29 @@ describe("mergeRpcEndpoints (additional paths)", () => {
     assert.equal(out.contract_version, "cv");
     const a = out.endpoints.find((e) => e.id === "a");
     assert.equal(a.archive_support, true); // fallback to static
-    assert.equal(a.health_source, "live-cron-prober");
+    assert.equal(a.health_source, "probe-derived");
     assert.equal(a.health_stale, false);
+    assert.equal(a.pool_eligible, undefined);
+    assert.deepEqual(out.summary, { total: 1 });
     assert.equal(a.observed_at, "r"); // last_ok null → last_run_at
   });
 
-  test("static WITHOUT an endpoints array → uses the live endpoint pool directly", () => {
+  test("static WITHOUT an endpoints array → null so caller serves static", () => {
     const live = {
       last_run_at: "r",
       generated_at: "g",
       endpoints: [{ id: "x", status: "ok" }],
     };
-    const out = mergeRpcEndpoints({ schema_version: 1 }, live);
-    assert.deepEqual(out.endpoints, live.endpoints);
-    assert.equal(out.source, "live-cron-prober");
-    assert.equal(out.operational_observed_at, "r");
+    assert.equal(mergeRpcEndpoints({ schema_version: 1 }, live), null);
   });
 
-  test("static null entirely → defaults + live endpoints", () => {
+  test("static null entirely → null so caller serves static", () => {
     const live = {
       last_run_at: null,
       generated_at: "g",
       endpoints: [{ id: "x", status: "ok" }],
     };
-    const out = mergeRpcEndpoints(null, live);
-    assert.equal(out.schema_version, 1);
-    assert.equal(out.contract_version, undefined);
-    assert.equal(out.operational_observed_at, null);
-    assert.deepEqual(out.endpoints, live.endpoints);
+    assert.equal(mergeRpcEndpoints(null, live), null);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The live RPC pool overlay previously constructed a replacement artifact that omitted required fields like `summary` and emitted `health_source: "live-cron-prober"` and `pool_eligible`, which violates the published `RpcEndpointsArtifact` and `RpcEndpoint` schemas.
- This could cause client-side schema validation failures and break consumers when the live KV snapshot is present.

### Description
- Change `mergeRpcEndpoints` to only apply live overlays when a valid static RPC endpoints artifact with an `endpoints` array is present, returning `null` otherwise so callers fall back to the static artifact.
- Preserve the static artifact shape by returning `...staticArtifact` and only updating `generated_at`, `source`, `operational_observed_at`, and the overlaid `endpoints` array.
- Keep overlaid endpoint `health_source` within the published enum by setting it to `"probe-derived"` and stop copying `pool_eligible` (a pool-only field) into public RPC endpoint objects.
- Update unit tests in `tests/health-serving.test.mjs` to assert that `summary` is preserved, `health_source` remains schema-compatible, `pool_eligible` is not leaked, and that missing/invalid static artifacts cause a `null` overlay.

### Testing
- Ran `npm test -- --run tests/health-serving.test.mjs` and the health-serving tests passed (`50` tests in the file passed).
- Ran `npm run lint` and ESLint completed without new errors for the modified files.
- Ran `npm run format:check` which reported pre-existing formatting warnings in unrelated files (`docs/adr/0001-r2-only-data-artifacts.md` and `tests/webhooks-worker.test.mjs`) but these are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a3f691634832aa0c026b0e94e8299)