### PR TITLE
feat(ai): semantic search + grounded /ask (AI-3)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -176,6 +176,10 @@ jobs:
         if: steps.route.outputs.mode == 'full'
         run: npm run validate:mcp
 
+      - name: Validate AI routes
+        if: steps.route.outputs.mode == 'full'
+        run: npm run validate:ai
+
       - name: Validate OpenAPI
         if: steps.route.outputs.mode == 'full'
         run: npm run validate:openapi

--- a/docs/adr/0003-ai-native-layer.md
+++ b/docs/adr/0003-ai-native-layer.md
@@ -1,6 +1,6 @@
 # ADR 0003 — AI-native layer (agent catalog, llms.txt, remote MCP server)
 
-- **Status:** Accepted — implementing. AI-1 (agent catalog + llms.txt) and AI-2 (MCP server) shipped; AI-3 (semantic search + `/ask`) planned.
+- **Status:** Accepted — implementing. AI-1 (agent catalog + llms.txt), AI-2 (MCP server), and AI-3 (semantic search + `/ask`) shipped.
 - **Date:** 2026-06-10
 - **Relates to:** ADR 0001 (R2-only data artifacts), ADR 0002 (live operational health).
 
@@ -94,6 +94,24 @@ contract. No new authority, no new pipeline.
   `ci-verify-submitted-artifacts` + subset-commit discipline).
 - `get_best_rpc_endpoint` depends on the live health KV (ADR 0002); with no live
   snapshot it degrades to the build-time pool eligibility rather than failing.
-- AI-3 (semantic search + `/ask` via Vectorize + Workers AI) will add the only
-  pieces that need new bindings and a kill-switch; it is intentionally deferred
-  so the zero-binding agent surface ships first.
+
+## AI-3 — semantic search + `/ask`
+
+`GET /api/v1/search/semantic` and `POST /api/v1/ask` (`src/ai-search.mjs`) are
+the only pieces that need new bindings (`AI` + `VECTORIZE`). They are
+**out-of-contract dynamic routes** — special-handled like `/api/v1/events`, not
+in `API_ROUTES`/OpenAPI/the `validate-api` count invariant — so the contract
+spine and the count invariant are untouched. Semantic search embeds the query
+(`bge-base-en-v1.5`, 768-dim) and queries Vectorize; `/ask` is grounded RAG over
+the top-k with a cite-only prompt to `llama-3.1-8b`.
+
+Three gates bound cost/abuse: the `METAGRAPH_ENABLE_AI` kill-switch, binding
+presence (absent in local/CI → `503 ai_unavailable`, so CI never calls Workers
+AI), and the `AI_RATE_LIMITER` native rate-limit binding (20/60s per IP; absent
+→ allow), plus hard result/context/question caps. A daily embedding-sync cron
+(`37 3 * * *`, Worker-runtime) diffs `search.json` against a KV content-hash
+manifest and re-embeds only deltas, so embeddings stay ≤24h fresh while
+structural data stays fresh on the existing path. The KV-based rate limiter from
+the original plan was replaced by the native binding already used by the RPC
+proxy (zero KV cost, same config shape). Validated by `npm run validate:ai`
+against standalone `schemas/ai/*.schema.json`.

--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -203,6 +203,15 @@ At publish time the dispatcher reads `changelog.json`, matches each subscription
 
 Tools (thin wrappers over the artifact contract): `search_subnets`, `find_subnets_by_capability`, `get_subnet`, `get_subnet_health`, `list_subnet_apis`, `get_api_schema`, `get_agent_catalog`, `get_best_rpc_endpoint` (live-health-filtered), and `registry_summary`. `tools/call` returns the MCP result envelope (`content[]` text + `structuredContent`); argument and artifact failures degrade to an `isError: true` result rather than a transport error. The server is validated by `npm run validate:mcp` (lifecycle + one `tools/call` per tool against a cold local env) and smoke-checked live by `scripts/smoke-live-api.mjs`. The endpoint is excluded from the `validate-api` route-count invariant and is added to `assets.run_worker_first`.
 
+## AI Search + Ask (semantic + RAG)
+
+Two **out-of-contract dynamic routes** (special-handled like `/api/v1/events`, so they are not in `API_ROUTES`, OpenAPI, or the `validate-api` route-count invariant) power natural-language discovery, backed by Workers AI + a Vectorize index:
+
+- `GET /api/v1/search/semantic?q=&limit=` — embeds the query (`@cf/baai/bge-base-en-v1.5`, 768-dim) and returns the nearest registry entries `{ score, type, netuid, slug, title, subtitle, url }` (limit ≤ 20). Vector search, so it matches intent without exact keywords.
+- `POST /api/v1/ask` — body `{ question }`. Retrieves the top-6 registry entries and prompts `@cf/meta/llama-3.1-8b-instruct` with a cite-only system prompt, returning `{ question, answer, citations[], context_count, model }`. The answer is grounded in registry context and cites sources as `[n]`.
+
+Both live in `src/ai-search.mjs`, return the standard `{ ok, schema_version, data, meta }` envelope, and are gated three ways: the `METAGRAPH_ENABLE_AI` kill-switch, the presence of the `AI` + `VECTORIZE` bindings (absent in local/CI → `503 ai_unavailable`), and the `AI_RATE_LIMITER` binding (20 req/60s per client IP; absent → allow). Hard caps bound cost: result/context size and a 1000-char question limit. The Vectorize index is kept warm by a daily embedding-sync cron (`37 3 * * *`) that diffs the `search.json` index against a content-hash manifest in KV and re-embeds only the deltas. Response shapes are validated by `npm run validate:ai` (disabled→503, stubbed-enabled→200 against `schemas/ai/*.schema.json`, negatives + rate-limit); see ADR 0003.
+
 ## Current Domain Scope
 
 Use `metagraph.sh` for the current launch. Do not use `subnet.health` for v1 registry, status, badge, health, or probe contracts.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "validate:schemas": "node scripts/validate-schemas.mjs",
     "validate:api": "node scripts/validate-api.mjs",
     "validate:mcp": "node scripts/validate-mcp.mjs",
+    "validate:ai": "node scripts/validate-ai-routes.mjs",
     "validate:openapi": "node scripts/validate-openapi.mjs",
     "validate:types": "node scripts/validate-types.mjs",
     "validate:contract-drift": "node scripts/validate-contract-drift.mjs",

--- a/public/.well-known/llms.txt
+++ b/public/.well-known/llms.txt
@@ -8,6 +8,8 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools
+- [Semantic search](https://api.metagraph.sh/api/v1/search/semantic?q=): natural-language vector search over subnets/surfaces
+- [Ask](https://api.metagraph.sh/api/v1/ask): POST { question } for a grounded, cited answer over the registry
 - [API index](https://api.metagraph.sh/api/v1): route list + response envelope
 - [Registry summary](https://api.metagraph.sh/api/v1/registry/summary): coverage + completeness leaderboard
 

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -8,6 +8,8 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools
+- [Semantic search](https://api.metagraph.sh/api/v1/search/semantic?q=): natural-language vector search over subnets/surfaces
+- [Ask](https://api.metagraph.sh/api/v1/ask): POST { question } for a grounded, cited answer over the registry
 - [API index](https://api.metagraph.sh/api/v1): route list + response envelope
 - [Registry summary](https://api.metagraph.sh/api/v1/registry/summary): coverage + completeness leaderboard
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -8,6 +8,8 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - [OpenAPI 3.1](https://api.metagraph.sh/metagraph/openapi.json): full machine contract for all routes
 - [Agent capability catalog](https://api.metagraph.sh/api/v1/agent-catalog): per-subnet callable services + their schemas + health
 - [MCP server](https://api.metagraph.sh/mcp): Model Context Protocol endpoint — agents query the registry as tools
+- [Semantic search](https://api.metagraph.sh/api/v1/search/semantic?q=): natural-language vector search over subnets/surfaces
+- [Ask](https://api.metagraph.sh/api/v1/ask): POST { question } for a grounded, cited answer over the registry
 - [API index](https://api.metagraph.sh/api/v1): route list + response envelope
 - [Registry summary](https://api.metagraph.sh/api/v1/registry/summary): coverage + completeness leaderboard
 

--- a/schemas/ai/ask-answer.schema.json
+++ b/schemas/ai/ask-answer.schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://metagraph.sh/ai/ask-answer.schema.json",
+  "title": "AskAnswerData",
+  "description": "Data payload for POST /api/v1/ask (out-of-contract dynamic route).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["question", "answer", "citations", "context_count", "model"],
+  "properties": {
+    "question": { "type": "string" },
+    "answer": { "type": "string" },
+    "context_count": { "type": "integer", "minimum": 0 },
+    "model": { "type": "string" },
+    "citations": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["ref", "title", "netuid", "slug", "url"],
+        "properties": {
+          "ref": { "type": "integer", "minimum": 1 },
+          "title": { "type": ["string", "null"] },
+          "netuid": { "type": ["integer", "null"] },
+          "slug": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/schemas/ai/semantic-search.schema.json
+++ b/schemas/ai/semantic-search.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://metagraph.sh/ai/semantic-search.schema.json",
+  "title": "SemanticSearchData",
+  "description": "Data payload for GET /api/v1/search/semantic (out-of-contract dynamic route).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["query", "count", "results", "model"],
+  "properties": {
+    "query": { "type": "string" },
+    "count": { "type": "integer", "minimum": 0 },
+    "model": { "type": "string" },
+    "results": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": [
+          "score",
+          "type",
+          "netuid",
+          "slug",
+          "title",
+          "subtitle",
+          "url"
+        ],
+        "properties": {
+          "score": { "type": "number" },
+          "type": { "type": ["string", "null"] },
+          "netuid": { "type": ["integer", "null"] },
+          "slug": { "type": ["string", "null"] },
+          "title": { "type": ["string", "null"] },
+          "subtitle": { "type": ["string", "null"] },
+          "url": { "type": ["string", "null"] }
+        }
+      }
+    }
+  }
+}

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -787,6 +787,8 @@ const llmsHeader = [
   `- [OpenAPI 3.1](${llmsApiBase}/metagraph/openapi.json): full machine contract for all routes`,
   `- [Agent capability catalog](${llmsApiBase}/api/v1/agent-catalog): per-subnet callable services + their schemas + health`,
   `- [MCP server](${llmsApiBase}/mcp): Model Context Protocol endpoint — agents query the registry as tools`,
+  `- [Semantic search](${llmsApiBase}/api/v1/search/semantic?q=): natural-language vector search over subnets/surfaces`,
+  `- [Ask](${llmsApiBase}/api/v1/ask): POST { question } for a grounded, cited answer over the registry`,
   `- [API index](${llmsApiBase}/api/v1): route list + response envelope`,
   `- [Registry summary](${llmsApiBase}/api/v1/registry/summary): coverage + completeness leaderboard`,
   "",

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -216,6 +216,49 @@ assert.ok(
   "MCP list_subnet_apis(7) must return at least one service",
 );
 
+// AI routes (semantic search + /ask). Tolerant of the kill-switch: a 503
+// ai_unavailable is an accepted "disabled" state; when enabled we validate the
+// envelope shape (results may be empty if the embedding index is still cold).
+let aiStatus = "disabled";
+const semantic = await fetchJson(
+  `${baseUrl}/api/v1/search/semantic?q=image%20generation&limit=5`,
+);
+if (semantic.status === 200) {
+  aiStatus = "enabled";
+  assert.equal(
+    semantic.body?.ok,
+    true,
+    "semantic search must return an ok envelope",
+  );
+  assert.ok(
+    Array.isArray(semantic.body?.data?.results),
+    "semantic search must return a results array",
+  );
+
+  const ask = await fetchJson(`${baseUrl}/api/v1/ask`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ question: "Which subnets expose a public API?" }),
+  });
+  assert.equal(ask.status, 200, "ask must return HTTP 200 when AI is enabled");
+  assert.equal(
+    typeof ask.body?.data?.answer,
+    "string",
+    "ask must return an answer string",
+  );
+  assert.ok(
+    Array.isArray(ask.body?.data?.citations),
+    "ask must return a citations array",
+  );
+} else {
+  assert.equal(
+    semantic.status,
+    503,
+    "semantic search must be 200 (enabled) or 503 (disabled)",
+  );
+  assert.equal(semantic.body?.error?.code, "ai_unavailable");
+}
+
 console.log(
   JSON.stringify(
     {
@@ -224,6 +267,7 @@ console.log(
       api_route_count: apiChecks.length,
       raw_artifact_count: rawArtifactChecks.length,
       mcp_tool_count: MCP_TOOLS.length,
+      ai_status: aiStatus,
       health_history_date: healthDate,
       checked_paths: results,
     },

--- a/scripts/validate-ai-routes.mjs
+++ b/scripts/validate-ai-routes.mjs
@@ -1,0 +1,170 @@
+// Contract validator for the AI routes (GET /api/v1/search/semantic, POST
+// /api/v1/ask). These are out-of-contract dynamic routes (like /api/v1/events),
+// so they are validated here rather than through validate-api's
+// `checks.length === API_ROUTES.length` invariant.
+//
+// Two passes: (1) bindings absent -> 503 ai_unavailable; (2) stubbed AI +
+// Vectorize bindings + kill-switch on -> 200 with a payload that matches the
+// standalone AI response schemas, plus the input/rate-limit negative paths.
+import assert from "node:assert/strict";
+import path from "node:path";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv, readJson, repoRoot } from "./lib.mjs";
+
+const ajv = new Ajv2020({ allErrors: true, strict: false });
+addFormats(ajv);
+const semanticSchema = ajv.compile(
+  await readJson(path.join(repoRoot, "schemas/ai/semantic-search.schema.json")),
+);
+const askSchema = ajv.compile(
+  await readJson(path.join(repoRoot, "schemas/ai/ask-answer.schema.json")),
+);
+
+const SEMANTIC_URL = "https://api.metagraph.sh/api/v1/search/semantic";
+const ASK_URL = "https://api.metagraph.sh/api/v1/ask";
+
+function get(url, env) {
+  return handleRequest(new Request(url), env, {});
+}
+function post(url, body, env, headers = {}) {
+  return handleRequest(
+    new Request(url, {
+      method: "POST",
+      headers: { "content-type": "application/json", ...headers },
+      body: typeof body === "string" ? body : JSON.stringify(body),
+    }),
+    env,
+    {},
+  );
+}
+
+// --- Pass 1: AI disabled (no bindings) -> 503 ------------------------------
+
+const coldEnv = createLocalArtifactEnv();
+const coldSemantic = await get(`${SEMANTIC_URL}?q=image`, coldEnv);
+assert.equal(
+  coldSemantic.status,
+  503,
+  "semantic must 503 when AI is unconfigured",
+);
+assert.equal(
+  (await coldSemantic.json()).error.code,
+  "ai_unavailable",
+  "semantic must report ai_unavailable when disabled",
+);
+const coldAsk = await post(
+  ASK_URL,
+  { question: "what subnets do images?" },
+  coldEnv,
+);
+assert.equal(coldAsk.status, 503, "ask must 503 when AI is unconfigured");
+assert.equal((await coldAsk.json()).error.code, "ai_unavailable");
+
+// --- Stub AI + Vectorize bindings ------------------------------------------
+
+function stubMatch(i) {
+  return {
+    id: `subnet:${i}`,
+    score: 0.9 - i * 0.1,
+    metadata: {
+      type: "subnet",
+      netuid: i,
+      slug: `sn-${i}`,
+      title: `Subnet ${i}`,
+      subtitle: `Subnet ${i} summary`,
+      url: `https://api.metagraph.sh/api/v1/subnets/${i}/overview`,
+    },
+  };
+}
+
+function makeAiEnv(overrides = {}) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ENABLE_AI: "true",
+    AI: {
+      run(model, input) {
+        if (model.includes("bge")) {
+          const n = Array.isArray(input.text) ? input.text.length : 1;
+          return Promise.resolve({
+            data: Array.from({ length: n }, () => new Array(768).fill(0.01)),
+          });
+        }
+        return Promise.resolve({ response: "Subnet 1 serves images [1]." });
+      },
+    },
+    VECTORIZE: {
+      query(_vector, options) {
+        const topK = options?.topK ?? 3;
+        return Promise.resolve({
+          matches: Array.from({ length: Math.min(topK, 3) }, (_, i) =>
+            stubMatch(i + 1),
+          ),
+        });
+      },
+    },
+    ...overrides,
+  };
+}
+
+// --- Pass 2: enabled -> 200 + schema ---------------------------------------
+
+const aiEnv = makeAiEnv();
+
+const semantic = await get(
+  `${SEMANTIC_URL}?q=image%20generation&limit=5`,
+  aiEnv,
+);
+assert.equal(semantic.status, 200, "enabled semantic must return 200");
+const semanticBody = await semantic.json();
+assert.equal(semanticBody.ok, true);
+assert.equal(
+  semanticSchema(semanticBody.data),
+  true,
+  `semantic data must match schema: ${ajv.errorsText(semanticSchema.errors)}`,
+);
+assert.ok(semanticBody.data.results.length > 0, "semantic must return results");
+
+const ask = await post(
+  ASK_URL,
+  { question: "Which subnet does image generation?" },
+  aiEnv,
+);
+assert.equal(ask.status, 200, "enabled ask must return 200");
+const askBody = await ask.json();
+assert.equal(askBody.ok, true);
+assert.equal(
+  askSchema(askBody.data),
+  true,
+  `ask data must match schema: ${ajv.errorsText(askSchema.errors)}`,
+);
+assert.ok(askBody.data.citations.length > 0, "ask must return citations");
+
+// --- Negative paths --------------------------------------------------------
+
+const noQuery = await get(SEMANTIC_URL, aiEnv);
+assert.equal(noQuery.status, 400, "semantic without q must be 400");
+assert.equal((await noQuery.json()).error.code, "invalid_query");
+
+const emptyQuestion = await post(ASK_URL, { question: "  " }, aiEnv);
+assert.equal(emptyQuestion.status, 400, "ask with blank question must be 400");
+
+const badJson = await post(ASK_URL, "{not json", aiEnv);
+assert.equal(badJson.status, 400, "ask with invalid JSON must be 400");
+assert.equal((await badJson.json()).error.code, "invalid_json");
+
+const askViaGet = await get(ASK_URL, aiEnv);
+assert.equal(askViaGet.status, 405, "GET /api/v1/ask must be 405");
+
+// Rate limiting: a limiter that denies -> 429.
+const limitedEnv = makeAiEnv({
+  AI_RATE_LIMITER: { limit: () => Promise.resolve({ success: false }) },
+});
+const limited = await get(`${SEMANTIC_URL}?q=image`, limitedEnv);
+assert.equal(limited.status, 429, "rate-limited semantic must be 429");
+assert.equal((await limited.json()).error.code, "rate_limited");
+
+console.log(
+  "AI route validation passed: disabled->503, enabled->200 (schema-valid), negatives + rate-limit.",
+);

--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -1,0 +1,285 @@
+// AI-native search layer: semantic search + grounded `/ask` (RAG) over the
+// registry, plus the embedding-sync cron that keeps the Vectorize index warm.
+//
+// Bindings (Workers AI `AI`, `VECTORIZE` index) are absent in CI/local, so every
+// entry point degrades cleanly: the request handlers return `503 ai_unavailable`
+// and the cron no-ops. Functions are env-injected and pure of I/O beyond the
+// bindings, so they unit-test with stubs.
+//
+// Cost/abuse controls: a kill-switch (`METAGRAPH_ENABLE_AI`), an optional native
+// rate-limit binding (`AI_RATE_LIMITER`), and hard caps on result/context size
+// and question length.
+
+export const EMBED_MODEL = "@cf/baai/bge-base-en-v1.5"; // 768-dim
+export const ASK_MODEL = "@cf/meta/llama-3.1-8b-instruct";
+export const EMBED_MANIFEST_KEY = "ai:embed-manifest";
+
+export const SEMANTIC_DEFAULT_LIMIT = 10;
+export const SEMANTIC_MAX_LIMIT = 20;
+export const ASK_CONTEXT_COUNT = 6;
+export const ASK_MAX_QUESTION_LENGTH = 1000;
+export const ASK_MAX_TOKENS = 512;
+const EMBED_BATCH_SIZE = 100;
+const VECTOR_ID_MAX_BYTES = 64;
+
+const ASK_SYSTEM_PROMPT =
+  "You are the metagraphed assistant. metagraphed is the operational + " +
+  "integration registry for Bittensor subnets. Answer ONLY from the registry " +
+  "context provided in the user message. Cite every claim with its bracketed " +
+  "source number, e.g. [1]. If the context does not contain the answer, say so " +
+  "plainly — never invent subnets, endpoints, or numbers. Be concise.";
+
+// A user-input error: the request handlers translate it to a 400, not a 500.
+export function aiInputError(message) {
+  const error = new Error(message);
+  error.aiInput = true;
+  return error;
+}
+
+// The AI bindings exist (independent of the kill-switch). Used by the cron,
+// which should run whenever the bindings are present.
+export function aiConfigured(env) {
+  return Boolean(env?.AI?.run && env?.VECTORIZE);
+}
+
+// AI request handling is permitted: bindings present AND the kill-switch is on.
+export function aiEnabled(env) {
+  return env?.METAGRAPH_ENABLE_AI === "true" && aiConfigured(env);
+}
+
+// Optional native Workers rate limiter. Absent in local/CI (and when the
+// binding is not configured) -> allow. Never throws.
+export async function withinRateLimit(env, key) {
+  if (!env?.AI_RATE_LIMITER?.limit) return true;
+  try {
+    const outcome = await env.AI_RATE_LIMITER.limit({ key });
+    return outcome?.success !== false;
+  } catch {
+    return true;
+  }
+}
+
+function clampLimit(value, fallback, max) {
+  const n = Number(value);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(1, Math.min(max, Math.floor(n)));
+}
+
+// Stable, dependency-free 53-bit string hash (cyrb53) for change detection.
+function contentHash(text) {
+  let h1 = 0xdeadbeef;
+  let h2 = 0x41c6ce57;
+  for (let i = 0; i < text.length; i += 1) {
+    const ch = text.charCodeAt(i);
+    h1 = Math.imul(h1 ^ ch, 2654435761);
+    h2 = Math.imul(h2 ^ ch, 1597334677);
+  }
+  h1 = Math.imul(h1 ^ (h1 >>> 16), 2246822507);
+  h1 ^= Math.imul(h2 ^ (h2 >>> 13), 3266489909);
+  h2 = Math.imul(h2 ^ (h2 >>> 16), 2246822507);
+  h2 ^= Math.imul(h1 ^ (h1 >>> 13), 3266489909);
+  return (4294967296 * (2097151 & h2) + (h1 >>> 0)).toString(36);
+}
+
+export function embeddingText(doc) {
+  return [
+    doc.title,
+    doc.subtitle,
+    ...(Array.isArray(doc.tokens) ? doc.tokens : []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .slice(0, 1500);
+}
+
+// Vectorize ids are capped at 64 bytes; long surface ids are folded to a stable
+// hashed id. The real identity lives in metadata, so query results are unaffected.
+export function vectorId(docId) {
+  const id = String(docId);
+  return id.length <= VECTOR_ID_MAX_BYTES ? id : `h:${contentHash(id)}`;
+}
+
+export function embeddingMetadata(doc) {
+  return {
+    type: doc.type ?? null,
+    netuid: doc.netuid ?? null,
+    slug: doc.slug ?? null,
+    title: doc.title ?? null,
+    subtitle: doc.subtitle ?? null,
+    url: doc.url ?? null,
+  };
+}
+
+function chunk(items, size) {
+  const out = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+async function readManifest(env) {
+  if (!env?.METAGRAPH_CONTROL?.get) return {};
+  try {
+    return (
+      (await env.METAGRAPH_CONTROL.get(EMBED_MANIFEST_KEY, { type: "json" })) ||
+      {}
+    );
+  } catch {
+    return {};
+  }
+}
+
+// Embedding-sync cron: diff the search index against a content-hash manifest in
+// KV, (re)embed only the deltas, upsert to Vectorize, drop removed ids. Runs in
+// the Worker runtime (CI has no AI bindings). `deps.readArtifact` is injected.
+export async function runEmbeddingSync(env, deps = {}) {
+  if (!aiConfigured(env)) return { ok: false, reason: "ai_unconfigured" };
+  if (typeof deps.readArtifact !== "function") {
+    return { ok: false, reason: "reader_unavailable" };
+  }
+  const index = await deps.readArtifact(env, "/metagraph/search.json");
+  if (!index?.ok) return { ok: false, reason: "search_index_unavailable" };
+
+  const docs = Array.isArray(index.data?.documents) ? index.data.documents : [];
+  const previous = await readManifest(env);
+  const next = {};
+  const pending = [];
+  for (const doc of docs) {
+    if (!doc?.id) continue;
+    const id = vectorId(doc.id);
+    const hash = contentHash(embeddingText(doc));
+    next[id] = hash;
+    if (previous[id] !== hash) pending.push({ id, doc });
+  }
+  const removed = Object.keys(previous).filter((id) => !(id in next));
+
+  let embedded = 0;
+  for (const batch of chunk(pending, EMBED_BATCH_SIZE)) {
+    const response = await env.AI.run(EMBED_MODEL, {
+      text: batch.map((entry) => embeddingText(entry.doc)),
+    });
+    const data = response?.data || [];
+    const vectors = batch.map((entry, i) => ({
+      id: entry.id,
+      values: data[i],
+      metadata: embeddingMetadata(entry.doc),
+    }));
+    await env.VECTORIZE.upsert(vectors);
+    embedded += vectors.length;
+  }
+  if (removed.length && typeof env.VECTORIZE.deleteByIds === "function") {
+    await env.VECTORIZE.deleteByIds(removed);
+  }
+  if (env?.METAGRAPH_CONTROL?.put) {
+    await env.METAGRAPH_CONTROL.put(EMBED_MANIFEST_KEY, JSON.stringify(next));
+  }
+  return {
+    ok: true,
+    total: docs.length,
+    embedded,
+    removed: removed.length,
+  };
+}
+
+async function embedQuery(env, text) {
+  const response = await env.AI.run(EMBED_MODEL, { text: [text] });
+  const vector = response?.data?.[0];
+  if (!Array.isArray(vector)) {
+    throw new Error("embedding model returned no vector");
+  }
+  return vector;
+}
+
+function mapMatch(match) {
+  const metadata = match?.metadata || {};
+  return {
+    score: Math.round((match?.score ?? 0) * 1e4) / 1e4,
+    type: metadata.type ?? null,
+    netuid: metadata.netuid ?? null,
+    slug: metadata.slug ?? null,
+    title: metadata.title ?? null,
+    subtitle: metadata.subtitle ?? null,
+    url: metadata.url ?? null,
+  };
+}
+
+// Semantic search: embed the query, query Vectorize, project metadata. Throws
+// aiInputError for a blank query.
+export async function semanticSearch(env, query, options = {}) {
+  const q = typeof query === "string" ? query.trim() : "";
+  if (!q) throw aiInputError("Query parameter `q` is required.");
+  const limit = clampLimit(
+    options.limit,
+    SEMANTIC_DEFAULT_LIMIT,
+    SEMANTIC_MAX_LIMIT,
+  );
+  const vector = await embedQuery(env, q);
+  const result = await env.VECTORIZE.query(vector, {
+    topK: limit,
+    returnMetadata: "all",
+    returnValues: false,
+  });
+  const results = (result?.matches || []).map(mapMatch);
+  return { query: q, count: results.length, results, model: EMBED_MODEL };
+}
+
+// Grounded question answering (RAG): retrieve top-k registry context, prompt the
+// LLM to answer only from it with bracketed citations.
+export async function askQuestion(env, question, options = {}) {
+  const q = typeof question === "string" ? question.trim() : "";
+  if (!q) throw aiInputError("Field `question` is required.");
+  if (q.length > ASK_MAX_QUESTION_LENGTH) {
+    throw aiInputError(
+      `Field \`question\` must be at most ${ASK_MAX_QUESTION_LENGTH} characters.`,
+    );
+  }
+  const topK = clampLimit(options.topK, ASK_CONTEXT_COUNT, ASK_CONTEXT_COUNT);
+  const vector = await embedQuery(env, q);
+  const result = await env.VECTORIZE.query(vector, {
+    topK,
+    returnMetadata: "all",
+    returnValues: false,
+  });
+  const matches = result?.matches || [];
+  const citations = matches.map((match, i) => {
+    const metadata = match?.metadata || {};
+    return {
+      ref: i + 1,
+      title: metadata.title ?? null,
+      netuid: metadata.netuid ?? null,
+      slug: metadata.slug ?? null,
+      url: metadata.url ?? null,
+    };
+  });
+  const contextBlock = matches
+    .map((match, i) => {
+      const m = match?.metadata || {};
+      const subject =
+        m.netuid != null ? `${m.title} (subnet ${m.netuid})` : m.title;
+      return `[${i + 1}] ${subject || "registry entry"}: ${m.subtitle || ""}`.trim();
+    })
+    .join("\n");
+
+  const messages = [
+    { role: "system", content: ASK_SYSTEM_PROMPT },
+    {
+      role: "user",
+      content:
+        `Question: ${q}\n\nRegistry context:\n${contextBlock || "(no matching registry entries)"}\n\n` +
+        "Answer using only the context above and cite sources as [n].",
+    },
+  ];
+  const completion = await env.AI.run(ASK_MODEL, {
+    messages,
+    max_tokens: ASK_MAX_TOKENS,
+  });
+  const answer = (completion?.response || "").trim();
+  return {
+    question: q,
+    answer,
+    citations,
+    context_count: matches.length,
+    model: ASK_MODEL,
+  };
+}

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -1,0 +1,557 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  EMBED_MODEL,
+  ASK_MODEL,
+  EMBED_MANIFEST_KEY,
+  aiConfigured,
+  aiEnabled,
+  withinRateLimit,
+  embeddingText,
+  embeddingMetadata,
+  vectorId,
+  runEmbeddingSync,
+  semanticSearch,
+  askQuestion,
+} from "../src/ai-search.mjs";
+import { handleRequest, handleScheduled } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+const SEMANTIC_URL = "https://api.metagraph.sh/api/v1/search/semantic";
+const ASK_URL = "https://api.metagraph.sh/api/v1/ask";
+const EMBEDDING_SYNC_CRON = "37 3 * * *";
+
+// In-memory KV stub.
+function memKv(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    store,
+    get(key, opts) {
+      const value = store.get(key);
+      if (value === undefined) return Promise.resolve(null);
+      return Promise.resolve(opts?.type === "json" ? JSON.parse(value) : value);
+    },
+    put(key, value) {
+      store.set(key, value);
+      return Promise.resolve();
+    },
+  };
+}
+
+function stubAi() {
+  const calls = [];
+  return {
+    calls,
+    run(model, input) {
+      calls.push({ model, input });
+      if (model.includes("bge")) {
+        const n = Array.isArray(input.text) ? input.text.length : 1;
+        return Promise.resolve({
+          data: Array.from({ length: n }, () => new Array(768).fill(0.02)),
+        });
+      }
+      return Promise.resolve({ response: "Subnet 1 does images [1]." });
+    },
+  };
+}
+
+function stubVectorize() {
+  const ops = { upserts: [], deletes: [] };
+  return {
+    ops,
+    upsert(vectors) {
+      ops.upserts.push(vectors);
+      return Promise.resolve({ count: vectors.length });
+    },
+    deleteByIds(ids) {
+      ops.deletes.push(ids);
+      return Promise.resolve({ count: ids.length });
+    },
+    query(_vector, options) {
+      const topK = options?.topK ?? 3;
+      return Promise.resolve({
+        matches: Array.from({ length: Math.min(topK, 3) }, (_, i) => ({
+          id: `subnet:${i + 1}`,
+          score: 0.9 - i * 0.05,
+          metadata: {
+            type: "subnet",
+            netuid: i + 1,
+            slug: `sn-${i + 1}`,
+            title: `Subnet ${i + 1}`,
+            subtitle: `summary ${i + 1}`,
+            url: `https://api.metagraph.sh/api/v1/subnets/${i + 1}/overview`,
+          },
+        })),
+      });
+    },
+  };
+}
+
+function aiWorkerEnv(overrides = {}) {
+  return {
+    ...createLocalArtifactEnv(),
+    METAGRAPH_ENABLE_AI: "true",
+    AI: stubAi(),
+    VECTORIZE: stubVectorize(),
+    ...overrides,
+  };
+}
+
+describe("ai-search configuration gates", () => {
+  test("aiConfigured requires AI.run and VECTORIZE", () => {
+    assert.equal(aiConfigured({}), false);
+    assert.equal(aiConfigured({ AI: { run() {} } }), false);
+    assert.equal(aiConfigured({ AI: { run() {} }, VECTORIZE: {} }), true);
+  });
+
+  test("aiEnabled requires the kill-switch and the bindings", () => {
+    const bindings = { AI: { run() {} }, VECTORIZE: {} };
+    assert.equal(aiEnabled({ ...bindings }), false);
+    assert.equal(
+      aiEnabled({ ...bindings, METAGRAPH_ENABLE_AI: "false" }),
+      false,
+    );
+    assert.equal(aiEnabled({ ...bindings, METAGRAPH_ENABLE_AI: "true" }), true);
+    assert.equal(aiEnabled({ METAGRAPH_ENABLE_AI: "true" }), false);
+  });
+});
+
+describe("withinRateLimit", () => {
+  test("allows when no limiter is bound", async () => {
+    assert.equal(await withinRateLimit({}, "k"), true);
+  });
+  test("reflects the limiter outcome", async () => {
+    const ok = {
+      AI_RATE_LIMITER: { limit: () => Promise.resolve({ success: true }) },
+    };
+    const no = {
+      AI_RATE_LIMITER: { limit: () => Promise.resolve({ success: false }) },
+    };
+    assert.equal(await withinRateLimit(ok, "k"), true);
+    assert.equal(await withinRateLimit(no, "k"), false);
+  });
+  test("fails open when the limiter throws", async () => {
+    const env = {
+      AI_RATE_LIMITER: { limit: () => Promise.reject(new Error("x")) },
+    };
+    assert.equal(await withinRateLimit(env, "k"), true);
+  });
+});
+
+describe("embedding helpers", () => {
+  test("embeddingText joins title/subtitle/tokens and truncates", () => {
+    assert.equal(
+      embeddingText({ title: "A", subtitle: "B", tokens: ["c", "d"] }),
+      "A B c d",
+    );
+    assert.equal(embeddingText({ title: "A" }), "A");
+    assert.ok(embeddingText({ title: "x".repeat(5000) }).length <= 1500);
+  });
+  test("vectorId keeps short ids and hashes long ones", () => {
+    assert.equal(vectorId("subnet:7"), "subnet:7");
+    const long = "surface:" + "x".repeat(80);
+    assert.ok(vectorId(long).startsWith("h:"));
+    assert.ok(vectorId(long).length <= 64);
+  });
+  test("embeddingMetadata normalises missing fields to null", () => {
+    assert.deepEqual(embeddingMetadata({ type: "subnet", netuid: 7 }), {
+      type: "subnet",
+      netuid: 7,
+      slug: null,
+      title: null,
+      subtitle: null,
+      url: null,
+    });
+  });
+});
+
+describe("runEmbeddingSync", () => {
+  const searchDocs = {
+    ok: true,
+    data: {
+      documents: [
+        {
+          id: "subnet:1",
+          type: "subnet",
+          netuid: 1,
+          title: "One",
+          tokens: ["a"],
+        },
+        {
+          id: "subnet:2",
+          type: "subnet",
+          netuid: 2,
+          title: "Two",
+          tokens: ["b"],
+        },
+      ],
+    },
+  };
+  const reader = (data) => () => Promise.resolve(data);
+
+  test("no-ops when AI is unconfigured", async () => {
+    const r = await runEmbeddingSync({}, { readArtifact: () => {} });
+    assert.deepEqual(r, { ok: false, reason: "ai_unconfigured" });
+  });
+
+  test("requires a readArtifact dependency", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const r = await runEmbeddingSync(env, {});
+    assert.equal(r.reason, "reader_unavailable");
+  });
+
+  test("reports when the search index is unavailable", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const r = await runEmbeddingSync(env, {
+      readArtifact: () => Promise.resolve({ ok: false }),
+    });
+    assert.equal(r.reason, "search_index_unavailable");
+  });
+
+  test("embeds all docs on a cold manifest and records hashes", async () => {
+    const env = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: memKv(),
+    };
+    const r = await runEmbeddingSync(env, { readArtifact: reader(searchDocs) });
+    assert.deepEqual(
+      { ok: r.ok, total: r.total, embedded: r.embedded, removed: r.removed },
+      {
+        ok: true,
+        total: 2,
+        embedded: 2,
+        removed: 0,
+      },
+    );
+    assert.equal(env.VECTORIZE.ops.upserts[0].length, 2);
+    assert.ok(env.METAGRAPH_CONTROL.store.get(EMBED_MANIFEST_KEY));
+  });
+
+  test("re-embeds only deltas and deletes removed ids on a second run", async () => {
+    const kv = memKv();
+    const env = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+    await runEmbeddingSync(env, { readArtifact: reader(searchDocs) });
+
+    // Second run: doc 2 changed, doc 1 unchanged, doc 3 added, original doc 2 id stays.
+    const changed = {
+      ok: true,
+      data: {
+        documents: [
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "One",
+            tokens: ["a"],
+          },
+          {
+            id: "subnet:2",
+            type: "subnet",
+            netuid: 2,
+            title: "Two CHANGED",
+            tokens: ["b"],
+          },
+        ],
+      },
+    };
+    const env2 = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+    const r2 = await runEmbeddingSync(env2, { readArtifact: reader(changed) });
+    assert.equal(r2.embedded, 1, "only the changed doc re-embeds");
+    assert.equal(r2.removed, 0);
+
+    // Third run drops doc 2 -> removal.
+    const dropped = {
+      ok: true,
+      data: {
+        documents: [
+          {
+            id: "subnet:1",
+            type: "subnet",
+            netuid: 1,
+            title: "One",
+            tokens: ["a"],
+          },
+        ],
+      },
+    };
+    const env3 = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: kv,
+    };
+    const r3 = await runEmbeddingSync(env3, { readArtifact: reader(dropped) });
+    assert.equal(r3.removed, 1, "dropped doc is deleted");
+    assert.deepEqual(env3.VECTORIZE.ops.deletes[0], ["subnet:2"]);
+  });
+
+  test("skips docs without an id", async () => {
+    const env = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: memKv(),
+    };
+    const docs = {
+      ok: true,
+      data: { documents: [{ type: "subnet", title: "x" }] },
+    };
+    const r = await runEmbeddingSync(env, { readArtifact: reader(docs) });
+    assert.equal(r.embedded, 0);
+  });
+});
+
+describe("semanticSearch", () => {
+  test("maps Vectorize matches to results", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const out = await semanticSearch(env, "image generation", { limit: 3 });
+    assert.equal(out.model, EMBED_MODEL);
+    assert.equal(out.count, 3);
+    assert.equal(out.results[0].netuid, 1);
+    assert.equal(typeof out.results[0].score, "number");
+  });
+  test("rejects a blank query", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    await assert.rejects(() => semanticSearch(env, "   "), /required/);
+  });
+  test("clamps the limit to the maximum", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const out = await semanticSearch(env, "x", { limit: 999 });
+    assert.ok(out.results.length <= 20);
+  });
+});
+
+describe("askQuestion", () => {
+  test("returns an answer with citations from the retrieved context", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const out = await askQuestion(env, "Which subnet does images?");
+    assert.equal(out.model, ASK_MODEL);
+    assert.ok(out.answer.length > 0);
+    assert.equal(out.citations[0].ref, 1);
+    assert.equal(out.context_count, 3);
+  });
+  test("rejects a blank question", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    await assert.rejects(() => askQuestion(env, ""), /required/);
+  });
+  test("rejects an overly long question", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    await assert.rejects(() => askQuestion(env, "x".repeat(1001)), /at most/);
+  });
+});
+
+describe("AI routes through the Worker dispatch", () => {
+  test("semantic + ask return 503 when AI is disabled", async () => {
+    const env = createLocalArtifactEnv();
+    const s = await handleRequest(new Request(`${SEMANTIC_URL}?q=x`), env, {});
+    assert.equal(s.status, 503);
+    const a = await handleRequest(
+      new Request(ASK_URL, {
+        method: "POST",
+        body: JSON.stringify({ question: "x" }),
+      }),
+      env,
+      {},
+    );
+    assert.equal(a.status, 503);
+  });
+
+  test("enabled semantic returns a 200 envelope", async () => {
+    const res = await handleRequest(
+      new Request(`${SEMANTIC_URL}?q=images&limit=5`),
+      aiWorkerEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.meta.source, "ai-live");
+    assert.ok(body.data.results.length > 0);
+  });
+
+  test("enabled ask returns a 200 envelope with citations", async () => {
+    const res = await handleRequest(
+      new Request(ASK_URL, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ question: "Which subnet does images?" }),
+      }),
+      aiWorkerEnv(),
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.data.citations.length > 0);
+  });
+
+  test("semantic without q is a 400", async () => {
+    const res = await handleRequest(
+      new Request(SEMANTIC_URL),
+      aiWorkerEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_query");
+  });
+
+  test("ask with invalid JSON is a 400", async () => {
+    const res = await handleRequest(
+      new Request(ASK_URL, { method: "POST", body: "{bad" }),
+      aiWorkerEnv(),
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_json");
+  });
+
+  test("GET /api/v1/ask is a 405", async () => {
+    const res = await handleRequest(new Request(ASK_URL), aiWorkerEnv(), {});
+    assert.equal(res.status, 405);
+  });
+
+  test("rate-limited request returns 429", async () => {
+    const env = aiWorkerEnv({
+      AI_RATE_LIMITER: { limit: () => Promise.resolve({ success: false }) },
+    });
+    const res = await handleRequest(
+      new Request(`${SEMANTIC_URL}?q=x`),
+      env,
+      {},
+    );
+    assert.equal(res.status, 429);
+    assert.equal(res.headers.get("retry-after"), "60");
+  });
+
+  test("an AI backend failure degrades to 502", async () => {
+    const env = aiWorkerEnv({
+      AI: { run: () => Promise.reject(new Error("model down")) },
+    });
+    const res = await handleRequest(
+      new Request(`${SEMANTIC_URL}?q=x`),
+      env,
+      {},
+    );
+    assert.equal(res.status, 502);
+    assert.equal((await res.json()).error.code, "ai_error");
+  });
+
+  test("ask backend failure degrades to 502", async () => {
+    const env = aiWorkerEnv({
+      AI: { run: () => Promise.reject(new Error("model down")) },
+    });
+    const res = await handleRequest(
+      new Request(ASK_URL, {
+        method: "POST",
+        body: JSON.stringify({ question: "x" }),
+      }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 502);
+  });
+});
+
+describe("ai-search defensive branches", () => {
+  const oneDoc = {
+    ok: true,
+    data: {
+      documents: [{ id: "subnet:1", type: "subnet", netuid: 1, title: "One" }],
+    },
+  };
+
+  test("runEmbeddingSync tolerates a KV read failure and a missing KV writer", async () => {
+    const env = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: { get: () => Promise.reject(new Error("kv down")) },
+    };
+    const r = await runEmbeddingSync(env, {
+      readArtifact: () => Promise.resolve(oneDoc),
+    });
+    assert.equal(r.ok, true);
+    assert.equal(r.embedded, 1);
+  });
+
+  test("runEmbeddingSync runs with no KV binding at all", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const r = await runEmbeddingSync(env, {
+      readArtifact: () => Promise.resolve(oneDoc),
+    });
+    assert.equal(r.ok, true);
+  });
+
+  test("runEmbeddingSync skips deletion when VECTORIZE lacks deleteByIds", async () => {
+    const kv = memKv({
+      [EMBED_MANIFEST_KEY]: JSON.stringify({ "subnet:9": "stalehash" }),
+    });
+    const vectorize = stubVectorize();
+    delete vectorize.deleteByIds;
+    const env = { AI: stubAi(), VECTORIZE: vectorize, METAGRAPH_CONTROL: kv };
+    const r = await runEmbeddingSync(env, {
+      readArtifact: () => Promise.resolve(oneDoc),
+    });
+    assert.equal(
+      r.removed,
+      1,
+      "removed is still counted even when deletion is unsupported",
+    );
+  });
+
+  test("semanticSearch throws when the embedding model returns no vector", async () => {
+    const env = {
+      AI: { run: () => Promise.resolve({ data: [] }) },
+      VECTORIZE: stubVectorize(),
+    };
+    await assert.rejects(() => semanticSearch(env, "x"), /no vector/);
+  });
+
+  test("semanticSearch tolerates matches with no metadata", async () => {
+    const env = {
+      AI: stubAi(),
+      VECTORIZE: { query: () => Promise.resolve({ matches: [{ id: "x" }] }) },
+    };
+    const out = await semanticSearch(env, "x");
+    assert.equal(out.results[0].score, 0);
+    assert.equal(out.results[0].netuid, null);
+  });
+
+  test("askQuestion formats informational (netuid-less) context entries", async () => {
+    const env = {
+      AI: stubAi(),
+      VECTORIZE: {
+        query: () =>
+          Promise.resolve({
+            matches: [
+              {
+                id: "provider:x",
+                metadata: { type: "provider", title: "Acme", subtitle: "host" },
+              },
+            ],
+          }),
+      },
+    };
+    const out = await askQuestion(env, "who hosts?");
+    assert.equal(out.citations[0].netuid, null);
+    assert.equal(out.context_count, 1);
+  });
+});
+
+describe("embedding-sync cron", () => {
+  test("the daily cron triggers an embedding sync", async () => {
+    const env = aiWorkerEnv({ METAGRAPH_CONTROL: memKv() });
+    const result = await handleScheduled(
+      { cron: EMBEDDING_SYNC_CRON },
+      env,
+      {},
+    );
+    assert.equal(result.ok, true);
+    assert.ok(result.total >= 0);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -40,10 +40,21 @@ import {
   subnetBadgeStatus,
 } from "../src/health-serving.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
+import {
+  aiEnabled,
+  askQuestion,
+  runEmbeddingSync,
+  semanticSearch,
+  withinRateLimit,
+} from "../src/ai-search.mjs";
 
 // Cron schedule strings (must match wrangler.jsonc `triggers.crons`). The hourly
 // trigger prunes the D1 time-series; every other trigger runs the 2-minute probe.
 const HEALTH_PRUNE_CRON = "0 * * * *";
+// Daily embedding-sync trigger (Worker-runtime, since CI has no AI bindings).
+// Distinct minute (odd) so it never collides with the 2-minute probe or the
+// top-of-hour prune. Must match a wrangler.jsonc `triggers.crons` entry.
+const EMBEDDING_SYNC_CRON = "37 3 * * *";
 // Trend windows for /api/v1/subnets/{netuid}/health/trends.
 const HEALTH_TREND_WINDOWS = { "7d": 7, "30d": 30 };
 const TRENDS_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/health\/trends$/;
@@ -127,6 +138,9 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
   if (cron === HEALTH_PRUNE_CRON) {
     return pruneHealthHistory(env);
   }
+  if (cron === EMBEDDING_SYNC_CRON) {
+    return runEmbeddingSync(env, { readArtifact });
+  }
   return runHealthProber(env, ctx);
 }
 
@@ -154,6 +168,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     return handleMcpRequest(request, env, { readArtifact, readHealthKv });
   }
 
+  // Grounded RAG answer endpoint (POST). Runs before the read-only method gate
+  // and degrades to 503 when the AI bindings/kill-switch are absent.
+  if (url.pathname === "/api/v1/ask") {
+    return handleAskRequest(request, env);
+  }
+
   if (!["GET", "HEAD"].includes(request.method)) {
     return errorResponse(
       "method_not_allowed",
@@ -172,6 +192,12 @@ export async function handleRequest(request, env = {}, ctx = {}) {
 
   if (url.pathname === "/api/v1/events") {
     return handleEventsRequest(request, env);
+  }
+
+  // Semantic (vector) search over the registry. Special-handled (dynamic, not
+  // artifact-backed) like /api/v1/events; degrades to 503 when AI is off.
+  if (url.pathname === "/api/v1/search/semantic") {
+    return handleSemanticSearchRequest(request, env, url);
   }
 
   if (url.pathname === "/api/v1" || url.pathname.startsWith("/api/v1/")) {
@@ -1596,6 +1622,103 @@ async function handleEventsRequest(request, env) {
   return new Response(frame, { status: 200, headers });
 }
 
+// --- AI search / ask (semantic + RAG) --------------------------------------
+
+function aiUnavailableResponse() {
+  return errorResponse(
+    "ai_unavailable",
+    "AI features are not enabled on this deployment.",
+    503,
+  );
+}
+
+function aiRateLimitedResponse() {
+  return errorResponse(
+    "rate_limited",
+    "Too many AI requests. Please retry shortly.",
+    429,
+    {},
+    { "retry-after": "60" },
+  );
+}
+
+function aiClientKey(request, scope) {
+  const ip =
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for") ||
+    "anon";
+  return `${scope}:${ip}`;
+}
+
+async function handleSemanticSearchRequest(request, env, url) {
+  if (!aiEnabled(env)) {
+    return aiUnavailableResponse();
+  }
+  if (!(await withinRateLimit(env, aiClientKey(request, "semantic")))) {
+    return aiRateLimitedResponse();
+  }
+  try {
+    const data = await semanticSearch(env, url.searchParams.get("q"), {
+      limit: url.searchParams.get("limit"),
+    });
+    return dataResponse(env, data, 200, { source: "ai-live" });
+  } catch (error) {
+    if (error?.aiInput) {
+      return errorResponse("invalid_query", error.message, 400);
+    }
+    logEvent(env, "error", "semantic_search_failed", {
+      message: error?.message,
+    });
+    return errorResponse(
+      "ai_error",
+      "Semantic search failed. Please retry shortly.",
+      502,
+    );
+  }
+}
+
+async function handleAskRequest(request, env) {
+  if (request.method !== "POST") {
+    return errorResponse(
+      "method_not_allowed",
+      "POST a JSON body { question } to /api/v1/ask.",
+      405,
+      {},
+      { allow: "POST, OPTIONS" },
+    );
+  }
+  if (!aiEnabled(env)) {
+    return aiUnavailableResponse();
+  }
+  if (!(await withinRateLimit(env, aiClientKey(request, "ask")))) {
+    return aiRateLimitedResponse();
+  }
+  let body;
+  try {
+    body = await request.json();
+  } catch {
+    return errorResponse(
+      "invalid_json",
+      "Request body must be valid JSON.",
+      400,
+    );
+  }
+  try {
+    const data = await askQuestion(env, body?.question, { topK: body?.topK });
+    return dataResponse(env, data, 200, { source: "ai-live" });
+  } catch (error) {
+    if (error?.aiInput) {
+      return errorResponse("invalid_request", error.message, 400);
+    }
+    logEvent(env, "error", "ask_failed", { message: error?.message });
+    return errorResponse(
+      "ai_error",
+      "The answer service failed. Please retry shortly.",
+      502,
+    );
+  }
+}
+
 // Success envelope for non-cacheable (mutation / dynamic) JSON responses.
 function dataResponse(env, data, status = 200, extraMeta = {}) {
   const headers = apiHeaders("short");
@@ -1956,6 +2079,8 @@ function corsPreflight(request) {
     methods = "POST, OPTIONS";
   } else if (url.pathname.startsWith("/api/v1/webhooks/")) {
     methods = "POST, GET, DELETE, OPTIONS";
+  } else if (url.pathname === "/mcp" || url.pathname === "/api/v1/ask") {
+    methods = "POST, OPTIONS";
   }
   headers.set("access-control-allow-methods", methods);
   headers.set(

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -30,6 +30,10 @@
     "METAGRAPH_CONTRACT_VERSION": "2026-06-06.1",
     "METAGRAPH_ENABLE_RPC_PROXY": "true",
     "METAGRAPH_R2_LATEST_PREFIX": "latest/",
+    // Kill-switch for the AI layer (semantic search + /ask). When "true" and the
+    // AI/VECTORIZE bindings are present, the routes serve live; otherwise they
+    // return 503 ai_unavailable. Flip to "false" to instantly disable.
+    "METAGRAPH_ENABLE_AI": "true",
   },
   "routes": [{ "pattern": "api.metagraph.sh", "custom_domain": true }],
   "kv_namespaces": [
@@ -42,6 +46,19 @@
     {
       "binding": "METAGRAPH_ARCHIVE",
       "bucket_name": "metagraphed-artifacts",
+    },
+  ],
+  // AI-native layer (semantic search + grounded /ask). Workers AI runs the
+  // embedding (bge-base-en-v1.5, 768-dim) + answer (llama-3.1-8b) models; the
+  // Vectorize index holds the registry embeddings, refreshed by the daily
+  // embedding-sync cron. Absent in local/CI, so the AI routes degrade to 503.
+  "ai": {
+    "binding": "AI",
+  },
+  "vectorize": [
+    {
+      "binding": "VECTORIZE",
+      "index_name": "metagraphed-registry",
     },
   ],
   // Live operational-health store. Written every 2 minutes by the cron prober
@@ -59,7 +76,7 @@
   // (served live); the hourly trigger prunes the D1 time-series. Registered
   // automatically on the next Workers Builds deploy.
   "triggers": {
-    "crons": ["*/2 * * * *", "0 * * * *"],
+    "crons": ["*/2 * * * *", "0 * * * *", "37 3 * * *"],
   },
   // Per-client abuse control for the read-only RPC proxy (an abuse prerequisite
   // for enabling METAGRAPH_ENABLE_RPC_PROXY). 100 requests / 60s per client IP;
@@ -71,6 +88,17 @@
       "namespace_id": "1001",
       "simple": {
         "limit": 100,
+        "period": 60,
+      },
+    },
+    // Per-client abuse control for the AI routes (semantic + /ask). 20 requests
+    // / 60s per client IP — tighter than the RPC proxy because /ask drives an
+    // LLM call. Skipped when the binding is absent (local dev/CI).
+    {
+      "name": "AI_RATE_LIMITER",
+      "namespace_id": "1002",
+      "simple": {
+        "limit": 20,
         "period": 60,
       },
     },


### PR DESCRIPTION
## Summary

Phase 3 of the AI-native roadmap: **natural-language discovery** over the registry, backed by Workers AI + a Vectorize index. Shipped **both on, rate-limited** (per your call), behind a kill-switch.

**What this unlocks:** a human or agent can ask *"decentralized scraping with a public API"* and get ranked subnets without exact keywords, or `POST /api/v1/ask { question }` for a **grounded, cited** answer over the registry — no hallucination, every claim sourced to a real subnet/surface.

## Routes (`src/ai-search.mjs`)
Both are **out-of-contract dynamic routes** — special-handled like `/api/v1/events`, so they're not in `API_ROUTES`/OpenAPI/the `validate-api` count invariant and the contract spine is untouched.
- `GET /api/v1/search/semantic?q=&limit=` → embeds the query (`@cf/baai/bge-base-en-v1.5`, 768-dim) → Vectorize query → nearest entries `{score,type,netuid,slug,title,subtitle,url}` (limit ≤ 20).
- `POST /api/v1/ask { question }` → retrieve top-6 → `@cf/meta/llama-3.1-8b-instruct` with a cite-only prompt → `{question, answer, citations[], context_count, model}`.

## Cost/abuse controls
- **`METAGRAPH_ENABLE_AI`** kill-switch — flip to `"false"` to disable instantly.
- **Binding presence** — `AI`/`VECTORIZE` absent in local/CI → `503 ai_unavailable`, so **CI never calls Workers AI**.
- **`AI_RATE_LIMITER`** native binding — 20 req/60s per client IP (same mechanism as the RPC proxy limiter, zero KV cost; replaces the plan's KV limiter). Absent → allow.
- Hard caps: result/context size + 1000-char question limit.

## Embedding sync
Daily cron (`37 3 * * *`, Worker-runtime since CI has no AI bindings) diffs `search.json` against a content-hash manifest in KV and **re-embeds only deltas**, dropping removed ids. Embeddings stay ≤24h fresh; structural data unaffected.

## Provisioning
- Vectorize index `metagraphed-registry` (768-dim, cosine) **created** on the production account.
- `wrangler.jsonc`: `ai` + `vectorize` bindings, `METAGRAPH_ENABLE_AI` var, daily cron, `AI_RATE_LIMITER` (namespace 1002). Validated by `wrangler deploy --dry-run` (all bindings recognized).

## Verification
- **668 tests pass**; coverage **98.5% stmts / 91.2% branch / 99.1% funcs / 98.6% lines** (`ai-search.mjs` 100% lines).
- New `validate:ai` (CI step): disabled→503, stubbed-enabled→200 against `schemas/ai/*.schema.json`, negatives (400/405) + rate-limit (429).
- Green: `validate` / `:schemas` / `:api` (still 48 routes) / `:mcp` / `:ai` / `:openapi` / `:types` / `:docs` / `:artifact-budgets` / `:workflows` + `cloudflare:verify:dry-run` + `worker:deploy:dry-run`.
- Subset-commit discipline: only `llms.txt` regenerated; no contract-artifact drift.
- ADR `docs/adr/0003` + a `backend-artifact-contracts.md` section; `smoke-live-api.mjs` extended (tolerant of the kill-switch + a cold index).

Post-merge I'll trigger the embedding sync to warm Vectorize, then verify both endpoints live.

Part of the AI-native roadmap (AI-3 of 6). Next: historical analytics + bulk datasets (AI-4).