### PR TITLE
feat(multi-network): cross-network subnet lineage + /api/v1/lineage (#353)

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -54,6 +54,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/evidence/{netuid}.json`: public evidence ledger claims for one subnet. R2-backed.
 - `/metagraph/overview/{netuid}.json`: composed per-subnet overview (profile + health + curation + gaps + counts). R2-backed.
 - `/metagraph/registry-summary.json`: registry-wide summary (completeness, top subnets, level counts, latest changes). R2-backed.
+- `/metagraph/lineage.json`: cross-network subnet lineage — mainnet subnets matched to their testnet counterpart by github_repo or chain name, plus the testnet-only (deploying-soon) count.
 - `/metagraph/health/latest.json`: latest live or build-time surface health snapshot. R2-backed.
 - `/metagraph/health/summary.json`: global and per-subnet health rollup.
 - `/metagraph/health/history/{date}.json`: compact daily health-history snapshot. R2-backed.
@@ -98,6 +99,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/agent-catalog`: list subnets exposing callable services for AI agents (compact index: service kinds + callable count per subnet).
 - `/api/v1/agent-catalog/{netuid}`: fetch one subnet's agent capability catalog — each callable service with base URL, auth, machine-readable schema, and health/eligibility.
 - `/api/v1/registry/summary`: fetch the registry-wide summary (completeness, top subnets, level counts, latest changes).
+- `/api/v1/lineage`: fetch cross-network subnet lineage (mainnet ↔ testnet identity mapping: graduated subnets + the deploying-soon testnet pipeline).
 - `/api/v1/subnets/{netuid}/health/percentiles`: fetch p50/p95/p99 latency percentiles per operational surface over a 7d/30d window (live from D1).
 - `/api/v1/subnets/{netuid}/health/incidents`: fetch SLA (uptime ratio) + reconstructed downtime incidents per operational surface over a 7d/30d window (live from D1).
 - `/api/v1/subnets/{netuid}/trajectory`: fetch the week-over-week structural trajectory (completeness + counts) from daily snapshots (live from D1).

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -310,6 +310,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/lineage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch cross-network subnet lineage: mainnet ↔ testnet identity mapping (graduated subnets + the deploying-soon testnet pipeline). */
+        get: operations["lineage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/openapi.json": {
         parameters: {
             query?: never;
@@ -1651,6 +1668,30 @@ export interface components {
         JsonObject: {
             [key: string]: unknown;
         };
+        LineageArtifact: components["schemas"]["ArtifactBase"] & ({
+            graduated_subnet_count?: number;
+            link_count: number;
+            links: ({
+                mainnet_name?: string | null;
+                mainnet_netuid: number;
+                mainnet_slug?: string | null;
+                /** @enum {unknown} */
+                matched_by: "github_repo" | "chain_name";
+                testnet_name?: string | null;
+                testnet_netuid: number;
+            } & {
+                [key: string]: unknown;
+            })[];
+            matched_by_counts?: {
+                [key: string]: number;
+            };
+            published_at?: string | null;
+            source_network: string;
+            target_network: string;
+            testnet_only_count?: number;
+        } & {
+            [key: string]: unknown;
+        });
         OpenApiArtifact: {
             components: {
                 [key: string]: unknown;
@@ -2568,6 +2609,21 @@ export interface components {
             injection_scrubbed?: boolean;
             integration_readiness?: number;
             interface_count?: number;
+            /** @description Cross-network lineage (issue #353): when this mainnet subnet has a testnet counterpart (matched by github_repo or chain name), { graduated_from_testnet: true, also_on: [{ network, netuid, name, matched_by }] }; null otherwise. Reporting-only. */
+            lineage?: ({
+                also_on?: ({
+                    /** @enum {unknown} */
+                    matched_by?: "github_repo" | "chain_name";
+                    name?: string | null;
+                    netuid?: number;
+                    network?: string;
+                } & {
+                    [key: string]: unknown;
+                })[];
+                graduated_from_testnet?: boolean;
+            } & {
+                [key: string]: unknown;
+            }) | null;
             missing_critical_count: number;
             missing_identity: components["schemas"]["SurfaceKind"][];
             missing_operational: components["schemas"]["SurfaceKind"][];
@@ -4134,6 +4190,74 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthHistoryArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    lineage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["LineageArtifact"];
                     };
                 };
             };

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -182,6 +182,7 @@ Prefix any `/api/v1/` or `/metagraph/` path with a network to scope it: `/api/v1
 - `GET /api/v1/providers/{slug}/endpoints` — List endpoint resources for one provider or operator.
 - `GET /api/v1/coverage` — Fetch registry coverage summary.
 - `GET /api/v1/registry/summary` — Fetch the registry-wide summary (completeness, top subnets, level counts, latest changes).
+- `GET /api/v1/lineage` — Fetch cross-network subnet lineage: mainnet ↔ testnet identity mapping (graduated subnets + the deploying-soon testnet pipeline).
 - `GET /api/v1/curation` — Fetch curation states by subnet.
 - `GET /api/v1/gaps` — Fetch interface gap report.
 - `GET /api/v1/review/gaps` — Fetch contributor-targeted subnet gap priorities.

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -170,6 +170,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "lineage",
+      "path": "/metagraph/lineage.json",
+      "schema_ref": "#/components/schemas/LineageArtifact",
+      "storage_tier": "dual"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "curation",
       "path": "/metagraph/curation.json",
       "schema_ref": "#/components/schemas/CurationArtifact",
@@ -1732,6 +1739,18 @@
       "id": "registry-summary",
       "method": "GET",
       "path": "/api/v1/registry/summary",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": []
+    },
+    {
+      "artifact_path": "/metagraph/lineage.json",
+      "cache": "standard",
+      "description": "Fetch cross-network subnet lineage: mainnet ↔ testnet identity mapping (graduated subnets + the deploying-soon testnet pipeline).",
+      "id": "lineage",
+      "method": "GET",
+      "path": "/api/v1/lineage",
       "public": true,
       "query_collection": null,
       "query_filter_names": [],

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -219,6 +219,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Cross-network subnet lineage: mainnet subnets matched to their testnet counterpart by github_repo or chain name.",
+      "id": "lineage",
+      "path": "/metagraph/lineage.json",
+      "schema_ref": "#/components/schemas/LineageArtifact",
+      "storage_tier": "dual"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Curation state and gaps for every active subnet.",
       "id": "curation",
       "path": "/metagraph/curation.json",

--- a/public/metagraph/lineage.json
+++ b/public/metagraph/lineage.json
@@ -1,0 +1,248 @@
+{
+  "generated_at": "1970-01-01T00:00:00.000Z",
+  "graduated_subnet_count": 29,
+  "link_count": 29,
+  "links": [
+    {
+      "mainnet_name": "Apex",
+      "mainnet_netuid": 1,
+      "mainnet_slug": "sn-1",
+      "matched_by": "chain_name",
+      "testnet_name": "apex",
+      "testnet_netuid": 1
+    },
+    {
+      "mainnet_name": "Targon",
+      "mainnet_netuid": 4,
+      "mainnet_slug": "sn-4",
+      "matched_by": "chain_name",
+      "testnet_name": "targon",
+      "testnet_netuid": 4
+    },
+    {
+      "mainnet_name": "Zeus",
+      "mainnet_netuid": 18,
+      "mainnet_slug": "sn-18",
+      "matched_by": "chain_name",
+      "testnet_name": "zeus",
+      "testnet_netuid": 301
+    },
+    {
+      "mainnet_name": "Quasar",
+      "mainnet_netuid": 24,
+      "mainnet_slug": "sn-24",
+      "matched_by": "github_repo",
+      "testnet_name": "quasar-test",
+      "testnet_netuid": 383
+    },
+    {
+      "mainnet_name": "ItsAI",
+      "mainnet_netuid": 32,
+      "mainnet_slug": "sn-32",
+      "matched_by": "chain_name",
+      "testnet_name": "itsai",
+      "testnet_netuid": 32
+    },
+    {
+      "mainnet_name": "Aurelius",
+      "mainnet_netuid": 37,
+      "mainnet_slug": "sn-37",
+      "matched_by": "chain_name",
+      "testnet_name": "Aurelius",
+      "testnet_netuid": 455
+    },
+    {
+      "mainnet_name": "Graphite",
+      "mainnet_netuid": 43,
+      "mainnet_slug": "sn-43",
+      "matched_by": "chain_name",
+      "testnet_name": "graphite",
+      "testnet_netuid": 43
+    },
+    {
+      "mainnet_name": "Synth",
+      "mainnet_netuid": 50,
+      "mainnet_slug": "sn-50",
+      "matched_by": "github_repo",
+      "testnet_name": "Synth",
+      "testnet_netuid": 247
+    },
+    {
+      "mainnet_name": "Dojo",
+      "mainnet_netuid": 52,
+      "mainnet_slug": "sn-52",
+      "matched_by": "chain_name",
+      "testnet_name": "dojo",
+      "testnet_netuid": 52
+    },
+    {
+      "mainnet_name": "NIOME",
+      "mainnet_netuid": 55,
+      "mainnet_slug": "sn-55",
+      "matched_by": "github_repo",
+      "testnet_name": "Gen Test",
+      "testnet_netuid": 289
+    },
+    {
+      "mainnet_name": "Gradients",
+      "mainnet_netuid": 56,
+      "mainnet_slug": "gradients",
+      "matched_by": "chain_name",
+      "testnet_name": "gradients",
+      "testnet_netuid": 56
+    },
+    {
+      "mainnet_name": "Sparket",
+      "mainnet_netuid": 57,
+      "mainnet_slug": "sn-57",
+      "matched_by": "chain_name",
+      "testnet_name": "gaia",
+      "testnet_netuid": 57
+    },
+    {
+      "mainnet_name": "Babelbit",
+      "mainnet_netuid": 59,
+      "mainnet_slug": "sn-59",
+      "matched_by": "chain_name",
+      "testnet_name": "babelbit",
+      "testnet_netuid": 288
+    },
+    {
+      "mainnet_name": "Ridges",
+      "mainnet_netuid": 62,
+      "mainnet_slug": "sn-62",
+      "matched_by": "chain_name",
+      "testnet_name": "ridges",
+      "testnet_netuid": 372
+    },
+    {
+      "mainnet_name": "Chutes",
+      "mainnet_netuid": 64,
+      "mainnet_slug": "sn-64",
+      "matched_by": "chain_name",
+      "testnet_name": "chutes",
+      "testnet_netuid": 64
+    },
+    {
+      "mainnet_name": "NOVA",
+      "mainnet_netuid": 68,
+      "mainnet_slug": "sn-68",
+      "matched_by": "chain_name",
+      "testnet_name": "NOVA",
+      "testnet_netuid": 379
+    },
+    {
+      "mainnet_name": "ain",
+      "mainnet_netuid": 69,
+      "mainnet_slug": "ain",
+      "matched_by": "chain_name",
+      "testnet_name": "ain",
+      "testnet_netuid": 69
+    },
+    {
+      "mainnet_name": "MVTRX",
+      "mainnet_netuid": 79,
+      "mainnet_slug": "sn-79",
+      "matched_by": "github_repo",
+      "testnet_name": "τaos",
+      "testnet_netuid": 366
+    },
+    {
+      "mainnet_name": "dogelayer",
+      "mainnet_netuid": 80,
+      "mainnet_slug": "sn-80",
+      "matched_by": "chain_name",
+      "testnet_name": "dogelayer",
+      "testnet_netuid": 284
+    },
+    {
+      "mainnet_name": "Compelle",
+      "mainnet_netuid": 82,
+      "mainnet_slug": "sn-82",
+      "matched_by": "chain_name",
+      "testnet_name": "Compelle",
+      "testnet_netuid": 449
+    },
+    {
+      "mainnet_name": "ansuz",
+      "mainnet_netuid": 84,
+      "mainnet_slug": "sn-84",
+      "matched_by": "chain_name",
+      "testnet_name": "ansuz",
+      "testnet_netuid": 84
+    },
+    {
+      "mainnet_name": "DegenBrain",
+      "mainnet_netuid": 90,
+      "mainnet_slug": "sn-90",
+      "matched_by": "chain_name",
+      "testnet_name": "ogham",
+      "testnet_netuid": 90
+    },
+    {
+      "mainnet_name": "Verathos",
+      "mainnet_netuid": 96,
+      "mainnet_slug": "sn-96",
+      "matched_by": "chain_name",
+      "testnet_name": "verathos",
+      "testnet_netuid": 405
+    },
+    {
+      "mainnet_name": "ForeverMoney",
+      "mainnet_netuid": 98,
+      "mainnet_slug": "sn-98",
+      "matched_by": "github_repo",
+      "testnet_name": "forevermoney",
+      "testnet_netuid": 374
+    },
+    {
+      "mainnet_name": "eni",
+      "mainnet_netuid": 101,
+      "mainnet_slug": "eni",
+      "matched_by": "chain_name",
+      "testnet_name": "eni",
+      "testnet_netuid": 101
+    },
+    {
+      "mainnet_name": "oneoneone",
+      "mainnet_netuid": 111,
+      "mainnet_slug": "sn-111",
+      "matched_by": "chain_name",
+      "testnet_name": "oneoneone",
+      "testnet_netuid": 427
+    },
+    {
+      "mainnet_name": "TensorUSD",
+      "mainnet_netuid": 113,
+      "mainnet_slug": "sn-113",
+      "matched_by": "chain_name",
+      "testnet_name": "TensorUSD",
+      "testnet_netuid": 421
+    },
+    {
+      "mainnet_name": "TaoLend",
+      "mainnet_netuid": 116,
+      "mainnet_slug": "taolend",
+      "matched_by": "chain_name",
+      "testnet_name": "hard_sign",
+      "testnet_netuid": 116
+    },
+    {
+      "mainnet_name": "Bitrecs",
+      "mainnet_netuid": 122,
+      "mainnet_slug": "sn-122",
+      "matched_by": "chain_name",
+      "testnet_name": "gamma_small",
+      "testnet_netuid": 122
+    }
+  ],
+  "matched_by_counts": {
+    "chain_name": 24,
+    "github_repo": 5
+  },
+  "published_at": null,
+  "schema_version": 1,
+  "source_network": "mainnet",
+  "target_network": "testnet",
+  "testnet_only_count": 476
+}

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3113,6 +3113,102 @@
         "additionalProperties": true,
         "type": "object"
       },
+      "LineageArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "graduated_subnet_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "link_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "links": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "mainnet_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "mainnet_netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "mainnet_slug": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "matched_by": {
+                      "enum": [
+                        "github_repo",
+                        "chain_name"
+                      ]
+                    },
+                    "testnet_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "testnet_netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "mainnet_netuid",
+                    "testnet_netuid",
+                    "matched_by"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "matched_by_counts": {
+                "additionalProperties": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              "published_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_network": {
+                "type": "string"
+              },
+              "target_network": {
+                "type": "string"
+              },
+              "testnet_only_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "source_network",
+              "target_network",
+              "link_count",
+              "links"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "OpenApiArtifact": {
         "additionalProperties": true,
         "properties": {
@@ -7004,6 +7100,47 @@
             "minimum": 0,
             "type": "integer"
           },
+          "lineage": {
+            "additionalProperties": true,
+            "description": "Cross-network lineage (issue #353): when this mainnet subnet has a testnet counterpart (matched by github_repo or chain name), { graduated_from_testnet: true, also_on: [{ network, netuid, name, matched_by }] }; null otherwise. Reporting-only.",
+            "properties": {
+              "also_on": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "matched_by": {
+                      "enum": [
+                        "github_repo",
+                        "chain_name"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "network": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "graduated_from_testnet": {
+                "type": "boolean"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "missing_critical_count": {
             "minimum": 0,
             "type": "integer"
@@ -10707,6 +10844,95 @@
         "summary": "Fetch compact daily health history.",
         "tags": [
           "health"
+        ]
+      }
+    },
+    "/api/v1/lineage": {
+      "get": {
+        "operationId": "lineage",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/LineageArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch cross-network subnet lineage: mainnet ↔ testnet identity mapping (graduated subnets + the deploying-soon testnet pipeline).",
+        "tags": [
+          "registry",
+          "multi-network"
         ]
       }
     },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -310,6 +310,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/lineage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch cross-network subnet lineage: mainnet ↔ testnet identity mapping (graduated subnets + the deploying-soon testnet pipeline). */
+        get: operations["lineage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/openapi.json": {
         parameters: {
             query?: never;
@@ -1651,6 +1668,30 @@ export interface components {
         JsonObject: {
             [key: string]: unknown;
         };
+        LineageArtifact: components["schemas"]["ArtifactBase"] & ({
+            graduated_subnet_count?: number;
+            link_count: number;
+            links: ({
+                mainnet_name?: string | null;
+                mainnet_netuid: number;
+                mainnet_slug?: string | null;
+                /** @enum {unknown} */
+                matched_by: "github_repo" | "chain_name";
+                testnet_name?: string | null;
+                testnet_netuid: number;
+            } & {
+                [key: string]: unknown;
+            })[];
+            matched_by_counts?: {
+                [key: string]: number;
+            };
+            published_at?: string | null;
+            source_network: string;
+            target_network: string;
+            testnet_only_count?: number;
+        } & {
+            [key: string]: unknown;
+        });
         OpenApiArtifact: {
             components: {
                 [key: string]: unknown;
@@ -2568,6 +2609,21 @@ export interface components {
             injection_scrubbed?: boolean;
             integration_readiness?: number;
             interface_count?: number;
+            /** @description Cross-network lineage (issue #353): when this mainnet subnet has a testnet counterpart (matched by github_repo or chain name), { graduated_from_testnet: true, also_on: [{ network, netuid, name, matched_by }] }; null otherwise. Reporting-only. */
+            lineage?: ({
+                also_on?: ({
+                    /** @enum {unknown} */
+                    matched_by?: "github_repo" | "chain_name";
+                    name?: string | null;
+                    netuid?: number;
+                    network?: string;
+                } & {
+                    [key: string]: unknown;
+                })[];
+                graduated_from_testnet?: boolean;
+            } & {
+                [key: string]: unknown;
+            }) | null;
             missing_critical_count: number;
             missing_identity: components["schemas"]["SurfaceKind"][];
             missing_operational: components["schemas"]["SurfaceKind"][];
@@ -4134,6 +4190,74 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthHistoryArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    lineage: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["LineageArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3091,6 +3091,102 @@
         "additionalProperties": true,
         "type": "object"
       },
+      "LineageArtifact": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/ArtifactBase"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "graduated_subnet_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "link_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "links": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "mainnet_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "mainnet_netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "mainnet_slug": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "matched_by": {
+                      "enum": [
+                        "github_repo",
+                        "chain_name"
+                      ]
+                    },
+                    "testnet_name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "testnet_netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    }
+                  },
+                  "required": [
+                    "mainnet_netuid",
+                    "testnet_netuid",
+                    "matched_by"
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "matched_by_counts": {
+                "additionalProperties": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "type": "object"
+              },
+              "published_at": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "source_network": {
+                "type": "string"
+              },
+              "target_network": {
+                "type": "string"
+              },
+              "testnet_only_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "source_network",
+              "target_network",
+              "link_count",
+              "links"
+            ],
+            "type": "object"
+          }
+        ]
+      },
       "OpenApiArtifact": {
         "additionalProperties": true,
         "properties": {
@@ -6981,6 +7077,47 @@
           "interface_count": {
             "minimum": 0,
             "type": "integer"
+          },
+          "lineage": {
+            "additionalProperties": true,
+            "description": "Cross-network lineage (issue #353): when this mainnet subnet has a testnet counterpart (matched by github_repo or chain name), { graduated_from_testnet: true, also_on: [{ network, netuid, name, matched_by }] }; null otherwise. Reporting-only.",
+            "properties": {
+              "also_on": {
+                "items": {
+                  "additionalProperties": true,
+                  "properties": {
+                    "matched_by": {
+                      "enum": [
+                        "github_repo",
+                        "chain_name"
+                      ]
+                    },
+                    "name": {
+                      "type": [
+                        "string",
+                        "null"
+                      ]
+                    },
+                    "netuid": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "network": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              },
+              "graduated_from_testnet": {
+                "type": "boolean"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "missing_critical_count": {
             "minimum": 0,

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -750,6 +750,27 @@
             "type": ["string", "null"],
             "description": "Fallback 'what does it do' blurb from a curated provider's notes (source: derived-from-provider-notes), present only when the curated description is null. Display-only — never backfills description or feeds completeness_score."
           },
+          "lineage": {
+            "type": ["object", "null"],
+            "description": "Cross-network lineage (issue #353): when this mainnet subnet has a testnet counterpart (matched by github_repo or chain name), { graduated_from_testnet: true, also_on: [{ network, netuid, name, matched_by }] }; null otherwise. Reporting-only.",
+            "properties": {
+              "graduated_from_testnet": { "type": "boolean" },
+              "also_on": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "network": { "type": "string" },
+                    "netuid": { "type": "integer", "minimum": 0 },
+                    "name": { "type": ["string", "null"] },
+                    "matched_by": { "enum": ["github_repo", "chain_name"] }
+                  },
+                  "additionalProperties": true
+                }
+              }
+            },
+            "additionalProperties": true
+          },
           "primary_links": {
             "$ref": "#/components/schemas/SubnetProfilePrimaryLinks"
           },
@@ -1459,6 +1480,55 @@
                 }
               },
               "recent_changes": { "type": "object" }
+            },
+            "additionalProperties": true
+          }
+        ]
+      },
+      "LineageArtifact": {
+        "allOf": [
+          { "$ref": "#/components/schemas/ArtifactBase" },
+          {
+            "type": "object",
+            "required": [
+              "source_network",
+              "target_network",
+              "link_count",
+              "links"
+            ],
+            "properties": {
+              "published_at": { "type": ["string", "null"] },
+              "source_network": { "type": "string" },
+              "target_network": { "type": "string" },
+              "link_count": { "type": "integer", "minimum": 0 },
+              "graduated_subnet_count": { "type": "integer", "minimum": 0 },
+              "matched_by_counts": {
+                "type": "object",
+                "additionalProperties": { "type": "integer", "minimum": 0 }
+              },
+              "testnet_only_count": { "type": "integer", "minimum": 0 },
+              "links": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "required": [
+                    "mainnet_netuid",
+                    "testnet_netuid",
+                    "matched_by"
+                  ],
+                  "properties": {
+                    "mainnet_netuid": { "type": "integer", "minimum": 0 },
+                    "mainnet_name": { "type": ["string", "null"] },
+                    "mainnet_slug": { "type": ["string", "null"] },
+                    "testnet_netuid": { "type": "integer", "minimum": 0 },
+                    "testnet_name": { "type": ["string", "null"] },
+                    "matched_by": {
+                      "enum": ["github_repo", "chain_name"]
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              }
             },
             "additionalProperties": true
           }

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
 import {
   backfilledIdentityUrl,
+  buildSubnetLineageLinks,
   buildEndpointResourceArtifact,
   buildEvidenceSubjectNetuidIndex,
   buildEndpointPoolArtifact,
@@ -214,6 +215,45 @@ for (const subnet of mergedSubnets) {
       break;
     }
   }
+}
+
+// Cross-network lineage (issue #353): join mainnet ↔ testnet on non-placeholder
+// github_repo, else on-chain name — the one mapping a chain explorer can't make.
+// A mainnet subnet with a testnet counterpart "graduated from testnet". Emitted
+// as a standalone /metagraph/lineage.json + onto each mainnet profile.
+const testnetSnapshot = await readOptionalJson(
+  path.join(repoRoot, "registry/native/test-subnets.json"),
+);
+const testnetSubnets = testnetSnapshot?.subnets || [];
+const testnetByNetuid = new Map(
+  testnetSubnets.map((subnet) => [subnet.netuid, subnet]),
+);
+const mergedByNetuid = new Map(
+  mergedSubnets.map((subnet) => [subnet.netuid, subnet]),
+);
+const lineageLinks = buildSubnetLineageLinks(chainSubnets, testnetSubnets);
+const lineageEntries = lineageLinks.map((link) => ({
+  mainnet_netuid: link.source_netuid,
+  mainnet_name: mergedByNetuid.get(link.source_netuid)?.name || null,
+  mainnet_slug: mergedByNetuid.get(link.source_netuid)?.slug || null,
+  testnet_netuid: link.target_netuid,
+  testnet_name: nativeDisplayName(
+    testnetByNetuid.get(link.target_netuid),
+    `Subnet ${link.target_netuid}`,
+  ),
+  matched_by: link.matched_by,
+}));
+const lineageByMainnetNetuid = new Map();
+for (const entry of lineageEntries) {
+  if (!lineageByMainnetNetuid.has(entry.mainnet_netuid)) {
+    lineageByMainnetNetuid.set(entry.mainnet_netuid, []);
+  }
+  lineageByMainnetNetuid.get(entry.mainnet_netuid).push({
+    network: "testnet",
+    netuid: entry.testnet_netuid,
+    name: entry.testnet_name,
+    matched_by: entry.matched_by,
+  });
 }
 
 // Honest first-party substrate (issue #348): of all curated surfaces, only the
@@ -508,6 +548,7 @@ const profileArtifacts = buildSubnetProfileArtifacts({
   // chain-backfilled. Keeps the SN74 curation flywheel queue unchanged.
   overlaysByNetuid: overlayByNetuid,
   derivedDescriptionByNetuid,
+  lineageByNetuid: lineageByMainnetNetuid,
   probeFinishedAt: healthArtifacts.latest.probe_finished_at || null,
   subnets: mergedSubnets,
   surfaces,
@@ -705,6 +746,28 @@ await writeJson(artifactFile("subnets.json"), {
   source: nativeSnapshot.source,
   native_snapshot_captured_at: nativeSnapshot.captured_at,
   subnets: subnetIndex,
+});
+
+// Cross-network lineage map (issue #353): mainnet subnets that have a testnet
+// counterpart (graduated), the join method, and how many testnet subnets are
+// not yet on mainnet (the deploying-soon pipeline).
+const graduatedMainnetNetuids = new Set(
+  lineageEntries.map((entry) => entry.mainnet_netuid),
+);
+const matchedTestnetNetuids = new Set(
+  lineageEntries.map((entry) => entry.testnet_netuid),
+);
+await writeJson(artifactFile("lineage.json"), {
+  schema_version: 1,
+  generated_at: generatedAt,
+  published_at: publishedAt(),
+  source_network: "mainnet",
+  target_network: "testnet",
+  link_count: lineageEntries.length,
+  graduated_subnet_count: graduatedMainnetNetuids.size,
+  matched_by_counts: countBy(lineageEntries, (entry) => entry.matched_by),
+  testnet_only_count: testnetSubnets.length - matchedTestnetNetuids.size,
+  links: lineageEntries,
 });
 
 await fs.rm(r2ArtifactDir("subnets"), { recursive: true, force: true });
@@ -1857,6 +1920,7 @@ function buildSubnetProfileArtifacts({
   nativeIdentitiesByNetuid = new Map(),
   overlaysByNetuid = new Map(),
   derivedDescriptionByNetuid = new Map(),
+  lineageByNetuid = new Map(),
   healthSurfaces = [],
   probeFinishedAt = null,
 }) {
@@ -1874,6 +1938,7 @@ function buildSubnetProfileArtifacts({
         overlay: overlaysByNetuid.get(subnet.netuid) || null,
         derivedDescription:
           derivedDescriptionByNetuid.get(subnet.netuid) || null,
+        lineage: lineageByNetuid.get(subnet.netuid) || null,
         probeFinishedAt,
         subnet,
         surfaces: surfacesByNetuid.get(subnet.netuid) || [],
@@ -2957,6 +3022,7 @@ function buildSubnetProfile({
   nativeIdentity,
   overlay = null,
   derivedDescription = null,
+  lineage = null,
   healthByKind = new Map(),
   probeFinishedAt = null,
 }) {
@@ -3030,6 +3096,9 @@ function buildSubnetProfile({
     categories: subnet.categories || [],
     derived_categories: subnet.derived_categories || [],
     derived_description: derivedDescription,
+    lineage: lineage
+      ? { graduated_from_testnet: true, also_on: lineage }
+      : null,
     primary_links: primaryLinks,
     primary_app_surface: surfaceSummary(primaryAppSurface(surfaces)),
     supported_interface_kinds: supportedKinds,

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -982,6 +982,78 @@ export function cleanDescription(value) {
 // vocabulary; re-exported here for the build-side import sites.
 export { DOMAIN_TAGS, deriveDomainTags } from "../src/domain-tags.mjs";
 
+// Cross-network lineage join (issue #353): match a subnet across networks by
+// its non-placeholder on-chain github_repo (strongest), else its on-chain name
+// slug (excluding generic/junk names). The one thing metagraphed can say that a
+// chain explorer cannot — which mainnet subnet a testnet subnet graduates into.
+const LINEAGE_GENERIC_NAMES = new Set([
+  "root",
+  "unknown",
+  "deprecated",
+  "none",
+  "test",
+  "testnet",
+]);
+
+function lineageRepoKey(subnet) {
+  const repo = normalizePublicUrl(subnet?.chain_identity?.github_repo);
+  return repo && !isPlaceholderIdentityUrl(repo) ? repo.toLowerCase() : null;
+}
+
+function lineageNameKey(subnet) {
+  if (!subnet || nativeNameQuality(subnet) !== "chain") return null;
+  const raw =
+    typeof subnet.raw_name === "string" ? subnet.raw_name : subnet.name;
+  const slug = slugify(raw || "");
+  if (!slug || LINEAGE_GENERIC_NAMES.has(slug)) return null;
+  return slug;
+}
+
+function pushToMapArray(map, key, value) {
+  if (!map.has(key)) map.set(key, []);
+  map.get(key).push(value);
+}
+
+// Join two native-subnet lists (each: { netuid, name/raw_name, chain_identity }).
+// Returns sorted links [{ source_netuid, target_netuid, matched_by }] where
+// matched_by is "github_repo" or "chain_name". Deterministic + pure so the build
+// and the validator never drift.
+export function buildSubnetLineageLinks(sourceSubnets, targetSubnets) {
+  const targetByRepo = new Map();
+  const targetByName = new Map();
+  for (const target of targetSubnets || []) {
+    const repoKey = lineageRepoKey(target);
+    if (repoKey) pushToMapArray(targetByRepo, repoKey, target);
+    const nameKey = lineageNameKey(target);
+    if (nameKey) pushToMapArray(targetByName, nameKey, target);
+  }
+  const links = [];
+  for (const source of sourceSubnets || []) {
+    const repoKey = lineageRepoKey(source);
+    const nameKey = lineageNameKey(source);
+    let matches = [];
+    let matchedBy = null;
+    if (repoKey && targetByRepo.has(repoKey)) {
+      matches = targetByRepo.get(repoKey);
+      matchedBy = "github_repo";
+    } else if (nameKey && targetByName.has(nameKey)) {
+      matches = targetByName.get(nameKey);
+      matchedBy = "chain_name";
+    }
+    for (const target of matches) {
+      links.push({
+        source_netuid: source.netuid,
+        target_netuid: target.netuid,
+        matched_by: matchedBy,
+      });
+    }
+  }
+  return links.sort(
+    (a, b) =>
+      a.source_netuid - b.source_netuid || a.target_netuid - b.target_netuid,
+  );
+}
+
 // Naive registrable domain (eTLD+1 by last-two-labels) of a URL, for the
 // provider shared-team cluster heuristic (issue #347). Good enough for the
 // .io/.ai/.com domains Bittensor teams use; not PSL-accurate for multi-part

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -214,6 +214,13 @@ const checks = [
     },
   ],
   [
+    "/api/v1/lineage",
+    (body) => {
+      assert.equal(typeof body.data.link_count, "number");
+      assert.equal(Array.isArray(body.data.links), true);
+    },
+  ],
+  [
     "/api/v1/review/gaps?limit=3",
     (body) => assert.equal(body.data.priorities.length <= 3, true),
   ],

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -97,6 +97,10 @@ const DUAL_PATTERNS = [
   // subnets.json (124 KB) stays committed: the changelog diffs it against the
   // committed HEAD version to produce the "what changed between publishes" feed.
   /^subnets\.json$/,
+  // Cross-network lineage map (issue #353): small (~6 KB), agent-facing, low
+  // churn (changes only with chain identities); committed + mirrored like the
+  // other small contract digests.
+  /^lineage\.json$/,
   /^types\.d\.ts$/,
 ];
 

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -672,6 +672,12 @@ export const PUBLIC_ARTIFACTS = [
     "RegistrySummaryArtifact",
   ),
   artifact(
+    "lineage",
+    "/metagraph/lineage.json",
+    "Cross-network subnet lineage: mainnet subnets matched to their testnet counterpart by github_repo or chain name.",
+    "LineageArtifact",
+  ),
+  artifact(
     "curation",
     "/metagraph/curation.json",
     "Curation state and gaps for every active subnet.",
@@ -1114,6 +1120,15 @@ export const API_ROUTES = [
     "Fetch the registry-wide summary (completeness, top subnets, level counts, latest changes).",
     "standard",
     ["registry"],
+  ),
+  route(
+    "lineage",
+    "GET",
+    "/api/v1/lineage",
+    "/metagraph/lineage.json",
+    "Fetch cross-network subnet lineage: mainnet ↔ testnet identity mapping (graduated subnets + the deploying-soon testnet pipeline).",
+    "standard",
+    ["registry", "multi-network"],
   ),
   route(
     "curation",

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -612,6 +612,7 @@ test("public artifacts are internally consistent", () => {
   const providerEndpoints = readArtifact("providers/allways/endpoints.json");
   const providersArtifact = readArtifact("providers.json");
   const agentCatalog = readArtifact("agent-catalog.json");
+  const lineage = readArtifact("lineage.json");
   const r2Manifest = readArtifact("r2-manifest.json");
   const schemaDrift = readArtifact("schema-drift.json");
   const schemaIndex = readArtifact("schemas/index.json");
@@ -873,6 +874,33 @@ test("public artifacts are internally consistent", () => {
     "agent-catalog must carry a deterministic content_hash",
   );
   assert.ok(agentCatalog.content_hash.length >= 16);
+
+  // Cross-network lineage (issue #353): mainnet ↔ testnet mapping, with the
+  // profile's lineage reconciled against the standalone artifact.
+  assert.equal(lineage.source_network, "mainnet");
+  assert.equal(lineage.target_network, "testnet");
+  assert.equal(Array.isArray(lineage.links), true);
+  assert.ok(lineage.link_count > 0, "expected lineage links between networks");
+  assert.equal(lineage.link_count, lineage.links.length);
+  const lineageMainnetNetuids = new Set();
+  for (const link of lineage.links) {
+    assert.equal(typeof link.mainnet_netuid, "number");
+    assert.equal(typeof link.testnet_netuid, "number");
+    assert.ok(["github_repo", "chain_name"].includes(link.matched_by));
+    lineageMainnetNetuids.add(link.mainnet_netuid);
+  }
+  assert.equal(lineage.graduated_subnet_count, lineageMainnetNetuids.size);
+  // every profile that claims to have graduated appears in the lineage artifact
+  for (const profile of profiles.profiles) {
+    if (profile.lineage) {
+      assert.equal(profile.lineage.graduated_from_testnet, true);
+      assert.ok(profile.lineage.also_on.length > 0);
+      assert.ok(
+        lineageMainnetNetuids.has(profile.netuid),
+        `profile ${profile.netuid}: lineage must be reflected in lineage.json`,
+      );
+    }
+  }
   // The domain coverage facet sums the per-subnet tags.
   assert.equal(typeof coverage.domain_coverage, "object");
   const facetSum = Object.values(coverage.domain_coverage).reduce(

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -16,6 +16,7 @@ import {
   DOMAIN_TAGS,
   deriveDescriptionFromNotes,
   clusterDomainFromUrl,
+  buildSubnetLineageLinks,
 } from "../scripts/lib.mjs";
 
 describe("stripUrls", () => {
@@ -516,6 +517,49 @@ describe("deriveDescriptionFromNotes", () => {
     assert.equal(deriveDescriptionFromNotes(42), null);
     assert.equal(deriveDescriptionFromNotes(""), null);
     assert.equal(deriveDescriptionFromNotes("   "), null);
+  });
+});
+
+describe("buildSubnetLineageLinks", () => {
+  const sub = (netuid, name, repo) => ({
+    netuid,
+    name,
+    raw_name: name,
+    chain_identity: { subnet_name: name, github_repo: repo || null },
+  });
+
+  test("matches by non-placeholder github_repo (strongest), then chain name", () => {
+    const mainnet = [
+      sub(24, "Quasar", "https://github.com/silx-labs/quasar-subnet"),
+      sub(4, "Targon", null),
+    ];
+    const testnet = [
+      sub(383, "quasar-test", "https://github.com/silx-labs/quasar-subnet"),
+      sub(4, "targon", null),
+    ];
+    const links = buildSubnetLineageLinks(mainnet, testnet);
+    assert.deepEqual(links, [
+      { source_netuid: 4, target_netuid: 4, matched_by: "chain_name" },
+      { source_netuid: 24, target_netuid: 383, matched_by: "github_repo" },
+    ]);
+  });
+
+  test("ignores placeholder repos and generic names", () => {
+    const mainnet = [
+      sub(3, "deprecated", "https://github.com/username/repo"),
+      sub(0, "root", null),
+    ];
+    const testnet = [
+      sub(295, "deprecated", "https://github.com/username/repo"),
+      sub(0, "root", null),
+    ];
+    // placeholder repo + generic names ("root"/"deprecated") must not match
+    assert.deepEqual(buildSubnetLineageLinks(mainnet, testnet), []);
+  });
+
+  test("returns [] for empty inputs", () => {
+    assert.deepEqual(buildSubnetLineageLinks([], []), []);
+    assert.deepEqual(buildSubnetLineageLinks(undefined, undefined), []);
   });
 });
 


### PR DESCRIPTION
Closes #353 (Wave 5). **The one mapping a chain explorer can't make** — which testnet subnet a mainnet subnet graduated from.

Post-build join over the finney vs testnet native snapshots, keyed on:
1. non-placeholder on-chain `github_repo` (strongest — **5 matches**, placeholder `username/repo` correctly dropped)
2. on-chain name slug (**24 matches**), excluding generic names (`root`/`unknown`/`deprecated`)

## What's added
- **`buildSubnetLineageLinks()`** — deterministic, pure join helper (unit-tested for repo-priority + placeholder/generic exclusion).
- **`/metagraph/lineage.json` + `GET /api/v1/lineage`** — every mainnet↔testnet link with its match method, `graduated_subnet_count` (29), and `testnet_only_count` (**476 — the deploying-soon pipeline**).
- **`lineage` on each mainnet profile**: `{ graduated_from_testnet, also_on: [{ network, netuid, name, matched_by }] }`.

Reporting-only — never feeds completeness. The testnet snapshot is loaded null-safe so the join no-ops if absent. Profile ↔ lineage.json reconciliation is asserted.

## Verification
Full suite **828 tests** + coverage gate; `validate`, `validate:contract-drift`, `validate:api` (53 routes), `validate:schemas`, `validate:openapi-examples`, `lint` — all green.