### PR TITLE
Add SN34 BitMind: GASBench evaluation SDK

### DIFF
--- a/registry/candidates/community/community-sn-34-sdk-github-com.json
+++ b/registry/candidates/community/community-sn-34-sdk-github-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-34-sdk-github-com",
+      "kind": "sdk",
+      "name": "BitMind GASBench evaluation SDK",
+      "netuid": 34,
+      "provider": "bitmind",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/BitMind-AI/bitmind-subnet",
+      "source_urls": ["https://github.com/BitMind-AI/bitmind-subnet"],
+      "state": "schema-valid",
+      "url": "https://github.com/BitMind-AI/gasbench"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
### New candidate surface

Adds **GASBench**, BitMind's benchmark/evaluation package, as an `sdk` surface for **Subnet 34 (BitMind / GAS)**.

| field | value |
|---|---|
| netuid | 34 |
| kind | `sdk` |
| provider | `bitmind` |
| url | https://github.com/BitMind-AI/gasbench |
| source_url | https://github.com/BitMind-AI/bitmind-subnet |

`BitMind-AI/gasbench` is a benchmark evaluation package for discriminative models on Bittensor Subnet 34, backed by the registered SN34 subnet repo `BitMind-AI/bitmind-subnet`. The `sdk` surface kind is not yet registered for SN34.