### PR TITLE
Add SN13 Data Universe: Macrocosmos Python SDK

### DIFF
--- a/registry/candidates/community/community-sn-13-sdk-pypi-org.json
+++ b/registry/candidates/community/community-sn-13-sdk-pypi-org.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-13-sdk-pypi-org",
+      "kind": "sdk",
+      "name": "Macrocosmos Python SDK",
+      "netuid": 13,
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/macrocosm-os/macrocosmos-py",
+      "source_urls": ["https://github.com/macrocosm-os/macrocosmos-py"],
+      "state": "schema-valid",
+      "url": "https://pypi.org/project/macrocosmos"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
### New candidate surface

Adds the official **Macrocosmos Python SDK** as an `sdk` surface for **Subnet 13 (Data Universe)**.

| field | value |
|---|---|
| netuid | 13 |
| kind | `sdk` |
| provider | `macrocosmos` |
| url | https://pypi.org/project/macrocosmos |
| source_url | https://github.com/macrocosm-os/macrocosmos-py |
| auth_required | false |

The PyPI package (`macrocosmos`, v3.1.0) is the official Python SDK for Macrocosmos and explicitly documents the SN13 Data Universe `Sn13Client` / OnDemand API; the backing repo is the same `macrocosm-os` org that operates the registered SN13 source repos. This `sdk` surface kind is not yet registered for SN13.