### PR TITLE
fix(ci): pin pypi-publish to the v1.14.0 commit SHA (was the tag-object SHA)

### DIFF
--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -83,7 +83,7 @@ jobs:
           path: ${{ runner.temp }}/dist
 
       - name: Publish to PyPI (OIDC Trusted Publishing)
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: ${{ runner.temp }}/dist
 


### PR DESCRIPTION
The **Publish Python SDK** workflow failed at the publish step:

```
docker: Error response from daemon: manifest unknown
Unable to find image 'ghcr.io/pypa/gh-action-pypi-publish:6733eb7d741f0b11ec6a39b58540dab7590f9b7d'
```

## Cause
The action was pinned to `6733eb7d741f0b11ec6a39b58540dab7590f9b7d`, which is the **annotated tag object** SHA of `v1.14.0`, not the commit. `pypa/gh-action-pypi-publish` is a **Docker** action, so GitHub pulls `ghcr.io/pypa/gh-action-pypi-publish:<pinned-sha>` — and pypa only publishes images tagged by the **commit** SHA. The tag-object SHA has no image → 404.

Verified against ghcr.io:
- `6733eb7d…` (tag object) → **404**
- `cef22109…` (v1.14.0 commit) → **200** ✅

## Fix
Repin to the real v1.14.0 commit `cef221092ed1bacb1cc03d23a2d87d1d172e277b`. Still fully SHA-pinned (immutable, supply-chain-safe) — just the *correct* SHA. Only `pypa/gh-action-pypi-publish` was affected; the JS actions (checkout/setup-uv/upload-artifact) tolerate tag-object SHAs and already pass CI.

`validate:workflows` passes.