### PR TITLE
fix(contract): regenerate openapi + types for the too-large schema enum

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2255,7 +2255,7 @@ export interface components {
             /** Format: uri */
             schema_url: string | null;
             /** @enum {unknown} */
-            status: "captured" | "error" | "not-found" | "pending-snapshot" | "ui-only-or-undiscovered" | "unsafe";
+            status: "captured" | "error" | "not-found" | "pending-snapshot" | "too-large" | "ui-only-or-undiscovered" | "unsafe";
             subnet_slug: string;
             surface_id: string;
             /** Format: uri */
@@ -2282,7 +2282,7 @@ export interface components {
                 [key: string]: unknown;
             };
             /** @enum {unknown} */
-            status: "captured" | "error" | "not-found" | "unsafe";
+            status: "captured" | "error" | "not-found" | "too-large" | "unsafe";
             subnet_slug?: string;
             surface_id: string;
             /** Format: uri */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -5741,6 +5741,7 @@
               "error",
               "not-found",
               "pending-snapshot",
+              "too-large",
               "ui-only-or-undiscovered",
               "unsafe"
             ]
@@ -5854,6 +5855,7 @@
               "captured",
               "error",
               "not-found",
+              "too-large",
               "unsafe"
             ]
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2255,7 +2255,7 @@ export interface components {
             /** Format: uri */
             schema_url: string | null;
             /** @enum {unknown} */
-            status: "captured" | "error" | "not-found" | "pending-snapshot" | "ui-only-or-undiscovered" | "unsafe";
+            status: "captured" | "error" | "not-found" | "pending-snapshot" | "too-large" | "ui-only-or-undiscovered" | "unsafe";
             subnet_slug: string;
             surface_id: string;
             /** Format: uri */
@@ -2282,7 +2282,7 @@ export interface components {
                 [key: string]: unknown;
             };
             /** @enum {unknown} */
-            status: "captured" | "error" | "not-found" | "unsafe";
+            status: "captured" | "error" | "not-found" | "too-large" | "unsafe";
             subnet_slug?: string;
             surface_id: string;
             /** Format: uri */


### PR DESCRIPTION
Follow-up to #293. The merged PR added the `too-large` snapshot status to two schema enums but didn't regenerate the derived public contract, so `public/metagraph/openapi.json` is stale and `validate:contract-drift` fails on main.

Regenerates the 3 schema-derived artifacts (`openapi.json` + `generated/metagraphed-api.d.ts` + `public/metagraph/types.d.ts`); build-summary/changelog/r2-manifest restored per subset-commit discipline.

Verified locally: `validate:contract-drift`, `validate:types`, `validate:generated-client`, `validate:schemas`, `validate:openapi` all pass.