### PR TITLE
fix(mcp): get_best_rpc_endpoint returns url, dedupes, drops bogus network (TS3)

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -388,24 +388,34 @@ export const MCP_TOOLS = [
         poolData.pools && typeof poolData.pools === "object"
           ? poolData.pools
           : {};
-      const candidates = [];
-      for (const [network, pool] of Object.entries(pools)) {
+      // Pool map keys ("0"/"1"/"2") are pool indices, NOT networks — and the
+      // same physical endpoint can appear in more than one pool. Dedupe by
+      // endpoint id, keeping the best-scored instance.
+      const bestById = new Map();
+      for (const pool of Object.values(pools)) {
         const overlaid = overlayRpcPoolEligibility(pool, liveRpcPool);
         for (const endpoint of overlaid.endpoints || []) {
           if (!endpoint.pool_eligible) continue;
-          candidates.push({ network, ...endpoint });
+          const existing = bestById.get(endpoint.id);
+          if (!existing || (endpoint.score || 0) > (existing.score || 0)) {
+            bestById.set(endpoint.id, endpoint);
+          }
         }
       }
-      candidates.sort(
+      const candidates = [...bestById.values()].sort(
         (a, b) =>
           (b.score || 0) - (a.score || 0) ||
           (a.latency_ms ?? Infinity) - (b.latency_ms ?? Infinity),
       );
       const endpoints = candidates.slice(0, limit).map((endpoint) => ({
         id: endpoint.id,
-        network: endpoint.network,
-        provider: endpoint.provider,
-        kind: endpoint.kind,
+        // The connectable endpoint URL — the whole point of the tool.
+        url: endpoint.url ?? null,
+        provider: endpoint.provider ?? null,
+        kind: endpoint.kind ?? null,
+        // These pools are the Bittensor mainnet (Finney) base layer.
+        network: "finney",
+        layer: endpoint.layer ?? "bittensor-base",
         score: endpoint.score ?? null,
         latency_ms: endpoint.latency_ms ?? null,
         status: endpoint.status ?? null,

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -317,6 +317,7 @@ describe("MCP tools (injected deps)", () => {
             endpoints: [
               {
                 id: "a",
+                url: "wss://a.example",
                 provider: "x",
                 kind: "subtensor-rpc",
                 score: 90,
@@ -325,6 +326,7 @@ describe("MCP tools (injected deps)", () => {
               },
               {
                 id: "b",
+                url: "wss://b.example",
                 provider: "y",
                 kind: "subtensor-rpc",
                 score: 95,
@@ -333,10 +335,26 @@ describe("MCP tools (injected deps)", () => {
               },
               {
                 id: "c",
+                url: "wss://c.example",
                 provider: "z",
                 kind: "subtensor-rpc",
                 score: 99,
                 pool_eligible: false,
+              },
+            ],
+          },
+          // Same physical endpoint 'b' also appears in a second pool — must be
+          // deduped, not returned twice.
+          1: {
+            endpoints: [
+              {
+                id: "b",
+                url: "wss://b.example",
+                provider: "y",
+                kind: "subtensor-wss",
+                score: 95,
+                pool_eligible: true,
+                latency_ms: 80,
               },
             ],
           },
@@ -455,14 +473,20 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(res.body.result.structuredContent.netuid, 7);
   });
 
-  test("get_best_rpc_endpoint excludes down endpoints and applies live health", async () => {
+  test("get_best_rpc_endpoint dedupes, exposes url/network, applies live health", async () => {
     const res = await callTool("get_best_rpc_endpoint", { limit: 5 }, { deps });
     const out = res.body.result.structuredContent;
     assert.equal(out.live_health, true);
-    // 'a' and 'b' are pool_eligible; 'c' is not. 'b' gets live latency 70.
+    // 'a' and 'b' are pool_eligible ('c' is not); 'b' appears in two pools but
+    // must be deduped -> exactly 2 eligible. 'b' gets live latency 70.
     assert.equal(out.eligible_count, 2);
+    assert.equal(out.endpoints.filter((e) => e.id === "b").length, 1);
     assert.equal(out.endpoints[0].id, "b");
     assert.equal(out.endpoints[0].latency_ms, 70);
+    assert.equal(out.endpoints[0].url, "wss://b.example");
+    assert.equal(out.endpoints[0].network, "finney");
+    // The bogus pool-key network ("0"/"1") must never leak.
+    assert.ok(out.endpoints.every((e) => e.network === "finney"));
   });
 
   test("get_best_rpc_endpoint works without a live KV snapshot", async () => {


### PR DESCRIPTION
## Summary
Truth Sprint #3. The tool was structurally broken for its one job (pick an RPC endpoint to connect to):

| bug | fix |
|---|---|
| **No `url`** — couldn't connect to anything | Added the connectable endpoint URL |
| **`network` = pool-map key** (`"0"`/`"1"`/`"2"` internal indices) | Real `network: "finney"` + `layer` |
| **Duplicates** (same endpoint across pools) | Deduped by id, keeping the best-scored instance |

## Verification
Live before: `{id: "opentensor-finney-wss", network: "1", ...}` and `{..., network: "2"}` — same endpoint twice, no URL. After: one entry per endpoint with `url`, `network: "finney"`.

`tests/mcp-server.test.mjs` adds dedupe + url + no-pool-key-leak assertions. 46 MCP tests pass; `validate:mcp` green.