### PR TITLE
Add SN13 Data Universe: Macrocosmos Python SDK

### DIFF
--- a/registry/candidates/community/community-sn-13-sdk-github-com.json
+++ b/registry/candidates/community/community-sn-13-sdk-github-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-13-sdk-github-com",
+      "kind": "sdk",
+      "name": "Macrocosmos Python SDK",
+      "netuid": 13,
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/macrocosm-os/data-universe",
+      "source_urls": ["https://github.com/macrocosm-os/data-universe"],
+      "state": "schema-valid",
+      "url": "https://github.com/macrocosm-os/macrocosmos-py"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
### New candidate surface

Adds the official **Macrocosmos Python SDK** repo as an `sdk` surface for **Subnet 13 (Data Universe)**.

| field | value |
|---|---|
| netuid | 13 |
| kind | `sdk` |
| provider | `macrocosmos` |
| url | https://github.com/macrocosm-os/macrocosmos-py |
| source_url | https://github.com/macrocosm-os/data-universe |
| auth_required | false |

`macrocosm-os/macrocosmos-py` ("Macrocosmos Python SDK") explicitly documents the SN13 Data Universe `Sn13Client`/OnDemand API; the backing `macrocosm-os/data-universe` repo is the registered SN13 subnet source. The `sdk` surface kind is not yet registered for SN13.