### PR TITLE
Add SN22 Desearch: Python SDK

### DIFF
--- a/registry/candidates/community/community-sn-22-sdk-github-com.json
+++ b/registry/candidates/community/community-sn-22-sdk-github-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-22-sdk-github-com",
+      "kind": "sdk",
+      "name": "Desearch Python SDK",
+      "netuid": 22,
+      "provider": "desearch",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/Desearch-ai/subnet-22",
+      "source_urls": ["https://github.com/Desearch-ai/subnet-22"],
+      "state": "schema-valid",
+      "url": "https://github.com/Desearch-ai/desearch.py"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
### New candidate surface

Adds the official **Desearch Python SDK** as an `sdk` surface for **Subnet 22 (Desearch)**.

| field | value |
|---|---|
| netuid | 22 |
| kind | `sdk` |
| provider | `desearch` |
| url | https://github.com/Desearch-ai/desearch.py |
| source_url | https://github.com/Desearch-ai/subnet-22 |

`Desearch-ai/desearch.py` is the official async Python SDK for the Desearch API, backed by the same `Desearch-ai` org's registered SN22 subnet repo `Desearch-ai/subnet-22` (netuid 22). The `sdk` surface kind is not yet registered for SN22.