### PR TITLE
fix: harden atomic JSON writes

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -126,26 +126,29 @@ export async function readArtifactJson(relativePath) {
   return readJson(artifactFilePath(relativePath));
 }
 
-// Monotonic suffix so two writers (or one writer with many files) never collide
-// on a temp name within a process.
-let atomicWriteCounter = 0;
-
-// Write a file atomically: stage to a sibling temp path (same directory, so the
-// same filesystem → rename() is atomic) then rename over the target. A
-// concurrent reader always sees a complete old-or-new file, never the
-// zero-length window a plain truncate-write exposes. This makes the build safe
-// to run while tests / the Worker read the committed artifacts in parallel
-// (fixes the vitest file-scheduling race where a reader saw a half-written
-// subnets.json and 404'd).
+// Write a file atomically: stage inside a private sibling temp directory (same
+// filesystem, so rename() is atomic) then rename over the target. A concurrent
+// reader always sees a complete old-or-new file, never the zero-length window a
+// plain truncate-write exposes. The randomly-created temp directory also avoids
+// following attacker-precreated symlinks at predictable staging paths. This
+// makes the build safe to run while tests / the Worker read the committed
+// artifacts in parallel (fixes the vitest file-scheduling race where a reader
+// saw a half-written subnets.json and 404'd).
 async function atomicWriteFile(filePath, content) {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
-  const tempPath = `${filePath}.${process.pid}.${atomicWriteCounter++}.tmp`;
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+  const tempDir = await fs.mkdtemp(
+    path.join(dir, `${path.basename(filePath)}.${process.pid}.`),
+  );
+  const tempPath = path.join(tempDir, "write.tmp");
   try {
     await fs.writeFile(tempPath, content, "utf8");
     await fs.rename(tempPath, filePath);
   } catch (error) {
     await fs.rm(tempPath, { force: true }).catch(() => {});
     throw error;
+  } finally {
+    await fs.rm(tempDir, { force: true, recursive: true }).catch(() => {});
   }
 }
 
@@ -1147,7 +1150,10 @@ export function deriveDescriptionFromNotes(notes, { maxLength = 280 } = {}) {
   const cleaned = cleanDescription(notes);
   if (!cleaned) return null;
   if (cleaned.length <= maxLength) return cleaned;
-  return `${cleaned.slice(0, maxLength).replace(/\s+\S*$/, "").trimEnd()}…`;
+  return `${cleaned
+    .slice(0, maxLength)
+    .replace(/\s+\S*$/, "")
+    .trimEnd()}…`;
 }
 
 // Derive auth metadata from a captured OpenAPI/Swagger spec: OpenAPI 3

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import {
   mkdirSync,
+  lstatSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -341,7 +343,10 @@ describe("isPlaceholderIdentityUrl", () => {
     assert.equal(isPlaceholderIdentityUrl("https://example.com"), true);
   });
   test("passes real links and non-strings through as not-placeholder", () => {
-    assert.equal(isPlaceholderIdentityUrl("https://github.com/opentensor/bt"), false);
+    assert.equal(
+      isPlaceholderIdentityUrl("https://github.com/opentensor/bt"),
+      false,
+    );
     assert.equal(isPlaceholderIdentityUrl("https://taofu.xyz"), false);
     assert.equal(isPlaceholderIdentityUrl(null), false);
     assert.equal(isPlaceholderIdentityUrl(undefined), false);
@@ -361,7 +366,10 @@ describe("backfilledIdentityUrl", () => {
       "https://github.com/opentensor/bittensor",
     );
     // bare domain gets https:// prefixed (root path keeps its trailing slash)
-    assert.equal(backfilledIdentityUrl(undefined, "nodexo.ai"), "https://nodexo.ai/");
+    assert.equal(
+      backfilledIdentityUrl(undefined, "nodexo.ai"),
+      "https://nodexo.ai/",
+    );
   });
   test("rejects placeholder junk and unusable chain values", () => {
     assert.equal(backfilledIdentityUrl(null, "https://deprecated.png"), null);
@@ -575,11 +583,30 @@ describe("buildSubnetLineageLinks", () => {
 });
 
 describe("writeJson (atomic)", () => {
+  test("does not follow a preexisting predictable temp-path symlink", async () => {
+    const dir = mkdtempSync(path.join(tmpdir(), "wj-symlink-"));
+    const file = path.join(dir, "out.json");
+    const clobberTarget = path.join(dir, "clobbered.txt");
+    const oldPredictableTempPath = `${file}.${process.pid}.0.tmp`;
+    writeFileSync(clobberTarget, "keep me");
+    symlinkSync(clobberTarget, oldPredictableTempPath);
+
+    await writeJson(file, { safe: true });
+
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf8")), { safe: true });
+    assert.equal(readFileSync(clobberTarget, "utf8"), "keep me");
+    assert.equal(lstatSync(file).isSymbolicLink(), false);
+    assert.equal(lstatSync(oldPredictableTempPath).isSymbolicLink(), true);
+  });
+
   test("writes JSON atomically via a temp file + rename", async () => {
     const dir = mkdtempSync(path.join(tmpdir(), "wj-ok-"));
     const file = path.join(dir, "out.json");
     await writeJson(file, { a: 1, b: [2, 3] });
-    assert.deepEqual(JSON.parse(readFileSync(file, "utf8")), { a: 1, b: [2, 3] });
+    assert.deepEqual(JSON.parse(readFileSync(file, "utf8")), {
+      a: 1,
+      b: [2, 3],
+    });
     assert.ok(readFileSync(file, "utf8").endsWith("\n"));
     // no temp artifact survives a successful write
     assert.equal(readdirSync(dir).filter((f) => f.endsWith(".tmp")).length, 0);


### PR DESCRIPTION
### Motivation
- The atomic writer previously staged output to a predictable sibling temp path derived from the final path, PID, and a counter which allowed an attacker with write access to precreate a symlink and cause `fs.writeFile` to follow it and `rename` the symlink over the intended output.
- Hardening is needed to avoid symlink-follow/trampoline attacks while preserving the atomic rename semantics that fixed the test race.

### Description
- Replace the deterministic temp-file staging with a private staging directory created via `fs.mkdtemp` inside the target directory and write the temp file inside that directory, preserving atomic `rename` semantics (`scripts/lib.mjs`).
- Ensure the staging directory is removed in all paths by cleaning it up in a `finally` block (`scripts/lib.mjs`).
- Add a regression test that pre-creates the old predictable temp-path symlink and asserts `writeJson` does not follow or clobber it, and adjust imports to use `symlinkSync`/`lstatSync` in the test (`tests/lib-helpers.test.mjs`).

### Testing
- Ran `npm test -- --run tests/lib-helpers.test.mjs` and the single test file completed successfully (all tests passed).
- Ran `npm run lint` and it completed without new lint errors for the changed files.
- Ran `npm run format:check` which reported existing unrelated formatting warnings in other files but did not affect the correctness of the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c130aa1f8832a9f09c87322cbc6df)