### PR TITLE
feat(ci): assert completeness is never fed by derived/backfilled fields (#343)

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -817,6 +817,7 @@ async function validateGeneratedArtifacts(
 
   const providersArtifact = await readArtifactJson("providers.json");
   const subnetsArtifact = await readArtifactJson("subnets.json");
+  const profilesArtifact = await readArtifactJson("profiles.json");
   const surfacesArtifact = await readArtifactJson("surfaces.json");
   const candidatesArtifact = await readArtifactJson("candidates.json");
   const curationArtifact = await readArtifactJson("curation.json");
@@ -947,6 +948,44 @@ async function validateGeneratedArtifacts(
         continue;
       }
       throw error;
+    }
+  }
+
+  // --- Flywheel-preservation invariant (#343) -------------------------------
+  // completeness_score / missing_* must derive ONLY from curated signals — the
+  // curated `primary_links` and verified surface kinds — never from chain-derived
+  // / backfilled passthrough fields. Otherwise auto-enrichment would silently
+  // satisfy gaps and drain the SN74 curation queue (gaps are the product). This
+  // gates Wave 4 enrichment: (a) re-derive `missing_required` from the profile's
+  // curated inputs and assert it matches, so no hidden field can feed it; and
+  // (b) assert chain-backfilled index links (display-only) never satisfy
+  // completeness. See ADR 0003 / docs/integration-readiness.md.
+  const indexByNetuid = new Map(
+    subnetsArtifact.subnets.map((subnet) => [subnet.netuid, subnet]),
+  );
+  const REQUIRED_IDENTITY = [
+    ["source-repo", "source_repo"],
+    ["website", "website_url"],
+  ];
+  for (const profile of profilesArtifact.profiles) {
+    const links = profile.primary_links || {};
+    const supported = new Set(profile.supported_interface_kinds || []);
+    const expectedMissingRequired = REQUIRED_IDENTITY.filter(
+      ([kind, linkField]) => !(links[linkField] || supported.has(kind)),
+    ).map(([kind]) => kind);
+    assert(
+      stableStringify([...(profile.missing_required || [])].sort()) ===
+        stableStringify(expectedMissingRequired.sort()),
+      `flywheel:${profile.netuid}: missing_required is not reproducible from curated inputs — a derived/passthrough field may be feeding completeness`,
+    );
+    const indexEntry = indexByNetuid.get(profile.netuid);
+    for (const [kind, linkField] of REQUIRED_IDENTITY) {
+      if (indexEntry?.[linkField] && !links[linkField]) {
+        assert(
+          (profile.missing_required || []).includes(kind),
+          `flywheel:${profile.netuid}: chain-backfilled ${linkField} must not satisfy completeness (it must stay in missing_required)`,
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Why

**Foundational guard for Wave 4** ([#350](https://github.com/JSONbored/metagraphed/issues/350)). The SN74 curation queue *is* the product — gaps are what gittensor pays to close. So `completeness_score` / `missing_*` must derive **only** from curated signals (curated `primary_links` + verified surface kinds), never from chain-derived / backfilled passthrough fields. Wave 4 adds aggressive auto-enrichment (`derived_description`, domain tags, chain discord, …); a single accidental wire from one of those into completeness would silently satisfy gaps and **drain the queue**. This codifies the rule so CI catches that regression.

## What

The reproducibility validator (`validate.mjs`, already a CI step) now asserts, for every profile:
1. **`missing_required` is reproducible from curated inputs** — re-derived from `primary_links` + `supported_interface_kinds` and asserted equal to the stored value. No hidden field can feed it without diverging.
2. **Chain-backfilled index links never satisfy completeness** — a subnet whose only `source_repo`/`website_url` is the display-only #318 backfill (7 subnets today) must keep that kind in `missing_required`.

## Verified

- ✅ Passes on all **129** current profiles.
- ✅ **Catches a simulated drain**: clearing `source-repo` from a backfill-only subnet's `missing_required` fails both assertions; restoring passes again.
- `lint` ✓ · `npm test` ✓ · coverage unchanged (validate.mjs is outside coverage scope) · runs in the `validate` CI step + the registry-validates test.

Closes #343. First item of Wave 4 (epic #350).