### PR TITLE
fix(analytics): bound health incidents route

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -325,18 +325,26 @@ export function formatPercentiles({ netuid, window, observedAt, rows }) {
 
 // SLA + downtime incidents per surface. `slaRows`: [{ surface_id, total,
 // ok_count }]. `incidentRows`: [{ surface_id, started_at, ended_at,
-// failed_samples }] — one row PER INCIDENT (gap-islands grouped in SQL), so the
-// payload is bounded by incident count, not by failure count (a fully-dead
-// subnet over 30 days cannot blow up the Worker isolate).
+// failed_samples }] — one row PER INCIDENT (gap-islands grouped in SQL).
+// `maxIncidents` is a defensive API cap so flapping endpoints cannot force the
+// formatter to materialize unbounded incident arrays.
 export function formatIncidents({
   netuid,
   window,
   observedAt,
   slaRows,
   incidentRows,
+  maxIncidents,
 }) {
+  const incidentLimit = Number.isInteger(maxIncidents)
+    ? Math.max(0, maxIncidents)
+    : Infinity;
   const incidentsBySurface = new Map();
+  let acceptedIncidents = 0;
   for (const row of incidentRows || []) {
+    if (acceptedIncidents >= incidentLimit) {
+      break;
+    }
     const list = incidentsBySurface.get(row.surface_id) || [];
     const startedAt = Number(row.started_at);
     const endedAt = Number(row.ended_at);
@@ -346,6 +354,7 @@ export function formatIncidents({
       duration_ms: endedAt - startedAt,
       failed_samples: Number(row.failed_samples) || 0,
     });
+    acceptedIncidents += 1;
     incidentsBySurface.set(row.surface_id, list);
   }
 

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -109,6 +109,22 @@ describe("formatIncidents", () => {
     });
     assert.equal(out.surfaces[0].uptime_ratio, null);
   });
+  test("caps materialized incidents when requested by the API", () => {
+    const t = 1_000_000_000_000;
+    const out = formatIncidents({
+      netuid: 1,
+      slaRows: [{ surface_id: "x", total: 10, ok_count: 5 }],
+      incidentRows: Array.from({ length: 3 }, (_, i) => ({
+        surface_id: "x",
+        started_at: t + i * 60000,
+        ended_at: t + i * 60000,
+        failed_samples: 1,
+      })),
+      maxIncidents: 2,
+    });
+    assert.equal(out.surfaces[0].incident_count, 2);
+    assert.equal(out.surfaces[0].incidents.length, 2);
+  });
 });
 
 describe("formatLeaderboards", () => {
@@ -385,6 +401,16 @@ describe("analytics routes (cold local D1)", () => {
     );
     assert.deepEqual(body.data.surfaces, []);
   });
+  test("incidents rejects unsupported query parameters", async () => {
+    for (const query of ["window=bogus", "window=7d&cacheBust=x"]) {
+      const { status, body } = await getJson(
+        `https://api.metagraph.sh/api/v1/subnets/7/health/incidents?${query}`,
+        env,
+      );
+      assert.equal(status, 400);
+      assert.equal(body.error.code, "invalid_query");
+    }
+  });
   test("trajectory returns empty-but-valid", async () => {
     const { body } = await getJson(
       "https://api.metagraph.sh/api/v1/subnets/7/trajectory",
@@ -430,6 +456,34 @@ describe("analytics routes (fake D1 with data)", () => {
     );
     assert.equal(body.data.surfaces[0].uptime_ratio, 0.98);
     assert.equal(body.data.surfaces[0].incident_count, 1);
+  });
+  test("incidents SQL uses a hard incident row cap", async () => {
+    const queries = [];
+    const envWithCapture = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              queries.push({ sql, params });
+              return {
+                all: () => Promise.resolve({ results: rowsForSql(sql) }),
+              };
+            },
+          };
+        },
+      },
+    };
+    const { status } = await getJson(
+      "https://api.metagraph.sh/api/v1/subnets/7/health/incidents",
+      envWithCapture,
+    );
+    assert.equal(status, 200);
+    const incidentQuery = queries.find((query) =>
+      query.sql.includes("WITH failures"),
+    );
+    assert.ok(incidentQuery.sql.includes("LIMIT ?"));
+    assert.equal(incidentQuery.params.at(-1), 1000);
   });
   test("trajectory computes deltas from snapshots", async () => {
     const { body } = await getJson(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -70,6 +70,8 @@ const PERCENTILES_PATH_PATTERN =
 const INCIDENTS_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/health\/incidents$/;
 const TRAJECTORY_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/trajectory$/;
 const ANALYTICS_WINDOWS = { "7d": 7, "30d": 30 };
+const ANALYTICS_WINDOW_PARAM = "window";
+const MAX_INCIDENT_ROWS = 1000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
@@ -638,9 +640,35 @@ async function handleHealthTrends(request, env, netuid) {
 }
 
 function analyticsWindow(url) {
-  const requested = url.searchParams.get("window");
-  const label = ANALYTICS_WINDOWS[requested] ? requested : "7d";
+  for (const key of url.searchParams.keys()) {
+    if (key !== ANALYTICS_WINDOW_PARAM) {
+      return {
+        error: {
+          parameter: key,
+          message: `${key} is not supported for this route.`,
+        },
+      };
+    }
+  }
+
+  const requested = url.searchParams.get(ANALYTICS_WINDOW_PARAM);
+  if (requested !== null && !ANALYTICS_WINDOWS[requested]) {
+    return {
+      error: {
+        parameter: ANALYTICS_WINDOW_PARAM,
+        message: `${ANALYTICS_WINDOW_PARAM} is not supported for this route.`,
+      },
+    };
+  }
+
+  const label = requested || "7d";
   return { label, days: ANALYTICS_WINDOWS[label] };
+}
+
+function analyticsQueryError(error) {
+  return errorResponse("invalid_query", error.message, 400, {
+    parameter: error.parameter,
+  });
 }
 
 async function d1All(env, sql, params) {
@@ -669,7 +697,8 @@ function analyticsMeta(env, artifactPath, observedAt) {
 
 // p50/p95/p99 latency percentiles per surface, computed in D1.
 async function handleHealthPercentiles(request, env, netuid, url) {
-  const { label, days } = analyticsWindow(url);
+  const { label, days, error } = analyticsWindow(url);
+  if (error) return analyticsQueryError(error);
   const rows = await d1All(
     env,
     `WITH ranked AS (
@@ -714,7 +743,8 @@ async function handleHealthPercentiles(request, env, netuid, url) {
 
 // SLA + reconstructed downtime incidents per surface.
 async function handleHealthIncidents(request, env, netuid, url) {
-  const { label, days } = analyticsWindow(url);
+  const { label, days, error } = analyticsWindow(url);
+  if (error) return analyticsQueryError(error);
   const since = Date.now() - days * DAY_MS;
   const [slaRows, incidentRows] = await Promise.all([
     d1All(
@@ -726,8 +756,8 @@ async function handleHealthIncidents(request, env, netuid, url) {
       [netuid, since],
     ),
     // Gap-island grouping in SQL: collapse consecutive failures (gap <= the
-    // incident threshold) into one incident row. Returns one row per incident,
-    // not per failure, so a fully-dead subnet can't return a huge result set.
+    // incident threshold) into one incident row, then cap the public payload so
+    // flapping endpoints cannot force unbounded result sets/responses.
     d1All(
       env,
       `WITH failures AS (
@@ -749,8 +779,9 @@ async function handleHealthIncidents(request, env, netuid, url) {
               COUNT(*) AS failed_samples
        FROM grouped
        GROUP BY surface_id, grp
-       ORDER BY surface_id, started_at`,
-      [netuid, since, INCIDENT_GAP_MS],
+       ORDER BY surface_id, started_at
+       LIMIT ?`,
+      [netuid, since, INCIDENT_GAP_MS, MAX_INCIDENT_ROWS],
     ),
   ]);
   const meta = await readHealthKv(env, KV_HEALTH_META);
@@ -760,6 +791,7 @@ async function handleHealthIncidents(request, env, netuid, url) {
     observedAt: meta?.last_run_at || null,
     slaRows,
     incidentRows,
+    maxIncidents: MAX_INCIDENT_ROWS,
   });
   return envelopeResponse(
     request,


### PR DESCRIPTION
### Motivation
- The live `/api/v1/subnets/{netuid}/health/incidents` analytics route silently accepted arbitrary query parameters and defaulted invalid `window` values, enabling cache-busting request variants and repeated expensive D1 work. 
- The incidents SQL materialized every reconstructed incident row with no hard cap, allowing flapping endpoints to drive large D1 results and unbounded Worker JSON responses and risking availability/OOM.

### Description
- Enforce strict query validation for analytics window routes by rejecting unsupported query parameters and invalid `window` values instead of silently defaulting (`analyticsWindow` now returns structured errors handled by `analyticsQueryError`).
- Add a hard public cap `MAX_INCIDENT_ROWS = 1000` and apply it to the reconstructed-incident D1 query via `LIMIT ?` to bound rows returned from D1.
- Pass the same cap into the formatter (`formatIncidents` via `maxIncidents`) and implement a defensive materialization cap so the formatter stops accumulating after the configured limit.
- Add regression tests covering invalid analytics query rejection, SQL incident-row limiting, and formatter capping, and update test fixtures accordingly.

### Testing
- Ran targeted unit tests with `npx vitest run tests/analytics.test.mjs -t "caps materialized|unsupported query|hard incident row cap|incidents computes"`, and the new/targeted tests passed.
- Ran lint and formatting checks with `npm run lint` and `npx prettier --check`, and they succeeded.
- Ran the full `npx vitest run tests/analytics.test.mjs` in this environment; the new tests passed but the full local run still shows unrelated fixture failures caused by missing local profile/snapshot artifacts in the checkout (not related to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a6d56b1f4832a89f5af1fc9a827b5)