### PR TITLE
fix(scan): narrow mirrored schema exemption

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -55,12 +55,14 @@ const patterns = [
 
 // Per-surface schema artifacts embed the full upstream OpenAPI/Swagger spec
 // (TS2). Those are public docs the subnet published; the soft wording
-// heuristics false-positive on their API terminology.
+// heuristics false-positive on their API terminology. Keep this exemption scoped
+// to generated public/R2 artifact directories so source schemas are still
+// covered by the terminology guard.
 function isMirroredExternalSpec(relativePath) {
-  return (
-    /(^|\/)schemas\/.+\.json$/.test(relativePath) &&
-    !relativePath.endsWith("schemas/index.json")
-  );
+  return [
+    /^public\/metagraph\/schemas\/(?!index\.json$)[^/]+\.json$/,
+    /^dist\/metagraph-r2\/metagraph\/schemas\/(?!index\.json$)[^/]+\.json$/,
+  ].some((pattern) => pattern.test(relativePath));
 }
 
 const findings = [];


### PR DESCRIPTION
### Motivation

- The previous `isMirroredExternalSpec()` matched any JSON under a `schemas/` path and therefore exempted canonical source schema files from soft wording checks, weakening the public-safety guard.
- The intent is to exempt only generated per-surface OpenAPI snapshots (mirrored artifacts), not repository source schemas.

### Description

- Replace the broad `isMirroredExternalSpec()` path test with explicit regexes that match only generated artifacts under `public/metagraph/schemas/*.json` and `dist/metagraph-r2/metagraph/schemas/*.json`, excluding `index.json`.
- Update the explanatory comment to clarify the exemption is limited to generated public/R2 artifact directories.
- Preserve existing behavior so hard secret/token patterns still apply to all files while only soft wording heuristics are exempted for the generated artifacts.

### Testing

- Ran `npm run scan:public-safety` which passes on the modified script.
- Added a probe `schemas/__scan_public_safety_probe.schema.json` containing soft wording and confirmed `npm run scan:public-safety` fails as expected for source schemas.
- Added a probe `public/metagraph/schemas/__scan-public-safety-probe.json` containing soft wording and confirmed `npm run scan:public-safety` passes for generated mirrored schema artifacts, and a probe with a `ghp_...` token confirmed hard token patterns still fail.
- Ran `npm run lint` and the lint check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a95795468832a9b9405b045457a8c)