### PR TITLE
feat(data): enrich provider records with operated subnets + cluster (#347)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1720,19 +1720,29 @@ export interface components {
         };
         Provider: {
             authority: components["schemas"]["Authority"];
+            /** @description Shared-team cluster id (registrable domain of team_url/website_url, else the provider id) grouping providers run by the same team (issue #347). */
+            cluster_id?: string;
             /** Format: uri */
             contact_url?: string;
             /** Format: uri */
             docs_url?: string;
+            /** @description Number of live endpoints attributed to this provider. */
+            endpoint_count?: number;
             /** Format: uri */
             github_url?: string;
             id: string;
             kind: components["schemas"]["ProviderKind"];
             name: string;
+            /** @description Sorted unique netuids this provider operates a curated surface on (issue #347). Derived/reporting — never feeds completeness. */
+            netuids?: number[];
             notes?: string;
             public_notes?: string;
             /** @constant */
             schema_version: 1;
+            /** @description Number of distinct subnets this provider operates (netuids.length). */
+            subnet_count?: number;
+            /** @description Number of curated surfaces attributed to this provider. */
+            surface_count?: number;
             /** Format: uri */
             team_url?: string;
             /** Format: uri */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3341,6 +3341,10 @@
           "authority": {
             "$ref": "#/components/schemas/Authority"
           },
+          "cluster_id": {
+            "description": "Shared-team cluster id (registrable domain of team_url/website_url, else the provider id) grouping providers run by the same team (issue #347).",
+            "type": "string"
+          },
           "contact_url": {
             "format": "uri",
             "type": "string"
@@ -3348,6 +3352,11 @@
           "docs_url": {
             "format": "uri",
             "type": "string"
+          },
+          "endpoint_count": {
+            "description": "Number of live endpoints attributed to this provider.",
+            "minimum": 0,
+            "type": "integer"
           },
           "github_url": {
             "format": "uri",
@@ -3364,6 +3373,14 @@
             "minLength": 1,
             "type": "string"
           },
+          "netuids": {
+            "description": "Sorted unique netuids this provider operates a curated surface on (issue #347). Derived/reporting — never feeds completeness.",
+            "items": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "notes": {
             "type": "string"
           },
@@ -3372,6 +3389,16 @@
           },
           "schema_version": {
             "const": 1
+          },
+          "subnet_count": {
+            "description": "Number of distinct subnets this provider operates (netuids.length).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "surface_count": {
+            "description": "Number of curated surfaces attributed to this provider.",
+            "minimum": 0,
+            "type": "integer"
           },
           "team_url": {
             "format": "uri",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1720,19 +1720,29 @@ export interface components {
         };
         Provider: {
             authority: components["schemas"]["Authority"];
+            /** @description Shared-team cluster id (registrable domain of team_url/website_url, else the provider id) grouping providers run by the same team (issue #347). */
+            cluster_id?: string;
             /** Format: uri */
             contact_url?: string;
             /** Format: uri */
             docs_url?: string;
+            /** @description Number of live endpoints attributed to this provider. */
+            endpoint_count?: number;
             /** Format: uri */
             github_url?: string;
             id: string;
             kind: components["schemas"]["ProviderKind"];
             name: string;
+            /** @description Sorted unique netuids this provider operates a curated surface on (issue #347). Derived/reporting — never feeds completeness. */
+            netuids?: number[];
             notes?: string;
             public_notes?: string;
             /** @constant */
             schema_version: 1;
+            /** @description Number of distinct subnets this provider operates (netuids.length). */
+            subnet_count?: number;
+            /** @description Number of curated surfaces attributed to this provider. */
+            surface_count?: number;
             /** Format: uri */
             team_url?: string;
             /** Format: uri */

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3319,6 +3319,10 @@
           "authority": {
             "$ref": "#/components/schemas/Authority"
           },
+          "cluster_id": {
+            "description": "Shared-team cluster id (registrable domain of team_url/website_url, else the provider id) grouping providers run by the same team (issue #347).",
+            "type": "string"
+          },
           "contact_url": {
             "format": "uri",
             "type": "string"
@@ -3326,6 +3330,11 @@
           "docs_url": {
             "format": "uri",
             "type": "string"
+          },
+          "endpoint_count": {
+            "description": "Number of live endpoints attributed to this provider.",
+            "minimum": 0,
+            "type": "integer"
           },
           "github_url": {
             "format": "uri",
@@ -3342,6 +3351,14 @@
             "minLength": 1,
             "type": "string"
           },
+          "netuids": {
+            "description": "Sorted unique netuids this provider operates a curated surface on (issue #347). Derived/reporting — never feeds completeness.",
+            "items": {
+              "minimum": 0,
+              "type": "integer"
+            },
+            "type": "array"
+          },
           "notes": {
             "type": "string"
           },
@@ -3350,6 +3367,16 @@
           },
           "schema_version": {
             "const": 1
+          },
+          "subnet_count": {
+            "description": "Number of distinct subnets this provider operates (netuids.length).",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "surface_count": {
+            "description": "Number of curated surfaces attributed to this provider.",
+            "minimum": 0,
+            "type": "integer"
           },
           "team_url": {
             "format": "uri",

--- a/schemas/components/03-providers.schema.json
+++ b/schemas/components/03-providers.schema.json
@@ -58,6 +58,30 @@
           },
           "notes": {
             "type": "string"
+          },
+          "netuids": {
+            "type": "array",
+            "items": { "type": "integer", "minimum": 0 },
+            "description": "Sorted unique netuids this provider operates a curated surface on (issue #347). Derived/reporting — never feeds completeness."
+          },
+          "subnet_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of distinct subnets this provider operates (netuids.length)."
+          },
+          "surface_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of curated surfaces attributed to this provider."
+          },
+          "endpoint_count": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of live endpoints attributed to this provider."
+          },
+          "cluster_id": {
+            "type": "string",
+            "description": "Shared-team cluster id (registrable domain of team_url/website_url, else the provider id) grouping providers run by the same team (issue #347)."
           }
         },
         "additionalProperties": false

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -33,6 +33,7 @@ import {
   normalizePublicUrl,
   publishedAt,
   readJson,
+  clusterDomainFromUrl,
   redactCredentialedUrls,
   sanitizeOpenApiDocument,
   repoRoot,
@@ -571,16 +572,72 @@ const gapsIndex = mergedSubnets.map((subnet) => ({
   slug: subnet.slug,
 }));
 
+// Generic hosting/social domains that must NOT form a shared-team cluster — a
+// github.com repo URL is not a shared team. Providers on these fall back to
+// their own id (singleton cluster).
+const GENERIC_CLUSTER_HOSTS = new Set([
+  "github.com",
+  "gitlab.com",
+  "bitbucket.org",
+  "gitbook.io",
+  "readthedocs.io",
+  "notion.so",
+  "medium.com",
+  "substack.com",
+  "discord.com",
+  "discord.gg",
+  "x.com",
+  "twitter.com",
+  "t.me",
+  "linktr.ee",
+  "huggingface.co",
+]);
+
+// Turn the flat provider directory into the supply-side map of the flywheel
+// (issue #347): attach the netuids each provider operates (from its curated
+// surfaces), the subnet/surface/endpoint counts, and a shared-team cluster id
+// (registrable domain of team_url/website_url, else the provider id). All
+// derived/reporting — none of it feeds completeness.
+const surfacesByProvider = groupBy(surfaces, (surface) => surface.provider);
+const endpointsByProvider = groupBy(
+  endpointResources.endpoints,
+  (endpoint) => endpoint.provider,
+);
+const enrichedProviders = providers.map((provider) => {
+  const providerSurfaces = surfacesByProvider.get(provider.id) || [];
+  const netuids = [
+    ...new Set(
+      providerSurfaces
+        .map((surface) => surface.netuid)
+        .filter((netuid) => Number.isInteger(netuid)),
+    ),
+  ].sort((a, b) => a - b);
+  const clusterDomain = clusterDomainFromUrl(
+    provider.team_url || provider.website_url,
+  );
+  return {
+    ...provider,
+    netuids,
+    subnet_count: netuids.length,
+    surface_count: providerSurfaces.length,
+    endpoint_count: (endpointsByProvider.get(provider.id) || []).length,
+    cluster_id:
+      clusterDomain && !GENERIC_CLUSTER_HOSTS.has(clusterDomain)
+        ? clusterDomain
+        : provider.id,
+  };
+});
+
 await writeJson(artifactFile("providers.json"), {
   schema_version: 1,
   generated_at: generatedAt,
-  providers,
+  providers: enrichedProviders,
 });
 await fs.rm(r2ArtifactDir("providers"), {
   recursive: true,
   force: true,
 });
-for (const provider of providers) {
+for (const provider of enrichedProviders) {
   const providerEndpoints = endpointResources.endpoints.filter(
     (endpoint) => endpoint.provider === provider.id,
   );

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -982,6 +982,22 @@ export function cleanDescription(value) {
 // vocabulary; re-exported here for the build-side import sites.
 export { DOMAIN_TAGS, deriveDomainTags } from "../src/domain-tags.mjs";
 
+// Naive registrable domain (eTLD+1 by last-two-labels) of a URL, for the
+// provider shared-team cluster heuristic (issue #347). Good enough for the
+// .io/.ai/.com domains Bittensor teams use; not PSL-accurate for multi-part
+// TLDs. Returns null on unparseable input.
+export function clusterDomainFromUrl(value) {
+  if (typeof value !== "string") return null;
+  try {
+    const host = new URL(value).hostname.toLowerCase().replace(/^www\./, "");
+    const labels = host.split(".").filter(Boolean);
+    if (labels.length >= 2) return labels.slice(-2).join(".");
+    return host || null;
+  } catch {
+    return null;
+  }
+}
+
 // Build a fallback "what does it do" blurb from curated provider notes when a
 // subnet has no chain/overlay description (issue #346). Sanitized + truncated to
 // a word boundary. This populates a SEPARATE derived_description field — it never

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -610,6 +610,7 @@ test("public artifacts are internally consistent", () => {
   const endpointIncidents = readArtifact("endpoint-incidents.json");
   const rpcEndpointPools = readArtifact("rpc/pools.json");
   const providerEndpoints = readArtifact("providers/allways/endpoints.json");
+  const providersArtifact = readArtifact("providers.json");
   const r2Manifest = readArtifact("r2-manifest.json");
   const schemaDrift = readArtifact("schema-drift.json");
   const schemaIndex = readArtifact("schemas/index.json");
@@ -768,6 +769,54 @@ test("public artifacts are internally consistent", () => {
   assert.ok(
     derivedDescCount > 0,
     "expected at least some null-description subnets to get a derived_description",
+  );
+
+  // Provider enrichment (issue #347): each provider record carries the netuids
+  // it operates, counts, and a non-generic cluster id.
+  const GENERIC_CLUSTER_HOSTS = new Set([
+    "github.com",
+    "gitlab.com",
+    "huggingface.co",
+    "discord.com",
+    "discord.gg",
+    "x.com",
+    "twitter.com",
+  ]);
+  let providersWithNetuids = 0;
+  for (const provider of providersArtifact.providers) {
+    assert.ok(
+      Array.isArray(provider.netuids),
+      `provider ${provider.id}: netuids must be an array`,
+    );
+    // sorted, unique, integer
+    const sorted = [...provider.netuids].sort((a, b) => a - b);
+    assert.deepEqual(
+      provider.netuids,
+      sorted,
+      `provider ${provider.id}: sorted`,
+    );
+    assert.equal(
+      provider.netuids.length,
+      new Set(provider.netuids).size,
+      `provider ${provider.id}: netuids unique`,
+    );
+    assert.equal(
+      provider.subnet_count,
+      provider.netuids.length,
+      `provider ${provider.id}: subnet_count == netuids.length`,
+    );
+    assert.equal(typeof provider.surface_count, "number");
+    assert.equal(typeof provider.endpoint_count, "number");
+    assert.equal(typeof provider.cluster_id, "string");
+    assert.ok(
+      !GENERIC_CLUSTER_HOSTS.has(provider.cluster_id),
+      `provider ${provider.id}: cluster_id must not be a generic host`,
+    );
+    if (provider.netuids.length) providersWithNetuids += 1;
+  }
+  assert.ok(
+    providersWithNetuids > 0,
+    "expected providers to be linked to the subnets they operate",
   );
   // The domain coverage facet sums the per-subnet tags.
   assert.equal(typeof coverage.domain_coverage, "object");

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -15,6 +15,7 @@ import {
   deriveDomainTags,
   DOMAIN_TAGS,
   deriveDescriptionFromNotes,
+  clusterDomainFromUrl,
 } from "../scripts/lib.mjs";
 
 describe("stripUrls", () => {
@@ -515,5 +516,27 @@ describe("deriveDescriptionFromNotes", () => {
     assert.equal(deriveDescriptionFromNotes(42), null);
     assert.equal(deriveDescriptionFromNotes(""), null);
     assert.equal(deriveDescriptionFromNotes("   "), null);
+  });
+});
+
+describe("clusterDomainFromUrl", () => {
+  test("returns the last-two-label registrable domain", () => {
+    assert.equal(
+      clusterDomainFromUrl("https://docs.all-ways.io/x"),
+      "all-ways.io",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://www.macrocosmos.ai"),
+      "macrocosmos.ai",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://backprop.finance"),
+      "backprop.finance",
+    );
+  });
+  test("returns null for non-URL / non-string input", () => {
+    assert.equal(clusterDomainFromUrl("not a url"), null);
+    assert.equal(clusterDomainFromUrl(null), null);
+    assert.equal(clusterDomainFromUrl(undefined), null);
   });
 });


### PR DESCRIPTION
Closes #347 (Wave 4).

Turn the flat provider directory into the supply-side map of the flywheel. Each provider record (`providers.json` + per-provider artifact) now carries:

- **`netuids`** — sorted unique subnets it operates a curated surface on
- **`subnet_count` / `surface_count` / `endpoint_count`**
- **`cluster_id`** — shared-team grouping by the registrable domain of `team_url`/`website_url`, with generic hosting/social domains (`github.com`, `discord.gg`, `x.com`, `huggingface.co`, …) **denied** so a shared repo host never forms a false cluster; falls back to the provider id.

All derived/reporting — none of it feeds completeness. 86/90 providers link to the subnets they operate.

`providers.json` is an R2-only artifact, so this commit carries the source + schema + regenerated contract surfaces; the data regenerates on the next refresh.

## Verification
Full suite **822 tests** + coverage gate; `validate`, `validate:contract-drift`, `validate:api`, `scan:public-safety`, `lint` — all green.