### PR TITLE
fix(registry): avoid lifecycle false positives from descriptions

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -708,17 +708,20 @@ export function extractAuth(spec) {
   return { auth_required: authSchemes.length > 0, auth_schemes: authSchemes };
 }
 
-// Declared lifecycle, derived from the on-chain identity name (teams set it to
-// "deprecated"/"Parked"/"Pending" when a subnet is no longer a live product),
-// distinct from `status` (chain-registration state, which stays "active").
-// Shared by the build + the reproducibility validator.
+// Declared lifecycle, derived from canonical on-chain identity names (teams set
+// subnet_name exactly to "deprecated"/"Parked"/"Pending" when a subnet is no
+// longer a live product), distinct from `status` (chain-registration state,
+// which stays "active"). Avoid scanning descriptions: they are free-form
+// attacker-influenced metadata and can contain words such as "not deprecated"
+// or "patent pending" for otherwise live subnets. Shared by the build + the
+// reproducibility validator.
 export function subnetLifecycle(nativeSubnet) {
-  const marker = `${nativeSubnet?.chain_identity?.subnet_name || ""} ${
-    nativeSubnet?.chain_identity?.description || ""
-  }`.toLowerCase();
-  if (/\bdeprecat/.test(marker)) return "deprecated";
-  if (/\bparked\b/.test(marker)) return "parked";
-  if (/\bpending\b/.test(marker)) return "pending";
+  const name = (nativeSubnet?.chain_identity?.subnet_name || "")
+    .trim()
+    .toLowerCase();
+  if (name === "deprecated") return "deprecated";
+  if (name === "parked") return "parked";
+  if (name === "pending") return "pending";
   return "active";
 }
 

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -49,10 +49,24 @@ describe("subnetLifecycle", () => {
     assert.equal(subnetLifecycle(withName("Parked")), "parked");
     assert.equal(subnetLifecycle(withName("Pending")), "pending");
   });
-  test("reads the description field too", () => {
+  test("requires exact canonical subnet names", () => {
+    assert.equal(subnetLifecycle(withName(" deprecated ")), "deprecated");
+    assert.equal(subnetLifecycle(withName("Deprecated Network")), "active");
+  });
+  test("ignores free-form descriptions to avoid false positive lifecycle markers", () => {
     assert.equal(
-      subnetLifecycle(withName("Foo", "this subnet is deprecated")),
-      "deprecated",
+      subnetLifecycle(withName("Foo", "not deprecated, actively maintained")),
+      "active",
+    );
+    assert.equal(
+      subnetLifecycle(
+        withName("InferenceNet", "patent pending inference network"),
+      ),
+      "active",
+    );
+    assert.equal(
+      subnetLifecycle(withName("LiveNet", "not parked; actively maintained")),
+      "active",
     );
   });
   test("defaults to active for live subnets and missing identity", () => {


### PR DESCRIPTION
### Motivation
- The previous `subnetLifecycle()` concatenated `chain_identity.subnet_name` and the free-form `chain_identity.description` and applied broad regexes, which caused false-positive classifications for active subnets when descriptions contained phrases like "not deprecated" or "patent pending"; public chain identity metadata is attacker-influenced so descriptions should not be used for security-sensitive classification. 

### Description
- Change `subnetLifecycle()` in `scripts/lib.mjs` to derive lifecycle only from the canonical `chain_identity.subnet_name` after trimming and lowercasing rather than scanning descriptions. 
- Stop inspecting `chain_identity.description` for lifecycle markers so only exact canonical names (`"deprecated"`, `"parked"`, `"pending"`) map to non-`active` lifecycles. 
- Update `tests/lib-helpers.test.mjs` to add regression coverage that verifies exact-name matching and that free-form descriptions containing phrases like `"not deprecated"`, `"patent pending"`, and `"not parked"` do not cause misclassification. 

### Testing
- Ran unit tests for the changed helper with `npm test -- tests/lib-helpers.test.mjs` and the suite passed (all lib-helpers tests green). 
- Ran `npm run lint` and linting completed without errors for the repository. 
- Ran `npx prettier --check` for the modified files and formatting checks passed for those files while `npm run format:check` reported pre-existing formatting warnings in unrelated files. 
- Attempted broader validation (`npm test -- tests/search-quality.test.mjs` and `npm run validate`) but those jobs failed to run to completion due to missing local/generated artifact files in this checkout (e.g. `public/metagraph/providers.json` / `search.json`), so full integration validation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a93273cc4832a94c4c60b51f4d41c)