### PR TITLE
feat(schema): unlock network const→enum (multi-network Phase 0)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1030,6 +1030,11 @@ export interface components {
         };
         /** @enum {unknown} */
         Authority: "official" | "provider-claimed" | "community" | "registry-observed";
+        /**
+         * @description Bittensor chain network this record belongs to. Values are the chain-accurate SDK network names; the public API + UI address them with the friendly aliases mainnet (finney), testnet (test), and local. 'finney' is the default for back-compatibility.
+         * @enum {unknown}
+         */
+        BittensorNetwork: "finney" | "test" | "local";
         BuildSummaryArtifact: components["schemas"]["ArtifactBase"] & ({
             artifact_budgets?: components["schemas"]["ArtifactSizeBudget"][];
             artifact_count: number;
@@ -1160,8 +1165,7 @@ export interface components {
             native_only_with_candidates: number;
             native_only_without_candidates: number;
             native_snapshot_captured_at: string;
-            /** @constant */
-            network: "finney";
+            network: components["schemas"]["BittensorNetwork"];
             probed_count: number;
             probed_surface_count: number;
             root_subnet_count: number;
@@ -1306,8 +1310,7 @@ export interface components {
             /** @enum {unknown} */
             monitoring_status: "monitored" | "not_monitored";
             netuid: number;
-            /** @constant */
-            network?: "finney";
+            network?: components["schemas"]["BittensorNetwork"];
             observed_at: string | null;
             operator: string;
             pool_eligibility_reasons?: string[];
@@ -2189,8 +2192,7 @@ export interface components {
                 [key: string]: boolean;
             } | string[] | null;
             netuid?: number;
-            /** @constant */
-            network: "finney";
+            network: components["schemas"]["BittensorNetwork"];
             observed_at: string | null;
             provider: string;
             public_safe?: boolean;
@@ -2646,8 +2648,7 @@ export interface components {
             url: string;
         } | null;
         SubnetsArtifact: components["schemas"]["ArtifactBase"] & ({
-            /** @constant */
-            network: "finney";
+            network: components["schemas"]["BittensorNetwork"];
             source: {
                 [key: string]: unknown;
             };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -552,6 +552,14 @@
           "registry-observed"
         ]
       },
+      "BittensorNetwork": {
+        "description": "Bittensor chain network this record belongs to. Values are the chain-accurate SDK network names; the public API + UI address them with the friendly aliases mainnet (finney), testnet (test), and local. 'finney' is the default for back-compatibility.",
+        "enum": [
+          "finney",
+          "test",
+          "local"
+        ]
+      },
       "BuildSummaryArtifact": {
         "allOf": [
           {
@@ -1044,7 +1052,7 @@
                 "type": "string"
               },
               "network": {
-                "const": "finney"
+                "$ref": "#/components/schemas/BittensorNetwork"
               },
               "probed_count": {
                 "minimum": 0,
@@ -1675,7 +1683,7 @@
             "type": "integer"
           },
           "network": {
-            "const": "finney"
+            "$ref": "#/components/schemas/BittensorNetwork"
           },
           "observed_at": {
             "type": [
@@ -5446,7 +5454,7 @@
             "type": "integer"
           },
           "network": {
-            "const": "finney"
+            "$ref": "#/components/schemas/BittensorNetwork"
           },
           "observed_at": {
             "type": [
@@ -7482,7 +7490,7 @@
             "additionalProperties": true,
             "properties": {
               "network": {
-                "const": "finney"
+                "$ref": "#/components/schemas/BittensorNetwork"
               },
               "source": {
                 "additionalProperties": true,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1030,6 +1030,11 @@ export interface components {
         };
         /** @enum {unknown} */
         Authority: "official" | "provider-claimed" | "community" | "registry-observed";
+        /**
+         * @description Bittensor chain network this record belongs to. Values are the chain-accurate SDK network names; the public API + UI address them with the friendly aliases mainnet (finney), testnet (test), and local. 'finney' is the default for back-compatibility.
+         * @enum {unknown}
+         */
+        BittensorNetwork: "finney" | "test" | "local";
         BuildSummaryArtifact: components["schemas"]["ArtifactBase"] & ({
             artifact_budgets?: components["schemas"]["ArtifactSizeBudget"][];
             artifact_count: number;
@@ -1160,8 +1165,7 @@ export interface components {
             native_only_with_candidates: number;
             native_only_without_candidates: number;
             native_snapshot_captured_at: string;
-            /** @constant */
-            network: "finney";
+            network: components["schemas"]["BittensorNetwork"];
             probed_count: number;
             probed_surface_count: number;
             root_subnet_count: number;
@@ -1306,8 +1310,7 @@ export interface components {
             /** @enum {unknown} */
             monitoring_status: "monitored" | "not_monitored";
             netuid: number;
-            /** @constant */
-            network?: "finney";
+            network?: components["schemas"]["BittensorNetwork"];
             observed_at: string | null;
             operator: string;
             pool_eligibility_reasons?: string[];
@@ -2189,8 +2192,7 @@ export interface components {
                 [key: string]: boolean;
             } | string[] | null;
             netuid?: number;
-            /** @constant */
-            network: "finney";
+            network: components["schemas"]["BittensorNetwork"];
             observed_at: string | null;
             provider: string;
             public_safe?: boolean;
@@ -2646,8 +2648,7 @@ export interface components {
             url: string;
         } | null;
         SubnetsArtifact: components["schemas"]["ArtifactBase"] & ({
-            /** @constant */
-            network: "finney";
+            network: components["schemas"]["BittensorNetwork"];
             source: {
                 [key: string]: unknown;
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -538,6 +538,14 @@
           "registry-observed"
         ]
       },
+      "BittensorNetwork": {
+        "description": "Bittensor chain network this record belongs to. Values are the chain-accurate SDK network names; the public API + UI address them with the friendly aliases mainnet (finney), testnet (test), and local. 'finney' is the default for back-compatibility.",
+        "enum": [
+          "finney",
+          "test",
+          "local"
+        ]
+      },
       "BuildSummaryArtifact": {
         "allOf": [
           {
@@ -1030,7 +1038,7 @@
                 "type": "string"
               },
               "network": {
-                "const": "finney"
+                "$ref": "#/components/schemas/BittensorNetwork"
               },
               "probed_count": {
                 "minimum": 0,
@@ -1661,7 +1669,7 @@
             "type": "integer"
           },
           "network": {
-            "const": "finney"
+            "$ref": "#/components/schemas/BittensorNetwork"
           },
           "observed_at": {
             "type": [
@@ -5424,7 +5432,7 @@
             "type": "integer"
           },
           "network": {
-            "const": "finney"
+            "$ref": "#/components/schemas/BittensorNetwork"
           },
           "observed_at": {
             "type": [
@@ -7460,7 +7468,7 @@
             "additionalProperties": true,
             "properties": {
               "network": {
-                "const": "finney"
+                "$ref": "#/components/schemas/BittensorNetwork"
               },
               "source": {
                 "additionalProperties": true,

--- a/schemas/components/01-enums.schema.json
+++ b/schemas/components/01-enums.schema.json
@@ -123,6 +123,10 @@
       },
       "SubnetType": {
         "enum": ["root", "application"]
+      },
+      "BittensorNetwork": {
+        "description": "Bittensor chain network this record belongs to. Values are the chain-accurate SDK network names; the public API + UI address them with the friendly aliases mainnet (finney), testnet (test), and local. 'finney' is the default for back-compatibility.",
+        "enum": ["finney", "test", "local"]
       }
     }
   }

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -916,7 +916,7 @@
             "required": ["network", "source", "subnets"],
             "properties": {
               "network": {
-                "const": "finney"
+                "$ref": "#/components/schemas/BittensorNetwork"
               },
               "source": {
                 "type": "object",
@@ -1089,7 +1089,7 @@
                 "type": "string"
               },
               "network": {
-                "const": "finney"
+                "$ref": "#/components/schemas/BittensorNetwork"
               },
               "probed_count": {
                 "type": "integer",

--- a/schemas/components/07-endpoints-rpc.schema.json
+++ b/schemas/components/07-endpoints-rpc.schema.json
@@ -58,7 +58,7 @@
             "$ref": "#/components/schemas/Classification"
           },
           "network": {
-            "const": "finney"
+            "$ref": "#/components/schemas/BittensorNetwork"
           },
           "chain": {
             "const": "bittensor"
@@ -316,7 +316,7 @@
             "const": "bittensor"
           },
           "network": {
-            "const": "finney"
+            "$ref": "#/components/schemas/BittensorNetwork"
           },
           "layer": {
             "$ref": "#/components/schemas/EndpointLayer"


### PR DESCRIPTION
## Multi-network — Phase 0 (foundation)
First step of the network feature (path-prefix `/api/v1/{network}/`, naming mainnet/testnet/local, full testnet pipeline — per the agreed plan).

Replaces the four `"network": {"const": "finney"}` schema locks with a shared **`BittensorNetwork`** enum `[finney, test, local]` (defined once in `01-enums.schema.json`, $ref'd from `05-subnets` (SubnetsArtifact + SubnetDetailArtifact) and `07-endpoints-rpc` (RpcEndpoint + RpcPool)).

### Why it's safe to ship alone
- **Pure widening**: const→enum is strictly more permissive; all existing `finney` data still validates. **Zero behavior change** — the build still emits `network: "finney"`.
- Data stays **chain-accurate** (finney/test/local = the Bittensor SDK names + what `fetch-native-subnets.py --network` produces); the friendly **mainnet/testnet/local** aliases live in the URL/UI layer (Phase 1).
- Reversible.

### Verification
Regenerated contract (openapi.json + types.d.ts + generated types). `npm test` (745 pass) · `validate:contract-drift` · `validate:schemas` · `validate:api` — all green.