### PR TITLE
fix(search): default semantic-search limit returns full set, not 1 (#330)

### DIFF
--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -76,8 +76,12 @@ export async function withinRateLimit(env, key) {
 
 function clampLimit(value, fallback, max) {
   const n = Number(value);
-  if (!Number.isFinite(n)) return fallback;
-  return Math.max(1, Math.min(max, Math.floor(n)));
+  // Number(null) and Number("") are 0 (not NaN), so a missing/blank/<1 limit
+  // must fall back to the default — NOT clamp UP to 1. The old `Math.max(1, …)`
+  // turned every default-limit query (e.g. `?q=…` with no &limit) into a single
+  // result, which read as "this registry knows one subnet" to agents.
+  if (!Number.isFinite(n) || n < 1) return fallback;
+  return Math.min(max, Math.floor(n));
 }
 
 // Stable, dependency-free 53-bit string hash (cyrb53) for change detection.

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -348,6 +348,19 @@ describe("semanticSearch", () => {
     const out = await semanticSearch(env, "x", { limit: 999 });
     assert.ok(out.results.length <= 20);
   });
+  test("falls back to the default limit when none is given (regression: #330)", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    // `url.searchParams.get("limit")` is null when absent — the exact prod path
+    // that previously clamped to 1. Should now use SEMANTIC_DEFAULT_LIMIT.
+    for (const noLimit of [{}, { limit: null }, { limit: "" }, { limit: 0 }]) {
+      const out = await semanticSearch(env, "x", noLimit);
+      assert.equal(
+        out.count,
+        3,
+        `expected default-limit fan-out, got ${out.count} for ${JSON.stringify(noLimit)}`,
+      );
+    }
+  });
 });
 
 describe("askQuestion", () => {


### PR DESCRIPTION
## Problem (confirmed live)
`GET /api/v1/search/semantic?q=bitcoin` returns **count:1**; `&limit=10` returns 10. `clampLimit(null)` → `Number(null)===0` → `Math.max(1, Math.min(max, 0))` → **1**. So every default NL query — the headline discovery surface advertised in `llms.txt` + `SKILL.md` — silently returned one result. To an agent that reads as "this registry knows one subnet."

## Fix
`src/ai-search.mjs` `clampLimit`: any missing / blank / `<1` value falls back to the default instead of clamping up to 1. Also corrects `/ask`'s `topK` (same helper).

## Test
Added a regression in `tests/ai-search.test.mjs` exercising the exact production path — `{}`, `{limit:null}`, `{limit:""}`, `{limit:0}` all return the default fan-out (count 3 via the stub, was 1).

`npm test` (ai-search 42/42), `lint` green. The unrelated `registry validates` flake is pre-existing test-pollution (`validate` passes standalone — confirmed).

Closes #330.