### PR TITLE
feat(ask): enrich /ask context with callable_count + base_url + health (#334)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -909,9 +909,11 @@ export interface components {
             callable_service_count?: number;
             subnet_count: number;
             subnets: ({
+                base_url?: string | null;
                 callable_count?: number;
                 categories?: string[];
                 completeness_score?: number | null;
+                health?: string;
                 integration_readiness?: number;
                 name?: string;
                 netuid: number;

--- a/public/metagraph/agent-catalog.json
+++ b/public/metagraph/agent-catalog.json
@@ -6,6 +6,7 @@
   "subnet_count": 30,
   "subnets": [
     {
+      "base_url": "https://api.numinouslabs.io/api/health",
       "callable_count": 4,
       "categories": [
         "baseline-augmented",
@@ -18,6 +19,7 @@
         "subnet-api"
       ],
       "completeness_score": 85,
+      "health": "unknown",
       "integration_readiness": 100,
       "name": "Numinous",
       "netuid": 6,
@@ -42,6 +44,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.all-ways.io/health",
       "callable_count": 13,
       "categories": [
         "baseline-augmented",
@@ -50,6 +53,7 @@
         "subnet-api"
       ],
       "completeness_score": 97,
+      "health": "unknown",
       "integration_readiness": 100,
       "name": "Allways",
       "netuid": 7,
@@ -75,6 +79,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.desearch.ai",
       "callable_count": 3,
       "categories": [
         "baseline-augmented",
@@ -89,6 +94,7 @@
         "social-data"
       ],
       "completeness_score": 85,
+      "health": "unknown",
       "integration_readiness": 85,
       "name": "Desearch",
       "netuid": 22,
@@ -113,6 +119,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.trishool.ai/",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -123,6 +130,7 @@
         "subnet-api-observed"
       ],
       "completeness_score": 70,
+      "health": "unknown",
       "integration_readiness": 75,
       "name": "Trishool",
       "netuid": 23,
@@ -146,6 +154,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://huggingface.co/silx-ai/Quasar-3B-A1B-Preview",
       "callable_count": 3,
       "categories": [
         "baseline-augmented",
@@ -158,6 +167,7 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "Quasar",
       "netuid": 24,
@@ -181,6 +191,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://huggingface.co/datasets/HuggingFaceFW/fineweb-edu-score-2",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -193,6 +204,7 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "Coldint",
       "netuid": 29,
@@ -216,6 +228,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://huggingface.co/datasets/ReadyAi/5000-podcast-conversations-with-metadata-and-embedding-dataset",
       "callable_count": 2,
       "categories": [
         "baseline-augmented",
@@ -228,6 +241,7 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "ReadyAI",
       "netuid": 33,
@@ -251,11 +265,13 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://zipcode.ai/openapi.json",
       "callable_count": 1,
       "categories": [
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "health": "unknown",
       "integration_readiness": 95,
       "name": "Zipcode",
       "netuid": 46,
@@ -279,6 +295,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://huggingface.co/datasets/evolai/universal_qa",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -288,6 +305,7 @@
         "official-source-repo"
       ],
       "completeness_score": 48,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "EvolAI",
       "netuid": 47,
@@ -311,6 +329,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://tournament-api.nepher.ai",
       "callable_count": 2,
       "categories": [
         "baseline-augmented",
@@ -325,6 +344,7 @@
         "tournament"
       ],
       "completeness_score": 85,
+      "health": "unknown",
       "integration_readiness": 85,
       "name": "Nepher Robotics",
       "netuid": 49,
@@ -349,11 +369,13 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://lium.io/api",
       "callable_count": 1,
       "categories": [
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "lium.io",
       "netuid": 51,
@@ -377,6 +399,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.gradients.io/v1/performance/last-boss-battle",
       "callable_count": 5,
       "categories": [
         "ai-training",
@@ -389,6 +412,7 @@
         "operational-interface"
       ],
       "completeness_score": 93,
+      "health": "unknown",
       "integration_readiness": 100,
       "name": "Gradients",
       "netuid": 56,
@@ -414,6 +438,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://handshake58.com/api/drain/signing",
       "callable_count": 4,
       "categories": [
         "ai-marketplace",
@@ -427,6 +452,7 @@
         "payments"
       ],
       "completeness_score": 85,
+      "health": "unknown",
       "integration_readiness": 90,
       "name": "Handshake58",
       "netuid": 58,
@@ -451,11 +477,13 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.babelbit.ai/",
       "callable_count": 1,
       "categories": [
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "Babelbit",
       "netuid": 59,
@@ -479,6 +507,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.chutes.ai/openapi.json",
       "callable_count": 4,
       "categories": [
         "baseline-augmented",
@@ -492,6 +521,7 @@
         "official-website"
       ],
       "completeness_score": 93,
+      "health": "unknown",
       "integration_readiness": 100,
       "name": "Chutes",
       "netuid": 64,
@@ -517,6 +547,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://ninja.arbos.life/health",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -530,6 +561,7 @@
         "workflow"
       ],
       "completeness_score": 70,
+      "health": "unknown",
       "integration_readiness": 75,
       "name": "ninja",
       "netuid": 66,
@@ -553,11 +585,13 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://www.metanova-labs.ai/models",
       "callable_count": 1,
       "categories": [
         "baseline-curated"
       ],
       "completeness_score": 58,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "NOVA",
       "netuid": 68,
@@ -581,11 +615,13 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://nexisgen.ai/commission",
       "callable_count": 1,
       "categories": [
         "baseline-curated"
       ],
       "completeness_score": 58,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "NexisGen",
       "netuid": 70,
@@ -609,6 +645,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://huggingface.co/natix-network-org",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -622,6 +659,7 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "StreetVision by NATIX",
       "netuid": 72,
@@ -645,6 +683,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.gittensor.io/swagger-json",
       "callable_count": 2,
       "categories": [
         "baseline-augmented",
@@ -653,6 +692,7 @@
         "repositories"
       ],
       "completeness_score": 83,
+      "health": "unknown",
       "integration_readiness": 100,
       "name": "Gittensor",
       "netuid": 74,
@@ -677,6 +717,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://simulate.trading/taos-im-paper",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -686,6 +727,7 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "MVTRX",
       "netuid": 79,
@@ -709,6 +751,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.investing88.ai/assets",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -721,6 +764,7 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "Investing",
       "netuid": 88,
@@ -744,6 +788,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://models.actual.inc/",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -754,6 +799,7 @@
         "official-website"
       ],
       "completeness_score": 48,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "Actual",
       "netuid": 95,
@@ -777,6 +823,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.verathos.ai/v1/models",
       "callable_count": 2,
       "categories": [
         "baseline-augmented",
@@ -791,6 +838,7 @@
         "official-website"
       ],
       "completeness_score": 85,
+      "health": "unknown",
       "integration_readiness": 100,
       "name": "Verathos",
       "netuid": 96,
@@ -815,11 +863,13 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://us-east-1.hippius.com/openapi.json",
       "callable_count": 1,
       "categories": [
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "health": "unknown",
       "integration_readiness": 95,
       "name": "Albedo",
       "netuid": 97,
@@ -843,11 +893,13 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.theminos.ai/",
       "callable_count": 1,
       "categories": [
         "baseline-curated"
       ],
       "completeness_score": 65,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "Minos",
       "netuid": 107,
@@ -871,6 +923,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://github.com/fx-integral/academia-archives",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -880,6 +933,7 @@
         "official-source-repo"
       ],
       "completeness_score": 48,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "Academia",
       "netuid": 109,
@@ -903,6 +957,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://api.green-compute.com/v1/chat/completions",
       "callable_count": 5,
       "categories": [
         "baseline-augmented",
@@ -913,6 +968,7 @@
         "official-website"
       ],
       "completeness_score": 93,
+      "health": "unknown",
       "integration_readiness": 85,
       "name": "Green Compute",
       "netuid": 110,
@@ -938,6 +994,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://thesoma.ai/mcp",
       "callable_count": 1,
       "categories": [
         "baseline-augmented",
@@ -948,6 +1005,7 @@
         "official-website"
       ],
       "completeness_score": 63,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "SOMA",
       "netuid": 114,
@@ -971,6 +1029,7 @@
       "subnet_type": "application"
     },
     {
+      "base_url": "https://heyditto.ai/ditto-vs-frontier-open-models",
       "callable_count": 1,
       "categories": [
         "agent-memory",
@@ -981,6 +1040,7 @@
         "official-website"
       ],
       "completeness_score": 48,
+      "health": "unknown",
       "integration_readiness": 70,
       "name": "Ditto",
       "netuid": 118,

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -78,6 +78,12 @@
                 "items": {
                   "additionalProperties": true,
                   "properties": {
+                    "base_url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "callable_count": {
                       "minimum": 0,
                       "type": "integer"
@@ -93,6 +99,9 @@
                         "number",
                         "null"
                       ]
+                    },
+                    "health": {
+                      "type": "string"
                     },
                     "integration_readiness": {
                       "maximum": 100,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -909,9 +909,11 @@ export interface components {
             callable_service_count?: number;
             subnet_count: number;
             subnets: ({
+                base_url?: string | null;
                 callable_count?: number;
                 categories?: string[];
                 completeness_score?: number | null;
+                health?: string;
                 integration_readiness?: number;
                 name?: string;
                 netuid: number;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -64,6 +64,12 @@
                 "items": {
                   "additionalProperties": true,
                   "properties": {
+                    "base_url": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
                     "callable_count": {
                       "minimum": 0,
                       "type": "integer"
@@ -79,6 +85,9 @@
                         "number",
                         "null"
                       ]
+                    },
+                    "health": {
+                      "type": "string"
                     },
                     "integration_readiness": {
                       "maximum": 100,

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -598,7 +598,9 @@
                     "service_kinds": {
                       "type": "array",
                       "items": { "type": "string" }
-                    }
+                    },
+                    "base_url": { "type": ["string", "null"] },
+                    "health": { "type": "string" }
                   },
                   "additionalProperties": true
                 }

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -898,6 +898,13 @@ for (const subnet of mergedSubnets) {
   if (services.length > 0) {
     const callable = services.filter((s) => s.eligibility.callable).length;
     callableServiceCount += callable;
+    // Primary callable surface (first callable, else first overall) — gives the
+    // index a "where do I call this + is it up" rollup so single-read consumers
+    // (e.g. the /ask RAG join) don't have to fan out to per-subnet detail files.
+    const primary =
+      services.find((service) => service.eligibility.callable) ||
+      services[0] ||
+      null;
     agentCatalogIndex.push({
       netuid: subnet.netuid,
       slug: subnet.slug,
@@ -910,6 +917,8 @@ for (const subnet of mergedSubnets) {
       service_count: services.length,
       callable_count: callable,
       service_kinds: [...new Set(services.map((s) => s.kind))].sort(),
+      base_url: primary?.base_url ?? null,
+      health: primary?.health?.status ?? "unknown",
     });
   }
 }

--- a/src/ai-search.mjs
+++ b/src/ai-search.mjs
@@ -254,7 +254,7 @@ export async function semanticSearch(env, query, options = {}) {
   return { query: q, count: results.length, results, model: EMBED_MODEL };
 }
 
-export function formatAskContextBlock(matches) {
+export function formatAskContextBlock(matches, enrichByNetuid = new Map()) {
   return (matches || [])
     .map((match, i) => {
       const m = match?.metadata || {};
@@ -269,14 +269,54 @@ export function formatAskContextBlock(matches) {
         description: m.subtitle ?? null,
         url: m.url ?? null,
       };
+      // Actionability facets for subnet sources: where to call it, whether it's
+      // up, and how many callable services it exposes — so the model can answer
+      // "how do I use it" not just "what is it". Only present for subnets that
+      // expose callable services (joined from the agent-catalog).
+      const enrich =
+        m.netuid != null ? enrichByNetuid.get(m.netuid) : undefined;
+      if (enrich) {
+        entry.callable_count = enrich.callable_count;
+        entry.base_url = enrich.base_url;
+        entry.health = enrich.health;
+      }
       return JSON.stringify(entry);
     })
     .join("\n");
 }
 
+// Builds a netuid → {callable_count, base_url, health} lookup from the
+// agent-catalog index for enriching /ask context. Best-effort: any read failure
+// degrades to an empty map (context just omits the actionability facets).
+async function loadAskEnrichment(env, deps) {
+  if (typeof deps.readArtifact !== "function") return new Map();
+  try {
+    const catalog = await deps.readArtifact(
+      env,
+      "/metagraph/agent-catalog.json",
+    );
+    const subnets = catalog?.ok ? catalog.data?.subnets : catalog?.subnets;
+    if (!Array.isArray(subnets)) return new Map();
+    return new Map(
+      subnets
+        .filter((entry) => Number.isInteger(entry?.netuid))
+        .map((entry) => [
+          entry.netuid,
+          {
+            callable_count: entry.callable_count ?? 0,
+            base_url: entry.base_url ?? null,
+            health: entry.health ?? "unknown",
+          },
+        ]),
+    );
+  } catch {
+    return new Map();
+  }
+}
+
 // Grounded question answering (RAG): retrieve top-k registry context, prompt the
 // LLM to answer only from it with bracketed citations.
-export async function askQuestion(env, question, options = {}) {
+export async function askQuestion(env, question, options = {}, deps = {}) {
   const q = typeof question === "string" ? question.trim() : "";
   if (!q) throw aiInputError("Field `question` is required.");
   if (q.length > ASK_MAX_QUESTION_LENGTH) {
@@ -302,7 +342,8 @@ export async function askQuestion(env, question, options = {}) {
       url: metadata.url ?? null,
     };
   });
-  const contextBlock = formatAskContextBlock(matches);
+  const enrichByNetuid = await loadAskEnrichment(env, deps);
+  const contextBlock = formatAskContextBlock(matches, enrichByNetuid);
 
   const messages = [
     { role: "system", content: ASK_SYSTEM_PROMPT },

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -712,6 +712,76 @@ describe("ai-search defensive branches", () => {
     assert.equal(out.citations[0].netuid, null);
     assert.equal(out.context_count, 1);
   });
+
+  test("formatAskContextBlock adds actionability facets for enriched subnets", () => {
+    const block = formatAskContextBlock(
+      [{ metadata: { type: "subnet", title: "Apex", netuid: 1 } }],
+      new Map([
+        [1, { callable_count: 2, base_url: "https://api.apex.io", health: "operational" }],
+      ]),
+    );
+    const parsed = JSON.parse(block);
+    assert.equal(parsed.callable_count, 2);
+    assert.equal(parsed.base_url, "https://api.apex.io");
+    assert.equal(parsed.health, "operational");
+  });
+
+  test("formatAskContextBlock omits facets for subnets absent from the catalog", () => {
+    const block = formatAskContextBlock(
+      [{ metadata: { type: "subnet", title: "Quiet", netuid: 99 } }],
+      new Map(),
+    );
+    const parsed = JSON.parse(block);
+    assert.equal("base_url" in parsed, false);
+    assert.equal("callable_count" in parsed, false);
+    assert.equal("health" in parsed, false);
+  });
+
+  test("askQuestion joins the agent-catalog to enrich subnet context", async () => {
+    let askedPath = null;
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const readArtifact = (_env, path) => {
+      askedPath = path;
+      return Promise.resolve({
+        ok: true,
+        data: {
+          subnets: [
+            {
+              netuid: 1,
+              callable_count: 3,
+              base_url: "https://api.one.io",
+              health: "operational",
+            },
+          ],
+        },
+      });
+    };
+    const out = await askQuestion(
+      env,
+      "Which subnet does images?",
+      {},
+      { readArtifact },
+    );
+    assert.equal(askedPath, "/metagraph/agent-catalog.json");
+    assert.ok(out.answer.length > 0);
+    // The enriched facets reach the prompt's context block.
+    const askCall = env.AI.calls.find((c) => c.model === ASK_MODEL);
+    const userMessage = askCall.input.messages.at(-1).content;
+    assert.match(userMessage, /api\.one\.io/);
+  });
+
+  test("askQuestion degrades gracefully when the catalog read fails", async () => {
+    const env = { AI: stubAi(), VECTORIZE: stubVectorize() };
+    const readArtifact = () => Promise.reject(new Error("r2 down"));
+    const out = await askQuestion(
+      env,
+      "Which subnet does images?",
+      {},
+      { readArtifact },
+    );
+    assert.ok(out.answer.length > 0);
+    assert.equal(out.context_count, 3);
+  });
 });
 
 describe("embedding-sync cron", () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2359,7 +2359,12 @@ async function handleAskRequest(request, env) {
     );
   }
   try {
-    const data = await askQuestion(env, body?.question, { topK: body?.topK });
+    const data = await askQuestion(
+      env,
+      body?.question,
+      { topK: body?.topK },
+      { readArtifact },
+    );
     return dataResponse(env, data, 200, { source: "ai-live" });
   } catch (error) {
     if (error?.aiInput) {


### PR DESCRIPTION
## What

The RAG `/ask` endpoint answered _"what is this subnet"_ well but couldn't answer _"how do I use it"_ — retrieved context carried only title/description/url, with no signal about whether a subnet is callable, **where**, or whether it's **up**.

- The **agent-catalog index entry** gains a `base_url` (primary callable surface) + `health` (that surface's last status) rollup, alongside the existing `callable_count`. The compact 30-entry index is now self-sufficient for _"where do I call this + is it up"_ without fanning out to per-subnet detail.
- **`askQuestion`** joins subnet matches against the agent-catalog (a single injected `readArtifact` read) and folds `callable_count` + `base_url` + `health` into each subnet's context line, so the model can ground **actionable** answers.

## Safety / scope

- **Best-effort:** a failed catalog read degrades to prior behavior (facets omitted) — never breaks `/ask`.
- Join is keyed on `netuid`: non-subnet sources (providers/surfaces) and non-callable subnets are untouched.
- Untrusted-data framing of context is preserved (existing prompt-injection guard still holds).

## Verification

- `npm run build` ✓ — all 30 catalog entries carry `base_url` + `health` (+60/-0 lines)
- `validate:schemas` / `validate:contract-drift` / `validate:api` / `validate:openapi-examples` ✓
- `scan:public-safety` ✓ · `lint` ✓ · reproducibility validator ✓
- `npm test` ✓ — **764/764** (4 new: facet enrichment, omission for absent subnets, catalog join, graceful degradation on read failure)

Closes #334. Part of Wave 2 (epic #338).