### PR TITLE
fix(ci): allowlist build-generated public assets in subnet sync

### DIFF
--- a/.github/workflows/sync-subnets.yml
+++ b/.github/workflows/sync-subnets.yml
@@ -66,6 +66,13 @@ jobs:
         run: |
           allowed_paths=(
             public/metagraph
+            public/.well-known
+            public/datasets
+            public/skills
+            public/llms.txt
+            public/llms-full.txt
+            public/robots.txt
+            public/sitemap.xml
             registry/adapters/latest
             registry/candidates/generated
             registry/generated
@@ -77,7 +84,7 @@ jobs:
           while IFS= read -r file; do
             [ -n "$file" ] || continue
             case "$file" in
-              public/metagraph/*|registry/adapters/latest/*|registry/candidates/generated/*|registry/generated/*|registry/native/finney-subnets.json|registry/subnets/*|registry/verification/*) ;;
+              public/metagraph/*|public/.well-known/*|public/datasets/*|public/skills/*|public/llms.txt|public/llms-full.txt|public/robots.txt|public/sitemap.xml|registry/adapters/latest/*|registry/candidates/generated/*|registry/generated/*|registry/native/finney-subnets.json|registry/subnets/*|registry/verification/*) ;;
               *)
                 echo "Unexpected untracked file outside the sync allowlist: $file" >&2
                 exit 1
@@ -89,7 +96,7 @@ jobs:
           while IFS= read -r file; do
             [ -n "$file" ] || continue
             case "$file" in
-              public/metagraph/*|registry/adapters/latest/*|registry/candidates/generated/*|registry/generated/*|registry/native/finney-subnets.json|registry/subnets/*|registry/verification/*) ;;
+              public/metagraph/*|public/.well-known/*|public/datasets/*|public/skills/*|public/llms.txt|public/llms-full.txt|public/robots.txt|public/sitemap.xml|registry/adapters/latest/*|registry/candidates/generated/*|registry/generated/*|registry/native/finney-subnets.json|registry/subnets/*|registry/verification/*) ;;
               *)
                 echo "Unexpected generated change outside the sync allowlist: $file" >&2
                 exit 1


### PR DESCRIPTION
## Problem
The `Sync Subnets` scheduled workflow fails at the **Capture generated changes** step:
```
Unexpected generated change outside the sync allowlist: public/.well-known/llms.txt
```
This step enforces an allowlist of paths the sync may touch (defense-in-depth: a buggy/compromised refresh can't commit arbitrary files). It only permitted `public/metagraph` + the `registry/*` dirs.

Recent shipped features (#309 distribution, #313 datasets, #314 sitemap, plus the pre-existing llms.txt) added **build-generated static assets** under `public/` that the refresh pipeline regenerates from the same chain data:
- `public/.well-known/{llms.txt,mcp.json,mcp/server-card.json}`
- `public/datasets/` (CSV exports + index.json)
- `public/llms.txt`, `public/llms-full.txt`
- `public/robots.txt`, `public/sitemap.xml`

The sync never reached this step before (it failed earlier at `validate:openapi-examples` (#307) and the freshness tests (#315)). With those fixed, it now reaches the guard and is rejected on the first un-allowlisted file.

## Fix
Add those build-target paths to the allowlist (the `allowed_paths` array + both `case` guards). These are legitimate, deterministic outputs of the refresh — verified locally that a rebuild on unchanged data produces **zero** diff in them (deterministic build timestamps), so they only change when chain data actually changes; no PR noise.

## Verification
- `npm run validate:workflows` → `Validated 7 workflow file(s).`
- Local `npm run build` + simulated the exact `case` guard against every build-written path → none trip.
- Will confirm a green `Sync Subnets` run after merge.