### PR TITLE
feat(api): expose published_at as a header on the raw artifact path

### DIFF
--- a/tests/raw-artifact-freshness.test.mjs
+++ b/tests/raw-artifact-freshness.test.mjs
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+const PUB = "2026-06-11T12:00:00.000Z";
+const EPOCH = "1970-01-01T00:00:00.000Z";
+
+function envWithPointer() {
+  return createLocalArtifactEnv({
+    METAGRAPH_CONTROL: {
+      get: async (key) =>
+        key === "metagraph:latest" ? { published_at: PUB } : null,
+    },
+  });
+}
+
+async function rawSubnets(env) {
+  const res = await handleRequest(
+    new Request("https://api.metagraph.sh/metagraph/subnets.json"),
+    env,
+    {},
+  );
+  return { res, body: JSON.parse(await res.text()) };
+}
+
+describe("raw artifact published_at header", () => {
+  test("exposes the real publish time as a header without changing the body", async () => {
+    const { res, body } = await rawSubnets(envWithPointer());
+    assert.equal(res.headers.get("x-metagraph-published-at"), PUB);
+    // The body stays byte-identical to the committed artifact: generated_at is
+    // the deterministic epoch content marker by design, not overwritten.
+    assert.equal(body.generated_at, EPOCH);
+  });
+
+  test("omits the header when there is no latest pointer", async () => {
+    const { res, body } = await rawSubnets(createLocalArtifactEnv());
+    assert.equal(res.headers.get("x-metagraph-published-at"), null);
+    assert.equal(body.generated_at, EPOCH);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -307,11 +307,19 @@ async function handleRawArtifactRequest(request, env, url) {
       artifact_path: url.pathname,
     });
   }
+  // The raw artifact path has no envelope, so direct fetchers of
+  // /metagraph/*.json have no freshness signal — the body's generated_at is the
+  // deterministic epoch content marker by design. Expose the real publish time
+  // as a header; the body stays byte-identical to the committed artifact.
+  const pub = await publishedAt(env);
   const body = JSON.stringify(artifact.data);
   const headers = apiHeaders("standard");
   headers.set("content-type", JSON_CONTENT_TYPE);
   headers.set("x-metagraph-artifact-source", artifact.source);
   headers.set("x-metagraph-storage-tier", artifact.storage_tier);
+  if (pub) {
+    headers.set("x-metagraph-published-at", pub);
+  }
   headers.set("etag", await weakEtag(body));
   if (request.headers.get("if-none-match") === headers.get("etag")) {
     return new Response(null, { status: 304, headers });


### PR DESCRIPTION
Direct fetchers of `/metagraph/*.json` had no freshness signal — that path has no envelope, and the body's `generated_at` is the deterministic epoch content marker by design (the enveloped `/api/v1/*` routes already carry `meta.published_at`).

Adds an **`x-metagraph-published-at`** response header (real publish time from the KV latest pointer) to the raw artifact handler, **without altering the body** — it stays byte-identical to the committed artifact, preserving the `generated_at` content-marker semantics (and the existing test asserting they stay distinct). No-ops when there's no pointer.

> Scoped deliberately small: an earlier draft overlaid `generated_at` in the body, but that conflicts with the intentional "generated_at = content marker, published_at = real time" design — reverted in favor of the header.

Verified: validate:api + 738 tests + lint green (the lone failure is the pre-existing flaky registry-validates test-isolation issue, tracked separately).