### PR TITLE
fix(api): preserve default network alias dispatch

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -65,7 +65,53 @@ describe("multi-network routing prefix (Phase 1)", () => {
     const aliased = await get(env, "/api/v1/mainnet/subnets/7");
     assert.equal(bare.res.status, 200);
     assert.equal(aliased.res.status, 200);
-    assert.equal(aliased.body.data?.subnet?.netuid, bare.body.data?.subnet?.netuid);
+    assert.equal(
+      aliased.body.data?.subnet?.netuid,
+      bare.body.data?.subnet?.netuid,
+    );
+  });
+
+  test("mainnet + finney aliases preserve dynamic mainnet routes", async () => {
+    const env = createLocalArtifactEnv();
+
+    for (const route of [
+      "/api/v1/registry/leaderboards",
+      "/api/v1/subnets/7/health/trends",
+    ]) {
+      const bare = await get(env, route);
+      const mainnet = await get(
+        env,
+        route.replace("/api/v1/", "/api/v1/mainnet/"),
+      );
+      const finney = await get(
+        env,
+        route.replace("/api/v1/", "/api/v1/finney/"),
+      );
+
+      assert.equal(
+        mainnet.res.status,
+        bare.res.status,
+        `mainnet alias for ${route}`,
+      );
+      assert.equal(
+        finney.res.status,
+        bare.res.status,
+        `finney alias for ${route}`,
+      );
+    }
+
+    const askInit = {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ question: "What is subnet 7?" }),
+    };
+    const bareAsk = await get(env, "/api/v1/ask", askInit);
+    const mainnetAsk = await get(env, "/api/v1/mainnet/ask", askInit);
+    const finneyAsk = await get(env, "/api/v1/finney/ask", askInit);
+
+    assert.notEqual(bareAsk.res.status, 405);
+    assert.equal(mainnetAsk.res.status, bareAsk.res.status);
+    assert.equal(finneyAsk.res.status, bareAsk.res.status);
   });
 
   test("testnet route serves network-partitioned data from the testnet key", async () => {
@@ -101,7 +147,7 @@ describe("multi-network routing prefix (Phase 1)", () => {
     assert.equal(data.res.status, 404);
   });
 
-  test("mainnet-only dynamic routes 404 under a network prefix, naming the network", async () => {
+  test("mainnet-only dynamic routes 404 under a non-default network prefix, naming the network", async () => {
     const env = createLocalArtifactEnv();
     const semantic = await get(env, "/api/v1/testnet/search/semantic");
     assert.equal(semantic.res.status, 404);
@@ -135,7 +181,11 @@ describe("multi-network routing prefix (Phase 1)", () => {
   test("a real route segment that merely looks adjacent is never shadowed by the alias set", async () => {
     const env = createLocalArtifactEnv();
     // "subnets"/"providers"/"surfaces" are real routes, not network aliases.
-    for (const route of ["/api/v1/subnets", "/api/v1/providers", "/api/v1/surfaces"]) {
+    for (const route of [
+      "/api/v1/subnets",
+      "/api/v1/providers",
+      "/api/v1/surfaces",
+    ]) {
       const { res } = await get(env, route);
       assert.equal(res.status, 200, `${route} should be unaffected`);
     }

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -176,6 +176,13 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // mainnet behaviour is byte-identical to before networks existed.
   const networkRoute = resolveNetworkPrefix(url);
   if (networkRoute.explicit) {
+    if (networkRoute.network.isDefault) {
+      return handleRequest(
+        new Request(networkRoute.url.toString(), request),
+        env,
+        ctx,
+      );
+    }
     return handleNetworkScopedRequest(
       request,
       env,
@@ -399,7 +406,10 @@ async function handleNetworkScopedRequest(request, env, url, network) {
     return handleApiRequest(request, env, resolved.url, network);
   }
 
-  if (url.pathname.startsWith("/metagraph/") && url.pathname.endsWith(".json")) {
+  if (
+    url.pathname.startsWith("/metagraph/") &&
+    url.pathname.endsWith(".json")
+  ) {
     return handleRawArtifactRequest(request, env, url, network);
   }
 
@@ -411,7 +421,12 @@ async function handleNetworkScopedRequest(request, env, url, network) {
   );
 }
 
-async function handleRawArtifactRequest(request, env, url, network = DEFAULT_NETWORK) {
+async function handleRawArtifactRequest(
+  request,
+  env,
+  url,
+  network = DEFAULT_NETWORK,
+) {
   if (!matchRawArtifact(url.pathname)) {
     return errorResponse(
       "not_found",
@@ -578,7 +593,12 @@ function renderBadgeSvg(rawLabel, rawMessage, color) {
 const NETWORKS = {
   mainnet: { id: "mainnet", chain: "finney", prefix: "", isDefault: true },
   finney: { id: "mainnet", chain: "finney", prefix: "", isDefault: true },
-  testnet: { id: "testnet", chain: "test", prefix: "testnet", isDefault: false },
+  testnet: {
+    id: "testnet",
+    chain: "test",
+    prefix: "testnet",
+    isDefault: false,
+  },
   test: { id: "testnet", chain: "test", prefix: "testnet", isDefault: false },
   local: { id: "local", chain: "local", prefix: "local", isDefault: false },
 };
@@ -627,7 +647,10 @@ function artifactPathForNetwork(artifactPath, network = DEFAULT_NETWORK) {
   if (!network || !network.prefix) {
     return artifactPath;
   }
-  return artifactPath.replace(/^\/metagraph\//, `/metagraph/${network.prefix}/`);
+  return artifactPath.replace(
+    /^\/metagraph\//,
+    `/metagraph/${network.prefix}/`,
+  );
 }
 
 // Friendly per-subnet routes: /api/v1/subnets/<slug>/... resolves to the netuid


### PR DESCRIPTION
### Motivation
- Explicit `/api/v1/{network}/` prefixes were routed into the network-scoped handler unconditionally, which caused `mainnet`/`finney` aliases to be treated as non-default and therefore to 404 or be method-gated for dynamic/mainnet-only routes such as `/api/v1/registry/leaderboards`, `/api/v1/subnets/<n>/health/trends`, and POST `/api/v1/ask`.
- The intent is that default-network aliases (`mainnet` and `finney`) behave byte-identically to bare mainnet paths, so the alias should re-enter the normal dispatcher rather than be handled as a non-default network.

### Description
- If an explicit network prefix was detected and `network.isDefault` is true, the request is re-dispatched into the normal bare-path dispatcher by calling `handleRequest` with the prefix-stripped URL so default aliases behave exactly like unprefixed mainnet paths. (`workers/api.mjs`)
- Non-default networks still route through `handleNetworkScopedRequest` and preserve the previous guarded behavior for testnet/local. (`workers/api.mjs`)
- Added a regression test `mainnet + finney aliases preserve dynamic mainnet routes` that asserts parity for leaderboards, health trends, and POST `/api/v1/ask` between bare, `mainnet`, and `finney` paths. (`tests/network-routing.test.mjs`)
- Minor formatting/whitespace adjustments applied for readability and to satisfy linting/Prettier.

### Testing
- Manually verified status parity with a script invoking `handleRequest` for bare, `/api/v1/mainnet/...`, and `/api/v1/finney/...` routes for leaderboards, trends, and `ask`, and observed matching responses for those aliases. (passed)
- Ran the new regression test via `npx vitest run tests/network-routing.test.mjs -t 'preserve dynamic'` and observed the test passed. (passed)
- Ran `npm run lint` and `npx prettier --check` against modified files and they succeeded. (passed)
- Ran the full test file with `npm test -- --run tests/network-routing.test.mjs`; the newly-added regression test passed but the full test run showed two pre-existing failures in unrelated fixture expectations (two assertions expecting `200` observed `404`) that are outside the scope of this change. (regression test: pass; full file: 2 unrelated failures)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b8f66b720832ab6976af6dec6e0f7)