### PR TITLE
feat(search): enrich embeddings + index with categories + service_kinds (#333)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2315,8 +2315,10 @@ export interface components {
         });
         SearchDocument: {
             artifact_path: string;
+            categories?: string[];
             id: string;
             netuid?: number;
+            service_kinds?: string[];
             slug?: string;
             subtitle?: string;
             title: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -5979,12 +5979,24 @@
           "artifact_path": {
             "type": "string"
           },
+          "categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "id": {
             "type": "string"
           },
           "netuid": {
             "minimum": 0,
             "type": "integer"
+          },
+          "service_kinds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "slug": {
             "type": "string"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2315,8 +2315,10 @@ export interface components {
         });
         SearchDocument: {
             artifact_path: string;
+            categories?: string[];
             id: string;
             netuid?: number;
+            service_kinds?: string[];
             slug?: string;
             subtitle?: string;
             title: string;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -5957,12 +5957,24 @@
           "artifact_path": {
             "type": "string"
           },
+          "categories": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "id": {
             "type": "string"
           },
           "netuid": {
             "minimum": 0,
             "type": "integer"
+          },
+          "service_kinds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
           },
           "slug": {
             "type": "string"

--- a/schemas/components/08-evidence-search-sources.schema.json
+++ b/schemas/components/08-evidence-search-sources.schema.json
@@ -39,6 +39,18 @@
             "items": {
               "type": "string"
             }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "service_kinds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           }
         },
         "additionalProperties": false

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -416,12 +416,36 @@ const agentEndpointBySurfaceId = new Map(
 // this subnet worth integrating" lives on the surfaces agents actually land on.
 // Read-only derived signal: it never feeds completeness_score or curation gaps,
 // so the SN74 curation flywheel is untouched.
+// Callable services per subnet, resolved once and reused by integration
+// readiness, the search index (service_kinds), and the agent-catalog.
+const servicesByNetuid = new Map(
+  mergedSubnets.map((subnet) => [
+    subnet.netuid,
+    buildSubnetServices(subnet.netuid),
+  ]),
+);
+// Distinct callable-service kinds per subnet (subnet-api/openapi/sse/
+// data-artifact). Feeds capability-aware discovery: the search index tokens +
+// the embedding text, so "which subnet has an inference API" ranks on what a
+// subnet can actually do, not just its prose description.
+const serviceKindsByNetuid = new Map(
+  mergedSubnets.map((subnet) => [
+    subnet.netuid,
+    [
+      ...new Set(
+        (servicesByNetuid.get(subnet.netuid) || []).map(
+          (service) => service.kind,
+        ),
+      ),
+    ].sort(),
+  ]),
+);
 const READINESS_VERSION = 1;
 const readinessByNetuid = new Map(
   mergedSubnets.map((subnet) => [
     subnet.netuid,
     subnetIntegrationReadiness({
-      services: buildSubnetServices(subnet.netuid),
+      services: servicesByNetuid.get(subnet.netuid),
       lifecycle: subnet.lifecycle,
       completenessScore: profileArtifacts.byNetuid.get(subnet.netuid)
         ?.completeness_score,
@@ -853,7 +877,7 @@ const agentCatalogIndex = [];
 let callableServiceCount = 0;
 for (const subnet of mergedSubnets) {
   const profile = profileArtifacts.byNetuid.get(subnet.netuid) || null;
-  const services = buildSubnetServices(subnet.netuid);
+  const services = servicesByNetuid.get(subnet.netuid) || [];
   // Reuse the readiness computed once above for the index/profile surfaces.
   const readiness = readinessByNetuid.get(subnet.netuid);
   await writeJson(artifactFile(`agent-catalog/${subnet.netuid}.json`), {
@@ -1077,6 +1101,7 @@ await writeJson(
     surfaces,
     providers,
     profileArtifacts.byNetuid,
+    serviceKindsByNetuid,
   ),
 );
 await writeJson(
@@ -3831,10 +3856,15 @@ function buildSearchIndex(
   surfacesForIndex,
   providerList,
   profilesByNetuid = new Map(),
+  serviceKindsByNetuid = new Map(),
 ) {
   const documents = [
     ...subnets.map((subnet) => {
       const profile = profilesByNetuid.get(subnet.netuid);
+      const categories = Array.isArray(subnet.categories)
+        ? subnet.categories
+        : [];
+      const serviceKinds = serviceKindsByNetuid.get(subnet.netuid) || [];
       return {
         id: `subnet:${subnet.netuid}`,
         type: "subnet",
@@ -3848,11 +3878,18 @@ function buildSearchIndex(
           `SN${subnet.netuid} ${subnet.symbol || ""}`.trim(),
         url: `/subnets/${subnet.netuid}`,
         artifact_path: `/metagraph/subnets/${subnet.netuid}.json`,
+        // Explicit capability facets: what the subnet is (categories) and what
+        // it exposes (callable service kinds). Surfaced as fields for filtering
+        // and folded into tokens + the embedding so capability-shaped queries
+        // ("inference api", "sse stream") rank on what a subnet can do.
+        categories,
+        service_kinds: serviceKinds,
         tokens: compactTokens([
           subnet.name,
           subnet.slug,
           subnet.description,
-          subnet.categories?.join(" "),
+          categories.join(" "),
+          serviceKinds.join(" "),
           nativeIdentityTokenText(profile?.native_identity),
         ]),
       };

--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -101,10 +101,16 @@ function contentHash(text) {
 }
 
 export function embeddingText(doc) {
+  // Capability facets (what a subnet IS + what it EXPOSES) are appended after the
+  // free-text tokens so they explicitly bias the embedding toward capability —
+  // "inference api", "sse stream", "data-artifact" queries rank on what a subnet
+  // can do, not just its prose. Non-subnet docs simply omit these (empty).
   return [
     doc.title,
     doc.subtitle,
     ...(Array.isArray(doc.tokens) ? doc.tokens : []),
+    ...(Array.isArray(doc.categories) ? doc.categories : []),
+    ...(Array.isArray(doc.service_kinds) ? doc.service_kinds : []),
   ]
     .filter(Boolean)
     .join(" ")
@@ -126,6 +132,10 @@ export function embeddingMetadata(doc) {
     title: doc.title ?? null,
     subtitle: doc.subtitle ?? null,
     url: doc.url ?? null,
+    // Returned with each hit so callers can see/post-filter on capability without
+    // a second round-trip. Only subnet docs carry these.
+    categories: Array.isArray(doc.categories) ? doc.categories : [],
+    service_kinds: Array.isArray(doc.service_kinds) ? doc.service_kinds : [],
   };
 }
 

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -149,6 +149,18 @@ describe("embedding helpers", () => {
     assert.equal(embeddingText({ title: "A" }), "A");
     assert.ok(embeddingText({ title: "x".repeat(5000) }).length <= 1500);
   });
+  test("embeddingText appends capability facets (categories + service_kinds)", () => {
+    assert.equal(
+      embeddingText({
+        title: "Apex",
+        subtitle: "text gen",
+        tokens: ["chat"],
+        categories: ["inference"],
+        service_kinds: ["openapi", "sse"],
+      }),
+      "Apex text gen chat inference openapi sse",
+    );
+  });
   test("vectorId keeps short ids and hashes long ones", () => {
     assert.equal(vectorId("subnet:7"), "subnet:7");
     const long = "surface:" + "x".repeat(80);
@@ -163,7 +175,29 @@ describe("embedding helpers", () => {
       title: null,
       subtitle: null,
       url: null,
+      categories: [],
+      service_kinds: [],
     });
+  });
+  test("embeddingMetadata carries capability facets when present", () => {
+    assert.deepEqual(
+      embeddingMetadata({
+        type: "subnet",
+        netuid: 1,
+        categories: ["inference"],
+        service_kinds: ["openapi"],
+      }),
+      {
+        type: "subnet",
+        netuid: 1,
+        slug: null,
+        title: null,
+        subtitle: null,
+        url: null,
+        categories: ["inference"],
+        service_kinds: ["openapi"],
+      },
+    );
   });
 });
 


### PR DESCRIPTION
## What

Make discovery **capability-aware**. Semantic + keyword search ranked subnets almost entirely on prose (name + description), so capability-shaped queries — _"inference api"_, _"sse stream"_, _"data artifact"_ — had little to bite on.

- **Search-index subnet docs** gain explicit `categories` + `service_kinds` arrays (distinct callable kinds: `subnet-api` / `openapi` / `sse` / `data-artifact`) and fold both into `tokens` for keyword parity.
- **`embeddingText()`** appends the capability facets after the free-text tokens, biasing the vector toward what a subnet *can do*, not just how it's described.
- **`embeddingMetadata()`** returns `categories` + `service_kinds` with each hit, so callers can see/post-filter on capability without a second round-trip.

## How

Service kinds are resolved **once** into `servicesByNetuid` / `serviceKindsByNetuid` and reused by integration readiness, the search index, and the agent-catalog (the catalog now reads the shared map instead of recomputing `buildSubnetServices` — net DRY win on top of #335).

`SearchDocument` schema (`additionalProperties: false`) extended with the two array fields; contract regenerated.

## Re-embedding

`embeddingText()`'s content changes → its content hash changes → the embedding-sync cron re-embeds the affected subnet docs on the next deploy automatically. No manual backfill.

## Verification

- `npm run build` ✓ — 129/129 subnet docs carry `categories` + `service_kinds`; 30 expose ≥1 callable kind
- `validate:schemas` / `validate:contract-drift` / `validate:api` / `validate:openapi-examples` ✓
- `scan:public-safety` ✓ · `lint` ✓ · reproducibility validator ✓
- `npm test` ✓ — **760/760** (3 new: embeddingText facet append + embeddingMetadata facet carry)

Closes #333. Part of Wave 2 (epic #338).