### PR TITLE
feat(sdk): Python client + OIDC PyPI Trusted Publishing workflow

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,105 @@
+name: Publish Python SDK
+
+# Publishes `metagraphed` (python/) to PyPI via OIDC Trusted Publishing — no
+# token. Manual trigger; the version is read from python/pyproject.toml.
+# Requires a one-time PyPI-side setup (see python/PUBLISHING.md): a pending
+# trusted publisher pointing at this repo + workflow + the `pypi-production`
+# environment.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: python-package-release
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Validate release version
+        run: bash scripts/validate-python-release.sh
+
+      # Build happens in THIS unprivileged job (no id-token). The privileged
+      # publish job below never builds, so a compromised build dependency can't
+      # reach the OIDC token (mirrors the npm publish split, codex #251).
+      - name: Build sdist + wheel
+        working-directory: python
+        run: |
+          set -euo pipefail
+          uv build --out-dir "$RUNNER_TEMP/dist"
+          count=$(find "$RUNNER_TEMP/dist" -maxdepth 1 -type f \( -name "*.whl" -o -name "*.tar.gz" \) | wc -l | tr -d ' ')
+          if [ "$count" != "2" ]; then
+            echo "Expected exactly one wheel + one sdist, found $count file(s)" >&2
+            find "$RUNNER_TEMP/dist" -maxdepth 1 -type f -print >&2
+            exit 1
+          fi
+
+      - name: Upload dist
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: python-dist
+          path: ${{ runner.temp }}/dist/*
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: build
+    environment: pypi-production
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Validate release version
+        id: release
+        run: bash scripts/validate-python-release.sh
+
+      # Pull the dist built by the unprivileged build job — this job never builds,
+      # so no third-party code runs while the OIDC token is available.
+      - name: Download dist
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
+        with:
+          name: python-dist
+          path: ${{ runner.temp }}/dist
+
+      - name: Publish to PyPI (OIDC Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        with:
+          packages-dir: ${{ runner.temp }}/dist
+
+      - name: Tag + GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$RELEASE_TAG" -m "metagraphed (Python) v$RELEASE_VERSION"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          gh auth setup-git
+          git push origin "$RELEASE_TAG"
+          gh release create "$RELEASE_TAG" \
+            --title "metagraphed (Python) v$RELEASE_VERSION" \
+            --notes "Published \`metagraphed==$RELEASE_VERSION\` to PyPI via OIDC Trusted Publishing. https://pypi.org/project/metagraphed/$RELEASE_VERSION/"

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 node_modules
+python
 packages/*/dist
 packages/*/src/metagraphed-api.ts
 packages/*/src/metagraphed-client.ts

--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,7 @@
+dist/
+build/
+*.egg-info/
+__pycache__/
+.venv/
+.pytest_cache/
+uv.lock

--- a/python/PUBLISHING.md
+++ b/python/PUBLISHING.md
@@ -1,0 +1,39 @@
+# Publishing `metagraphed` to PyPI
+
+Releases go out via **OIDC Trusted Publishing** — no API token is ever created
+or stored. The `.github/workflows/publish-python.yml` workflow builds the wheel +
+sdist in an unprivileged job and publishes from a separate privileged job, so no
+third-party code runs while the OIDC token is live.
+
+## One-time bootstrap (owner, no placeholder upload needed)
+
+1. **Confirm the project name is free** at <https://pypi.org/project/metagraphed/>
+   (a 404 means available). If it's taken, change `[project].name` in
+   `python/pyproject.toml`, the `pip install` command in the README, and the
+   PyPI Project Name field below to e.g. `metagraphed-client`.
+
+2. **Add a PyPI pending publisher** at
+   <https://pypi.org/manage/account/publishing/> → "Add a new pending publisher"
+   with EXACTLY:
+   - PyPI Project Name: `metagraphed`
+   - Owner: `JSONbored`
+   - Repository name: `metagraphed`
+   - Workflow name: `publish-python.yml`
+   - Environment name: `pypi-production`
+
+3. **Create the GitHub Environment** in repo Settings → Environments → New
+   environment named EXACTLY `pypi-production` (optionally add required reviewers
+   for a manual approval gate before each publish).
+
+That's it — no token, no bootstrap upload. The pending publisher converts to a
+normal Trusted Publisher on the first successful publish.
+
+## Cutting a release
+
+1. Bump `[project].version` in `python/pyproject.toml` (strict semver, no `v`
+   prefix) on `main`.
+2. Actions → **Publish Python SDK** → Run workflow.
+
+The release gate (`scripts/validate-python-release.sh`) refuses to run off
+`main`, requires strict semver, and aborts if the git tag `python-v<version>` or
+the PyPI version already exists.

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,57 @@
+# metagraphed (Python)
+
+Thin, dependency-free Python client for **metagraphed** — the operational +
+integration registry for Bittensor subnets at `https://api.metagraph.sh`.
+
+It mirrors the [npm client](https://www.npmjs.com/package/@jsonbored/metagraphed):
+one generic GET helper over the uniform, read-only API surface, returning the
+parsed `{ ok, schema_version, data, meta }` envelope. Stdlib only — no transitive
+dependencies.
+
+## Install
+
+```bash
+pip install metagraphed
+```
+
+## Usage
+
+```python
+from metagraphed import MetagraphedClient, metagraphed_fetch
+
+client = MetagraphedClient()  # base_url defaults to https://api.metagraph.sh
+
+# List subnets (query params; None values are dropped)
+subnets = client.fetch(
+    "/api/v1/subnets",
+    query={"limit": 10, "sort": "completeness_score", "order": "desc"},
+)
+print(subnets["data"][0]["name"])
+
+# One subnet by netuid (path params)
+detail = client.fetch("/api/v1/subnets/{netuid}", path_params={"netuid": 7})
+
+# Which subnets are buildable? (integration readiness lives in the agent catalog)
+catalog = client.fetch("/api/v1/agent-catalog")
+
+# Point at the frontend origin instead, ad hoc:
+metagraphed_fetch("/api/v1/health", base_url="https://metagraph.sh")
+```
+
+Every response is the standard envelope:
+
+```python
+{"ok": True, "schema_version": 1, "data": ..., "meta": {...}}
+```
+
+On a network failure or non-2xx response, a `MetagraphedError` is raised (with
+`.status` for HTTP errors).
+
+## Versioning & stability
+
+Tracks the public `/api/v1` contract; changes are additive within v1. See the
+backend's [API stability policy](https://github.com/JSONbored/metagraphed/blob/main/docs/api-stability.md).
+
+## License
+
+MIT

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "metagraphed"
+version = "0.1.0"
+description = "Thin Python client for metagraphed — the operational + integration registry for Bittensor subnets (api.metagraph.sh)."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.9"
+authors = [{ name = "JSONbored" }]
+keywords = ["bittensor", "metagraph", "subnet", "registry", "api-client"]
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Typing :: Typed",
+]
+
+[project.urls]
+Homepage = "https://metagraph.sh"
+Repository = "https://github.com/JSONbored/metagraphed"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/metagraphed"]

--- a/python/src/metagraphed/__init__.py
+++ b/python/src/metagraphed/__init__.py
@@ -1,0 +1,17 @@
+"""metagraphed — thin Python client for the Bittensor subnet registry API."""
+
+from .client import (
+    DEFAULT_BASE_URL,
+    MetagraphedClient,
+    MetagraphedError,
+    metagraphed_fetch,
+)
+
+__version__ = "0.1.0"
+__all__ = [
+    "DEFAULT_BASE_URL",
+    "MetagraphedClient",
+    "MetagraphedError",
+    "metagraphed_fetch",
+    "__version__",
+]

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -1,0 +1,105 @@
+"""Thin Python client for the metagraphed API (https://api.metagraph.sh).
+
+Dependency-free (stdlib ``urllib`` only). Mirrors the generated TypeScript
+client: one generic GET helper over the uniform, read-only API surface,
+returning the parsed ``{ ok, schema_version, data, meta }`` envelope as a dict.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any, Mapping, Optional
+
+DEFAULT_BASE_URL = "https://api.metagraph.sh"
+_PATH_PARAM = re.compile(r"\{([^{}]+)\}")
+
+
+class MetagraphedError(Exception):
+    """Raised on a network failure or a non-2xx HTTP response."""
+
+    def __init__(self, message: str, *, status: Optional[int] = None) -> None:
+        super().__init__(message)
+        self.status = status
+
+
+def _interpolate(path: str, path_params: Optional[Mapping[str, Any]]) -> str:
+    params = path_params or {}
+
+    def repl(match: "re.Match[str]") -> str:
+        name = match.group(1)
+        if name not in params or params[name] is None:
+            raise MetagraphedError(f"Missing path parameter: {name}")
+        return urllib.parse.quote(str(params[name]), safe="")
+
+    return _PATH_PARAM.sub(repl, path)
+
+
+def metagraphed_fetch(
+    path: str,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    path_params: Optional[Mapping[str, Any]] = None,
+    query: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    timeout: float = 30.0,
+) -> Any:
+    """GET ``path`` against metagraphed and return the parsed JSON envelope.
+
+    ``path`` may contain ``{name}`` segments filled from ``path_params``.
+    ``query`` values that are ``None`` are dropped. Raises
+    :class:`MetagraphedError` on a network failure or a non-2xx response.
+    """
+    url = base_url.rstrip("/") + _interpolate(path, path_params)
+    if query:
+        pairs = [(key, value) for key, value in query.items() if value is not None]
+        if pairs:
+            url += "?" + urllib.parse.urlencode(pairs, doseq=True)
+
+    request = urllib.request.Request(url, method="GET")
+    request.add_header("Accept", "application/json")
+    for key, value in (headers or {}).items():
+        request.add_header(key, value)
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as error:
+        raise MetagraphedError(
+            f"GET {url} failed: HTTP {error.code}", status=error.code
+        ) from error
+    except urllib.error.URLError as error:
+        raise MetagraphedError(f"GET {url} failed: {error.reason}") from error
+
+    return json.loads(body)
+
+
+class MetagraphedClient:
+    """Convenience wrapper binding a ``base_url`` + default ``timeout``."""
+
+    def __init__(
+        self, base_url: str = DEFAULT_BASE_URL, *, timeout: float = 30.0
+    ) -> None:
+        self.base_url = base_url
+        self.timeout = timeout
+
+    def fetch(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        """GET ``path`` using this client's ``base_url`` + ``timeout``."""
+        return metagraphed_fetch(
+            path,
+            base_url=self.base_url,
+            path_params=path_params,
+            query=query,
+            headers=headers,
+            timeout=self.timeout,
+        )

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,0 +1,89 @@
+"""Hermetic tests for the metagraphed client (urllib mocked, no network)."""
+
+import json
+import unittest
+import urllib.error
+from unittest import mock
+
+from metagraphed import MetagraphedClient, MetagraphedError, metagraphed_fetch
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class ClientTest(unittest.TestCase):
+    def test_interpolates_path_params_and_sets_accept(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["accept"] = request.get_header("Accept")
+            return _FakeResponse({"ok": True, "data": {"netuid": 7}})
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            out = metagraphed_fetch(
+                "/api/v1/subnets/{netuid}", path_params={"netuid": 7}
+            )
+
+        self.assertEqual(captured["url"], "https://api.metagraph.sh/api/v1/subnets/7")
+        self.assertEqual(captured["accept"], "application/json")
+        self.assertEqual(out["data"]["netuid"], 7)
+
+    def test_missing_path_param_raises(self):
+        with self.assertRaises(MetagraphedError):
+            metagraphed_fetch("/api/v1/subnets/{netuid}")
+
+    def test_drops_none_query_values_and_encodes(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            metagraphed_fetch(
+                "/api/v1/search",
+                query={"q": "image gen", "cursor": None, "limit": 5},
+            )
+
+        self.assertIn("q=image+gen", captured["url"])
+        self.assertIn("limit=5", captured["url"])
+        self.assertNotIn("cursor", captured["url"])
+
+    def test_base_url_override(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            MetagraphedClient(base_url="https://metagraph.sh").fetch("/api/v1/health")
+
+        self.assertTrue(
+            captured["url"].startswith("https://metagraph.sh/api/v1/health")
+        )
+
+    def test_http_error_becomes_metagraphed_error(self):
+        def fake_urlopen(request, timeout=None):
+            raise urllib.error.HTTPError(request.full_url, 404, "Not Found", {}, None)
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            with self.assertRaises(MetagraphedError) as ctx:
+                metagraphed_fetch("/api/v1/subnets/{netuid}", path_params={"netuid": 9999})
+        self.assertEqual(ctx.exception.status, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/validate-python-release.sh
+++ b/scripts/validate-python-release.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Gate the metagraphed PyPI release: run from main, read the version from
+# python/pyproject.toml, require strict semver, and refuse if the git tag or the
+# PyPI version already exists. Mirrors scripts/validate-client-release.sh.
+set -euo pipefail
+
+if [ "${GITHUB_REF:-}" != "refs/heads/main" ]; then
+  echo "::error::metagraphed PyPI releases must run from main."
+  exit 1
+fi
+if [ -z "${GITHUB_OUTPUT:-}" ]; then
+  echo "::error::GITHUB_OUTPUT is required."
+  exit 1
+fi
+
+release_version="$(python3 -c "import tomllib, pathlib; print(tomllib.loads(pathlib.Path('python/pyproject.toml').read_text())['project']['version'])")"
+if ! printf '%s' "$release_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "::error::python/pyproject.toml version must be strict semver without a v prefix."
+  exit 1
+fi
+
+release_tag="python-v$release_version"
+if git rev-parse "$release_tag" >/dev/null 2>&1; then
+  echo "::error::Release tag already exists: $release_tag"
+  exit 1
+fi
+if curl -fsS "https://pypi.org/pypi/metagraphed/$release_version/json" >/dev/null 2>&1; then
+  echo "::error::PyPI version already exists: metagraphed==$release_version"
+  exit 1
+fi
+
+{
+  echo "version=$release_version"
+  echo "tag=$release_tag"
+} >>"$GITHUB_OUTPUT"
+echo "Releasing metagraphed==$release_version (tag $release_tag)."


### PR DESCRIPTION
A pip-installable Python client mirroring the npm client — one generic GET helper over the uniform read-only API, returning the `{ok,schema_version,data,meta}` envelope. **Dependency-free** (stdlib `urllib`), src-layout, typed (`py.typed`).

## Adds
- `python/` — `pyproject.toml` (hatchling, `name=metagraphed`, `requires-python>=3.9`, zero runtime deps), `src/metagraphed/{client,__init__,py.typed}`, README, PUBLISHING.md, hermetic `unittest` suite (urllib mocked, 5 cases).
- `.github/workflows/publish-python.yml` — two-job **OIDC Trusted Publishing** (no token): unprivileged job builds wheel+sdist via `uv`; separate privileged job (env `pypi-production`, `id-token: write`) downloads the prebuilt dist and publishes via `pypa/gh-action-pypi-publish`, so no third-party code runs while the OIDC token is live. Every action pinned to a 40-char SHA.
- `scripts/validate-python-release.sh` — main-only + strict-semver + tag/PyPI-existence gate.

## ⚠️ Blocked on you (one-time, no token)
Before the publish workflow can run, bootstrap PyPI (see `python/PUBLISHING.md`):
1. PyPI → Publishing → **pending publisher**: project `metagraphed`, owner `JSONbored`, repo `metagraphed`, workflow `publish-python.yml`, environment `pypi-production`.
2. GitHub → Settings → Environments → new `pypi-production`.

## Verified
5 unittest cases pass · `uv build` produces wheel + sdist · `validate:workflows` accepts the new workflow · eslint clean.