### PR TITLE
fix(ci): keep mixed UGC submissions on preflight route

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -94,7 +94,7 @@ jobs:
                       "category": "generated-artifact-tampering",
                       "message": "direct submissions cannot change other files: " + ", ".join(unrelated),
                   })
-          mode = "ugc" if scope in {"direct-candidate", "direct-provider"} and not errors else "full"
+          mode = "ugc" if scope in {"direct-candidate", "direct-provider"} else "full"
           report = {
               "schema_version": 1,
               "mode": mode,


### PR DESCRIPTION
### Motivation
- Ensure any PR that targets a direct community submission (`direct-candidate` or `direct-provider`) is routed through the deterministic UGC preflight even when the route classifier reports submission-shape or unrelated-file errors, because allowing such mixed submissions to fall back to the normal full validation path weakens the UGC gate.

### Description
- Change the routing logic in `.github/workflows/validate.yml` so `mode` is set to `ugc` whenever `scope` is `direct-candidate` or `direct-provider` (i.e., `mode = "ugc" if scope in {"direct-candidate", "direct-provider"} else "full"`), preserving `full` for normal PRs.

### Testing
- Ran `npm run validate:workflows` and `npm test -- tests/submission-gate.test.mjs`, and both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a9a90b768832a82c1668678d07aa5)