### PR TITLE
feat(api-dx): ready-to-run integration snippets per callable service (#351)

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import { promisify } from "node:util";
 import path from "node:path";
 import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
+import { generateServiceSnippets } from "../src/integration-snippets.mjs";
 import {
   backfilledIdentityUrl,
   buildSubnetLineageLinks,
@@ -1043,6 +1044,10 @@ function buildSubnetServices(netuid) {
       const endpoint = agentEndpointBySurfaceId.get(surface.id) || null;
       const schema = agentSchemaBySurfaceId.get(surface.id) || null;
       const classification = endpoint?.classification || null;
+      const authRequired = Boolean(
+        surface.auth_required || schema?.snapshot?.auth_required,
+      );
+      const authSchemes = schema?.snapshot?.auth_schemes || [];
       return {
         surface_id: surface.id,
         kind: surface.kind,
@@ -1054,10 +1059,15 @@ function buildSubnetServices(netuid) {
         // Trust the captured spec's securitySchemes over the (often-unset)
         // curated flag: if the upstream OpenAPI declares auth, the agent needs a
         // credential (fixes Chutes etc. that declared apiKey yet showed false).
-        auth_required: Boolean(
-          surface.auth_required || schema?.snapshot?.auth_required,
-        ),
-        auth_schemes: schema?.snapshot?.auth_schemes || [],
+        auth_required: authRequired,
+        auth_schemes: authSchemes,
+        // Copy-paste curl/Python/TS that GETs this surface, auth header
+        // pre-filled from the declared scheme (issue #351). Reporting-only.
+        snippets: generateServiceSnippets({
+          base_url: surface.url,
+          auth_required: authRequired,
+          auth_schemes: authSchemes,
+        }),
         schema_url: surface.schema_url || null,
         schema_status: surface.schema_status || null,
         schema_artifact: schema?.path || null,

--- a/src/integration-snippets.mjs
+++ b/src/integration-snippets.mjs
@@ -1,0 +1,79 @@
+// Ready-to-run integration snippets (issue #351): given a callable service's
+// base_url + declared auth, emit copy-paste curl / Python / TypeScript that does
+// a GET against the service — the fastest path to a first successful call.
+// Worker-safe (pure string ops, no node deps) so the build generates them once
+// into the agent-catalog and the Worker/MCP can regenerate on demand if needed.
+//
+// We snippet a GET of the surface URL itself (always a valid, documented entry
+// point regardless of surface kind); for subnet-api surfaces with a captured
+// schema the agent then reads it (get_api_schema) for specific endpoints. The
+// auth header is a best-effort placeholder from the declared scheme types — the
+// captured spec carries scheme TYPES, not header names, so we use conventions.
+
+function authHeaderForSchemes(schemes) {
+  const types = new Set(
+    (Array.isArray(schemes) ? schemes : []).map((scheme) =>
+      String(scheme).toLowerCase(),
+    ),
+  );
+  if (
+    types.has("http") ||
+    types.has("bearer") ||
+    types.has("oauth2") ||
+    types.has("openidconnect")
+  ) {
+    return { name: "Authorization", value: "Bearer YOUR_API_KEY" };
+  }
+  if (types.has("apikey")) {
+    return { name: "X-API-Key", value: "YOUR_API_KEY" };
+  }
+  // Auth required but scheme unknown — a generic bearer placeholder + a hint.
+  return { name: "Authorization", value: "Bearer YOUR_API_KEY" };
+}
+
+// A validated public URL never contains a quote/backtick/newline (normalizePublicUrl
+// rejects credentials and percent-encodes the rest), but guard anyway so a snippet
+// string can never break out of its quoting.
+function isSnippetSafeUrl(url) {
+  return typeof url === "string" && url.length > 0 && !/['"`\\\s]/.test(url);
+}
+
+// Returns { curl, python, typescript } or null when there is no usable base_url.
+export function generateServiceSnippets(service) {
+  const url = service?.base_url;
+  if (!isSnippetSafeUrl(url)) return null;
+  const authHeader = service?.auth_required
+    ? authHeaderForSchemes(service?.auth_schemes)
+    : null;
+
+  const curl = authHeader
+    ? `curl -sS '${url}' \\\n  -H '${authHeader.name}: ${authHeader.value}'`
+    : `curl -sS '${url}'`;
+
+  const pythonHeaders = authHeader
+    ? `, headers={"${authHeader.name}": "${authHeader.value}"}`
+    : "";
+  const python = [
+    "import requests",
+    "",
+    `resp = requests.get("${url}"${pythonHeaders})`,
+    "resp.raise_for_status()",
+    "print(resp.json())",
+  ].join("\n");
+
+  const typescript = authHeader
+    ? [
+        `const resp = await fetch("${url}", {`,
+        `  headers: { "${authHeader.name}": "${authHeader.value}" },`,
+        "});",
+        "if (!resp.ok) throw new Error(`HTTP ${resp.status}`);",
+        "const data = await resp.json();",
+      ].join("\n")
+    : [
+        `const resp = await fetch("${url}");`,
+        "if (!resp.ok) throw new Error(`HTTP ${resp.status}`);",
+        "const data = await resp.json();",
+      ].join("\n");
+
+  return { curl, python, typescript };
+}

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -11,6 +11,7 @@
 // this module is pure and unit-testable, and so it reuses the exact same
 // R2/ASSETS resolution the REST routes use.
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
+import { generateServiceSnippets } from "./integration-snippets.mjs";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.mjs";
 import { overlayRpcPoolEligibility } from "./health-serving.mjs";
 import {
@@ -758,6 +759,10 @@ export const MCP_TOOLS = [
           required: Boolean(s.auth_required),
           schemes: Array.isArray(s.auth_schemes) ? s.auth_schemes : [],
         },
+        // Ready-to-run curl/Python/TS for a first call (issue #351), generated
+        // at build time from base_url + auth. Falls back to on-the-fly
+        // generation for older catalogs that predate the field.
+        snippets: s.snippets || generateServiceSnippets(s) || null,
         schema: s.schema_artifact
           ? {
               available: true,

--- a/tests/integration-snippets.test.mjs
+++ b/tests/integration-snippets.test.mjs
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { generateServiceSnippets } from "../src/integration-snippets.mjs";
+
+describe("generateServiceSnippets (#351)", () => {
+  test("no-auth service: plain GET in all three languages", () => {
+    const out = generateServiceSnippets({
+      base_url: "https://api.example.io/health",
+      auth_required: false,
+    });
+    assert.equal(out.curl, "curl -sS 'https://api.example.io/health'");
+    assert.match(out.python, /import requests/);
+    assert.match(
+      out.python,
+      /requests\.get\("https:\/\/api\.example\.io\/health"\)/,
+    );
+    assert.ok(!out.python.includes("headers="));
+    assert.match(
+      out.typescript,
+      /await fetch\("https:\/\/api\.example\.io\/health"\)/,
+    );
+    assert.ok(!out.typescript.includes("headers"));
+  });
+
+  test("apiKey scheme → X-API-Key header placeholder", () => {
+    const out = generateServiceSnippets({
+      base_url: "https://api.example.io/v1",
+      auth_required: true,
+      auth_schemes: ["apiKey"],
+    });
+    assert.match(out.curl, /-H 'X-API-Key: YOUR_API_KEY'/);
+    assert.match(out.python, /"X-API-Key": "YOUR_API_KEY"/);
+    assert.match(out.typescript, /"X-API-Key": "YOUR_API_KEY"/);
+  });
+
+  test("http/bearer/oauth2 schemes → Authorization: Bearer placeholder", () => {
+    for (const scheme of ["http", "bearer", "oauth2", "openIdConnect"]) {
+      const out = generateServiceSnippets({
+        base_url: "https://api.example.io/v1",
+        auth_required: true,
+        auth_schemes: [scheme],
+      });
+      assert.match(out.curl, /Authorization: Bearer YOUR_API_KEY/, scheme);
+    }
+  });
+
+  test("auth required but scheme unknown → generic bearer placeholder", () => {
+    const out = generateServiceSnippets({
+      base_url: "https://api.example.io/v1",
+      auth_required: true,
+      auth_schemes: ["mutualTLS"],
+    });
+    assert.match(out.curl, /Authorization: Bearer YOUR_API_KEY/);
+  });
+
+  test("returns null for missing or unsafe base_url", () => {
+    assert.equal(generateServiceSnippets({ base_url: null }), null);
+    assert.equal(generateServiceSnippets({}), null);
+    assert.equal(generateServiceSnippets(null), null);
+    // a URL that could break out of the snippet quoting is rejected
+    assert.equal(
+      generateServiceSnippets({ base_url: "https://x.io/'; rm -rf /" }),
+      null,
+    );
+    assert.equal(
+      generateServiceSnippets({ base_url: "https://x.io/a b" }),
+      null,
+    );
+  });
+});

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1032,6 +1032,15 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
     assert.deepEqual(out.services[0].auth.schemes, ["apiKey"]);
     assert.equal(out.services[0].schema.available, true);
     assert.match(out.services[0].schema.fetch_with, /get_api_schema/);
+    // ready-to-run snippets (#351): curl/python/typescript for a first call
+    assert.ok(out.services[0].snippets, "expected integration snippets");
+    assert.match(
+      out.services[0].snippets.curl,
+      /^curl -sS 'https:\/\/api\.data\.io'/,
+    );
+    assert.match(out.services[0].snippets.curl, /X-API-Key: YOUR_API_KEY/);
+    assert.match(out.services[0].snippets.python, /import requests/);
+    assert.match(out.services[0].snippets.typescript, /await fetch/);
     assert.ok(out.next_steps.some((s) => /get_subnet_health/.test(s)));
   });
 


### PR DESCRIPTION
Closes #351 (Wave 5). Collapses time-to-first-successful-call: every callable service in the agent catalog now carries copy-paste **curl / Python / TypeScript** that GETs its `base_url`, with an auth header pre-filled from the declared scheme (`apiKey` → `X-API-Key`, `http`/`bearer`/`oauth2` → `Authorization: Bearer`).

- **`src/integration-snippets.mjs`** (worker-safe): `generateServiceSnippets()` — pure, URL-safety-guarded so a hostile `base_url` can't break out of the snippet quoting. Generated once at build time onto each per-subnet agent-catalog service.
- **`how_do_i_call`** MCP tool returns the snippets (build-time value, with on-the-fly fallback for older catalogs).

Reporting-only — never feeds completeness. The per-subnet catalog is R2-only, so this is a code+tests change; the snippets regenerate on the next build. (The "frontend API tab" surface is the separate metagraph-finder repo — the backend now provides the data it renders.)

## Verification
Full suite **833 tests** (new `integration-snippets.test.mjs` covers every auth branch + the URL-safety guard) + coverage gate; `validate`, `validate:contract-drift`, `validate:api`, `validate:mcp`, `validate:schemas`, `validate:docs`, `scan:public-safety`, `lint` — all green.