### PR TITLE
fix(build): capture live OpenAPI schemas in the production publish (TS2)

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -69,6 +69,12 @@ function localSteps() {
 function productionSteps() {
   return [
     nodeStep("bundle-schemas", "scripts/bundle-schemas.mjs", "--write"),
+    // Capture live OpenAPI/Swagger specs (full document + auth) before
+    // build-artifacts, so the per-surface schema files carry the real spec for
+    // get_api_schema. build-artifacts grabs the document before its staging wipe
+    // and re-attaches it; the index stays light. Degrades to digests if a spec
+    // is unreachable (snapshot-openapi handles unavailable surfaces).
+    nodeStep("schemas-snapshot", "scripts/snapshot-openapi.mjs", "--write"),
     // Re-snapshot adapters from live GitHub metadata so the publish is
     // self-sufficient for freshness: adapter-snapshots are then fresh by
     // construction at publish time (the publish already re-probes health),


### PR DESCRIPTION
TS2 persisted the full OpenAPI `document`, but `schemas:snapshot` never ran in the automated pipeline — so production rebuilt per-surface schema files from the committed index (digests only) and `get_api_schema` returned no `document` live (`auth_required` did land, since it's in the index). This adds `schemas-snapshot` to `build.mjs` productionSteps before build-artifacts. Verified snapshot→build→build preserves the document across both passes; degrades to digests if a spec is unreachable.