### PR TITLE
docs(network): document mainnet/testnet/local addressing in llms.txt (Phase 4)

### DIFF
--- a/public/.well-known/llms.txt
+++ b/public/.well-known/llms.txt
@@ -23,5 +23,11 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - Schemas: `GET /api/v1/schemas`, `GET /metagraph/schemas/{surface_id}.json`
 - RPC pool: `GET /api/v1/rpc/endpoints`
 
+## Networks (mainnet / testnet / local)
+Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1/{network}/…`. Bare paths default to mainnet, so every URL above is the mainnet view.
+- `mainnet` (alias `finney`): the full registry — curated services, schemas, 2-minute health. The default.
+- `testnet` (alias `test`): native chain registry only — subnet identity from the testnet chain, no curated services/health. Testnet netuids are independent of mainnet. e.g. `GET /api/v1/testnet/subnets`, `GET /api/v1/testnet/subnets/{netuid}`.
+- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at `ws://127.0.0.1:9944`).
+
 ## Optional
 - [llms-full.txt](https://api.metagraph.sh/llms-full.txt): expanded index with every subnet + route

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -23,6 +23,12 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - Schemas: `GET /api/v1/schemas`, `GET /metagraph/schemas/{surface_id}.json`
 - RPC pool: `GET /api/v1/rpc/endpoints`
 
+## Networks (mainnet / testnet / local)
+Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1/{network}/…`. Bare paths default to mainnet, so every URL above is the mainnet view.
+- `mainnet` (alias `finney`): the full registry — curated services, schemas, 2-minute health. The default.
+- `testnet` (alias `test`): native chain registry only — subnet identity from the testnet chain, no curated services/health. Testnet netuids are independent of mainnet. e.g. `GET /api/v1/testnet/subnets`, `GET /api/v1/testnet/subnets/{netuid}`.
+- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at `ws://127.0.0.1:9944`).
+
 ## Subnets
 - SN0 root (root); no catalogued public API yet — https://api.metagraph.sh/api/v1/agent-catalog/0
 - SN1 Apex (sn-1); no catalogued public API yet — https://api.metagraph.sh/api/v1/agent-catalog/1

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -23,5 +23,11 @@ metagraphed catalogs the application/operational layer of Bittensor (complementa
 - Schemas: `GET /api/v1/schemas`, `GET /metagraph/schemas/{surface_id}.json`
 - RPC pool: `GET /api/v1/rpc/endpoints`
 
+## Networks (mainnet / testnet / local)
+Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1/{network}/…`. Bare paths default to mainnet, so every URL above is the mainnet view.
+- `mainnet` (alias `finney`): the full registry — curated services, schemas, 2-minute health. The default.
+- `testnet` (alias `test`): native chain registry only — subnet identity from the testnet chain, no curated services/health. Testnet netuids are independent of mainnet. e.g. `GET /api/v1/testnet/subnets`, `GET /api/v1/testnet/subnets/{netuid}`.
+- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at `ws://127.0.0.1:9944`).
+
 ## Optional
 - [llms-full.txt](https://api.metagraph.sh/llms-full.txt): expanded index with every subnet + route

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -895,6 +895,12 @@ const llmsHeader = [
   "- Callable APIs: `GET /api/v1/agent-catalog/{netuid}`, `GET /api/v1/subnets/{netuid}/surfaces`",
   "- Schemas: `GET /api/v1/schemas`, `GET /metagraph/schemas/{surface_id}.json`",
   "- RPC pool: `GET /api/v1/rpc/endpoints`",
+  "",
+  "## Networks (mainnet / testnet / local)",
+  "Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1/{network}/…`. Bare paths default to mainnet, so every URL above is the mainnet view.",
+  "- `mainnet` (alias `finney`): the full registry — curated services, schemas, 2-minute health. The default.",
+  "- `testnet` (alias `test`): native chain registry only — subnet identity from the testnet chain, no curated services/health. Testnet netuids are independent of mainnet. e.g. `GET /api/v1/testnet/subnets`, `GET /api/v1/testnet/subnets/{netuid}`.",
+  "- `local`: a per-developer subtensor metagraphed can't host — `GET /api/v1/local` returns setup guidance (point your SDK/RPC at `ws://127.0.0.1:9944`).",
 ].join("\n");
 const llmsShort = `${llmsHeader}\n\n## Optional\n- [llms-full.txt](${llmsApiBase}/llms-full.txt): expanded index with every subnet + route\n`;
 const llmsSubnetLines = mergedSubnets


### PR DESCRIPTION
## Multi-network — Phase 4 (agent discoverability)
The OpenAPI spec doesn't encode the `/{network}/` prefix (it's a routing prefix dimension, not a per-route multiplier), so agents reading the contract wouldn't know testnet/local exist. Adds a **Networks** section to the agent-facing `llms.txt` / `llms-full.txt` / `.well-known/llms.txt`: how to scope any path with `/api/v1/{network}/…`, and mainnet (full) vs testnet (native registry, independent netuids) vs local (dev-mode pointer).

Completes the multi-network rollout (Phases 0→4 all shipped). `npm test` (755) · `validate` · `lint` green.