### PR TITLE
feat(release): categorized GitHub release notes + release-process ADR (#395)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,33 @@
+# Categorization for GitHub's auto-generated release notes (issue #395).
+#
+# The publish workflows (publish-client.yml / publish-python.yml) call
+# `gh release create --generate-notes`, which groups the merged PRs since the
+# previous release tag into the categories below by PR label. Until release-please
+# (issue #394) lands commit-type-driven notes, label your PRs to land them in the
+# right bucket; anything unlabeled falls into "Other Changes".
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+      - stale
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: 🚀 Features
+      labels:
+        - enhancement
+    - title: 🐛 Fixes
+      labels:
+        - bug
+    - title: 🔒 Security
+      labels:
+        - area:security
+    - title: 📚 Documentation
+      labels:
+        - documentation
+    - title: 🧹 Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -124,4 +124,5 @@ jobs:
           git push origin "$RELEASE_TAG"
           gh release create "$RELEASE_TAG" \
             --title "@jsonbored/metagraphed v$RELEASE_VERSION" \
+            --generate-notes \
             --notes "Published \`@jsonbored/metagraphed@$RELEASE_VERSION\` to npm with provenance via OIDC trusted publishing. https://www.npmjs.com/package/@jsonbored/metagraphed/v/$RELEASE_VERSION"

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -102,4 +102,5 @@ jobs:
           git push origin "$RELEASE_TAG"
           gh release create "$RELEASE_TAG" \
             --title "metagraphed (Python) v$RELEASE_VERSION" \
+            --generate-notes \
             --notes "Published \`metagraphed==$RELEASE_VERSION\` to PyPI via OIDC Trusted Publishing. https://pypi.org/project/metagraphed/$RELEASE_VERSION/"

--- a/docs/adr/0005-release-process.md
+++ b/docs/adr/0005-release-process.md
@@ -1,0 +1,73 @@
+# ADR 0005 — Release-channel policy
+
+Status: accepted (2026-06-12)
+
+## Context
+
+metagraphed is a private monorepo app (`private: true`) that **generates** two
+shippable client libraries from its OpenAPI contract, plus a continuously
+deployed hosted service. There are three distinct shipping tracks with different
+versioning rhythms, and until now the release-channel policy lived only in
+maintainers' heads:
+
+1. **npm — `@jsonbored/metagraphed`** (`packages/client/`): the typed TS client.
+   SemVer; published from `publish-client.yml`.
+2. **PyPI — `metagraphed`** (`python/`): the typed Python client. SemVer;
+   published from `publish-python.yml`. Blocked on the one-time PyPI
+   pending-publisher bootstrap (#378) before its first publish.
+3. **Hosted Worker / API / MCP**: continuous-deploy via `publish-cloudflare.yml`,
+   versioned by the date-string `CONTRACT_VERSION` in `src/contracts.mjs` — **not**
+   a packaged release.
+
+Both package workflows already use OIDC trusted publishing (no long-lived
+tokens), a hardened split unprivileged-build / privileged-publish design, a
+strict release gate (must be on `main`, strict SemVer, refuse if the tag or
+registry version already exists), and — as their final step — create the git tag
+and a matching GitHub Release. What was missing: a written policy for **which
+channels we use**, and release notes worth reading (the GitHub Release body was a
+hardcoded one-liner). This ADR records the policy and the categorized-notes
+mechanism (issue #395, part of the #392 release-engineering epic).
+
+## Decision
+
+**Release channels: npm + PyPI + GitHub Releases. GitHub Packages is
+deliberately excluded.**
+
+- **Each package publish creates a matching GitHub Release atomically.** One
+  workflow run does: publish to the registry → `git tag` (`client-v<ver>` /
+  `python-v<ver>`) → `gh release create`. The npm/PyPI version, the git tag, and
+  the GitHub Release are always the same version, created together. There is no
+  separate "make a GitHub release" step to forget.
+- **GitHub Packages is NOT used.** It is redundant with npmjs.org / PyPI (which
+  already carry provenance) and adds install-time auth friction (consumers would
+  need a GitHub token to `npm install`). GitHub Releases — the human-readable
+  changelog + tag — are kept; GitHub _Packages_ — the registry — are not.
+- **All publishing stays OIDC trusted publishing + provenance. No long-lived
+  tokens** (no `NPM_TOKEN` / PyPI API token in secrets). Publishes run in the
+  `npm-production` / `pypi-production` GitHub Environments.
+- **Release notes are auto-generated and categorized.** `.github/release.yml`
+  groups merged PRs since the previous release tag into Features / Fixes /
+  Security / Documentation / Other by PR label, and the workflows pass
+  `--generate-notes` to `gh release create` (the branded "published to npm/PyPI
+  via OIDC" line is kept as the note header).
+- **Triggers stay manual (`workflow_dispatch`).** A maintainer bumps the package
+  version on `main`, then dispatches the workflow; the gate refuses anything that
+  isn't strict SemVer / is already published. Automating the version bump +
+  changelog is deferred to release-please (#394).
+
+## Consequences
+
+- **Categorization is label-driven** (GitHub's native mechanism). PRs without a
+  type label land under "Other Changes". This is the lightweight, tool-agnostic
+  interim; commit-type-driven notes + an auto-maintained `CHANGELOG.md` arrive
+  with release-please monorepo mode (#394), at which point `--generate-notes` can
+  be swapped for release-please's notes.
+- **To cut a release:** bump the version in the package's `package.json` /
+  `pyproject.toml` on `main`, then run the corresponding `publish-*` workflow.
+  Do not hand-create tags or GitHub Releases — the workflow owns that.
+- **PyPI is one bootstrap away.** `publish-python.yml` is fully wired but cannot
+  authenticate until the PyPI pending publisher + `pypi-production` Environment
+  exist (#378, owner action).
+- The hosted Worker/API/MCP track is intentionally out of scope here — it has no
+  packaged release. A dedicated `MCP_SERVER_VERSION` SemVer (independent of the
+  date-string `CONTRACT_VERSION`) is tracked separately in #393.


### PR DESCRIPTION
Closes #395 (part of the #392 release-engineering epic) — the lightweight, tool-agnostic piece.

The package-publish workflows already bind **publish → git tag → GitHub Release** atomically via OIDC. This makes the Release body worth reading and writes down the channel policy.

## Changes
- **`.github/release.yml`** — GitHub auto-categorizes merged PRs into **Features / Fixes / Security / Documentation / Other** by label; excludes `duplicate`/`invalid`/`wontfix`/`stale` + bot authors.
- **`publish-client.yml` / `publish-python.yml`** — add `--generate-notes` to `gh release create`. The branded "published via OIDC" line stays as the note header; the categorized PR changelog is appended. *(Only the final release-notes step changed — the OIDC publish, split build/publish jobs, and the SemVer gate are untouched.)*
- **`docs/adr/0005-release-process.md`** — records the policy: npm (`@jsonbored/metagraphed`) + PyPI (`metagraphed`) + GitHub Releases; **GitHub Packages intentionally excluded** (redundant with registry provenance, adds install-time auth friction); all OIDC trusted-publishing + provenance, no long-lived tokens; manual `workflow_dispatch` with a strict SemVer gate.

## Notes
- Categorization is **label-driven** (GitHub's native mechanism) — unlabeled PRs land under "Other Changes". Commit-type-driven notes + an auto-maintained `CHANGELOG.md` come later with release-please (#394); MCP's own SemVer is #393.

## Verification
- `npm run validate:workflows` ✓ (7 workflows)
- `npm run validate:docs` ✓
- both workflows parse as YAML; `.github/release.yml` + ADR are prettier-clean