### PR TITLE
feat(readiness): integration-readiness score on the agent catalog + MCP ranking

### DIFF
--- a/docs/integration-readiness.md
+++ b/docs/integration-readiness.md
@@ -1,0 +1,50 @@
+# Integration readiness
+
+`integration_readiness` is a codified, **objective** score (0–100) for the
+question developers and their agents actually ask: *can I build on this subnet
+today?* It appears on each subnet in the agent catalog
+(`/api/v1/agent-catalog`, `/api/v1/agent-catalog/{netuid}`) and ranks
+`find_subnets_by_capability` results in the MCP server.
+
+It is deliberately **not** a subjective quality rating. Every input is a fact
+metagraphed already measures, the formula is published here, and the component
+breakdown ships alongside the score so you can re-weight it for your own needs.
+
+## What it is not
+
+- **Not live up/down.** Readiness is a *build-time eligibility* signal computed
+  from the reproducible registry snapshot — never the 2-minute health prober.
+  A subnet can be "ready" and momentarily down. For "is it up right now" use
+  `get_subnet_health` / the per-service `health` block. Keeping live status out
+  of the score is what lets it stay a deterministic, reproducible artifact value.
+- **Not a verdict on the ~99 non-API subnets.** Only ~30 subnets expose callable
+  public APIs today; the rest score low because they have nothing to build on
+  *yet*, not because they're "bad". This is the buildable-today subset.
+- **Not chain economics.** Whether a subnet is worth *running a validator on*
+  (emissions, TAO price, miner quality) is a different question — that's chain
+  data, not metagraphed's lane.
+
+## Rubric (`readiness_version: 1`)
+
+Score = sum of the component weights below, clamped to 100. Each component is an
+objective boolean published under `readiness.components`.
+
+| Component | Weight | True when |
+|---|---|---|
+| `has_callable_api` | 30 | the subnet exposes ≥1 catalogued service surface |
+| `documented` | 25 | ≥1 service has a captured OpenAPI/Swagger schema |
+| `auth_clarity` | 15 | every callable service has clear auth — either no auth, or auth required *with* known schemes (so an agent knows whether and how to authenticate) |
+| `callable_now` | 15 | ≥1 service is structurally callable (public-safe, not dead/unsafe) |
+| `active_lifecycle` | 10 | `lifecycle === "active"` (not deprecated/parked/pending) |
+| `profile_complete` | 5 | the subnet's `completeness_score` ≥ 70 |
+
+`auth_clarity` intentionally treats "auth required, schemes known" as **clear** —
+it does not penalize an honestly auth-gated API.
+
+## Re-weighting
+
+The composite is one reasonable default. Because every component boolean ships
+in `readiness.components`, an agent that, say, doesn't care about docs can
+recompute its own score from the components. Treat `integration_readiness` as a
+sort key and a filter, and read the components when the default weighting
+doesn't match your use case.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -912,8 +912,10 @@ export interface components {
                 callable_count?: number;
                 categories?: string[];
                 completeness_score?: number | null;
+                integration_readiness?: number;
                 name?: string;
                 netuid: number;
+                readiness?: components["schemas"]["IntegrationReadiness"];
                 service_count: number;
                 service_kinds?: string[];
                 slug?: string;
@@ -928,8 +930,10 @@ export interface components {
         AgentCatalogSubnetArtifact: components["schemas"]["ArtifactBase"] & ({
             categories?: string[];
             completeness_score?: number | null;
+            integration_readiness?: number;
             name?: string;
             netuid: number;
+            readiness?: components["schemas"]["IntegrationReadiness"];
             service_count: number;
             services: ({
                 auth_required?: boolean;
@@ -1625,6 +1629,19 @@ export interface components {
             };
         } & {
             [key: string]: unknown;
+        };
+        /** @description Codified, objective build-time readiness for building on a subnet (0-100). Deterministic; live up/down status is separate (get_subnet_health). See docs/integration-readiness.md. */
+        IntegrationReadiness: {
+            components: {
+                active_lifecycle?: boolean;
+                auth_clarity?: boolean;
+                callable_now?: boolean;
+                documented?: boolean;
+                has_callable_api?: boolean;
+                profile_complete?: boolean;
+            };
+            readiness_version: number;
+            score: number;
         };
         JsonObject: {
             [key: string]: unknown;

--- a/public/metagraph/agent-catalog.json
+++ b/public/metagraph/agent-catalog.json
@@ -18,8 +18,21 @@
         "subnet-api"
       ],
       "completeness_score": 85,
+      "integration_readiness": 100,
       "name": "Numinous",
       "netuid": 6,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 100
+      },
       "service_count": 4,
       "service_kinds": [
         "openapi",
@@ -37,8 +50,21 @@
         "subnet-api"
       ],
       "completeness_score": 97,
+      "integration_readiness": 100,
       "name": "Allways",
       "netuid": 7,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 100
+      },
       "service_count": 13,
       "service_kinds": [
         "openapi",
@@ -63,8 +89,21 @@
         "social-data"
       ],
       "completeness_score": 85,
+      "integration_readiness": 85,
       "name": "Desearch",
       "netuid": 22,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": false,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 85
+      },
       "service_count": 3,
       "service_kinds": [
         "openapi",
@@ -84,8 +123,21 @@
         "subnet-api-observed"
       ],
       "completeness_score": 70,
+      "integration_readiness": 75,
       "name": "Trishool",
       "netuid": 23,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 75
+      },
       "service_count": 1,
       "service_kinds": [
         "subnet-api"
@@ -106,8 +158,21 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "integration_readiness": 70,
       "name": "Quasar",
       "netuid": 24,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 3,
       "service_kinds": [
         "data-artifact"
@@ -128,8 +193,21 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "integration_readiness": 70,
       "name": "Coldint",
       "netuid": 29,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -150,8 +228,21 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "integration_readiness": 70,
       "name": "ReadyAI",
       "netuid": 33,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 2,
       "service_kinds": [
         "data-artifact"
@@ -165,8 +256,21 @@
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "integration_readiness": 95,
       "name": "Zipcode",
       "netuid": 46,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 95
+      },
       "service_count": 1,
       "service_kinds": [
         "openapi"
@@ -184,8 +288,21 @@
         "official-source-repo"
       ],
       "completeness_score": 48,
+      "integration_readiness": 70,
       "name": "EvolAI",
       "netuid": 47,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -208,8 +325,21 @@
         "tournament"
       ],
       "completeness_score": 85,
+      "integration_readiness": 85,
       "name": "Nepher Robotics",
       "netuid": 49,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": false,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 85
+      },
       "service_count": 2,
       "service_kinds": [
         "openapi",
@@ -224,8 +354,21 @@
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "integration_readiness": 70,
       "name": "lium.io",
       "netuid": 51,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "subnet-api"
@@ -246,8 +389,21 @@
         "operational-interface"
       ],
       "completeness_score": 93,
+      "integration_readiness": 100,
       "name": "Gradients",
       "netuid": 56,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 100
+      },
       "service_count": 5,
       "service_kinds": [
         "data-artifact",
@@ -271,8 +427,21 @@
         "payments"
       ],
       "completeness_score": 85,
+      "integration_readiness": 90,
       "name": "Handshake58",
       "netuid": 58,
+      "readiness": {
+        "components": {
+          "active_lifecycle": false,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 90
+      },
       "service_count": 4,
       "service_kinds": [
         "openapi",
@@ -287,8 +456,21 @@
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "integration_readiness": 70,
       "name": "Babelbit",
       "netuid": 59,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "subnet-api"
@@ -310,8 +492,21 @@
         "official-website"
       ],
       "completeness_score": 93,
+      "integration_readiness": 100,
       "name": "Chutes",
       "netuid": 64,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 100
+      },
       "service_count": 4,
       "service_kinds": [
         "data-artifact",
@@ -335,8 +530,21 @@
         "workflow"
       ],
       "completeness_score": 70,
+      "integration_readiness": 75,
       "name": "ninja",
       "netuid": 66,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 75
+      },
       "service_count": 1,
       "service_kinds": [
         "subnet-api"
@@ -350,8 +558,21 @@
         "baseline-curated"
       ],
       "completeness_score": 58,
+      "integration_readiness": 70,
       "name": "NOVA",
       "netuid": 68,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -365,8 +586,21 @@
         "baseline-curated"
       ],
       "completeness_score": 58,
+      "integration_readiness": 70,
       "name": "NexisGen",
       "netuid": 70,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -388,8 +622,21 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "integration_readiness": 70,
       "name": "StreetVision by NATIX",
       "netuid": 72,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -406,8 +653,21 @@
         "repositories"
       ],
       "completeness_score": 83,
+      "integration_readiness": 100,
       "name": "Gittensor",
       "netuid": 74,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 100
+      },
       "service_count": 2,
       "service_kinds": [
         "data-artifact",
@@ -426,8 +686,21 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "integration_readiness": 70,
       "name": "MVTRX",
       "netuid": 79,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -448,8 +721,21 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "integration_readiness": 70,
       "name": "Investing",
       "netuid": 88,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -468,8 +754,21 @@
         "official-website"
       ],
       "completeness_score": 48,
+      "integration_readiness": 70,
       "name": "Actual",
       "netuid": 95,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -492,8 +791,21 @@
         "official-website"
       ],
       "completeness_score": 85,
+      "integration_readiness": 100,
       "name": "Verathos",
       "netuid": 96,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 100
+      },
       "service_count": 2,
       "service_kinds": [
         "openapi",
@@ -508,8 +820,21 @@
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "integration_readiness": 95,
       "name": "Albedo",
       "netuid": 97,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 95
+      },
       "service_count": 1,
       "service_kinds": [
         "openapi"
@@ -523,8 +848,21 @@
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "integration_readiness": 70,
       "name": "Minos",
       "netuid": 107,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "subnet-api"
@@ -542,8 +880,21 @@
         "official-source-repo"
       ],
       "completeness_score": 48,
+      "integration_readiness": 70,
       "name": "Academia",
       "netuid": 109,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -562,8 +913,21 @@
         "official-website"
       ],
       "completeness_score": 93,
+      "integration_readiness": 85,
       "name": "Green Compute",
       "netuid": 110,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": false,
+          "callable_now": true,
+          "documented": true,
+          "has_callable_api": true,
+          "profile_complete": true
+        },
+        "readiness_version": 1,
+        "score": 85
+      },
       "service_count": 5,
       "service_kinds": [
         "data-artifact",
@@ -584,8 +948,21 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "integration_readiness": 70,
       "name": "SOMA",
       "netuid": 114,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"
@@ -604,8 +981,21 @@
         "official-website"
       ],
       "completeness_score": 48,
+      "integration_readiness": 70,
       "name": "Ditto",
       "netuid": 118,
+      "readiness": {
+        "components": {
+          "active_lifecycle": true,
+          "auth_clarity": true,
+          "callable_now": true,
+          "documented": false,
+          "has_callable_api": true,
+          "profile_complete": false
+        },
+        "readiness_version": 1,
+        "score": 70
+      },
       "service_count": 1,
       "service_kinds": [
         "data-artifact"

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -94,12 +94,20 @@
                         "null"
                       ]
                     },
+                    "integration_readiness": {
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "name": {
                       "type": "string"
                     },
                     "netuid": {
                       "minimum": 0,
                       "type": "integer"
+                    },
+                    "readiness": {
+                      "$ref": "#/components/schemas/IntegrationReadiness"
                     },
                     "service_count": {
                       "minimum": 0,
@@ -162,12 +170,20 @@
                   "null"
                 ]
               },
+              "integration_readiness": {
+                "maximum": 100,
+                "minimum": 0,
+                "type": "integer"
+              },
               "name": {
                 "type": "string"
               },
               "netuid": {
                 "minimum": 0,
                 "type": "integer"
+              },
+              "readiness": {
+                "$ref": "#/components/schemas/IntegrationReadiness"
               },
               "service_count": {
                 "minimum": 0,
@@ -3028,6 +3044,51 @@
           "netuid",
           "source",
           "windows"
+        ],
+        "type": "object"
+      },
+      "IntegrationReadiness": {
+        "additionalProperties": false,
+        "description": "Codified, objective build-time readiness for building on a subnet (0-100). Deterministic; live up/down status is separate (get_subnet_health). See docs/integration-readiness.md.",
+        "properties": {
+          "components": {
+            "additionalProperties": false,
+            "properties": {
+              "active_lifecycle": {
+                "type": "boolean"
+              },
+              "auth_clarity": {
+                "type": "boolean"
+              },
+              "callable_now": {
+                "type": "boolean"
+              },
+              "documented": {
+                "type": "boolean"
+              },
+              "has_callable_api": {
+                "type": "boolean"
+              },
+              "profile_complete": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "readiness_version": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "score",
+          "readiness_version",
+          "components"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -912,8 +912,10 @@ export interface components {
                 callable_count?: number;
                 categories?: string[];
                 completeness_score?: number | null;
+                integration_readiness?: number;
                 name?: string;
                 netuid: number;
+                readiness?: components["schemas"]["IntegrationReadiness"];
                 service_count: number;
                 service_kinds?: string[];
                 slug?: string;
@@ -928,8 +930,10 @@ export interface components {
         AgentCatalogSubnetArtifact: components["schemas"]["ArtifactBase"] & ({
             categories?: string[];
             completeness_score?: number | null;
+            integration_readiness?: number;
             name?: string;
             netuid: number;
+            readiness?: components["schemas"]["IntegrationReadiness"];
             service_count: number;
             services: ({
                 auth_required?: boolean;
@@ -1625,6 +1629,19 @@ export interface components {
             };
         } & {
             [key: string]: unknown;
+        };
+        /** @description Codified, objective build-time readiness for building on a subnet (0-100). Deterministic; live up/down status is separate (get_subnet_health). See docs/integration-readiness.md. */
+        IntegrationReadiness: {
+            components: {
+                active_lifecycle?: boolean;
+                auth_clarity?: boolean;
+                callable_now?: boolean;
+                documented?: boolean;
+                has_callable_api?: boolean;
+                profile_complete?: boolean;
+            };
+            readiness_version: number;
+            score: number;
         };
         JsonObject: {
             [key: string]: unknown;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -80,12 +80,20 @@
                         "null"
                       ]
                     },
+                    "integration_readiness": {
+                      "maximum": 100,
+                      "minimum": 0,
+                      "type": "integer"
+                    },
                     "name": {
                       "type": "string"
                     },
                     "netuid": {
                       "minimum": 0,
                       "type": "integer"
+                    },
+                    "readiness": {
+                      "$ref": "#/components/schemas/IntegrationReadiness"
                     },
                     "service_count": {
                       "minimum": 0,
@@ -148,12 +156,20 @@
                   "null"
                 ]
               },
+              "integration_readiness": {
+                "maximum": 100,
+                "minimum": 0,
+                "type": "integer"
+              },
               "name": {
                 "type": "string"
               },
               "netuid": {
                 "minimum": 0,
                 "type": "integer"
+              },
+              "readiness": {
+                "$ref": "#/components/schemas/IntegrationReadiness"
               },
               "service_count": {
                 "minimum": 0,
@@ -3006,6 +3022,51 @@
           "netuid",
           "source",
           "windows"
+        ],
+        "type": "object"
+      },
+      "IntegrationReadiness": {
+        "additionalProperties": false,
+        "description": "Codified, objective build-time readiness for building on a subnet (0-100). Deterministic; live up/down status is separate (get_subnet_health). See docs/integration-readiness.md.",
+        "properties": {
+          "components": {
+            "additionalProperties": false,
+            "properties": {
+              "active_lifecycle": {
+                "type": "boolean"
+              },
+              "auth_clarity": {
+                "type": "boolean"
+              },
+              "callable_now": {
+                "type": "boolean"
+              },
+              "documented": {
+                "type": "boolean"
+              },
+              "has_callable_api": {
+                "type": "boolean"
+              },
+              "profile_complete": {
+                "type": "boolean"
+              }
+            },
+            "type": "object"
+          },
+          "readiness_version": {
+            "minimum": 1,
+            "type": "integer"
+          },
+          "score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "score",
+          "readiness_version",
+          "components"
         ],
         "type": "object"
       },

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -538,6 +538,28 @@
           }
         ]
       },
+      "IntegrationReadiness": {
+        "type": "object",
+        "description": "Codified, objective build-time readiness for building on a subnet (0-100). Deterministic; live up/down status is separate (get_subnet_health). See docs/integration-readiness.md.",
+        "required": ["score", "readiness_version", "components"],
+        "additionalProperties": false,
+        "properties": {
+          "score": { "type": "integer", "minimum": 0, "maximum": 100 },
+          "readiness_version": { "type": "integer", "minimum": 1 },
+          "components": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "has_callable_api": { "type": "boolean" },
+              "documented": { "type": "boolean" },
+              "auth_clarity": { "type": "boolean" },
+              "callable_now": { "type": "boolean" },
+              "active_lifecycle": { "type": "boolean" },
+              "profile_complete": { "type": "boolean" }
+            }
+          }
+        }
+      },
       "AgentCatalogArtifact": {
         "allOf": [
           { "$ref": "#/components/schemas/ArtifactBase" },
@@ -563,6 +585,14 @@
                     },
                     "subnet_type": { "type": ["string", "null"] },
                     "completeness_score": { "type": ["number", "null"] },
+                    "integration_readiness": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "maximum": 100
+                    },
+                    "readiness": {
+                      "$ref": "#/components/schemas/IntegrationReadiness"
+                    },
                     "service_count": { "type": "integer", "minimum": 0 },
                     "callable_count": { "type": "integer", "minimum": 0 },
                     "service_kinds": {
@@ -594,6 +624,14 @@
               },
               "subnet_type": { "type": ["string", "null"] },
               "completeness_score": { "type": ["number", "null"] },
+              "integration_readiness": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 100
+              },
+              "readiness": {
+                "$ref": "#/components/schemas/IntegrationReadiness"
+              },
               "service_count": { "type": "integer", "minimum": 0 },
               "services": {
                 "type": "array",

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -772,12 +772,52 @@ function buildSubnetServices(netuid) {
     })
     .sort((a, b) => a.surface_id.localeCompare(b.surface_id));
 }
+
+const READINESS_VERSION = 1;
+
+// Codified, OBJECTIVE "can a developer build on this subnet today" score
+// (0-100), composed only from deterministic build-time signals — never the live
+// 2-minute prober — so it stays a reproducible committed value. The live "is it
+// up right now" dimension is intentionally separate (get_subnet_health / the
+// health overlay). Components are published so agents can re-weight to their own
+// needs. Rubric: docs/integration-readiness.md.
+function subnetIntegrationReadiness({ services, lifecycle, completenessScore }) {
+  const callable = services.filter((service) => service.eligibility.callable);
+  const components = {
+    has_callable_api: services.length > 0,
+    documented: services.some((service) => Boolean(service.schema_artifact)),
+    auth_clarity:
+      services.length > 0 &&
+      callable.every(
+        (service) => !service.auth_required || service.auth_schemes.length > 0,
+      ),
+    callable_now: callable.length > 0,
+    active_lifecycle: lifecycle === "active",
+    profile_complete: (completenessScore ?? 0) >= 70,
+  };
+  const score = Math.min(
+    100,
+    (components.has_callable_api ? 30 : 0) +
+      (components.documented ? 25 : 0) +
+      (components.auth_clarity ? 15 : 0) +
+      (components.callable_now ? 15 : 0) +
+      (components.active_lifecycle ? 10 : 0) +
+      (components.profile_complete ? 5 : 0),
+  );
+  return { score, readiness_version: READINESS_VERSION, components };
+}
+
 await fs.rm(r2ArtifactDir("agent-catalog"), { recursive: true, force: true });
 const agentCatalogIndex = [];
 let callableServiceCount = 0;
 for (const subnet of mergedSubnets) {
   const profile = profileArtifacts.byNetuid.get(subnet.netuid) || null;
   const services = buildSubnetServices(subnet.netuid);
+  const readiness = subnetIntegrationReadiness({
+    services,
+    lifecycle: subnet.lifecycle,
+    completenessScore: profile?.completeness_score,
+  });
   await writeJson(artifactFile(`agent-catalog/${subnet.netuid}.json`), {
     schema_version: 1,
     contract_version: contractVersion,
@@ -788,6 +828,8 @@ for (const subnet of mergedSubnets) {
     categories: Array.isArray(profile?.categories) ? profile.categories : [],
     subnet_type: profile?.subnet_type || null,
     completeness_score: profile?.completeness_score ?? null,
+    integration_readiness: readiness.score,
+    readiness,
     service_count: services.length,
     services,
   });
@@ -801,6 +843,8 @@ for (const subnet of mergedSubnets) {
       categories: Array.isArray(profile?.categories) ? profile.categories : [],
       subnet_type: profile?.subnet_type || null,
       completeness_score: profile?.completeness_score ?? null,
+      integration_readiness: readiness.score,
+      readiness,
       service_count: services.length,
       callable_count: callable,
       service_kinds: [...new Set(services.map((s) => s.kind))].sort(),

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -230,6 +230,8 @@ export const MCP_TOOLS = [
         .sort(
           (a, b) =>
             b.score - a.score ||
+            (b.subnet.integration_readiness || 0) -
+              (a.subnet.integration_readiness || 0) ||
             b.subnet.callable_count - a.subnet.callable_count,
         )
         .slice(0, limit)
@@ -240,6 +242,7 @@ export const MCP_TOOLS = [
           categories: subnet.categories || [],
           service_kinds: subnet.service_kinds || [],
           callable_count: subnet.callable_count,
+          integration_readiness: subnet.integration_readiness ?? null,
         }));
       return { capability, count: ranked.length, results: ranked };
     },

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -352,6 +352,7 @@ describe("MCP tools (injected deps)", () => {
             categories: ["bitcoin", "data"],
             service_kinds: ["subnet-api", "openapi"],
             callable_count: 13,
+            integration_readiness: 100,
           },
           {
             netuid: 12,
@@ -472,6 +473,12 @@ describe("MCP tools (injected deps)", () => {
     const out = res.body.result.structuredContent;
     assert.equal(out.count, 1);
     assert.equal(out.results[0].netuid, 7);
+    // integration_readiness is surfaced so agents can rank/filter buildability
+    assert.equal(
+      typeof out.results[0].integration_readiness,
+      "number",
+      "find_subnets_by_capability results must carry integration_readiness",
+    );
   });
 
   test("find_subnets_by_capability with no match returns empty", async () => {


### PR DESCRIPTION
Answers "can I build on this subnet **today**?" with a codified, **objective** 0-100 `integration_readiness` score — not a subjective quality rating.

## Rubric (deterministic, reproducible)
Build-time signals only (live up/down stays in `get_subnet_health`, so the score is a stable committed value):
| Component | Weight |
|---|---|
| has_callable_api | 30 |
| documented (captured schema) | 25 |
| auth_clarity | 15 |
| callable_now | 15 |
| active_lifecycle | 10 |
| profile_complete (≥70) | 5 |

Components ship alongside the score so agents can **re-weight**.

## Where
- Computed in the agent-catalog loop (only stage with both `completeness_score` and per-surface services) → carried on the agent-catalog index + each per-subnet file. Lives in the agent catalog (the buildable subset) — its natural home, **no ripple** into the pre-loop subnets.json/latest.
- MCP `find_subnets_by_capability` ranks by readiness and returns it.
- Shared `IntegrationReadiness` schema component; types regenerated.
- Published rubric: `docs/integration-readiness.md`.

## Result
All 30 callable subnets scored (SN6/7/56/64/74/96 = 100). 737 tests + coverage gate + validate:api/mcp/openapi/contract-drift/schemas + lint all green.