### PR TITLE
feat(ai): stateless remote MCP server at POST /mcp (AI-2)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -172,6 +172,10 @@ jobs:
         if: steps.route.outputs.mode == 'full'
         run: npm run validate:api
 
+      - name: Validate MCP server
+        if: steps.route.outputs.mode == 'full'
+        run: npm run validate:mcp
+
       - name: Validate OpenAPI
         if: steps.route.outputs.mode == 'full'
         run: npm run validate:openapi

--- a/docs/adr/0003-ai-native-layer.md
+++ b/docs/adr/0003-ai-native-layer.md
@@ -1,0 +1,99 @@
+# ADR 0003 — AI-native layer (agent catalog, llms.txt, remote MCP server)
+
+- **Status:** Accepted — implementing. AI-1 (agent catalog + llms.txt) and AI-2 (MCP server) shipped; AI-3 (semantic search + `/ask`) planned.
+- **Date:** 2026-06-10
+- **Relates to:** ADR 0001 (R2-only data artifacts), ADR 0002 (live operational health).
+
+## Context
+
+metagraphed owns a unique niche: the **operational + integration layer** of
+Bittensor — what each of the ~129 subnets exposes (APIs, docs, schemas), whether
+those surfaces are healthy, and how to call them. Until now that data was
+**REST-only**: a human or program had to know the route shape, and there was no
+machine-first way for an AI agent or LLM to discover and integrate a subnet's
+services. The chain-data tools (taostats, the Bittensor SDK, RPC providers) do
+not cover this layer, and none of them are agent-consumable for _application_
+discovery.
+
+The registry is already generated, validated, and served as a stable artifact
+contract. The opportunity is to project that same data into the three shapes an
+AI consumer needs — a machine capability catalog, an `llms.txt` discovery file,
+and a Model Context Protocol server — **without** adding a second source of
+truth or touching the REST/RPC hot path.
+
+## Decision
+
+Add an AI-native layer as thin projections/wrappers over the existing artifact
+contract. No new authority, no new pipeline.
+
+1. **Agent capability catalog** (AI-1). `scripts/build-artifacts.mjs` joins
+   curated surfaces (`kind ∈ subnet-api/openapi/sse`) with the schema index and
+   endpoint health to emit `/metagraph/agent-catalog.json` (compact, committed
+   index of the subnets exposing callable services) and per-subnet
+   `/metagraph/agent-catalog/{netuid}.json` (R2; each service = capability, base
+   URL, auth, machine-readable schema URL/artifact, health, and
+   `eligibility.callable`). Served at `GET /api/v1/agent-catalog[/{netuid}]`
+   through the normal artifact-backed route harness.
+
+2. **`llms.txt`** (AI-1). The build emits `public/llms.txt`,
+   `public/llms-full.txt`, and `public/.well-known/llms.txt` from
+   `mergedSubnets` + `API_ROUTES`, served by ASSETS at the API root. Short index
+   plus an expanded per-subnet/route index so any LLM that ingests them answers
+   accurately about the ecosystem and links to the machine entrypoints
+   (OpenAPI, agent catalog, MCP).
+
+3. **Remote MCP server** (AI-2). `POST /mcp` is a **stateless** Model Context
+   Protocol server (Streamable HTTP, JSON-RPC 2.0) in `src/mcp-server.mjs`. It
+   exposes nine read-only tools (`search_subnets`,
+   `find_subnets_by_capability`, `get_subnet`, `get_subnet_health`,
+   `list_subnet_apis`, `get_api_schema`, `get_agent_catalog`,
+   `get_best_rpc_endpoint`, `registry_summary`) that are thin wrappers over the
+   same artifact/KV readers the REST routes use (injected as dependencies, so
+   the module stays pure and the resolution is identical).
+
+## Rationale for the key choices
+
+- **Hand-rolled MCP, not `@modelcontextprotocol/sdk` + a Durable Object.** The
+  registry is read-only and stateless, so the full Agents/MCP SDK (and the
+  Durable Object it implies for session state) is unjustified weight on a Worker
+  whose hot path is REST/RPC. JSON-RPC 2.0 over a single POST is small and fully
+  testable; we keep the bundle lean and the cold path unaffected. (If a future
+  tool needs server-initiated streaming or sessions, revisit.)
+- **Dependency-injected readers instead of extracting `readArtifact`.** The plan
+  considered moving `readArtifact`/`readHealthKv` into a shared
+  `src/artifact-reader.mjs`. That cluster pulls in `readR2`/`readAsset`/
+  `latestR2Key`/timeouts/logging and sits on the hot path; extracting it is a
+  large, risky refactor for no functional gain. Instead `handleMcpRequest`
+  receives `{ readArtifact, readHealthKv }` from `workers/api.mjs`. Same reuse,
+  zero hot-path churn, and the MCP module is unit-testable with stub deps.
+- **Catalog/llms.txt as build artifacts, MCP as a wrapper.** Both reuse the
+  generation and serving spine, inherit subset-commit discipline and the
+  artifact budgets, and add no new freshness class.
+
+## Validation
+
+- Agent-catalog routes go through the standard `validate-api` per-route harness
+  (+2 checks); the new schema components are AJV-validated, including the
+  per-subnet templated artifact.
+- The MCP server has its own contract validator, `npm run validate:mcp`
+  (lifecycle + one `tools/call` per tool against a cold local env), kept out of
+  the `validate-api` `checks.length === API_ROUTES.length` invariant because
+  `/mcp` is not artifact-backed.
+- `tests/mcp-server.test.mjs` unit-tests every tool and the JSON-RPC envelope
+  (notifications, batch, parse/transport errors, isError degradation) under the
+  ≥98%-line coverage gate.
+- `scripts/smoke-live-api.mjs` exercises the live MCP handshake + a `tools/call`
+  post-deploy.
+
+## Consequences
+
+- AI agents and LLM crawlers can discover and integrate Bittensor subnet
+  services directly; `/mcp` makes every MCP-capable assistant Bittensor-aware
+  with no custom code.
+- One more set of generated artifacts to keep reproducible (covered by
+  `ci-verify-submitted-artifacts` + subset-commit discipline).
+- `get_best_rpc_endpoint` depends on the live health KV (ADR 0002); with no live
+  snapshot it degrades to the build-time pool eligibility rather than failing.
+- AI-3 (semantic search + `/ask` via Vectorize + Workers AI) will add the only
+  pieces that need new bindings and a kill-switch; it is intentionally deferred
+  so the zero-binding agent surface ships first.

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -197,6 +197,12 @@ metagraph.sh regenerates its dataset on a ~6h schedule (ADR 0001), so the realti
 
 At publish time the dispatcher reads `changelog.json`, matches each subscription's filters, and `POST`s the change event signed with `HMAC-SHA256` (hex) over the raw body in the `x-metagraph-signature` header. Subscriptions auto-expire after 180 days of inactivity. The SSRF guard is best-effort and cannot prevent DNS rebinding; the dispatcher runs on GitHub-hosted runners with no access to the project's network, which bounds the residual risk.
 
+## Remote MCP Server (AI agents)
+
+`POST /mcp` is a stateless [Model Context Protocol](https://modelcontextprotocol.io) server (Streamable HTTP transport, JSON-RPC 2.0) that exposes the registry to AI agents (Claude Desktop/Code, Cursor, autonomous agents). It is read-only, so there is no session id, Durable Object, or server-initiated stream; `GET /mcp` returns `405`. The handler (`src/mcp-server.mjs`) is dispatched before the read-only method gate (it is POST-only, like the RPC proxy) and reuses the exact R2/ASSETS artifact resolution via injected readers, so MCP tools and REST routes always agree.
+
+Tools (thin wrappers over the artifact contract): `search_subnets`, `find_subnets_by_capability`, `get_subnet`, `get_subnet_health`, `list_subnet_apis`, `get_api_schema`, `get_agent_catalog`, `get_best_rpc_endpoint` (live-health-filtered), and `registry_summary`. `tools/call` returns the MCP result envelope (`content[]` text + `structuredContent`); argument and artifact failures degrade to an `isError: true` result rather than a transport error. The server is validated by `npm run validate:mcp` (lifecycle + one `tools/call` per tool against a cold local env) and smoke-checked live by `scripts/smoke-live-api.mjs`. The endpoint is excluded from the `validate-api` route-count invariant and is added to `assets.run_worker_first`.
+
 ## Current Domain Scope
 
 Use `metagraph.sh` for the current launch. Do not use `subnet.health` for v1 registry, status, badge, health, or probe contracts.

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "scan:public-safety": "node scripts/scan-public-safety.mjs",
     "validate:schemas": "node scripts/validate-schemas.mjs",
     "validate:api": "node scripts/validate-api.mjs",
+    "validate:mcp": "node scripts/validate-mcp.mjs",
     "validate:openapi": "node scripts/validate-openapi.mjs",
     "validate:types": "node scripts/validate-types.mjs",
     "validate:contract-drift": "node scripts/validate-contract-drift.mjs",

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -677,10 +677,7 @@ const AGENT_SERVICE_KINDS = new Set([
   "data-artifact",
 ]);
 const agentSchemaBySurfaceId = new Map(
-  (schemaIndexArtifact.schemas || []).map((entry) => [
-    entry.surface_id,
-    entry,
-  ]),
+  (schemaIndexArtifact.schemas || []).map((entry) => [entry.surface_id, entry]),
 );
 const agentEndpointBySurfaceId = new Map(
   endpointResources.endpoints
@@ -690,8 +687,7 @@ const agentEndpointBySurfaceId = new Map(
 function buildSubnetServices(netuid) {
   return (overviewSurfacesByNetuid.get(netuid) || [])
     .filter(
-      (surface) =>
-        AGENT_SERVICE_KINDS.has(surface.kind) && surface.public_safe,
+      (surface) => AGENT_SERVICE_KINDS.has(surface.kind) && surface.public_safe,
     )
     .map((surface) => {
       const endpoint = agentEndpointBySurfaceId.get(surface.id) || null;

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import { API_ROUTES } from "../src/contracts.mjs";
+import { MCP_TOOLS } from "../src/mcp-server.mjs";
 
 const DEFAULT_BASE_URL = "https://api.metagraph.sh";
 const baseUrl = normalizeBaseUrl(
@@ -165,6 +166,56 @@ assert.equal(
   "the /wss RPC route should return rpc_websocket_unsupported",
 );
 
+// Remote MCP server: the JSON-RPC handshake must work and expose every tool,
+// and a representative tools/call must resolve real registry data.
+const mcpInit = await fetchJson(`${baseUrl}/mcp`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18" },
+  }),
+});
+assert.equal(mcpInit.status, 200, "POST /mcp initialize must return HTTP 200");
+assert.equal(
+  mcpInit.body?.result?.serverInfo?.name,
+  "metagraphed",
+  "MCP initialize must identify the metagraphed server",
+);
+
+const mcpTools = await fetchJson(`${baseUrl}/mcp`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/list" }),
+});
+assert.equal(
+  mcpTools.body?.result?.tools?.length,
+  MCP_TOOLS.length,
+  `MCP tools/list must expose all ${MCP_TOOLS.length} tools`,
+);
+
+const mcpCall = await fetchJson(`${baseUrl}/mcp`, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "list_subnet_apis", arguments: { netuid: 7 } },
+  }),
+});
+assert.equal(
+  mcpCall.body?.result?.isError,
+  false,
+  "MCP list_subnet_apis(7) must succeed against live data",
+);
+assert.ok(
+  mcpCall.body?.result?.structuredContent?.service_count >= 1,
+  "MCP list_subnet_apis(7) must return at least one service",
+);
+
 console.log(
   JSON.stringify(
     {
@@ -172,6 +223,7 @@ console.log(
       status: "passed",
       api_route_count: apiChecks.length,
       raw_artifact_count: rawArtifactChecks.length,
+      mcp_tool_count: MCP_TOOLS.length,
       health_history_date: healthDate,
       checked_paths: results,
     },

--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -1,0 +1,171 @@
+// Contract validator for the remote MCP server at POST /mcp.
+//
+// Exercises the JSON-RPC lifecycle (initialize + tools/list) and a tools/call
+// for every registered tool against a cold local artifact env, asserting the
+// MCP result envelope shape. Kept separate from validate-api.mjs because the
+// MCP endpoint is not artifact-backed and must not enter the
+// `checks.length === API_ROUTES.length` invariant.
+import assert from "node:assert/strict";
+import { handleRequest } from "../workers/api.mjs";
+import { MCP_TOOLS } from "../src/mcp-server.mjs";
+import { createLocalArtifactEnv } from "./lib.mjs";
+
+const env = createLocalArtifactEnv();
+const MCP_URL = "https://api.metagraph.sh/mcp";
+
+async function mcp(payload, { method = "POST" } = {}) {
+  const request = new Request(MCP_URL, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: method === "POST" ? JSON.stringify(payload) : undefined,
+  });
+  const response = await handleRequest(request, env, {});
+  const text = await response.text();
+  return { status: response.status, body: text ? JSON.parse(text) : null };
+}
+
+async function call(name, args) {
+  const res = await mcp({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name, arguments: args },
+  });
+  assert.equal(res.status, 200, `${name}: expected HTTP 200`);
+  const result = res.body?.result;
+  assert.ok(result, `${name}: missing JSON-RPC result`);
+  assert.ok(
+    Array.isArray(result.content) && result.content.length > 0,
+    `${name}: result.content must be a non-empty array`,
+  );
+  assert.equal(
+    result.content[0].type,
+    "text",
+    `${name}: first content block must be text`,
+  );
+  return result;
+}
+
+async function callOk(name, args) {
+  const result = await call(name, args);
+  assert.equal(
+    result.isError,
+    false,
+    `${name}: expected a successful tool result, got isError=true (${result.content[0]?.text})`,
+  );
+  assert.equal(
+    typeof result.structuredContent,
+    "object",
+    `${name}: successful results must include structuredContent`,
+  );
+  return result.structuredContent;
+}
+
+// --- Lifecycle -------------------------------------------------------------
+
+const init = await mcp({
+  jsonrpc: "2.0",
+  id: 1,
+  method: "initialize",
+  params: { protocolVersion: "2025-06-18" },
+});
+assert.equal(init.status, 200, "initialize must return HTTP 200");
+assert.equal(
+  init.body.result.protocolVersion,
+  "2025-06-18",
+  "initialize must negotiate the requested protocol version",
+);
+assert.equal(init.body.result.serverInfo.name, "metagraphed");
+assert.ok(
+  init.body.result.capabilities.tools,
+  "must advertise tools capability",
+);
+
+const listed = await mcp({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+const tools = listed.body.result.tools;
+assert.equal(
+  tools.length,
+  MCP_TOOLS.length,
+  `tools/list must expose all ${MCP_TOOLS.length} registered tools`,
+);
+const listedNames = new Set(tools.map((tool) => tool.name));
+for (const tool of MCP_TOOLS) {
+  assert.ok(listedNames.has(tool.name), `tools/list missing ${tool.name}`);
+}
+for (const tool of tools) {
+  assert.equal(typeof tool.name, "string", "tool.name must be a string");
+  assert.equal(
+    typeof tool.description,
+    "string",
+    `${tool.name}: needs a description`,
+  );
+  assert.equal(
+    tool.inputSchema?.type,
+    "object",
+    `${tool.name}: inputSchema must be an object schema`,
+  );
+}
+
+// --- One tools/call per tool ----------------------------------------------
+
+await callOk("search_subnets", { query: "subnet", limit: 5 });
+await callOk("find_subnets_by_capability", { capability: "data", limit: 5 });
+const overview = await callOk("get_subnet", { netuid: 7 });
+assert.equal(overview.netuid ?? overview.subnet?.netuid ?? 7, 7);
+await callOk("get_subnet_health", { netuid: 7 });
+
+const apis = await callOk("list_subnet_apis", { netuid: 7 });
+assert.ok(
+  Array.isArray(apis.services),
+  "list_subnet_apis must return services[]",
+);
+
+await callOk("get_agent_catalog", {});
+await callOk("get_agent_catalog", { netuid: 7 });
+await callOk("registry_summary", {});
+
+// get_best_rpc_endpoint may legitimately return zero eligible endpoints on a
+// cold local build (no live probe KV), but must still succeed structurally.
+const rpc = await callOk("get_best_rpc_endpoint", { limit: 3 });
+assert.ok(
+  Array.isArray(rpc.endpoints),
+  "get_best_rpc_endpoint must return endpoints[]",
+);
+
+// Derive a real surface_id with a captured schema so get_api_schema resolves.
+const schemaService = apis.services.find((service) => service.schema_artifact);
+if (schemaService) {
+  const schema = await callOk("get_api_schema", {
+    surface_id: schemaService.surface_id,
+  });
+  assert.ok(schema, "get_api_schema must return the captured schema artifact");
+} else {
+  console.warn(
+    "validate-mcp: no SN7 service exposed a schema_artifact; skipped get_api_schema happy-path.",
+  );
+}
+
+// --- Negative paths --------------------------------------------------------
+
+const unknownMethod = await mcp({
+  jsonrpc: "2.0",
+  id: 9,
+  method: "no/such/method",
+});
+assert.equal(
+  unknownMethod.body.error.code,
+  -32601,
+  "unknown methods must return method-not-found",
+);
+
+const unknownTool = await call("not_a_real_tool", {});
+assert.equal(unknownTool.isError, true, "unknown tools must return isError");
+
+const getRejected = await mcp(null, { method: "GET" });
+assert.equal(getRejected.status, 405, "GET /mcp must be rejected with 405");
+
+console.log(
+  `MCP validation passed: ${MCP_TOOLS.length} tools, lifecycle + ${
+    schemaService ? "all" : "all-but-schema"
+  } tools/call.`,
+);

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1,0 +1,646 @@
+// Stateless remote MCP (Model Context Protocol) server for metagraphed.
+//
+// Exposes the operational registry to AI agents (Claude Desktop/Code, Cursor,
+// autonomous agents) over the MCP Streamable HTTP transport at `POST /mcp`.
+// The registry is read-only, so the server is fully stateless: no session id,
+// no Durable Object, no server-initiated streams. We hand-roll the JSON-RPC 2.0
+// envelope rather than pulling in `@modelcontextprotocol/sdk` so the Worker
+// bundle stays lean and the hot REST/RPC path is untouched.
+//
+// Artifact/KV reads are injected (`deps.readArtifact`, `deps.readHealthKv`) so
+// this module is pure and unit-testable, and so it reuses the exact same
+// R2/ASSETS resolution the REST routes use.
+import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
+import { KV_HEALTH_RPC_POOL } from "./health-prober.mjs";
+import { overlayRpcPoolEligibility } from "./health-serving.mjs";
+
+// Protocol versions we understand. We echo the client's requested version when
+// it is one of these, otherwise we answer with our latest.
+export const MCP_PROTOCOL_VERSIONS = ["2025-06-18", "2025-03-26", "2024-11-05"];
+const MCP_LATEST_PROTOCOL = MCP_PROTOCOL_VERSIONS[0];
+
+export const MCP_SERVER_INFO = {
+  name: "metagraphed",
+  title: "metagraphed — Bittensor subnet operational registry",
+  version: CONTRACT_VERSION,
+};
+
+const MCP_INSTRUCTIONS =
+  "metagraphed is the operational + integration registry for Bittensor subnets: " +
+  "what each of the ~129 subnets exposes (APIs, docs, schemas), whether those " +
+  "surfaces are healthy, and how to call them. Use search_subnets / " +
+  "find_subnets_by_capability to discover, get_subnet / get_subnet_health for " +
+  "detail, list_subnet_apis + get_api_schema to integrate a subnet's API, and " +
+  "get_best_rpc_endpoint for a live-healthy Bittensor base-layer RPC endpoint. " +
+  "All data is public and read-only.";
+
+const JSONRPC_VERSION = "2.0";
+
+// JSON-RPC error codes (subset of the spec we emit).
+const RPC_PARSE_ERROR = -32700;
+const RPC_INVALID_REQUEST = -32600;
+const RPC_METHOD_NOT_FOUND = -32601;
+const RPC_INTERNAL_ERROR = -32603;
+
+// A tool-level failure: surfaced to the client as a successful tools/call result
+// with isError:true (per MCP), not as a transport JSON-RPC error.
+function toolError(code, message) {
+  const error = new Error(message);
+  error.toolError = true;
+  error.code = code;
+  return error;
+}
+
+async function loadArtifactData(ctx, artifactPath) {
+  const result = await ctx.readArtifact(ctx.env, artifactPath);
+  if (!result || !result.ok) {
+    throw toolError(
+      result?.code || "artifact_unavailable",
+      result?.message || `Artifact is not available: ${artifactPath}`,
+    );
+  }
+  return result.data;
+}
+
+function requireNetuid(args) {
+  const netuid = args?.netuid;
+  if (!Number.isInteger(netuid) || netuid < 0) {
+    throw toolError(
+      "invalid_params",
+      "Argument `netuid` must be a non-negative integer.",
+    );
+  }
+  return netuid;
+}
+
+function requireString(args, key) {
+  const value = args?.[key];
+  if (typeof value !== "string" || value.trim() === "") {
+    throw toolError(
+      "invalid_params",
+      `Argument \`${key}\` must be a non-empty string.`,
+    );
+  }
+  return value.trim();
+}
+
+function clampLimit(value, fallback, max) {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.max(1, Math.min(max, Math.floor(value)));
+}
+
+// Score a search document against the query terms: how many distinct terms
+// appear as substrings of the document's title/subtitle/tokens haystack.
+function scoreDocument(doc, terms) {
+  const haystack = [
+    doc.title,
+    doc.subtitle,
+    doc.slug,
+    ...(Array.isArray(doc.tokens) ? doc.tokens : []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+  let score = 0;
+  for (const term of terms) {
+    if (haystack.includes(term)) score += 1;
+  }
+  return score;
+}
+
+function queryTerms(query) {
+  return query
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((term) => term.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Tool registry. Each tool is a thin wrapper over artifact/KV reads.
+// ---------------------------------------------------------------------------
+
+export const MCP_TOOLS = [
+  {
+    name: "search_subnets",
+    title: "Search Bittensor subnets",
+    description:
+      "Full-text search across Bittensor subnets by name, slug, capability, " +
+      "or keyword. Returns ranked matches with netuid, slug, title, and a one-" +
+      "line description. Use this to discover subnets before fetching detail.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search terms, e.g. 'image generation' or 'scraping'.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max results (1-50, default 10).",
+          minimum: 1,
+          maximum: 50,
+        },
+      },
+      required: ["query"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const query = requireString(args, "query");
+      const limit = clampLimit(args?.limit, 10, 50);
+      const index = await loadArtifactData(ctx, "/metagraph/search.json");
+      const terms = queryTerms(query);
+      const docs = Array.isArray(index.documents) ? index.documents : [];
+      const ranked = docs
+        .filter((doc) => doc.type === "subnet")
+        .map((doc) => ({ doc, score: scoreDocument(doc, terms) }))
+        .filter((entry) => entry.score > 0)
+        .sort((a, b) => b.score - a.score || a.doc.netuid - b.doc.netuid)
+        .slice(0, limit)
+        .map(({ doc }) => ({
+          netuid: doc.netuid,
+          slug: doc.slug,
+          title: doc.title,
+          description: doc.subtitle || null,
+          url: `https://${ctx.domain}/api/v1/subnets/${doc.netuid}/overview`,
+        }));
+      return { query, count: ranked.length, results: ranked };
+    },
+  },
+  {
+    name: "find_subnets_by_capability",
+    title: "Find subnets by capability",
+    description:
+      "Find Bittensor subnets that expose callable services (APIs, OpenAPI " +
+      "schemas, SSE streams) matching a capability or category. Returns only " +
+      "subnets an agent can actually call, ranked by callable-service count. " +
+      "Pair with list_subnet_apis to get concrete endpoints.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        capability: {
+          type: "string",
+          description:
+            "Capability/category to match, e.g. 'inference', 'data', 'bitcoin'.",
+        },
+        limit: {
+          type: "integer",
+          description: "Max results (1-50, default 10).",
+          minimum: 1,
+          maximum: 50,
+        },
+      },
+      required: ["capability"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const capability = requireString(args, "capability");
+      const limit = clampLimit(args?.limit, 10, 50);
+      const catalog = await loadArtifactData(
+        ctx,
+        "/metagraph/agent-catalog.json",
+      );
+      const terms = queryTerms(capability);
+      const subnets = Array.isArray(catalog.subnets) ? catalog.subnets : [];
+      const ranked = subnets
+        .map((subnet) => {
+          const haystack = [
+            subnet.name,
+            subnet.slug,
+            ...(Array.isArray(subnet.categories) ? subnet.categories : []),
+            ...(Array.isArray(subnet.service_kinds)
+              ? subnet.service_kinds
+              : []),
+          ]
+            .filter(Boolean)
+            .join(" ")
+            .toLowerCase();
+          let score = 0;
+          for (const term of terms) if (haystack.includes(term)) score += 1;
+          return { subnet, score };
+        })
+        .filter((entry) => entry.score > 0 && entry.subnet.callable_count > 0)
+        .sort(
+          (a, b) =>
+            b.score - a.score ||
+            b.subnet.callable_count - a.subnet.callable_count,
+        )
+        .slice(0, limit)
+        .map(({ subnet }) => ({
+          netuid: subnet.netuid,
+          slug: subnet.slug,
+          name: subnet.name,
+          categories: subnet.categories || [],
+          service_kinds: subnet.service_kinds || [],
+          callable_count: subnet.callable_count,
+        }));
+      return { capability, count: ranked.length, results: ranked };
+    },
+  },
+  {
+    name: "get_subnet",
+    title: "Get subnet overview",
+    description:
+      "Fetch the composed overview for one subnet by netuid: identity, " +
+      "completeness, curated surfaces, health summary, gaps, and counts.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      return loadArtifactData(ctx, `/metagraph/overview/${netuid}.json`);
+    },
+  },
+  {
+    name: "get_subnet_health",
+    title: "Get subnet health",
+    description:
+      "Fetch live operational health for one subnet's surfaces (probed every " +
+      "~2 minutes): per-surface status, latency, and last-ok timestamps.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      return loadArtifactData(ctx, `/metagraph/health/subnets/${netuid}.json`);
+    },
+  },
+  {
+    name: "list_subnet_apis",
+    title: "List a subnet's callable services",
+    description:
+      "List the callable services (subnet-api, openapi, sse) one subnet " +
+      "exposes, each with base URL, auth requirement, machine-readable schema " +
+      "URL, current health, and call eligibility. The agent integration path.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: { type: "integer", description: "Subnet netuid.", minimum: 0 },
+      },
+      required: ["netuid"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const netuid = requireNetuid(args);
+      const data = await loadArtifactData(
+        ctx,
+        `/metagraph/agent-catalog/${netuid}.json`,
+      );
+      return {
+        netuid: data.netuid ?? netuid,
+        service_count: Array.isArray(data.services) ? data.services.length : 0,
+        services: data.services || [],
+      };
+    },
+  },
+  {
+    name: "get_api_schema",
+    title: "Get a surface's API schema",
+    description:
+      "Fetch the captured machine-readable OpenAPI/Swagger schema snapshot for " +
+      "a subnet surface by its surface_id (from list_subnet_apis). Use this to " +
+      "generate a typed client or understand a subnet API's endpoints.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        surface_id: {
+          type: "string",
+          description: "Surface id, e.g. '7:subnet-api:allways'.",
+        },
+      },
+      required: ["surface_id"],
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const surfaceId = requireString(args, "surface_id");
+      // surface_id is part of an R2 key path; reject anything that could escape
+      // the schemas/ namespace.
+      if (!/^[A-Za-z0-9._:-]+$/.test(surfaceId)) {
+        throw toolError(
+          "invalid_params",
+          "surface_id contains invalid characters.",
+        );
+      }
+      return loadArtifactData(ctx, `/metagraph/schemas/${surfaceId}.json`);
+    },
+  },
+  {
+    name: "get_agent_catalog",
+    title: "Get the agent capability catalog",
+    description:
+      "Fetch the machine-readable agent capability catalog. With no argument " +
+      "returns the global index of subnets exposing callable services; with a " +
+      "netuid returns that subnet's full per-service catalog.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        netuid: {
+          type: "integer",
+          description: "Optional subnet netuid for the per-subnet catalog.",
+          minimum: 0,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      if (args?.netuid === undefined || args?.netuid === null) {
+        return loadArtifactData(ctx, "/metagraph/agent-catalog.json");
+      }
+      const netuid = requireNetuid(args);
+      return loadArtifactData(ctx, `/metagraph/agent-catalog/${netuid}.json`);
+    },
+  },
+  {
+    name: "get_best_rpc_endpoint",
+    title: "Get the best Bittensor RPC endpoint",
+    description:
+      "Return the best currently-eligible Bittensor base-layer RPC/WSS " +
+      "endpoint(s), scored and filtered by live health (down endpoints are " +
+      "excluded). Use this to pick a node endpoint for on-chain reads.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        limit: {
+          type: "integer",
+          description: "Max endpoints to return (1-10, default 3).",
+          minimum: 1,
+          maximum: 10,
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const limit = clampLimit(args?.limit, 3, 10);
+      const poolData = await loadArtifactData(ctx, "/metagraph/rpc/pools.json");
+      const liveRpcPool = ctx.readHealthKv
+        ? await ctx.readHealthKv(ctx.env, KV_HEALTH_RPC_POOL)
+        : null;
+      const pools =
+        poolData.pools && typeof poolData.pools === "object"
+          ? poolData.pools
+          : {};
+      const candidates = [];
+      for (const [network, pool] of Object.entries(pools)) {
+        const overlaid = overlayRpcPoolEligibility(pool, liveRpcPool);
+        for (const endpoint of overlaid.endpoints || []) {
+          if (!endpoint.pool_eligible) continue;
+          candidates.push({ network, ...endpoint });
+        }
+      }
+      candidates.sort(
+        (a, b) =>
+          (b.score || 0) - (a.score || 0) ||
+          (a.latency_ms ?? Infinity) - (b.latency_ms ?? Infinity),
+      );
+      const endpoints = candidates.slice(0, limit).map((endpoint) => ({
+        id: endpoint.id,
+        network: endpoint.network,
+        provider: endpoint.provider,
+        kind: endpoint.kind,
+        score: endpoint.score ?? null,
+        latency_ms: endpoint.latency_ms ?? null,
+        status: endpoint.status ?? null,
+        health_source: endpoint.health_source ?? null,
+      }));
+      return {
+        eligible_count: candidates.length,
+        endpoints,
+        live_health: Boolean(liveRpcPool),
+      };
+    },
+  },
+  {
+    name: "registry_summary",
+    title: "Get the registry-wide summary",
+    description:
+      "Fetch the registry-wide summary: overall completeness, the most " +
+      "complete subnets, coverage-level counts, and the latest registry " +
+      "changes. A fast orientation for the whole Bittensor application layer.",
+    inputSchema: {
+      type: "object",
+      properties: {},
+      additionalProperties: false,
+    },
+    async handler(_args, ctx) {
+      return loadArtifactData(ctx, "/metagraph/registry-summary.json");
+    },
+  },
+];
+
+const TOOLS_BY_NAME = new Map(MCP_TOOLS.map((tool) => [tool.name, tool]));
+
+export function listToolDefinitions() {
+  return MCP_TOOLS.map((tool) => ({
+    name: tool.name,
+    title: tool.title,
+    description: tool.description,
+    inputSchema: tool.inputSchema,
+  }));
+}
+
+function negotiateProtocol(requested) {
+  return MCP_PROTOCOL_VERSIONS.includes(requested)
+    ? requested
+    : MCP_LATEST_PROTOCOL;
+}
+
+async function callTool(params, ctx) {
+  const name = params?.name;
+  const tool = typeof name === "string" ? TOOLS_BY_NAME.get(name) : undefined;
+  if (!tool) {
+    return {
+      content: [{ type: "text", text: `Unknown tool: ${String(name)}` }],
+      isError: true,
+    };
+  }
+  try {
+    const data = await tool.handler(params?.arguments || {}, ctx);
+    return {
+      content: [{ type: "text", text: JSON.stringify(data) }],
+      structuredContent: data,
+      isError: false,
+    };
+  } catch (error) {
+    if (error?.toolError) {
+      return {
+        content: [{ type: "text", text: `${error.code}: ${error.message}` }],
+        isError: true,
+      };
+    }
+    throw error;
+  }
+}
+
+// Dispatch a single JSON-RPC message. Returns the response object for requests,
+// or null for notifications (no id).
+async function dispatchMessage(message, ctx) {
+  const isNotification =
+    message === null ||
+    typeof message !== "object" ||
+    message.id === undefined ||
+    message.id === null;
+  const id = isNotification ? null : message.id;
+
+  if (
+    message === null ||
+    typeof message !== "object" ||
+    message.jsonrpc !== JSONRPC_VERSION ||
+    typeof message.method !== "string"
+  ) {
+    if (isNotification) return null;
+    return rpcError(id, RPC_INVALID_REQUEST, "Invalid JSON-RPC request.");
+  }
+
+  const { method, params } = message;
+
+  try {
+    switch (method) {
+      case "initialize": {
+        const result = {
+          protocolVersion: negotiateProtocol(params?.protocolVersion),
+          capabilities: { tools: { listChanged: false } },
+          serverInfo: MCP_SERVER_INFO,
+          instructions: MCP_INSTRUCTIONS,
+        };
+        return isNotification ? null : rpcResult(id, result);
+      }
+      case "ping":
+        return isNotification ? null : rpcResult(id, {});
+      case "tools/list":
+        return isNotification
+          ? null
+          : rpcResult(id, { tools: listToolDefinitions() });
+      case "tools/call": {
+        const result = await callTool(params, ctx);
+        return isNotification ? null : rpcResult(id, result);
+      }
+      // Capabilities we do not advertise but answer gracefully so strict
+      // clients that probe them do not error.
+      case "resources/list":
+        return isNotification ? null : rpcResult(id, { resources: [] });
+      case "resources/templates/list":
+        return isNotification ? null : rpcResult(id, { resourceTemplates: [] });
+      case "prompts/list":
+        return isNotification ? null : rpcResult(id, { prompts: [] });
+      case "notifications/initialized":
+      case "notifications/cancelled":
+        return null;
+      default:
+        return isNotification
+          ? null
+          : rpcError(id, RPC_METHOD_NOT_FOUND, `Unknown method: ${method}`);
+    }
+  } catch (error) {
+    if (isNotification) return null;
+    return rpcError(
+      id,
+      RPC_INTERNAL_ERROR,
+      error?.message || "Internal error.",
+    );
+  }
+}
+
+function rpcResult(id, result) {
+  return { jsonrpc: JSONRPC_VERSION, id, result };
+}
+
+function rpcError(id, code, message) {
+  return { jsonrpc: JSONRPC_VERSION, id, error: { code, message } };
+}
+
+// Build the MCP processing context from the Worker request + injected deps.
+function buildContext(request, env, deps) {
+  let domain;
+  try {
+    domain = new URL(request.url).host || PRIMARY_DOMAIN;
+  } catch {
+    domain = PRIMARY_DOMAIN;
+  }
+  return {
+    env,
+    domain,
+    readArtifact: deps.readArtifact,
+    readHealthKv: deps.readHealthKv,
+  };
+}
+
+const MCP_HEADERS = {
+  "content-type": "application/json; charset=utf-8",
+  "access-control-allow-origin": "*",
+  "cache-control": "no-store",
+};
+
+function jsonResponse(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: MCP_HEADERS,
+  });
+}
+
+// Entry point wired into the Worker at `POST /mcp`. `deps` injects the shared
+// artifact/KV readers from workers/api.mjs.
+export async function handleMcpRequest(request, env, deps = {}) {
+  if (request.method !== "POST") {
+    return new Response(
+      JSON.stringify({
+        jsonrpc: JSONRPC_VERSION,
+        id: null,
+        error: {
+          code: RPC_INVALID_REQUEST,
+          message:
+            "The MCP endpoint accepts POST JSON-RPC requests over the " +
+            "Streamable HTTP transport.",
+        },
+      }),
+      { status: 405, headers: { ...MCP_HEADERS, allow: "POST, OPTIONS" } },
+    );
+  }
+
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return jsonResponse(
+      rpcError(null, RPC_PARSE_ERROR, "Request body is not valid JSON."),
+      400,
+    );
+  }
+
+  const ctx = buildContext(request, env, deps);
+
+  // Legacy JSON-RPC batch (array). MCP 2025-06-18 removed batching, but we stay
+  // lenient for older clients.
+  if (Array.isArray(body)) {
+    if (body.length === 0) {
+      return jsonResponse(
+        rpcError(null, RPC_INVALID_REQUEST, "Empty JSON-RPC batch."),
+        400,
+      );
+    }
+    const responses = [];
+    for (const message of body) {
+      const response = await dispatchMessage(message, ctx);
+      if (response) responses.push(response);
+    }
+    if (responses.length === 0) {
+      return new Response(null, { status: 202, headers: MCP_HEADERS });
+    }
+    return jsonResponse(responses);
+  }
+
+  const response = await dispatchMessage(body, ctx);
+  if (!response) {
+    // Notification(s) only — nothing to return.
+    return new Response(null, { status: 202, headers: MCP_HEADERS });
+  }
+  return jsonResponse(response);
+}

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1,0 +1,620 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  MCP_TOOLS,
+  MCP_PROTOCOL_VERSIONS,
+  MCP_SERVER_INFO,
+  listToolDefinitions,
+  handleMcpRequest,
+} from "../src/mcp-server.mjs";
+import { KV_HEALTH_RPC_POOL } from "../src/health-prober.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+import { handleRequest } from "../workers/api.mjs";
+
+const MCP_URL = "https://api.metagraph.sh/mcp";
+
+// Build injectable deps with controlled artifact + KV responses.
+function makeDeps(artifacts = {}, kv = {}) {
+  return {
+    readArtifact(_env, path) {
+      if (Object.prototype.hasOwnProperty.call(artifacts, path)) {
+        return Promise.resolve({
+          ok: true,
+          data: artifacts[path],
+          source: "test",
+          storage_tier: "git",
+        });
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        code: "artifact_not_found",
+        message: `Artifact not found: ${path}`,
+      });
+    },
+    readHealthKv(_env, key) {
+      return Promise.resolve(
+        Object.prototype.hasOwnProperty.call(kv, key) ? kv[key] : null,
+      );
+    },
+  };
+}
+
+async function rpc(
+  payload,
+  { deps = makeDeps(), env = {}, method = "POST" } = {},
+) {
+  const request = new Request(MCP_URL, {
+    method,
+    headers: { "content-type": "application/json" },
+    body: method === "POST" ? JSON.stringify(payload) : undefined,
+  });
+  const response = await handleMcpRequest(request, env, deps);
+  const text = await response.text();
+  return {
+    status: response.status,
+    headers: response.headers,
+    body: text ? JSON.parse(text) : null,
+  };
+}
+
+function callTool(name, args, opts) {
+  return rpc(
+    {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    },
+    opts,
+  );
+}
+
+describe("MCP tool registry", () => {
+  test("every tool has a unique name, description, and object inputSchema", () => {
+    const names = new Set();
+    for (const tool of MCP_TOOLS) {
+      assert.equal(typeof tool.name, "string");
+      assert.ok(!names.has(tool.name), `duplicate tool ${tool.name}`);
+      names.add(tool.name);
+      assert.ok(tool.description.length > 20);
+      assert.equal(tool.inputSchema.type, "object");
+      assert.equal(typeof tool.handler, "function");
+    }
+    assert.equal(names.size, MCP_TOOLS.length);
+  });
+
+  test("listToolDefinitions exposes name/title/description/inputSchema only", () => {
+    const defs = listToolDefinitions();
+    assert.equal(defs.length, MCP_TOOLS.length);
+    for (const def of defs) {
+      assert.deepEqual(Object.keys(def).sort(), [
+        "description",
+        "inputSchema",
+        "name",
+        "title",
+      ]);
+    }
+  });
+});
+
+describe("MCP JSON-RPC lifecycle", () => {
+  test("initialize echoes a supported protocol version", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "2025-03-26" },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(res.body.result.protocolVersion, "2025-03-26");
+    assert.deepEqual(res.body.result.serverInfo, MCP_SERVER_INFO);
+    assert.ok(res.body.result.capabilities.tools);
+    assert.ok(res.body.result.instructions.includes("Bittensor"));
+  });
+
+  test("initialize falls back to latest for an unknown protocol version", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "initialize",
+      params: { protocolVersion: "1999-01-01" },
+    });
+    assert.equal(res.body.result.protocolVersion, MCP_PROTOCOL_VERSIONS[0]);
+  });
+
+  test("ping returns an empty result", async () => {
+    const res = await rpc({ jsonrpc: "2.0", id: 7, method: "ping" });
+    assert.deepEqual(res.body.result, {});
+  });
+
+  test("tools/list returns all registered tools", async () => {
+    const res = await rpc({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    assert.equal(res.body.result.tools.length, MCP_TOOLS.length);
+  });
+
+  test("resources/list, templates, and prompts/list answer empty", async () => {
+    const resources = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "resources/list",
+    });
+    assert.deepEqual(resources.body.result, { resources: [] });
+    const templates = await rpc({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "resources/templates/list",
+    });
+    assert.deepEqual(templates.body.result, { resourceTemplates: [] });
+    const prompts = await rpc({
+      jsonrpc: "2.0",
+      id: 3,
+      method: "prompts/list",
+    });
+    assert.deepEqual(prompts.body.result, { prompts: [] });
+  });
+
+  test("notifications return 202 with no body", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      method: "notifications/initialized",
+    });
+    assert.equal(res.status, 202);
+    assert.equal(res.body, null);
+  });
+
+  test("notifications/cancelled is accepted silently", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      method: "notifications/cancelled",
+    });
+    assert.equal(res.status, 202);
+  });
+
+  test("unknown method on a request returns method-not-found", async () => {
+    const res = await rpc({ jsonrpc: "2.0", id: 9, method: "does/not/exist" });
+    assert.equal(res.body.error.code, -32601);
+  });
+
+  test("unknown method as a notification is dropped (202)", async () => {
+    const res = await rpc({ jsonrpc: "2.0", method: "does/not/exist" });
+    assert.equal(res.status, 202);
+  });
+
+  test("invalid jsonrpc envelope returns invalid-request", async () => {
+    const res = await rpc({ id: 1, method: "ping" });
+    assert.equal(res.body.error.code, -32600);
+  });
+
+  test("invalid envelope without id is dropped as a notification", async () => {
+    const res = await rpc({ method: "ping" });
+    assert.equal(res.status, 202);
+  });
+});
+
+describe("MCP transport handling", () => {
+  test("GET is rejected with 405 and an Allow header", async () => {
+    const res = await rpc(null, { method: "GET" });
+    assert.equal(res.status, 405);
+    assert.equal(res.headers.get("allow"), "POST, OPTIONS");
+    assert.equal(res.body.error.code, -32600);
+  });
+
+  test("non-JSON body returns a parse error", async () => {
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{not json",
+    });
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 400);
+    const body = await response.json();
+    assert.equal(body.error.code, -32700);
+  });
+
+  test("a batch processes each message and drops notifications", async () => {
+    const res = await rpc([
+      { jsonrpc: "2.0", id: 1, method: "ping" },
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+      { jsonrpc: "2.0", id: 2, method: "tools/list" },
+    ]);
+    assert.ok(Array.isArray(res.body));
+    assert.equal(res.body.length, 2);
+    assert.equal(res.body[0].id, 1);
+    assert.equal(res.body[1].id, 2);
+  });
+
+  test("a notification-only batch returns 202", async () => {
+    const res = await rpc([
+      { jsonrpc: "2.0", method: "notifications/initialized" },
+    ]);
+    assert.equal(res.status, 202);
+  });
+
+  test("an empty batch is an invalid request", async () => {
+    const res = await rpc([]);
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, -32600);
+  });
+
+  test("handleMcpRequest defaults deps to an empty object", async () => {
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+    const response = await handleMcpRequest(request, {});
+    assert.equal(response.status, 200);
+  });
+});
+
+describe("MCP tools (injected deps)", () => {
+  const deps = makeDeps(
+    {
+      "/metagraph/search.json": {
+        documents: [
+          {
+            type: "subnet",
+            netuid: 7,
+            slug: "allways",
+            title: "Allways",
+            subtitle: "Bitcoin data",
+            tokens: ["bitcoin", "data", "api"],
+          },
+          {
+            type: "subnet",
+            netuid: 12,
+            slug: "compute",
+            title: "Compute",
+            subtitle: "GPU compute",
+            tokens: ["gpu", "compute"],
+          },
+          {
+            type: "provider",
+            netuid: null,
+            slug: "p",
+            title: "Provider",
+            tokens: ["bitcoin"],
+          },
+        ],
+      },
+      "/metagraph/agent-catalog.json": {
+        subnets: [
+          {
+            netuid: 7,
+            slug: "allways",
+            name: "Allways",
+            categories: ["bitcoin", "data"],
+            service_kinds: ["subnet-api", "openapi"],
+            callable_count: 13,
+          },
+          {
+            netuid: 12,
+            slug: "compute",
+            name: "Compute",
+            categories: ["gpu"],
+            service_kinds: ["subnet-api"],
+            callable_count: 0,
+          },
+        ],
+      },
+      "/metagraph/agent-catalog/7.json": {
+        netuid: 7,
+        services: [{ surface_id: "7:subnet-api:allways", kind: "subnet-api" }],
+      },
+      "/metagraph/overview/7.json": { netuid: 7, name: "Allways" },
+      "/metagraph/health/subnets/7.json": {
+        netuid: 7,
+        summary: { status: "ok" },
+      },
+      "/metagraph/schemas/7:subnet-api:allways.json": {
+        surface_id: "7:subnet-api:allways",
+        openapi: "3.1.0",
+      },
+      "/metagraph/registry-summary.json": { completeness: 0.42 },
+      "/metagraph/rpc/pools.json": {
+        pools: {
+          0: {
+            endpoints: [
+              {
+                id: "a",
+                provider: "x",
+                kind: "subtensor-rpc",
+                score: 90,
+                pool_eligible: true,
+                latency_ms: 120,
+              },
+              {
+                id: "b",
+                provider: "y",
+                kind: "subtensor-rpc",
+                score: 95,
+                pool_eligible: true,
+                latency_ms: 80,
+              },
+              {
+                id: "c",
+                provider: "z",
+                kind: "subtensor-rpc",
+                score: 99,
+                pool_eligible: false,
+              },
+            ],
+          },
+        },
+      },
+    },
+    {
+      [KV_HEALTH_RPC_POOL]: {
+        endpoints: [
+          { id: "b", status: "ok", latency_ms: 70, consecutive_failures: 0 },
+        ],
+      },
+    },
+  );
+
+  test("search_subnets ranks subnet documents by term overlap", async () => {
+    const res = await callTool(
+      "search_subnets",
+      { query: "bitcoin data", limit: 5 },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.results[0].netuid, 7);
+    assert.ok(out.results[0].url.includes("/api/v1/subnets/7/overview"));
+    assert.ok(out.results.every((r) => r.netuid !== null));
+  });
+
+  test("search_subnets clamps the limit and reports zero matches", async () => {
+    const res = await callTool(
+      "search_subnets",
+      { query: "nonexistentxyz", limit: 999 },
+      { deps },
+    );
+    assert.equal(res.body.result.structuredContent.count, 0);
+  });
+
+  test("search_subnets requires a non-empty query", async () => {
+    const res = await callTool("search_subnets", { query: "   " }, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.ok(res.body.result.content[0].text.includes("query"));
+  });
+
+  test("find_subnets_by_capability returns only callable subnets", async () => {
+    const res = await callTool(
+      "find_subnets_by_capability",
+      { capability: "bitcoin" },
+      { deps },
+    );
+    const out = res.body.result.structuredContent;
+    assert.equal(out.count, 1);
+    assert.equal(out.results[0].netuid, 7);
+  });
+
+  test("find_subnets_by_capability with no match returns empty", async () => {
+    const res = await callTool(
+      "find_subnets_by_capability",
+      { capability: "gpu" },
+      { deps },
+    );
+    // netuid 12 has gpu but callable_count 0 -> excluded
+    assert.equal(res.body.result.structuredContent.count, 0);
+  });
+
+  test("get_subnet returns the overview artifact", async () => {
+    const res = await callTool("get_subnet", { netuid: 7 }, { deps });
+    assert.equal(res.body.result.structuredContent.netuid, 7);
+  });
+
+  test("get_subnet rejects a non-integer netuid", async () => {
+    const res = await callTool("get_subnet", { netuid: "seven" }, { deps });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("get_subnet surfaces an artifact-unavailable error", async () => {
+    const res = await callTool("get_subnet", { netuid: 999 }, { deps });
+    assert.equal(res.body.result.isError, true);
+    assert.ok(res.body.result.content[0].text.includes("artifact_not_found"));
+  });
+
+  test("get_subnet_health returns the health artifact", async () => {
+    const res = await callTool("get_subnet_health", { netuid: 7 }, { deps });
+    assert.equal(res.body.result.structuredContent.summary.status, "ok");
+  });
+
+  test("list_subnet_apis returns the per-subnet services", async () => {
+    const res = await callTool("list_subnet_apis", { netuid: 7 }, { deps });
+    assert.equal(res.body.result.structuredContent.service_count, 1);
+  });
+
+  test("get_api_schema fetches a schema by surface_id", async () => {
+    const res = await callTool(
+      "get_api_schema",
+      { surface_id: "7:subnet-api:allways" },
+      { deps },
+    );
+    assert.equal(res.body.result.structuredContent.openapi, "3.1.0");
+  });
+
+  test("get_api_schema rejects path-traversal surface ids", async () => {
+    const res = await callTool(
+      "get_api_schema",
+      { surface_id: "../secrets" },
+      { deps },
+    );
+    assert.equal(res.body.result.isError, true);
+    assert.ok(res.body.result.content[0].text.includes("invalid"));
+  });
+
+  test("get_agent_catalog returns the global catalog with no netuid", async () => {
+    const res = await callTool("get_agent_catalog", {}, { deps });
+    assert.ok(Array.isArray(res.body.result.structuredContent.subnets));
+  });
+
+  test("get_agent_catalog returns a per-subnet catalog with a netuid", async () => {
+    const res = await callTool("get_agent_catalog", { netuid: 7 }, { deps });
+    assert.equal(res.body.result.structuredContent.netuid, 7);
+  });
+
+  test("get_best_rpc_endpoint excludes down endpoints and applies live health", async () => {
+    const res = await callTool("get_best_rpc_endpoint", { limit: 5 }, { deps });
+    const out = res.body.result.structuredContent;
+    assert.equal(out.live_health, true);
+    // 'a' and 'b' are pool_eligible; 'c' is not. 'b' gets live latency 70.
+    assert.equal(out.eligible_count, 2);
+    assert.equal(out.endpoints[0].id, "b");
+    assert.equal(out.endpoints[0].latency_ms, 70);
+  });
+
+  test("get_best_rpc_endpoint works without a live KV snapshot", async () => {
+    const noKvDeps = makeDeps(
+      {
+        "/metagraph/rpc/pools.json": {
+          pools: {
+            0: { endpoints: [{ id: "a", pool_eligible: true, score: 1 }] },
+          },
+        },
+      },
+      {},
+    );
+    const res = await callTool("get_best_rpc_endpoint", {}, { deps: noKvDeps });
+    assert.equal(res.body.result.structuredContent.live_health, false);
+    assert.equal(res.body.result.structuredContent.eligible_count, 1);
+  });
+
+  test("get_best_rpc_endpoint tolerates a pools artifact with no pools", async () => {
+    const emptyDeps = makeDeps({ "/metagraph/rpc/pools.json": {} }, {});
+    const res = await callTool(
+      "get_best_rpc_endpoint",
+      {},
+      { deps: emptyDeps },
+    );
+    assert.equal(res.body.result.structuredContent.eligible_count, 0);
+  });
+
+  test("registry_summary returns the summary artifact", async () => {
+    const res = await callTool("registry_summary", {}, { deps });
+    assert.equal(res.body.result.structuredContent.completeness, 0.42);
+  });
+});
+
+describe("MCP edge cases", () => {
+  test("a request method behaves as a notification when sent without an id", async () => {
+    // Covers the isNotification short-circuit on otherwise-valid methods.
+    for (const method of [
+      "initialize",
+      "ping",
+      "tools/list",
+      "resources/list",
+    ]) {
+      const res = await rpc({ jsonrpc: "2.0", method });
+      assert.equal(res.status, 202, `${method} as notification`);
+    }
+  });
+
+  test("tools/call without an id is dropped as a notification", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: { name: "registry_summary", arguments: {} },
+    });
+    assert.equal(res.status, 202);
+  });
+
+  test("get_subnet rejects a negative netuid", async () => {
+    const res = await callTool("get_subnet", { netuid: -1 });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("a non-string tool name yields an unknown-tool error result", async () => {
+    const res = await rpc({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: 42 },
+    });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("a readArtifact rejection surfaces as a JSON-RPC internal error", async () => {
+    const throwingDeps = {
+      readArtifact() {
+        return Promise.reject(new Error("kv exploded"));
+      },
+      readHealthKv() {
+        return Promise.resolve(null);
+      },
+    };
+    const res = await callTool("registry_summary", {}, { deps: throwingDeps });
+    assert.equal(res.body.error.code, -32603);
+    assert.ok(res.body.error.message.includes("kv exploded"));
+  });
+
+  test("artifact failure without code/message uses default messaging", async () => {
+    const bareDeps = {
+      readArtifact() {
+        return Promise.resolve({ ok: false });
+      },
+      readHealthKv() {
+        return Promise.resolve(null);
+      },
+    };
+    const res = await callTool("registry_summary", {}, { deps: bareDeps });
+    assert.equal(res.body.result.isError, true);
+    assert.ok(res.body.result.content[0].text.includes("artifact_unavailable"));
+  });
+
+  test("a null artifact result is treated as unavailable", async () => {
+    const nullDeps = {
+      readArtifact() {
+        return Promise.resolve(null);
+      },
+      readHealthKv() {
+        return Promise.resolve(null);
+      },
+    };
+    const res = await callTool("get_subnet", { netuid: 7 }, { deps: nullDeps });
+    assert.equal(res.body.result.isError, true);
+  });
+
+  test("get_best_rpc_endpoint works when no readHealthKv dep is provided", async () => {
+    const depsNoKvFn = {
+      readArtifact() {
+        return Promise.resolve({
+          ok: true,
+          data: {
+            pools: {
+              0: { endpoints: [{ id: "a", pool_eligible: true, score: 5 }] },
+            },
+          },
+        });
+      },
+    };
+    const res = await callTool(
+      "get_best_rpc_endpoint",
+      {},
+      { deps: depsNoKvFn },
+    );
+    assert.equal(res.body.result.structuredContent.live_health, false);
+    assert.equal(res.body.result.structuredContent.endpoints[0].id, "a");
+  });
+});
+
+describe("MCP end-to-end through the Worker dispatch", () => {
+  test("POST /mcp tools/call resolves real artifacts from the local env", async () => {
+    const env = createLocalArtifactEnv();
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: "list_subnet_apis", arguments: { netuid: 7 } },
+      }),
+    });
+    const response = await handleRequest(request, env, {});
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    assert.ok(body.result.structuredContent.service_count >= 1);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -39,6 +39,7 @@ import {
   overlaySubnetHealth,
   subnetBadgeStatus,
 } from "../src/health-serving.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
 
 // Cron schedule strings (must match wrangler.jsonc `triggers.crons`). The hourly
 // trigger prunes the D1 time-series; every other trigger runs the 2-minute probe.
@@ -144,6 +145,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // must run before the read-only method gate below (like the RPC proxy).
   if (url.pathname.startsWith("/api/v1/webhooks/")) {
     return handleWebhookRequest(request, env, url);
+  }
+
+  // Remote MCP server (stateless JSON-RPC over POST), for AI agents. Runs before
+  // the read-only method gate (it is POST-only) like the RPC proxy. Artifact/KV
+  // readers are injected so the MCP tools reuse the exact R2/ASSETS resolution.
+  if (url.pathname === "/mcp") {
+    return handleMcpRequest(request, env, { readArtifact, readHealthKv });
   }
 
   if (!["GET", "HEAD"].includes(request.method)) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -23,7 +23,7 @@
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",
-    "run_worker_first": ["/api/*", "/rpc/*", "/metagraph/*", "/health"],
+    "run_worker_first": ["/api/*", "/rpc/*", "/metagraph/*", "/mcp", "/health"],
     "not_found_handling": "404-page",
   },
   "vars": {


### PR DESCRIPTION
## Summary

Phase 2 of the AI-native roadmap: a **stateless remote MCP server** at `POST /mcp` that exposes the operational registry to AI agents over the [Model Context Protocol](https://modelcontextprotocol.io).

**What this unlocks:** any MCP-capable assistant (Claude Desktop/Code, Cursor) or autonomous agent becomes Bittensor-aware with zero custom code — it can discover subnets, inspect their APIs/schemas/health, and pick a live-healthy RPC endpoint as first-class tools. metagraphed becomes *the agent gateway to the Bittensor application layer.*

## Design

- **Stateless Streamable-HTTP JSON-RPC 2.0** — no session id, no Durable Object, no server-initiated streams (the registry is read-only). **Hand-rolled** rather than pulling in `@modelcontextprotocol/sdk` + a DO, so the Worker bundle stays lean and the REST/RPC hot path is untouched. Dispatched in `handleRequest` **before** the read-only method gate (POST-only, like the RPC proxy); `GET /mcp` → `405`.
- **Dependency-injected readers** instead of extracting `readArtifact` onto the hot path: `handleMcpRequest(request, env, { readArtifact, readHealthKv })`. Same reuse, zero hot-path churn, fully unit-testable with stubs. (Rationale in ADR 0003.)

## Tools (9, read-only)
`search_subnets` · `find_subnets_by_capability` · `get_subnet` · `get_subnet_health` · `list_subnet_apis` · `get_api_schema` · `get_agent_catalog` · `get_best_rpc_endpoint` (live-health-filtered) · `registry_summary` — each a thin wrapper over the same artifact/KV resolution the REST routes use, so MCP and REST always agree. Tool/argument/artifact failures degrade to an MCP `isError` result, not a transport error.

## Validation
- `scripts/validate-mcp.mjs` (new `validate:mcp` + CI step): lifecycle + one `tools/call` per tool against a cold local env. Kept **out** of the `validate-api` `checks.length === API_ROUTES.length` invariant since `/mcp` isn't artifact-backed.
- `tests/mcp-server.test.mjs`: **46 tests** covering every tool + the JSON-RPC envelope (notifications, batch, parse/transport errors, isError degradation).
- `scripts/smoke-live-api.mjs`: live MCP handshake + `tools/call` post-deploy.
- ADR `docs/adr/0003-ai-native-layer.md` + a `backend-artifact-contracts.md` section.

## Verification
- **632 tests pass**; coverage **98.5% stmts / 91.4% branch / 99.0% funcs / 98.6% lines** (above the 97%+ gate).
- Green: `validate:mcp` / `:api` / `:openapi` / `:types` / `:docs` / `:schemas` / `:workflows`, plus `cloudflare:verify:dry-run` and `worker:deploy:dry-run`.
- No generated-artifact changes (MCP is not artifact-backed); `build-artifacts.mjs` change is Prettier-only tidy of the AI-1 region.

Part of the AI-native roadmap (AI-2 of 6). Next: semantic search + `/ask` (AI-3).