### PR TITLE
fix: bound fixture capture response reads

### DIFF
--- a/scripts/capture-fixtures.mjs
+++ b/scripts/capture-fixtures.mjs
@@ -33,6 +33,13 @@ const MAX_BYTES = 1_000_000; // hard cap before parsing
 const TIMEOUT_MS = 12_000;
 const CONCURRENCY = 6;
 
+class FixtureCaptureLimitError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = "FixtureCaptureLimitError";
+  }
+}
+
 async function mapLimit(items, limit, fn) {
   const results = [];
   let index = 0;
@@ -86,10 +93,14 @@ async function fetchSample(url, redirectCount = 0) {
         error: response.ok ? "non-json response" : `http ${response.status}`,
       };
     }
-    const raw = await response.text();
-    if (raw.length > MAX_BYTES) {
+    const contentLength = parseContentLength(
+      response.headers.get("content-length"),
+    );
+    if (contentLength !== null && contentLength > MAX_BYTES) {
+      await response.body?.cancel();
       return { ok: false, error: "response exceeds byte limit" };
     }
+    const raw = await readBoundedResponseText(response, MAX_BYTES);
     return {
       ok: true,
       status: response.status,
@@ -101,6 +112,50 @@ async function fetchSample(url, redirectCount = 0) {
   } finally {
     clearTimeout(timer);
   }
+}
+
+function parseContentLength(value) {
+  if (!value || !/^\d+$/.test(value)) {
+    return null;
+  }
+  return Number.parseInt(value, 10);
+}
+
+async function readBoundedResponseText(response, maxBytes) {
+  if (!response.body) {
+    return "";
+  }
+
+  const reader = response.body.getReader();
+  const chunks = [];
+  let receivedBytes = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      receivedBytes += value.byteLength;
+      if (receivedBytes > maxBytes) {
+        await reader.cancel();
+        throw new FixtureCaptureLimitError(
+          `JSON response exceeds ${maxBytes} byte limit`,
+        );
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(receivedBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(body);
 }
 
 const subnets = await loadSubnets();


### PR DESCRIPTION
### Motivation
- The fixture capture step used `response.text()` which buffers entire responses before enforcing `MAX_BYTES`, allowing attacker-controlled or streaming endpoints to exhaust CI memory.
- The script runs multiple concurrent fetches (`CONCURRENCY`) so unbounded reads multiply memory pressure across workers.

### Description
- Replace `response.text()` with a bounded reader: add `readBoundedResponseText(response, maxBytes)` that uses `response.body.getReader()` to count bytes and cancels the reader when the limit is exceeded.
- Reject oversized responses early by parsing `Content-Length` with `parseContentLength()` and cancelling when it reports a value larger than `MAX_BYTES`.
- Introduce `FixtureCaptureLimitError` to signal over-limit streamed responses and preserve the existing `{ ok: false, error, error_class }` handling and JSON parsing for within-limit responses.
- Keep existing redirect handling, content-type checks, JSON parsing, and `sanitizeFixtureBody` behavior unchanged for valid responses.

### Testing
- Ran linting with `npm run lint -- --quiet` and it passed.
- Performed a syntax/type check with `node --check scripts/capture-fixtures.mjs` and it passed.
- Exercised the script in dry-run mode with `npm run capture:fixtures:dry-run` and it completed successfully (returned a `dry-run` summary).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c144fabec832a8445423ea75ae8bc)