### PR TITLE
fix(ai): cap /api/v1/ask request body parsing

### DIFF
--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { ReadableStream } from "node:stream/web";
 import { describe, test } from "vitest";
 import {
   EMBED_MODEL,
@@ -409,6 +410,46 @@ describe("AI routes through the Worker dispatch", () => {
     );
     assert.equal(res.status, 400);
     assert.equal((await res.json()).error.code, "invalid_json");
+  });
+
+  test("ask rejects oversized Content-Length before parsing", async () => {
+    const env = aiWorkerEnv({
+      AI: { run: () => Promise.reject(new Error("body should not parse")) },
+    });
+    const res = await handleRequest(
+      new Request(ASK_URL, {
+        method: "POST",
+        headers: { "content-length": "4097" },
+        body: JSON.stringify({ question: "x" }),
+      }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 413);
+    assert.equal((await res.json()).error.code, "payload_too_large");
+  });
+
+  test("ask rejects oversized streamed bodies while reading", async () => {
+    const stream = new ReadableStream({
+      start(controller) {
+        controller.enqueue(
+          new TextEncoder().encode('{"question":"x","padding":"'),
+        );
+        controller.enqueue(new Uint8Array(4097));
+        controller.enqueue(new TextEncoder().encode('"}'));
+        controller.close();
+      },
+    });
+    const env = aiWorkerEnv({
+      AI: { run: () => Promise.reject(new Error("body should not parse")) },
+    });
+    const res = await handleRequest(
+      new Request(ASK_URL, { method: "POST", body: stream, duplex: "half" }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 413);
+    assert.equal((await res.json()).error.code, "payload_too_large");
   });
 
   test("GET /api/v1/ask is a 405", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -104,6 +104,7 @@ const DENIED_RPC_PREFIXES = [
 const MAX_RPC_BODY_BYTES = 65536;
 const METAGRAPH_LATEST_KEY = "metagraph:latest";
 const MAX_WEBHOOK_BODY_BYTES = 8192;
+const MAX_ASK_BODY_BYTES = 4096;
 const WEBHOOK_SUBSCRIPTION_TOKEN_HEADER =
   "x-metagraph-webhook-subscription-token";
 // Dormant subscriptions self-clean after 180 days; the publish-time dispatcher
@@ -1650,6 +1651,42 @@ function aiClientKey(request, scope) {
   return `${scope}:${ip}`;
 }
 
+async function readBoundedRequestText(request, maxBytes) {
+  const contentLength = Number(request.headers.get("content-length") || 0);
+  if (contentLength > maxBytes) {
+    return { ok: false, text: "" };
+  }
+
+  if (!request.body) {
+    return { ok: true, text: "" };
+  }
+
+  const reader = request.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const chunk =
+        typeof value === "string" ? new TextEncoder().encode(value) : value;
+      bytes += chunk.byteLength;
+      if (bytes > maxBytes) {
+        await reader.cancel();
+        return { ok: false, text: "" };
+      }
+      text += decoder.decode(chunk, { stream: true });
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  text += decoder.decode();
+  return { ok: true, text };
+}
+
 async function handleSemanticSearchRequest(request, env, url) {
   if (!aiEnabled(env)) {
     return aiUnavailableResponse();
@@ -1695,7 +1732,18 @@ async function handleAskRequest(request, env) {
   }
   let body;
   try {
-    body = await request.json();
+    const boundedBody = await readBoundedRequestText(
+      request,
+      MAX_ASK_BODY_BYTES,
+    );
+    if (!boundedBody.ok) {
+      return errorResponse(
+        "payload_too_large",
+        "Ask request body exceeds the size limit.",
+        413,
+      );
+    }
+    body = JSON.parse(boundedBody.text);
   } catch {
     return errorResponse(
       "invalid_json",


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory/CPU use by `/api/v1/ask` which previously called `request.json()` without a byte limit and parsed arbitrarily large or streamed bodies before enforcing the 1000-char `question` cap.
- Apply the same defensive, early-reject pattern used by other POST handlers to avoid resource exhaustion and DoS risk.

### Description
- Add a `MAX_ASK_BODY_BYTES` constant set to `4096` and a `readBoundedRequestText(request, maxBytes)` helper that checks `Content-Length`, streams the request body with a byte counter, cancels on overflow, and returns a bounded text buffer.
- Update `handleAskRequest` to use `readBoundedRequestText` and return `413 payload_too_large` when the body exceeds the byte cap, then `JSON.parse` the bounded text; retain existing `askQuestion` validation (including `ASK_MAX_QUESTION_LENGTH`).
- Add regression tests in `tests/ai-search.test.mjs` that assert oversized `Content-Length` headers are rejected and that oversized streamed bodies are rejected while reading.
- Changes are limited to `workers/api.mjs` (defensive read + cap) and `tests/ai-search.test.mjs` (new tests).

### Testing
- Ran the focused test group: `npm test -- tests/ai-search.test.mjs -t "AI routes through the Worker dispatch"` and the modified/targeted tests passed.
- Ran AI route validation: `npm run validate:ai` and it passed (disabled->503, enabled->200, negatives + rate-limit).
- Ran linter: `npm run lint` and it passed after adding the test import for `ReadableStream`.
- Ran the full AI test file: `npm test -- tests/ai-search.test.mjs` where the targeted changes pass, but the repository-wide run surfaced a pre-existing unrelated test failure in `embedding-sync cron > the daily cron triggers an embedding sync` (assertion expecting `result.ok` true but received false) and some unrelated formatting warnings from untouched files during `npm run format:check`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a5d744554832ab49a96791b2819e2)