### PR TITLE
docs: rename frontend worker references metagraph-finder → metagraphed-ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The contract chain is:
 
 Zod is not the backend source of truth in v1. If Zod helpers are added later, they should be generated consumer tooling for frontend/runtime form validation, not canonical registry authority.
 
-API consumers (including the separate `metagraph-finder` frontend) should start from `docs/api-stability.md` — the `/api/v1` stability contract covering the response envelope, pagination/sort/filter, cache profiles, `x-metagraph-*` headers, error codes, `meta.published_at` freshness, versioning guarantees, and copy-paste example queries. Generate a typed client from `/metagraph/openapi.json`, or consume the checked-in `generated/metagraphed-api.d.ts` and `generated/metagraphed-client.ts`.
+API consumers (including the separate `metagraphed-ui` frontend) should start from `docs/api-stability.md` — the `/api/v1` stability contract covering the response envelope, pagination/sort/filter, cache profiles, `x-metagraph-*` headers, error codes, `meta.published_at` freshness, versioning guarantees, and copy-paste example queries. Generate a typed client from `/metagraph/openapi.json`, or consume the checked-in `generated/metagraphed-api.d.ts` and `generated/metagraphed-client.ts`.
 
 Worker API routes expose stable envelopes over the same canonical artifacts:
 

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -2,7 +2,7 @@
 
 This is the consumer-facing stability contract for the Worker API served from
 `https://api.metagraph.sh/api/v1/*`. It is the reference for the frontend
-(`jsonbored/metagraph-finder`) and any external integrator. The canonical machine
+(`jsonbored/metagraphed-ui`) and any external integrator. The canonical machine
 contract is `public/metagraph/openapi.json` plus the generated
 `generated/metagraphed-api.d.ts` and `generated/metagraphed-client.ts`; this doc
 describes the guarantees around them. Behavior here is implemented in

--- a/docs/beta-roadmap.md
+++ b/docs/beta-roadmap.md
@@ -26,7 +26,7 @@ Locked decisions:
 
 - **Edge / moat:** coverage completeness, framed as _trustworthy, verified_
   completeness.
-- **Frontend:** `jsonbored/metagraph-finder` (Lovable-owned) stays a **separate
+- **Frontend:** `jsonbored/metagraphed-ui` (Lovable-owned) stays a **separate
   Cloudflare Worker** from the backend.
 - **Beta differentiator:** enable the read-only RPC proxy (with Cloudflare WAF +
   rate limiting as prerequisites).
@@ -188,7 +188,7 @@ examples):
   route patterns `metagraph.sh/api/*`, `metagraph.sh/metagraph/*`,
   `metagraph.sh/rpc/*`. Keep the `ASSETS` binding only for the compact
   `public/metagraph/*` artifacts. Drop SPA-serving responsibility.
-- **Frontend Worker (`metagraph-finder`)** — its own `wrangler` project, route
+- **Frontend Worker (`metagraphed-ui`)** — its own `wrangler` project, route
   `metagraph.sh/*` (catch-all, lowest precedence). Serves the SPA; its API base
   URL is same-origin `/api/v1`, so no CORS and no cross-origin cookies.
 - Cloudflare matches more-specific routes first, so `/api/*` and friends hit the
@@ -233,7 +233,7 @@ guarantees); and a handful of copy-paste example queries against the live beta.
   probe, time-bounded R2 reads (`r2_timeout` 504), and structured observability
   logging.
 - Restructure routing to two Workers via zone routes; coordinate the
-  `metagraph-finder` Worker project (architecture section). _Gated:_ needs the
+  `metagraphed-ui` Worker project (architecture section). _Gated:_ needs the
   frontend Worker deployed + DNS/zone-route changes, so the `wrangler.jsonc`
   `custom_domain` switch is intentionally not yet applied (it would orphan the
   apex until the UI Worker exists).
@@ -285,7 +285,7 @@ guarantees); and a handful of copy-paste example queries against the live beta.
 
 ## Open coordination items (not blockers)
 
-- Confirm the `metagraph-finder` deploy target (its own Worker project + route).
+- Confirm the `metagraphed-ui` deploy target (its own Worker project + route).
 - Decide whether to publish generated types as an npm package now or hand off
   files for beta.
 - Confirm the Cloudflare plan supports the WAF / Rate Limiting rules the RPC proxy

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -4,7 +4,7 @@ import { DOMAIN_TAGS } from "./domain-tags.mjs";
 export const CONTRACT_VERSION = "2026-06-06.1";
 export const SCHEMA_VERSION = 1;
 // The API + artifacts are served from the api subdomain; the bare apex
-// (metagraph.sh) is the metagraph-finder UI. PRIMARY_DOMAIN drives the OpenAPI
+// (metagraph.sh) is the metagraphed-ui UI. PRIMARY_DOMAIN drives the OpenAPI
 // server URL and the consumer metadata in contracts.json / api-index.json.
 export const PRIMARY_DOMAIN = "api.metagraph.sh";
 export const API_BASE_PATH = "/api/v1";


### PR DESCRIPTION
The frontend repo/worker was renamed **`metagraph-finder` → `metagraphed-ui`** (to pair with this backend). This updates the references in this repo to match.

All changes are **non-load-bearing** — this backend repo does not build or deploy the frontend worker, so these are documentation/comment hygiene only.

## Changed
- `docs/beta-roadmap.md` — 4 references (Frontend repo slug + Worker project name)
- `README.md` — API-consumers note naming the frontend
- `docs/api-stability.md` — frontend repo slug
- `src/contracts.mjs` — one code comment above `PRIMARY_DOMAIN`

## Preserved (deliberately untouched)
- Public hostnames `metagraph.sh` / `api.metagraph.sh`
- The `metagraph.sh/*` Cloudflare route
- `PRIMARY_DOMAIN = "api.metagraph.sh"` and all exported contract values

## Verification
- `npm run validate:contract-drift` ✓ (the `contracts.mjs` change is a comment — no generated artifact drifts)
- `npm run validate:docs` ✓

The worker-side rename (wrangler.jsonc + lockfiles + deploy docs) is in the companion PR [metagraphed-ui#48](https://github.com/JSONbored/metagraphed-ui/pull/48).