### PR TITLE
fix(mcp): enforce AI_RATE_LIMITER for MCP `semantic_search` and `ask`

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -13,7 +13,12 @@
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.mjs";
 import { overlayRpcPoolEligibility } from "./health-serving.mjs";
-import { aiEnabled, semanticSearch, askQuestion } from "./ai-search.mjs";
+import {
+  aiEnabled,
+  askQuestion,
+  semanticSearch,
+  withinRateLimit,
+} from "./ai-search.mjs";
 
 // Protocol versions we understand. We echo the client's requested version when
 // it is one of these, otherwise we answer with our latest.
@@ -84,6 +89,18 @@ function requireAi(ctx) {
         "find_subnets_by_capability for keyword discovery instead.",
     );
   }
+}
+
+function mcpAiClientKey(ctx, scope) {
+  return `${scope}:${ctx.clientIp || "anon"}`;
+}
+
+async function requireAiRateLimit(ctx, scope) {
+  if (await withinRateLimit(ctx.env, mcpAiClientKey(ctx, scope))) return;
+  throw toolError(
+    "rate_limited",
+    "Too many AI requests. Please retry shortly.",
+  );
 }
 
 // Run an ai-search call, mapping its input-validation errors to tool errors so
@@ -516,6 +533,7 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       requireAi(ctx);
       const query = requireString(args, "query");
+      await requireAiRateLimit(ctx, "semantic");
       return runAi(() =>
         semanticSearch(ctx.env, query, { limit: args?.limit }),
       );
@@ -544,6 +562,7 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       requireAi(ctx);
       const question = requireString(args, "question");
+      await requireAiRateLimit(ctx, "ask");
       return runAi(() =>
         askQuestion(ctx.env, question, {}, { readArtifact: ctx.readArtifact }),
       );
@@ -683,6 +702,7 @@ function buildContext(request, env, deps) {
   return {
     env,
     domain,
+    clientIp: mcpClientKey(request),
     readArtifact: deps.readArtifact,
     readHealthKv: deps.readHealthKv,
   };

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -824,6 +824,73 @@ describe("MCP AI tools (semantic_search + ask)", () => {
     assert.equal(out.citations[0].netuid, 1);
   });
 
+  test("semantic_search applies the AI rate limiter before embedding", async () => {
+    const env = aiEnv();
+    let limiterKey;
+    let aiRuns = 0;
+    env.AI.run = () => {
+      aiRuns += 1;
+      return Promise.resolve({ data: [new Array(1024).fill(0.02)] });
+    };
+    env.AI_RATE_LIMITER = {
+      async limit({ key }) {
+        limiterKey = key;
+        return { success: false };
+      },
+    };
+
+    const res = await callTool(
+      "semantic_search",
+      { query: "generate text" },
+      { env },
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.result.isError, true);
+    assert.match(res.body.result.content[0].text, /rate_limited/);
+    assert.equal(limiterKey, "semantic:anonymous");
+    assert.equal(aiRuns, 0);
+  });
+
+  test("ask applies the AI rate limiter to each JSON-RPC batch item", async () => {
+    const env = aiEnv();
+    let limiterCalls = 0;
+    let aiRuns = 0;
+    env.AI.run = () => {
+      aiRuns += 1;
+      return Promise.resolve({ response: "should not run" });
+    };
+    env.AI_RATE_LIMITER = {
+      async limit({ key }) {
+        limiterCalls += 1;
+        assert.equal(key, "ask:anonymous");
+        return { success: false };
+      },
+    };
+
+    const res = await rpc(
+      Array.from({ length: MAX_MCP_BATCH_LENGTH }, (_, index) => ({
+        jsonrpc: "2.0",
+        id: index + 1,
+        method: "tools/call",
+        params: {
+          name: "ask",
+          arguments: { question: `Which subnet? ${index}` },
+        },
+      })),
+      { env },
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(res.body.length, MAX_MCP_BATCH_LENGTH);
+    assert.equal(limiterCalls, MAX_MCP_BATCH_LENGTH);
+    assert.equal(aiRuns, 0);
+    for (const response of res.body) {
+      assert.equal(response.result.isError, true);
+      assert.match(response.result.content[0].text, /rate_limited/);
+    }
+  });
+
   test("semantic_search rejects a blank query with a clean tool error", async () => {
     const res = await callTool(
       "semantic_search",


### PR DESCRIPTION
### Motivation
- The MCP `semantic_search` and `ask` tools invoked expensive AI work (embeddings, Vectorize queries, LLM completions) after only checking `aiEnabled()`, thereby bypassing the tighter AI abuse control used by REST AI routes and allowing JSON-RPC batching to amplify requests. 
- The change aims to prevent unauthenticated clients from exhausting AI quotas or increasing costs by ensuring MCP AI tool calls are subject to the same per-client AI rate limits.

### Description
- Import and use the existing `withinRateLimit` helper from `src/ai-search.mjs` and add a small MCP-side wrapper `requireAiRateLimit(ctx, scope)` that maps denials to tool-level `rate_limited` errors. 
- Add `mcpClientKey`-scoped client context (`clientIp`) in `buildContext` so AI limiter keys are per-tool and per-client, e.g. `semantic:anon` / `ask:anon`. 
- Call `requireAiRateLimit(ctx,

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bad5eb45c832aae436b99af271f58)