### PR TITLE
fix(test): atomic artifact writes end the vitest file-scheduling race

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -126,9 +126,31 @@ export async function readArtifactJson(relativePath) {
   return readJson(artifactFilePath(relativePath));
 }
 
-export async function writeJson(filePath, value) {
+// Monotonic suffix so two writers (or one writer with many files) never collide
+// on a temp name within a process.
+let atomicWriteCounter = 0;
+
+// Write a file atomically: stage to a sibling temp path (same directory, so the
+// same filesystem → rename() is atomic) then rename over the target. A
+// concurrent reader always sees a complete old-or-new file, never the
+// zero-length window a plain truncate-write exposes. This makes the build safe
+// to run while tests / the Worker read the committed artifacts in parallel
+// (fixes the vitest file-scheduling race where a reader saw a half-written
+// subnets.json and 404'd).
+async function atomicWriteFile(filePath, content) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, `${stableStringify(value)}\n`, "utf8");
+  const tempPath = `${filePath}.${process.pid}.${atomicWriteCounter++}.tmp`;
+  try {
+    await fs.writeFile(tempPath, content, "utf8");
+    await fs.rename(tempPath, filePath);
+  } catch (error) {
+    await fs.rm(tempPath, { force: true }).catch(() => {});
+    throw error;
+  }
+}
+
+export async function writeJson(filePath, value) {
+  await atomicWriteFile(filePath, `${stableStringify(value)}\n`);
 }
 
 // String-aware JSONC comment stripper. Unlike a naive regex, it never treats
@@ -195,8 +217,7 @@ export async function formatRepositoryJson(value) {
 }
 
 export async function writeRepositoryJson(filePath, value) {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  await fs.writeFile(filePath, await formatRepositoryJson(value), "utf8");
+  await atomicWriteFile(filePath, await formatRepositoryJson(value));
 }
 
 export function artifactFilePath(relativePath, options = {}) {

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -1,4 +1,13 @@
 import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, test } from "vitest";
 import {
   stripUrls,
@@ -18,6 +27,7 @@ import {
   clusterDomainFromUrl,
   buildSubnetLineageLinks,
   sanitizeFixtureBody,
+  writeJson,
 } from "../scripts/lib.mjs";
 
 describe("stripUrls", () => {
@@ -561,6 +571,29 @@ describe("buildSubnetLineageLinks", () => {
   test("returns [] for empty inputs", () => {
     assert.deepEqual(buildSubnetLineageLinks([], []), []);
     assert.deepEqual(buildSubnetLineageLinks(undefined, undefined), []);
+  });
+});
+
+describe("writeJson (atomic)", () => {
+  test("writes JSON atomically via a temp file + rename", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wj-ok-"));
+    const file = path.join(dir, "out.json");
+    await writeJson(file, { a: 1, b: [2, 3] });
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf8")), { a: 1, b: [2, 3] });
+    assert.ok(readFileSync(file, "utf8").endsWith("\n"));
+    // no temp artifact survives a successful write
+    assert.equal(readdirSync(dir).filter((f) => f.endsWith(".tmp")).length, 0);
+  });
+
+  test("rethrows and cleans up the temp file when the rename fails", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wj-fail-"));
+    // target is a non-empty directory → rename(tempFile, dir) fails
+    const target = path.join(dir, "blocked");
+    mkdirSync(target);
+    writeFileSync(path.join(target, "child"), "x");
+    await assert.rejects(() => writeJson(target, { a: 1 }));
+    // the staged *.tmp must not be left behind
+    assert.equal(readdirSync(dir).filter((f) => f.endsWith(".tmp")).length, 0);
   });
 });
 


### PR DESCRIPTION
Fixes the intermittent, CI-only test race flagged after #410.

**Root cause:** `tests/artifacts.test.mjs` runs the real `build-artifacts.mjs` (rewriting `public/metagraph/*.json` in place, ~58s). vitest runs test files in parallel, so tests that read those artifacts via `createLocalArtifactEnv()` (e.g. `subnet-slug.test.mjs`) could hit the **zero-length window** of a plain truncate-write → `JSON.parse` fails → `404 !== 200`. Adding any new test file shifts scheduling and can expose it.

**Fix:** `writeJson` / `writeRepositoryJson` now write **atomically** — stage to a sibling temp path (same dir → same filesystem → `rename()` is atomic), then rename over the target. A concurrent reader always sees a complete old-or-new file, never a partial one. Temp is cleaned up on failure. This also hardens the publish pipeline.

**Verified:** ran `npm run test:coverage` repeatedly with extra throwaway test files to perturb scheduling — **0 race symptoms across runs** (was intermittent before). New `writeJson` test covers both the success and rename-failure paths (lib.mjs is coverage-included).

This is part of making CI rock-solid ahead of community contributions.