### PR TITLE
fix: harden provider cluster domain derivation

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -664,7 +664,8 @@ const gapsIndex = mergedSubnets.map((subnet) => ({
 
 // Generic hosting/social domains that must NOT form a shared-team cluster — a
 // github.com repo URL is not a shared team. Providers on these fall back to
-// their own id (singleton cluster).
+// their own id (singleton cluster). Multi-tenant hosts are matched by suffix so
+// tenant pages like alice.github.io and bob.github.io cannot imply affiliation.
 const GENERIC_CLUSTER_HOSTS = new Set([
   "github.com",
   "gitlab.com",
@@ -682,6 +683,29 @@ const GENERIC_CLUSTER_HOSTS = new Set([
   "linktr.ee",
   "huggingface.co",
 ]);
+const GENERIC_CLUSTER_HOST_SUFFIXES = new Set([
+  "github.io",
+  "pages.dev",
+  "workers.dev",
+  "vercel.app",
+  "netlify.app",
+  "web.app",
+  "firebaseapp.com",
+  "herokuapp.com",
+  "fly.dev",
+  "glitch.me",
+  "repl.co",
+  "webflow.io",
+]);
+
+function isGenericClusterHost(host) {
+  return (
+    GENERIC_CLUSTER_HOSTS.has(host) ||
+    [...GENERIC_CLUSTER_HOST_SUFFIXES].some(
+      (suffix) => host === suffix || host.endsWith(`.${suffix}`),
+    )
+  );
+}
 
 // Turn the flat provider directory into the supply-side map of the flywheel
 // (issue #347): attach the netuids each provider operates (from its curated
@@ -712,7 +736,7 @@ const enrichedProviders = providers.map((provider) => {
     surface_count: providerSurfaces.length,
     endpoint_count: (endpointsByProvider.get(provider.id) || []).length,
     cluster_id:
-      clusterDomain && !GENERIC_CLUSTER_HOSTS.has(clusterDomain)
+      clusterDomain && !isGenericClusterHost(clusterDomain)
         ? clusterDomain
         : provider.id,
   };

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1054,17 +1054,115 @@ export function buildSubnetLineageLinks(sourceSubnets, targetSubnets) {
   );
 }
 
-// Naive registrable domain (eTLD+1 by last-two-labels) of a URL, for the
-// provider shared-team cluster heuristic (issue #347). Good enough for the
-// .io/.ai/.com domains Bittensor teams use; not PSL-accurate for multi-part
-// TLDs. Returns null on unparseable input.
+// Public/private suffixes that make the last-two-label heuristic unsafe for
+// provider shared-team clustering. This deliberately covers common multi-label
+// Public Suffix List rules and private multi-tenant hosts used for documentation
+// or app/site hosting; matched hosts cluster on the tenant label, not the shared
+// suffix (for example team-a.co.uk, not co.uk).
+const CLUSTER_MULTI_LABEL_SUFFIXES = new Set([
+  "ac.uk",
+  "co.uk",
+  "gov.uk",
+  "ltd.uk",
+  "me.uk",
+  "net.uk",
+  "nhs.uk",
+  "org.uk",
+  "plc.uk",
+  "sch.uk",
+  "asn.au",
+  "com.au",
+  "edu.au",
+  "gov.au",
+  "net.au",
+  "org.au",
+  "co.nz",
+  "geek.nz",
+  "gen.nz",
+  "govt.nz",
+  "iwi.nz",
+  "maori.nz",
+  "net.nz",
+  "org.nz",
+  "school.nz",
+  "ac.jp",
+  "co.jp",
+  "ed.jp",
+  "go.jp",
+  "gr.jp",
+  "ne.jp",
+  "or.jp",
+  "com.br",
+  "com.cn",
+  "com.hk",
+  "com.mx",
+  "com.sg",
+  "com.tr",
+  "com.tw",
+  "co.in",
+  "co.kr",
+  "co.za",
+  "github.io",
+  "pages.dev",
+  "workers.dev",
+  "vercel.app",
+  "netlify.app",
+  "web.app",
+  "firebaseapp.com",
+  "herokuapp.com",
+  "fly.dev",
+  "glitch.me",
+  "repl.co",
+  "webflow.io",
+]);
+
+const CLUSTER_COUNTRY_CODE_SECOND_LEVEL_SUFFIX_LABELS = new Set([
+  "ac",
+  "co",
+  "com",
+  "edu",
+  "go",
+  "gov",
+  "net",
+  "ne",
+  "or",
+  "org",
+]);
+
+function clusterSuffixDomain(host) {
+  const labels = host.split(".").filter(Boolean);
+  if (labels.length < 2) return host || null;
+  for (
+    let suffixLabelCount = labels.length;
+    suffixLabelCount >= 2;
+    suffixLabelCount -= 1
+  ) {
+    const suffix = labels.slice(-suffixLabelCount).join(".");
+    if (CLUSTER_MULTI_LABEL_SUFFIXES.has(suffix)) {
+      return labels.length > suffixLabelCount
+        ? labels.slice(-(suffixLabelCount + 1)).join(".")
+        : null;
+    }
+  }
+  const [secondLevel, topLevel] = labels.slice(-2);
+  if (
+    labels.length >= 3 &&
+    topLevel.length === 2 &&
+    CLUSTER_COUNTRY_CODE_SECOND_LEVEL_SUFFIX_LABELS.has(secondLevel)
+  ) {
+    return labels.slice(-3).join(".");
+  }
+  return labels.slice(-2).join(".");
+}
+
+// Registrable domain (eTLD+1) of a URL, for the provider shared-team cluster
+// heuristic (issue #347). Returns null on unparseable input or bare shared
+// suffixes that cannot identify a provider team.
 export function clusterDomainFromUrl(value) {
   if (typeof value !== "string") return null;
   try {
     const host = new URL(value).hostname.toLowerCase().replace(/^www\./, "");
-    const labels = host.split(".").filter(Boolean);
-    if (labels.length >= 2) return labels.slice(-2).join(".");
-    return host || null;
+    return clusterSuffixDomain(host);
   } catch {
     return null;
   }

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -784,6 +784,13 @@ test("public artifacts are internally consistent", () => {
     "x.com",
     "twitter.com",
   ]);
+  const GENERIC_CLUSTER_HOST_SUFFIXES = [
+    "github.io",
+    "pages.dev",
+    "workers.dev",
+    "vercel.app",
+    "netlify.app",
+  ];
   let providersWithNetuids = 0;
   for (const provider of providersArtifact.providers) {
     assert.ok(
@@ -813,6 +820,14 @@ test("public artifacts are internally consistent", () => {
     assert.ok(
       !GENERIC_CLUSTER_HOSTS.has(provider.cluster_id),
       `provider ${provider.id}: cluster_id must not be a generic host`,
+    );
+    assert.ok(
+      !GENERIC_CLUSTER_HOST_SUFFIXES.some(
+        (suffix) =>
+          provider.cluster_id === suffix ||
+          provider.cluster_id.endsWith(`.${suffix}`),
+      ),
+      `provider ${provider.id}: cluster_id must not be a multi-tenant host`,
     );
     if (provider.netuids.length) providersWithNetuids += 1;
   }

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -564,7 +564,7 @@ describe("buildSubnetLineageLinks", () => {
 });
 
 describe("clusterDomainFromUrl", () => {
-  test("returns the last-two-label registrable domain", () => {
+  test("returns the registrable domain for ordinary team domains", () => {
     assert.equal(
       clusterDomainFromUrl("https://docs.all-ways.io/x"),
       "all-ways.io",
@@ -577,6 +577,31 @@ describe("clusterDomainFromUrl", () => {
       clusterDomainFromUrl("https://backprop.finance"),
       "backprop.finance",
     );
+  });
+
+  test("keeps the tenant label for multi-label public and private suffixes", () => {
+    assert.equal(
+      clusterDomainFromUrl("https://team-a.co.uk/docs"),
+      "team-a.co.uk",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://team-b.co.uk/docs"),
+      "team-b.co.uk",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://alice.github.io"),
+      "alice.github.io",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://bob.pages.dev"),
+      "bob.pages.dev",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://team.example.com.ar"),
+      "example.com.ar",
+    );
+    assert.equal(clusterDomainFromUrl("https://co.uk"), null);
+    assert.equal(clusterDomainFromUrl("https://github.io"), null);
   });
   test("returns null for non-URL / non-string input", () => {
     assert.equal(clusterDomainFromUrl("not a url"), null);


### PR DESCRIPTION
### Motivation

- Prevent unrelated providers from being grouped by a naïve last-two-label hostname heuristic that collapses multi-label public suffixes (e.g. `team-a.co.uk` -> `co.uk`) or multi-tenant hosts (e.g. `alice.github.io` -> `github.io`).

### Description

- Replace the simple last-two-label logic in `clusterDomainFromUrl` with a suffix-aware `clusterSuffixDomain` that handles known multi-label public suffixes and country-code second-level patterns and returns `null` for bare shared suffixes. 
- Add `CLUSTER_MULTI_LABEL_SUFFIXES` and `CLUSTER_COUNTRY_CODE_SECOND_LEVEL_SUFFIX_LABELS` in `scripts/lib.mjs` and implement `clusterSuffixDomain` so tenant labels are preserved for multi-label suffixes.
- Block multi-tenant hosted pages by suffix in the build step by adding `GENERIC_CLUSTER_HOST_SUFFIXES` and `isGenericClusterHost` to `scripts/build-artifacts.mjs`, and use it when choosing `provider.cluster_id` so hosted tenant pages fall back to the provider id instead of implying affiliation.
- Add and adjust regression tests in `tests/lib-helpers.test.mjs` and `tests/artifacts.test.mjs` to cover multi-label public suffixes, multi-tenant hosting suffixes, and to assert `cluster_id` is not a multi-tenant host string.

### Testing

- Ran `npm run build:artifacts` which completed and produced artifacts successfully. 
- Ran `npx vitest run tests/lib-helpers.test.mjs` and the updated `clusterDomainFromUrl` tests passed. 
- Ran `npx vitest run tests/artifacts.test.mjs -t "public artifacts are internally consistent"` and the artifact consistency test passed. 
- Linting with `npm run lint -- scripts/lib.mjs scripts/build-artifacts.mjs tests/lib-helpers.test.mjs tests/artifacts.test.mjs` completed without errors; a full two-file Vitest run (`tests/lib-helpers.test.mjs tests/artifacts.test.mjs`) initially timed out in a long-running R2 upload history test due to environment limits but the targeted consistency and unit tests shown above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf49384c8832abd0ad2848a5054af)