### PR TITLE
fix(mcp): bound public request processing

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -36,6 +36,14 @@ const MCP_INSTRUCTIONS =
 
 const JSONRPC_VERSION = "2.0";
 
+// Abuse controls for the public Streamable-HTTP endpoint. Keep these small
+// enough to prevent one unauthenticated request from amplifying into many
+// artifact/KV reads, while still allowing legacy clients that send tiny
+// JSON-RPC batches.
+export const MAX_MCP_BODY_BYTES = 64 * 1024;
+export const MAX_MCP_BATCH_LENGTH = 10;
+const MCP_RATE_LIMIT = { limit: 100, windowSeconds: 60 };
+
 // JSON-RPC error codes (subset of the spec we emit).
 const RPC_PARSE_ERROR = -32700;
 const RPC_INVALID_REQUEST = -32600;
@@ -579,16 +587,54 @@ const MCP_HEADERS = {
   "cache-control": "no-store",
 };
 
-function jsonResponse(payload, status = 200) {
+function jsonResponse(payload, status = 200, headers = {}) {
   return new Response(JSON.stringify(payload), {
     status,
-    headers: MCP_HEADERS,
+    headers: { ...MCP_HEADERS, ...headers },
   });
+}
+
+function mcpClientKey(request) {
+  return (
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for") ||
+    "anonymous"
+  );
+}
+
+async function enforceMcpRateLimit(request, env) {
+  const limiter = env.MCP_RATE_LIMITER || env.RPC_RATE_LIMITER;
+  if (!limiter?.limit) return null;
+
+  const { success } = await limiter.limit({ key: mcpClientKey(request) });
+  if (success) return null;
+
+  return jsonResponse(
+    rpcError(
+      null,
+      RPC_INVALID_REQUEST,
+      "Too many MCP requests from this client; slow down.",
+    ),
+    429,
+    {
+      "retry-after": String(MCP_RATE_LIMIT.windowSeconds),
+      "x-ratelimit-limit": String(MCP_RATE_LIMIT.limit),
+      "x-ratelimit-policy": `${MCP_RATE_LIMIT.limit};w=${MCP_RATE_LIMIT.windowSeconds}`,
+      "x-ratelimit-remaining": "0",
+    },
+  );
+}
+
+function bodyTooLargeResponse() {
+  return jsonResponse(
+    rpcError(null, RPC_INVALID_REQUEST, "MCP request body is too large."),
+    413,
+  );
 }
 
 // Entry point wired into the Worker at `POST /mcp`. `deps` injects the shared
 // artifact/KV readers from workers/api.mjs.
-export async function handleMcpRequest(request, env, deps = {}) {
+export async function handleMcpRequest(request, env = {}, deps = {}) {
   if (request.method !== "POST") {
     return new Response(
       JSON.stringify({
@@ -605,9 +651,21 @@ export async function handleMcpRequest(request, env, deps = {}) {
     );
   }
 
+  const rateLimitResponse = await enforceMcpRateLimit(request, env);
+  if (rateLimitResponse) return rateLimitResponse;
+
+  const contentLength = Number(request.headers.get("content-length") || 0);
+  if (contentLength > MAX_MCP_BODY_BYTES) {
+    return bodyTooLargeResponse();
+  }
+
   let body;
   try {
-    body = await request.json();
+    const bodyText = await request.text();
+    if (new TextEncoder().encode(bodyText).length > MAX_MCP_BODY_BYTES) {
+      return bodyTooLargeResponse();
+    }
+    body = JSON.parse(bodyText);
   } catch {
     return jsonResponse(
       rpcError(null, RPC_PARSE_ERROR, "Request body is not valid JSON."),
@@ -617,12 +675,22 @@ export async function handleMcpRequest(request, env, deps = {}) {
 
   const ctx = buildContext(request, env, deps);
 
-  // Legacy JSON-RPC batch (array). MCP 2025-06-18 removed batching, but we stay
-  // lenient for older clients.
+  // Legacy JSON-RPC batch (array). MCP 2025-06-18 removed batching, but cap
+  // older-client compatibility so one HTTP request cannot fan out unboundedly.
   if (Array.isArray(body)) {
     if (body.length === 0) {
       return jsonResponse(
         rpcError(null, RPC_INVALID_REQUEST, "Empty JSON-RPC batch."),
+        400,
+      );
+    }
+    if (body.length > MAX_MCP_BATCH_LENGTH) {
+      return jsonResponse(
+        rpcError(
+          null,
+          RPC_INVALID_REQUEST,
+          `JSON-RPC batch length exceeds the maximum of ${MAX_MCP_BATCH_LENGTH}.`,
+        ),
         400,
       );
     }

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -4,6 +4,8 @@ import {
   MCP_TOOLS,
   MCP_PROTOCOL_VERSIONS,
   MCP_SERVER_INFO,
+  MAX_MCP_BATCH_LENGTH,
+  MAX_MCP_BODY_BYTES,
   listToolDefinitions,
   handleMcpRequest,
 } from "../src/mcp-server.mjs";
@@ -235,6 +237,70 @@ describe("MCP transport handling", () => {
     const res = await rpc([]);
     assert.equal(res.status, 400);
     assert.equal(res.body.error.code, -32600);
+  });
+
+  test("an oversized batch is rejected before processing messages", async () => {
+    const calls = [];
+    const deps = {
+      ...makeDeps(),
+      readArtifact(_env, path) {
+        calls.push(path);
+        return Promise.resolve({ ok: true, data: {} });
+      },
+    };
+    const res = await rpc(
+      Array.from({ length: MAX_MCP_BATCH_LENGTH + 1 }, (_, index) => ({
+        jsonrpc: "2.0",
+        id: index + 1,
+        method: "tools/list",
+      })),
+      { deps },
+    );
+    assert.equal(res.status, 400);
+    assert.equal(res.body.error.code, -32600);
+    assert.match(res.body.error.message, /batch length exceeds/);
+    assert.deepEqual(calls, []);
+  });
+
+  test("an oversized decoded body is rejected before JSON parsing", async () => {
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: `"${"x".repeat(MAX_MCP_BODY_BYTES)}"`,
+    });
+    const response = await handleMcpRequest(request, {}, makeDeps());
+    assert.equal(response.status, 413);
+    const body = await response.json();
+    assert.equal(body.error.code, -32600);
+  });
+
+  test("the MCP rate limiter is enforced before body parsing", async () => {
+    let rateLimitKey;
+    const request = new Request(MCP_URL, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "cf-connecting-ip": "203.0.113.7",
+      },
+      body: "{not json",
+    });
+    const response = await handleMcpRequest(
+      request,
+      {
+        MCP_RATE_LIMITER: {
+          async limit({ key }) {
+            rateLimitKey = key;
+            return { success: false };
+          },
+        },
+      },
+      makeDeps(),
+    );
+    assert.equal(response.status, 429);
+    assert.equal(response.headers.get("retry-after"), "60");
+    assert.equal(rateLimitKey, "203.0.113.7");
+    const body = await response.json();
+    assert.match(body.error.message, /Too many MCP requests/);
   });
 
   test("handleMcpRequest defaults deps to an empty object", async () => {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -91,6 +91,18 @@
         "period": 60,
       },
     },
+    // Per-client abuse control for the MCP JSON-RPC endpoint. 100 requests /
+    // 60s per client IP, paired with MCP's body and batch caps so a public POST
+    // cannot amplify one request into unbounded artifact/KV reads. Skipped when
+    // the binding is absent (local dev/CI).
+    {
+      "name": "MCP_RATE_LIMITER",
+      "namespace_id": "1003",
+      "simple": {
+        "limit": 100,
+        "period": 60,
+      },
+    },
     // Per-client abuse control for the AI routes (semantic + /ask). 20 requests
     // / 60s per client IP — tighter than the RPC proxy because /ask drives an
     // LLM call. Skipped when the binding is absent (local dev/CI).


### PR DESCRIPTION
### Motivation
- The public `POST /mcp` handler accepted unbounded JSON bodies and legacy JSON-RPC batches and could amplify a single HTTP request into many artifact/KV reads, enabling CPU/time exhaustion and backend read amplification.\n
### Description
- Add abuse-control constants `MAX_MCP_BODY_BYTES` and `MAX_MCP_BATCH_LENGTH` and a small `MCP_RATE_LIMIT` policy for the MCP endpoint in `src/mcp-server.mjs`.\n- Enforce per-client rate limiting before parsing with `enforceMcpRateLimit`, and apply `Content-Length` and decoded-body size checks to reject oversized requests before JSON parsing.\n- Cap legacy JSON-RPC batch processing to `MAX_MCP_BATCH_LENGTH` so a single request cannot fan out unboundedly, while preserving legacy leniency for small batches.\n- Allow falling back to an existing RPC limiter and add a dedicated `MCP_RATE_LIMITER` binding to `wrangler.jsonc`.\n- Add regression tests in `tests/mcp-server.test.mjs` to cover oversized bodies, oversized batches, and pre-parse rate-limit enforcement.\n
### Testing
- Ran `npm run lint` which completed successfully.\n- Ran `npx prettier --check src/mcp-server.mjs tests/mcp-server.test.mjs wrangler.jsonc` which passed for the changed files.\n- Ran targeted tests with `npm test -- tests/mcp-server.test.mjs -t "oversized|rate limiter|batch processes|notification-only batch|empty batch"` and they all passed.\n- Running the full `tests/mcp-server.test.mjs` produced one failing end-to-end test because the local artifact fixture does not include `latest/agent-catalog/7.json`, causing the test to receive an `artifact_not_found` tool error rather than `structuredContent`.\n- `npm run format:check` failed due to pre-existing unrelated formatting issues in other files (unchanged by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a53d59e04832ab2780b4b2bbd786b)