### PR TITLE
feat(security): document + tighten the candidate base_url trust model (#341)

### DIFF
--- a/docs/adr/0004-candidate-trust-model.md
+++ b/docs/adr/0004-candidate-trust-model.md
@@ -1,0 +1,77 @@
+# ADR 0004 — Candidate → verified-surface trust model
+
+Status: accepted (2026-06-12)
+
+## Context
+
+metagraphed hands agents **base URLs to call**. The highest-consequence failure
+for an integration developer is a malicious `base_url` served as "callable" — the
+agent calls it and leaks credentials, gets injected, or reaches internal infra.
+
+URLs enter the system from progressively less-trusted sources:
+
+1. **Native chain identity** (`SubnetIdentitiesV3`: `subnet_url`, `github_repo`,
+   `discord`, `logo_url`) — set by whoever controls the subnet's hotkey.
+   Permissionless and attacker-controllable, on both mainnet and testnet.
+2. **Public discovery** (`scripts/discover-candidates.mjs`) — harvested from the
+   chain identity above plus README links and third-party directories
+   (taostats, taomarketcap, subnetradar, tensorplex docs).
+3. **Community intake** — UGC submissions under `registry/candidates/community/`.
+4. **Curated overlays** — maintainer-reviewed, the only tier the product treats
+   as a verified surface.
+
+Everything in tiers 1–3 is a **candidate**: explicitly "not verified by
+Metagraphed; requires safe probe verification and maintainer review before
+promotion." The trust boundary is **promotion to a curated overlay**.
+
+## Decision
+
+**Auto-harvested base URLs are never served as `callable` without crossing the
+promotion boundary.** Callability (`eligibility.callable` in the agent-catalog,
+`public_safe` surfaces) is derived only from curated-overlay surfaces — not from
+raw candidates. Candidates surface under explicitly-labelled
+`*/candidates/*` artifacts, never under `/agent-catalog`, `/surfaces`, or as a
+`how_do_i_call` answer.
+
+Three guards defend the path from attacker-controlled text to a callable URL:
+
+### 1. Prompt-injection sanitization (ADR 0003 / #339)
+All chain text is run through `sanitizeChainText` before it reaches an LLM, and
+the profile carries `injection_scrubbed`. The MCP tools + `llms.txt` additionally
+warn that field values are untrusted data (#340).
+
+### 2. SSRF protection (DNS-resolving)
+`isUnsafeUrl` / `isUnsafeResolvedUrl` (`scripts/lib.mjs`) reject URLs that target
+internal infrastructure, checking against `unsafeIpBlocks`:
+loopback (`127.0.0.0/8`, `::1`), RFC-1918 private (`10/8`, `172.16/12`,
+`192.168/16`), CGNAT (`100.64/10`), **link-local + cloud metadata
+(`169.254.0.0/16`, e.g. `169.254.169.254`)**, the unspecified range, multicast,
+and the IPv6 equivalents (`fc00::/7`, `fe80::/10`, NAT64).
+- **Intake** (`normalizePublicUrl`) applies the synchronous literal-IP filter
+  `isUnsafeUrl` so obviously-internal targets never enter the bundle.
+- **Probe + promotion** (`fetchWithSafeRedirects`, `generated-overlays.mjs`)
+  apply `isUnsafeResolvedUrl`, which **resolves DNS and re-checks every resolved
+  address** — defeating DNS-rebinding and redirect-to-internal.
+- Known limitation: intake is hostname-based; the authoritative resolve-time
+  check is what gates anything that gets probed or promoted.
+
+### 3. Brand-impersonation guard (#341)
+`isBrandImpersonationUrl` rejects candidate URLs that impersonate metagraphed's
+own domain (`metagraph.sh.evil.com`, `metagraphsh.com`, `metagraph-sh.io`). These
+pass the SSRF guard — they resolve to public IPs — but a `base_url` reading as
+"metagraph.sh" could get an agent to trust and call it. The real `metagraph.sh`
+and its subdomains are exempt; the rule targets squats of the exact domain, not
+the generic "metagraph" Bittensor term.
+
+## Consequences
+
+- Before **broadening auto-promotion** (auto-probing candidates into callable
+  surfaces), revisit this ADR: at minimum keep the resolve-time SSRF check, the
+  impersonation guard, and a maintainer-review step in the promotion path; add
+  per-source trust weighting (chain-identity < README < curated) before any
+  candidate is auto-promoted.
+- The guards are best-effort against a determined attacker who controls a benign
+  public domain that later turns malicious — promotion review remains the
+  backstop.
+- New trusted-infra domains worth impersonation protection (beyond
+  `metagraph.sh`) can be added to `isBrandImpersonationUrl` as the surface grows.

--- a/scripts/discover-candidates.mjs
+++ b/scripts/discover-candidates.mjs
@@ -1,7 +1,9 @@
 import path from "node:path";
 import {
   buildTimestamp,
+  isBrandImpersonationUrl,
   isUnsafeResolvedUrl,
+  isUnsafeUrl,
   loadNativeSnapshot,
   loadProviders,
   loadSubnets,
@@ -986,7 +988,17 @@ function normalizePublicUrl(value) {
     if (!["http:", "https:"].includes(url.protocol)) {
       return null;
     }
-    if (isUnsafeHost(url.hostname)) {
+    // SSRF pre-filter: literal private/loopback/link-local/metadata IPs +
+    // localhost. The authoritative, DNS-resolving check (isUnsafeResolvedUrl)
+    // still runs at probe + overlay-promotion time; this just keeps obviously
+    // internal targets out of the bundle entirely.
+    if (isUnsafeUrl(url.toString())) {
+      return null;
+    }
+    // Reject base_urls that impersonate metagraphed's own domain — they pass the
+    // SSRF guard (public attacker domain) but could trick an agent into trusting
+    // them. See ADR 0004.
+    if (isBrandImpersonationUrl(url.toString())) {
       return null;
     }
     url.hash = "";
@@ -1269,19 +1281,6 @@ function isBadgeOrAssetUrl(value) {
   } catch {
     return true;
   }
-}
-
-function isUnsafeHost(hostname) {
-  const host = hostname.toLowerCase();
-  return (
-    host === "localhost" ||
-    host === "0.0.0.0" ||
-    host === "127.0.0.1" ||
-    host === "::1" ||
-    host.startsWith("10.") ||
-    host.startsWith("192.168.") ||
-    /^172\.(1[6-9]|2\d|3[0-1])\./.test(host)
-  );
 }
 
 function isSocialUrl(value) {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -664,6 +664,30 @@ function isUnsafeHostname(host) {
   return isUnsafeIpAddress(host);
 }
 
+// metagraphed's own public domain. Candidate base_urls that impersonate it must
+// never enter the discovery bundle.
+const SELF_DOMAIN = "metagraph.sh";
+
+// Reject candidate URLs that trade on metagraphed's own identity. The SSRF guard
+// (isUnsafeUrl/isUnsafeResolvedUrl) passes for an attacker-registered PUBLIC
+// domain, so a base_url that reads as "metagraph.sh" — metagraph.sh.evil.com,
+// metagraphsh.com, metagraph-sh.io — would clear it yet could get an agent to
+// trust and call it. The real metagraph.sh and its subdomains are exempt; this
+// targets squats of our exact domain, not the generic "metagraph" Bittensor term
+// (a subnet legitimately named "…metagraph…" is unaffected).
+export function isBrandImpersonationUrl(value) {
+  let host;
+  try {
+    host = new URL(value).hostname.toLowerCase().replace(/^www\./, "");
+  } catch {
+    return false;
+  }
+  if (host === SELF_DOMAIN || host.endsWith(`.${SELF_DOMAIN}`)) {
+    return false;
+  }
+  return /metagraph\.sh(?:\.|$)|metagraph-?sh(?:[.-]|$)|metagraphsh/.test(host);
+}
+
 function isUnsafeIpAddress(address) {
   const normalized = normalizeHostname(address);
   const family = isIP(normalized);

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -4,6 +4,7 @@ import {
   stripUrls,
   cleanDescription,
   sanitizeChainText,
+  isBrandImpersonationUrl,
   subnetLifecycle,
   extractAuth,
   sanitizeOpenApiDocument,
@@ -124,6 +125,46 @@ describe("sanitizeChainText", () => {
     ).text;
     const twice = sanitizeChainText(once).text;
     assert.equal(once, twice);
+  });
+});
+
+describe("isBrandImpersonationUrl", () => {
+  test("allows the real metagraph.sh and its subdomains", () => {
+    for (const url of [
+      "https://metagraph.sh",
+      "https://metagraph.sh/api/v1/subnets",
+      "https://api.metagraph.sh/x",
+      "https://www.metagraph.sh",
+    ]) {
+      assert.equal(isBrandImpersonationUrl(url), false, url);
+    }
+  });
+
+  test("blocks squats of the exact domain", () => {
+    for (const url of [
+      "https://metagraph.sh.evil.com/api",
+      "https://metagraphsh.com",
+      "https://metagraph-sh.io/call",
+      "https://api.metagraphsh.net",
+    ]) {
+      assert.equal(isBrandImpersonationUrl(url), true, url);
+    }
+  });
+
+  test("does not flag the generic 'metagraph' term or unrelated hosts", () => {
+    for (const url of [
+      "https://my-metagraph-subnet.io", // generic Bittensor term
+      "https://taostats.io/subnets",
+      "https://example.com",
+      "https://metagraph.sharing.io", // 'metagraph.sh' is not a boundary here
+    ]) {
+      assert.equal(isBrandImpersonationUrl(url), false, url);
+    }
+  });
+
+  test("non-URL input is not an impersonation", () => {
+    assert.equal(isBrandImpersonationUrl("not a url"), false);
+    assert.equal(isBrandImpersonationUrl(null), false);
   });
 });
 


### PR DESCRIPTION
## Why

`discover-candidates.mjs` auto-harvests `base_url`s from attacker-controllable chain identity. A malicious `base_url` served as **callable** is the highest-consequence failure for an integration developer. This documents the full trust model and closes the one gap the existing guards don't cover.

## What I found (and documented)

The SSRF story is already **robust** — `lib.mjs`'s `unsafeIpBlocks` covers loopback, RFC-1918, CGNAT (`100.64/10`), **link-local + cloud metadata (`169.254.0.0/16`)**, and the IPv6 ranges, and `isUnsafeResolvedUrl` **resolves DNS and re-checks every address** (defeats rebinding) at probe + overlay-promotion time. Candidates are never served `callable` without crossing the maintainer-review promotion boundary.

## What this changes

- **ADR 0004** ([`docs/adr/0004-candidate-trust-model.md`](docs/adr/0004-candidate-trust-model.md)) — documents the source tiers (chain identity < discovery < community < curated overlay), the no-auto-promote invariant, and the three guards (injection sanitization #339, DNS-resolving SSRF, brand impersonation). Sets the bar for *before broadening auto-promotion*.
- **`isBrandImpersonationUrl`** (new, `lib.mjs`) — rejects candidate URLs that impersonate metagraphed's own domain (`metagraph.sh.evil.com`, `metagraphsh.com`, `metagraph-sh.io`). These **pass** the SSRF guard (public attacker domain) yet could trick an agent into trusting them. The real `metagraph.sh` + subdomains are exempt; the generic "metagraph" Bittensor term is unaffected.
- **`normalizePublicUrl`** now gates intake with the shared `isUnsafeUrl` + the impersonation guard, replacing a weaker **local** `isUnsafeHost` copy that missed the link-local/metadata + CGNAT ranges lib already covers.

## Verification

- `validate:contract-drift` / `validate:schemas` / `validate:api` / `validate:docs` / `validate:mcp` ✓ · `scan:public-safety` ✓ · `lint` ✓ · reproducibility ✓
- `npm test` ✓ — **798/798** (4 new: real-domain allow, exact-squat block, generic-term allow, non-URL) · coverage ≥98% / ≥90%
- No artifact churn — discovery is a separate workflow; the guards apply on its next run.

Closes #341. Completes Wave 3 (epic #342).