### PR TITLE
fix(api): canonicalize default network aliases iteratively

### DIFF
--- a/tests/network-routing.test.mjs
+++ b/tests/network-routing.test.mjs
@@ -71,6 +71,21 @@ describe("multi-network routing prefix (Phase 1)", () => {
     );
   });
 
+  test("repeated default aliases are canonicalized without recursive dispatch", async () => {
+    const env = createLocalArtifactEnv();
+    const aliases = Array.from({ length: 12000 }, (_, index) =>
+      index % 2 === 0 ? "mainnet" : "finney",
+    ).join("/");
+    const bare = await get(env, "/api/v1/subnets");
+    const aliased = await get(env, `/api/v1/${aliases}/subnets`);
+
+    assert.equal(aliased.res.status, bare.res.status);
+    assert.equal(
+      aliased.body.data?.subnets?.length,
+      bare.body.data?.subnets?.length,
+    );
+  });
+
   test("mainnet + finney aliases preserve dynamic mainnet routes", async () => {
     const env = createLocalArtifactEnv();
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -164,7 +164,7 @@ export async function handleScheduled(controller, env = {}, ctx = {}) {
 }
 
 export async function handleRequest(request, env = {}, ctx = {}) {
-  const url = new URL(request.url);
+  let url = new URL(request.url);
 
   if (request.method === "OPTIONS") {
     return corsPreflight(request);
@@ -177,18 +177,16 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   const networkRoute = resolveNetworkPrefix(url);
   if (networkRoute.explicit) {
     if (networkRoute.network.isDefault) {
-      return handleRequest(
-        new Request(networkRoute.url.toString(), request),
+      url = networkRoute.url;
+      request = new Request(url.toString(), request);
+    } else {
+      return handleNetworkScopedRequest(
+        request,
         env,
-        ctx,
+        networkRoute.url,
+        networkRoute.network,
       );
     }
-    return handleNetworkScopedRequest(
-      request,
-      env,
-      networkRoute.url,
-      networkRoute.network,
-    );
   }
 
   if (url.pathname.startsWith("/rpc/v1/")) {
@@ -626,18 +624,33 @@ const LOCAL_NETWORK_INFO = {
 const NETWORK_PREFIX_PATTERN =
   /^\/(api\/v1|metagraph)\/(mainnet|finney|testnet|test|local)(\/.*|$)/;
 
-// Splits an explicit /{network}/ prefix off the path. Returns the resolved
-// network descriptor + the prefix-stripped URL that all existing dispatch and
-// route matching run against. Bare paths resolve to mainnet with the URL
-// unchanged (explicit:false) — the zero-regression default.
+// Splits explicit /{network}/ prefixes off the path. Default-network aliases
+// (mainnet/finney) are canonicalized iteratively so repeated aliases preserve
+// the old bare-route dispatch without recursively re-entering handleRequest. If
+// a non-default prefix remains after default alias normalization, it is returned
+// for the network-scoped artifact handler. Bare paths resolve to mainnet with
+// the URL unchanged (explicit:false) — the zero-regression default.
 function resolveNetworkPrefix(url) {
-  const match = NETWORK_PREFIX_PATTERN.exec(url.pathname);
-  if (!match) {
-    return { network: DEFAULT_NETWORK, url, explicit: false };
+  let rewritten = url;
+  let explicit = false;
+
+  while (true) {
+    const match = NETWORK_PREFIX_PATTERN.exec(rewritten.pathname);
+    if (!match) {
+      return { network: DEFAULT_NETWORK, url: rewritten, explicit };
+    }
+
+    const network = NETWORKS[match[2]];
+    const nextUrl = new URL(rewritten);
+    nextUrl.pathname = `/${match[1]}${match[3] && match[3] !== "/" ? match[3] : ""}`;
+    explicit = true;
+
+    if (!network.isDefault) {
+      return { network, url: nextUrl, explicit };
+    }
+
+    rewritten = nextUrl;
   }
-  const rewritten = new URL(url);
-  rewritten.pathname = `/${match[1]}${match[3] && match[3] !== "/" ? match[3] : ""}`;
-  return { network: NETWORKS[match[2]], url: rewritten, explicit: true };
 }
 
 // Inserts the network key segment for non-default networks, so the artifact read


### PR DESCRIPTION
### Motivation
- Prevent synchronous recursion in `handleRequest` when a request path contains repeated default-network aliases (e.g. `/api/v1/mainnet/mainnet/...`) which could exhaust the JS call stack and crash the Worker.
- Preserve the prior byte-identical behavior for bare mainnet routes while allowing explicit non-default network prefixes to continue routing to the network-scoped handler.
- Make alias handling deterministic and safe by normalizing repeated default aliases before any dispatch occurs.

### Description
- Stop re-dispatching into `handleRequest` for explicit default networks and instead update `url` and `request` in-place so the normalized path continues through the existing dispatcher.  (changes in `handleRequest` in `workers/api.mjs`).
- Replace single-strip `resolveNetworkPrefix` with an iterative canonicalizer that repeatedly strips `mainnet`/`finney` aliases and returns either a non-default network route or a normalized default/mainnet URL and `explicit` flag. (changes in `resolveNetworkPrefix` in `workers/api.mjs`).
- Add a regression test `repeated default aliases are canonicalized without recursive dispatch` in `tests/network-routing.test.mjs` that constructs a long chain (12,000 segments) of alternating `mainnet`/`finney` aliases and asserts the aliased request matches the bare route.

### Testing
- Ran the new regression test with `npm test -- tests/network-routing.test.mjs -t "repeated default aliases"`, which passed. 
- Ran the existing alias dynamic-route test with `npm test -- tests/network-routing.test.mjs -t "mainnet \+ finney aliases preserve dynamic mainnet routes"`, which passed. 
- Ran lint and formatting checks with `npm run lint -- workers/api.mjs tests/network-routing.test.mjs` and `npx prettier --check workers/api.mjs tests/network-routing.test.mjs`, which succeeded. 
- A full run of `npm test -- tests/network-routing.test.mjs` shows unrelated existing fixture/data-dependent failures (some 404 expectations in other tests); these are pre-existing and not caused by the alias canonicalization change, while the new regression and alias-preservation tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bddb0021c832aa75db8e72550abaf)