### PR TITLE
chore(ci): remove publish-failure Discord alert (reviews-only channel)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -270,18 +270,6 @@ jobs:
         env:
           METAGRAPH_LIVE_BASE_URL: https://api.metagraph.sh
 
-      # Surfaces publish failures immediately (the original cascade went unnoticed
-      # for ~a day). Opt-in: no-ops unless METAGRAPH_ALERT_WEBHOOK_URL is set.
-      - name: Notify on failure
-        if: failure()
-        env:
-          ALERT_WEBHOOK_URL: ${{ secrets.METAGRAPH_ALERT_WEBHOOK_URL }}
-        run: |
-          if [ -z "${ALERT_WEBHOOK_URL:-}" ]; then
-            echo "No METAGRAPH_ALERT_WEBHOOK_URL configured; skipping alert."
-            exit 0
-          fi
-          RUN_URL="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
-          curl -fsS -m 15 -X POST "$ALERT_WEBHOOK_URL" \
-            -H 'content-type: application/json' \
-            -d "{\"content\":\"🔴 metagraphed data publish failed — ${RUN_URL}\"}" || true
+      # Publish-failure Discord alerts were removed: the metagraphed Discord channel is
+      # reviews-only (reviewbot gate decisions). Monitor publish failures via GitHub Actions
+      # notifications, or re-add an alert here pointing at a SEPARATE ops webhook if needed.


### PR DESCRIPTION
The metagraphed Discord channel is reviews-only (reviewbot gate decisions). Removes the bare publish-failure ping. Re-add pointing at a separate ops webhook if CI alerting is wanted.