### PR TITLE
fix(ai): scope embedding manifest to vector index

### DIFF
--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -18,7 +18,13 @@
 export const EMBED_MODEL = "@cf/qwen/qwen3-embedding-0.6b"; // 1024-dim
 export const EMBED_DIMENSIONS = 1024;
 export const ASK_MODEL = "@cf/meta/llama-4-scout-17b-16e-instruct";
-export const EMBED_MANIFEST_KEY = "ai:embed-manifest";
+export const VECTORIZE_INDEX_NAME = "metagraphed-registry-v2";
+export const EMBED_MANIFEST_KEY = [
+  "ai:embed-manifest",
+  VECTORIZE_INDEX_NAME,
+  EMBED_MODEL,
+  EMBED_DIMENSIONS,
+].join(":");
 
 export const SEMANTIC_DEFAULT_LIMIT = 10;
 export const SEMANTIC_MAX_LIMIT = 20;
@@ -136,8 +142,9 @@ async function readManifest(env) {
   }
 }
 
-// Embedding-sync cron: diff the search index against a content-hash manifest in
-// KV, (re)embed only the deltas, upsert to Vectorize, drop removed ids. Runs in
+// Embedding-sync cron: diff the search index against a deployment-scoped
+// content-hash manifest in KV, (re)embed only the deltas, upsert to Vectorize,
+// drop removed ids. Runs in
 // the Worker runtime (CI has no AI bindings). `deps.readArtifact` is injected.
 export async function runEmbeddingSync(env, deps = {}) {
   if (!aiConfigured(env)) return { ok: false, reason: "ai_unconfigured" };

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -228,6 +228,26 @@ describe("runEmbeddingSync", () => {
     assert.ok(env.METAGRAPH_CONTROL.store.get(EMBED_MANIFEST_KEY));
   });
 
+  test("ignores the legacy unscoped manifest after model/index migrations", async () => {
+    const env = {
+      AI: stubAi(),
+      VECTORIZE: stubVectorize(),
+      METAGRAPH_CONTROL: memKv({
+        "ai:embed-manifest": JSON.stringify({
+          "subnet:1": "legacy-hash",
+          "subnet:2": "legacy-hash",
+        }),
+      }),
+    };
+
+    const r = await runEmbeddingSync(env, { readArtifact: reader(searchDocs) });
+
+    assert.equal(r.embedded, 2);
+    assert.equal(env.VECTORIZE.ops.upserts[0].length, 2);
+    assert.ok(env.METAGRAPH_CONTROL.store.get(EMBED_MANIFEST_KEY));
+    assert.ok(env.METAGRAPH_CONTROL.store.get("ai:embed-manifest"));
+  });
+
   test("re-embeds only deltas and deletes removed ids on a second run", async () => {
     const kv = memKv();
     const env = {


### PR DESCRIPTION
### Motivation
- The embedding sync used an unscoped KV manifest key (`ai:embed-manifest`) so model/index migrations could reuse stale hashes and skip re-embedding unchanged documents into a new Vectorize index. This could leave a new index empty after cutover.
- Scope the manifest to the active deployment (index name + embedding model + dimensions) so migrations force a fresh delta pass and avoid silent availability/data-quality regressions.

### Description
- Introduce `VECTORIZE_INDEX_NAME` and compute `EMBED_MANIFEST_KEY` as `['ai:embed-manifest', VECTORIZE_INDEX_NAME, EMBED_MODEL, EMBED_DIMENSIONS].join(':')` so the manifest is deployment-scoped and unique per index/model/dimension combination. (`src/ai-search.mjs`).
- Update the embedding-sync comment to document the manifest is now deployment-scoped while preserving the delta-embedding, upsert, and deletion flow. (`src/ai-search.mjs`).
- Add a regression test that seeds a legacy unscoped `ai:embed-manifest` and asserts the scoped manifest is used and all docs are embedded/upserted into the current index. (`tests/ai-search.test.mjs`).

### Testing
- `node --check src/ai-search.mjs && node --check tests/ai-search.test.mjs` succeeded and reported no syntax errors. 
- Executed an automated Node run of `runEmbeddingSync` (via `node --input-type=module` script) that simulated a legacy `ai:embed-manifest` entry and confirmed `embedded: 2`, `upserts: 2`, and that both the legacy and new scoped manifest keys exist, demonstrating the intended cutover behavior. 
- `npm test` could not run because `vitest` was not installed in the environment (test runner unavailable); `npm ci` failed due to an environment/registry error installing `@esbuild/linux-x64` (403 / network resolution error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a5d22184c832a8d9b10070768c43d)