### PR TITLE
Suppress auth snippets on cleartext service URLs

### DIFF
--- a/src/integration-snippets.mjs
+++ b/src/integration-snippets.mjs
@@ -38,13 +38,23 @@ function isSnippetSafeUrl(url) {
   return typeof url === "string" && url.length > 0 && !/['"`\\\s]/.test(url);
 }
 
+function isCredentialSafeUrl(url) {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === "https:" || parsed.protocol === "wss:";
+  } catch {
+    return false;
+  }
+}
+
 // Returns { curl, python, typescript } or null when there is no usable base_url.
 export function generateServiceSnippets(service) {
   const url = service?.base_url;
   if (!isSnippetSafeUrl(url)) return null;
-  const authHeader = service?.auth_required
-    ? authHeaderForSchemes(service?.auth_schemes)
-    : null;
+  const authHeader =
+    service?.auth_required && isCredentialSafeUrl(url)
+      ? authHeaderForSchemes(service?.auth_schemes)
+      : null;
 
   const curl = authHeader
     ? `curl -sS '${url}' \\\n  -H '${authHeader.name}: ${authHeader.value}'`

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -793,10 +793,10 @@ export const MCP_TOOLS = [
           required: Boolean(s.auth_required),
           schemes: Array.isArray(s.auth_schemes) ? s.auth_schemes : [],
         },
-        // Ready-to-run curl/Python/TS for a first call (issue #351), generated
-        // at build time from base_url + auth. Falls back to on-the-fly
-        // generation for older catalogs that predate the field.
-        snippets: s.snippets || generateServiceSnippets(s) || null,
+        // Ready-to-run curl/Python/TS for a first call (issue #351).
+        // Regenerate from base_url + auth so cleartext credential guards stay
+        // current even when reading older catalogs with stored snippets.
+        snippets: generateServiceSnippets(s) || s.snippets || null,
         schema: s.schema_artifact
           ? {
               available: true,

--- a/tests/integration-snippets.test.mjs
+++ b/tests/integration-snippets.test.mjs
@@ -53,6 +53,38 @@ describe("generateServiceSnippets (#351)", () => {
     assert.match(out.curl, /Authorization: Bearer YOUR_API_KEY/);
   });
 
+  test("does not include credential placeholders for cleartext auth URLs", () => {
+    for (const base_url of [
+      "http://api.example.io/v1",
+      "ws://api.example.io/socket",
+    ]) {
+      const out = generateServiceSnippets({
+        base_url,
+        auth_required: true,
+        auth_schemes: ["apiKey"],
+      });
+
+      assert.equal(out.curl, `curl -sS '${base_url}'`);
+      assert.ok(!out.curl.includes("YOUR_API_KEY"));
+      assert.ok(!out.python.includes("YOUR_API_KEY"));
+      assert.ok(!out.typescript.includes("YOUR_API_KEY"));
+      assert.ok(!out.python.includes("headers="));
+      assert.ok(!out.typescript.includes("headers"));
+    }
+  });
+
+  test("allows credential placeholders for TLS-protected wss URLs", () => {
+    const out = generateServiceSnippets({
+      base_url: "wss://api.example.io/socket",
+      auth_required: true,
+      auth_schemes: ["bearer"],
+    });
+
+    assert.match(out.curl, /Authorization: Bearer YOUR_API_KEY/);
+    assert.match(out.python, /Authorization/);
+    assert.match(out.typescript, /Authorization/);
+  });
+
   test("returns null for missing or unsafe base_url", () => {
     assert.equal(generateServiceSnippets({ base_url: null }), null);
     assert.equal(generateServiceSnippets({}), null);

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1075,6 +1075,33 @@ describe("MCP goal-shaped tools (find_subnet_for_task + how_do_i_call)", () => {
     assert.ok(out.next_steps.some((s) => /get_subnet_health/.test(s)));
   });
 
+  test("how_do_i_call regenerates snippets without cleartext credentials", async () => {
+    const cleartextDetail = structuredClone(callDetail);
+    const service =
+      cleartextDetail["/metagraph/agent-catalog/7.json"].services[0];
+    service.base_url = "http://api.data.io";
+    service.snippets = {
+      curl: "curl -sS 'http://api.data.io' -H 'X-API-Key: YOUR_API_KEY'",
+      python:
+        'requests.get("http://api.data.io", headers={"X-API-Key": "YOUR_API_KEY"})',
+      typescript:
+        'fetch("http://api.data.io", { headers: { "X-API-Key": "YOUR_API_KEY" } })',
+    };
+
+    const res = await callTool(
+      "how_do_i_call",
+      { netuid: 7 },
+      { deps: makeDeps(cleartextDetail) },
+    );
+
+    assert.equal(res.status, 200);
+    const snippets = res.body.result.structuredContent.services[0].snippets;
+    assert.equal(snippets.curl, "curl -sS 'http://api.data.io'");
+    assert.ok(!snippets.curl.includes("YOUR_API_KEY"));
+    assert.ok(!snippets.python.includes("YOUR_API_KEY"));
+    assert.ok(!snippets.typescript.includes("YOUR_API_KEY"));
+  });
+
   test("how_do_i_call resolves a subnet by chain native_slug", async () => {
     const res = await callTool(
       "how_do_i_call",


### PR DESCRIPTION
### Motivation
- The snippet generator could emit credential-bearing examples for `http:`/`ws:` service URLs, risking credential disclosure over cleartext transport.\
- Prevent generating auth headers for non-TLS transports while preserving the original helper behavior for TLS (`https:`/`wss:`).\

### Description
- Add `isCredentialSafeUrl(url)` which accepts only `https:` or `wss:` and uses it to gate credential placeholders in `generateServiceSnippets`.\
- Only populate `authHeader` when `service.auth_required` is true and `isCredentialSafeUrl(url)` returns true.\
- Change MCP response construction to prefer `generateServiceSnippets(s)` over stored `s.snippets` so stale catalog snippets don’t reintroduce cleartext credentials.\
- Add unit and MCP regression tests in `tests/integration-snippets.test.mjs` and `tests/mcp-server.test.mjs` to cover cleartext (`http://`/`ws://`) and TLS (`wss://`) cases.\

### Testing
- Ran lint with `npm run lint` and formatting check with `npx prettier --check`; both succeeded.\
- Ran focused unit tests with `npx vitest run tests/integration-snippets.test.mjs` and the targeted MCP tests with `npx vitest run tests/mcp-server.test.mjs -t "generateServiceSnippets|how_do_i_call"`; the targeted test runs passed.\
- Note: a full run of `tests/mcp-server.test.mjs` still exhibits a pre-existing environment/local-artifact failure in one unrelated test (`POST /mcp tools/call resolves real artifacts from the local env`) where `body.result.structuredContent` was undefined; the regression coverage added here passes in targeted runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c144faed0832aa8fc08fe6bdbd5ab)