### PR TITLE
fix(api): suppress ambiguous native_slug aliases

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -107,6 +107,21 @@ describe("multi-network routing prefix (Phase 1)", () => {
     assert.equal((await get(env, "/api/v1/subnets/7")).res.status, 200);
   });
 
+  test("duplicate native_slug aliases are not routed by first artifact order", async () => {
+    const env = createLocalArtifactEnv();
+    // Several committed mainnet entries have native_slug="deprecated"; resolving
+    // that alias would be ambiguous and artifact-order dependent, so it must stay
+    // unavailable while canonical numeric routes continue to work.
+    const ambiguous = await get(env, "/api/v1/subnets/deprecated");
+    assert.equal(ambiguous.res.status, 404);
+
+    for (const netuid of [3, 39, 81]) {
+      const numeric = await get(env, `/api/v1/subnets/${netuid}/health/trends`);
+      assert.equal(numeric.res.status, 200);
+      assert.equal(numeric.body.data.netuid, netuid);
+    }
+  });
+
   test("local network exposes a client-side dev-mode setup pointer", async () => {
     const env = createLocalArtifactEnv();
     const info = await get(env, "/api/v1/local");

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -708,14 +708,27 @@ async function lookupSubnetNetuid(
       // Then the chain-name native_slug (e.g. "apex") fills any key it doesn't
       // already own, so subnets resolve by the name agents discover them by —
       // essential on testnet, where there are no curated overlay slugs. A
-      // curated slug always wins a collision.
+      // curated slug always wins a collision, and duplicate native slugs are
+      // suppressed so ambiguous aliases cannot resolve by artifact order.
+      const nativeSlugCounts = new Map();
       for (const subnet of artifact.data.subnets) {
         if (
           typeof subnet.native_slug === "string" &&
-          Number.isInteger(subnet.netuid) &&
-          !map.has(subnet.native_slug.toLowerCase())
+          Number.isInteger(subnet.netuid)
         ) {
-          map.set(subnet.native_slug.toLowerCase(), subnet.netuid);
+          const key = subnet.native_slug.toLowerCase();
+          nativeSlugCounts.set(key, (nativeSlugCounts.get(key) || 0) + 1);
+        }
+      }
+      for (const subnet of artifact.data.subnets) {
+        if (
+          typeof subnet.native_slug === "string" &&
+          Number.isInteger(subnet.netuid)
+        ) {
+          const key = subnet.native_slug.toLowerCase();
+          if (!map.has(key) && nativeSlugCounts.get(key) === 1) {
+            map.set(key, subnet.netuid);
+          }
         }
       }
       subnetSlugIndexByNetwork.set(network.id, { map, builtAt: now });


### PR DESCRIPTION
### Motivation

- Resolves an integrity bug where `native_slug` aliases could collide and be resolved by artifact order, causing friendly chain-name lookups to point to the wrong subnet.

### Description

- Count `native_slug` occurrences when building the per-network slug index and only register a `native_slug` alias if it is unique within the artifact, preserving curated `slug` precedence.
- Implemented the uniqueness suppression in the slug-index builder in `workers/api.mjs` so duplicate `native_slug` values no longer route by first-seen order.
- Added a regression test in `tests/network-routing.test.mjs` that asserts ambiguous aliases (e.g. `deprecated`) 404 while canonical numeric and dynamic routes continue to resolve.

### Testing

- Ran `node scripts/prepare-local-r2-staging.mjs` to stage local artifacts and the command completed successfully.
- Ran `npm test -- tests/network-routing.test.mjs` and the focused suite passed (all tests in that file succeeded).
- Ran `npm run lint -- workers/api.mjs tests/network-routing.test.mjs` and `npx prettier --check` which reported no remaining style issues.
- Ran `npm run validate` which completed without validation errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ba72d8fac832a96058115c065d656)