### PR TITLE
fix(test): make freshness + search-index assertions robust to fresh-data builds

### DIFF
--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -864,9 +864,14 @@ test("public artifacts are internally consistent", () => {
   const nodexoSearchDocument = search.documents.find(
     (document) => document.id === "subnet:27",
   );
+  // subnet:27 is indexed with a title + non-empty tokens. The specific token
+  // WORDS derive from the live chain description (which changes over time), so
+  // assert structure here, not volatile content — semantic/meaningful-word
+  // tokenization is covered by tests/search-quality.test.mjs.
+  assert.equal(typeof nodexoSearchDocument?.title, "string");
   assert.equal(
-    nodexoSearchDocument?.tokens.includes("decentralized") &&
-      nodexoSearchDocument.tokens.includes("compute"),
+    Array.isArray(nodexoSearchDocument?.tokens) &&
+      nodexoSearchDocument.tokens.length > 0,
     true,
   );
   assert.equal(

--- a/tests/raw-artifact-freshness.test.mjs
+++ b/tests/raw-artifact-freshness.test.mjs
@@ -4,7 +4,6 @@ import { handleRequest } from "../workers/api.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
 const PUB = "2026-06-11T12:00:00.000Z";
-const EPOCH = "1970-01-01T00:00:00.000Z";
 
 function envWithPointer() {
   return createLocalArtifactEnv({
@@ -28,14 +27,16 @@ describe("raw artifact published_at header", () => {
   test("exposes the real publish time as a header without changing the body", async () => {
     const { res, body } = await rawSubnets(envWithPointer());
     assert.equal(res.headers.get("x-metagraph-published-at"), PUB);
-    // The body stays byte-identical to the committed artifact: generated_at is
-    // the deterministic epoch content marker by design, not overwritten.
-    assert.equal(body.generated_at, EPOCH);
+    // The body is unchanged: generated_at is NOT overlaid with the publish
+    // time (proven without assuming the build's generated_at value, which is
+    // the epoch locally but a real timestamp in the publish/sync build).
+    assert.notEqual(body.generated_at, PUB);
   });
 
   test("omits the header when there is no latest pointer", async () => {
     const { res, body } = await rawSubnets(createLocalArtifactEnv());
     assert.equal(res.headers.get("x-metagraph-published-at"), null);
-    assert.equal(body.generated_at, EPOCH);
+    // body unchanged (not overlaid), timestamp-value-agnostic
+    assert.notEqual(body.generated_at, PUB);
   });
 });


### PR DESCRIPTION
The scheduled **Sync Subnets** job runs the full test suite against **freshly-fetched chain data + a real `METAGRAPH_BUILD_TIMESTAMP`** — a context regular CI (committed data + epoch) never hits. Two fragile assertions failed there (and would break regular CI the moment the sync commits fresh data):

- `raw-artifact-freshness.test.mjs` asserted `body.generated_at === EPOCH`, but the publish/sync build uses a real timestamp → assert `!== PUB` instead (proves no overlay, timestamp-agnostic). *[regression from #312]*
- `artifacts.test.mjs` asserted subnet:27 (nodexo) tokens include literal "decentralized"/"compute" — but those derive from the live chain description, which changed → assert structure (title + non-empty tokens); meaningful-word tokenization stays covered by `search-quality.test.mjs`.

This is the **second failure cause** for the chain-data refresh (on top of P0 #307's `validate:openapi-examples` fix). Verified both pass on a fresh consistent build.

After merge I'll re-run Sync Subnets to confirm it's green end-to-end.