### PR TITLE
add: Subnet 13 (Data Universe) documentation

### DIFF
--- a/public/metagraph/coverage.json
+++ b/public/metagraph/coverage.json
@@ -1,6 +1,6 @@
 {
   "application_subnet_count": 128,
-  "candidate_count": 2024,
+  "candidate_count": 2025,
   "candidate_subnet_count": 129,
   "chain_subnet_count": 129,
   "completeness": {

--- a/public/metagraph/review/profile-completeness.json
+++ b/public/metagraph/review/profile-completeness.json
@@ -2389,6 +2389,78 @@
         "missing-data-artifact"
       ],
       "identity_evidence": {
+        "candidate_identity_count": 13,
+        "curated_identity_count": 3,
+        "curated_identity_kinds": [
+          "docs",
+          "source-repo",
+          "website"
+        ],
+        "live_candidate_identity_kinds": [
+          "docs",
+          "source-repo",
+          "website"
+        ],
+        "native_contact_present": true,
+        "native_description_present": true,
+        "native_identity_count": 2,
+        "native_identity_kinds": [
+          "source-repo",
+          "website"
+        ],
+        "needs_promotion_kinds": [],
+        "stale_candidate_identity_kinds": [
+          "docs"
+        ],
+        "unverified_candidate_identity_kinds": [
+          "docs"
+        ]
+      },
+      "identity_level": "complete",
+      "identity_promotion_kind_count": 0,
+      "identity_promotion_kinds": [],
+      "identity_surface_count": 3,
+      "live_identity_candidate_kind_count": 3,
+      "missing_critical_count": 4,
+      "missing_identity": [],
+      "missing_operational": [
+        "openapi",
+        "subnet-api",
+        "sse",
+        "data-artifact"
+      ],
+      "missing_required": [],
+      "name": "Data Universe",
+      "native_identity_signal_count": 2,
+      "native_name_quality": "chain",
+      "netuid": 13,
+      "operational_interface_count": 0,
+      "priority_score": 89,
+      "profile_level": "identity-complete",
+      "review_state": "maintainer-reviewed",
+      "slug": "sn-13",
+      "source_count": 14,
+      "stale_identity_candidate_kind_count": 1,
+      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
+      "supported_interface_kinds": [
+        "dashboard",
+        "docs",
+        "source-repo",
+        "website"
+      ]
+    },
+    {
+      "candidate_count": 24,
+      "completeness_score": 55,
+      "confidence": "high",
+      "curation_level": "maintainer-reviewed",
+      "gap_reasons": [
+        "missing-openapi",
+        "missing-subnet-api",
+        "missing-sse",
+        "missing-data-artifact"
+      ],
+      "identity_evidence": {
         "candidate_identity_count": 15,
         "curated_identity_count": 3,
         "curated_identity_kinds": [
@@ -3351,76 +3423,6 @@
       "review_state": "machine-generated",
       "slug": "sn-126",
       "source_count": 8,
-      "stale_identity_candidate_kind_count": 1,
-      "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
-      "supported_interface_kinds": [
-        "dashboard",
-        "docs",
-        "source-repo",
-        "website"
-      ]
-    },
-    {
-      "candidate_count": 23,
-      "completeness_score": 55,
-      "confidence": "high",
-      "curation_level": "maintainer-reviewed",
-      "gap_reasons": [
-        "missing-openapi",
-        "missing-subnet-api",
-        "missing-sse",
-        "missing-data-artifact"
-      ],
-      "identity_evidence": {
-        "candidate_identity_count": 12,
-        "curated_identity_count": 3,
-        "curated_identity_kinds": [
-          "docs",
-          "source-repo",
-          "website"
-        ],
-        "live_candidate_identity_kinds": [
-          "docs",
-          "source-repo",
-          "website"
-        ],
-        "native_contact_present": true,
-        "native_description_present": true,
-        "native_identity_count": 2,
-        "native_identity_kinds": [
-          "source-repo",
-          "website"
-        ],
-        "needs_promotion_kinds": [],
-        "stale_candidate_identity_kinds": [
-          "docs"
-        ],
-        "unverified_candidate_identity_kinds": []
-      },
-      "identity_level": "complete",
-      "identity_promotion_kind_count": 0,
-      "identity_promotion_kinds": [],
-      "identity_surface_count": 3,
-      "live_identity_candidate_kind_count": 3,
-      "missing_critical_count": 4,
-      "missing_identity": [],
-      "missing_operational": [
-        "openapi",
-        "subnet-api",
-        "sse",
-        "data-artifact"
-      ],
-      "missing_required": [],
-      "name": "Data Universe",
-      "native_identity_signal_count": 2,
-      "native_name_quality": "chain",
-      "netuid": 13,
-      "operational_interface_count": 0,
-      "priority_score": 88,
-      "profile_level": "identity-complete",
-      "review_state": "maintainer-reviewed",
-      "slug": "sn-13",
-      "source_count": 14,
       "stale_identity_candidate_kind_count": 1,
       "suggested_next_action": "submit public API, OpenAPI, SSE, or data-artifact surfaces if the subnet exposes them",
       "supported_interface_kinds": [

--- a/public/metagraph/subnets.json
+++ b/public/metagraph/subnets.json
@@ -470,7 +470,7 @@
     },
     {
       "block": 8378523,
-      "candidate_count": 23,
+      "candidate_count": 24,
       "categories": [
         "baseline-augmented",
         "baseline-curated",

--- a/registry/candidates/community/community-sn-13-docs-data-universe.json
+++ b/registry/candidates/community/community-sn-13-docs-data-universe.json
@@ -1,0 +1,25 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-13-docs-data-universe",
+      "kind": "docs",
+      "name": "Data Universe (Subnet 13) documentation",
+      "netuid": 13,
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public documentation surface for Subnet 13 (Data Universe).",
+      "schema_version": 1,
+      "source_tier": "provider-claimed",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/macrocosm-os/data-universe",
+      "source_urls": ["https://github.com/macrocosm-os/data-universe"],
+      "state": "schema-valid",
+      "url": "https://docs.macrocosmos.ai/subnets/subnet-13-data-universe"
+    }
+  ],
+  "schema_version": 1,
+  "submission": { "submitted_by": "jsonbored", "submitted_by_url": "https://github.com/jsonbored" }
+}


### PR DESCRIPTION
Real, non-duplicate SN13 Data Universe docs surface (docs.macrocosmos.ai), backed by macrocosm-os/data-universe (provider macrocosmos). Includes regenerated deterministic registry artifacts so validate + ci-verify pass.