### PR TITLE
fix(test): serialize test files to end the flaky artifact-read race (404≠200)

### DIFF
--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -4,6 +4,22 @@ export default defineConfig({
   test: {
     environment: "node",
     exclude: ["node_modules/**", "private/**"],
+    // Run test FILES sequentially (each still in its own isolated fork). The
+    // artifact-build tests (tests/artifacts.test.mjs) execFileSync the real
+    // scripts/build-artifacts.mjs, which mutates the shared on-disk artifact
+    // trees in place: it rm's + repopulates the R2 staging dir
+    // (dist/metagraph-r2/metagraph, where R2-only artifacts such as
+    // registry-summary.json live with NO committed public/metagraph fallback)
+    // and writeFileSyncs forged JSON into committed public/metagraph files
+    // before restoring them. Reader tests that serve those artifacts via
+    // createLocalArtifactEnv (subnet-overview, mcp-server, api-coverage, …)
+    // would otherwise race that rebuild and intermittently 404 (e.g.
+    // GET /api/v1/registry/summary -> 404 instead of 200). The build output
+    // root resolves from the script's own location, so it can't be redirected
+    // to a temp dir without a full input+output tree copy — serializing files
+    // is the clean, low-risk fix. Per-file fork isolation is preserved; only
+    // filesystem-race concurrency is removed.
+    fileParallelism: false,
     coverage: {
       provider: "v8",
       reporter: ["text", "json-summary"],


### PR DESCRIPTION
Fixes the intermittent CI flake where reader tests assert 200 but get **404** from R2-only artifact routes (seen on #423: `GET /api/v1/registry/summary` → 404 in the `validate` Test step; a rerun went green).

## Root cause
`tests/artifacts.test.mjs` `execFileSync`s the real `scripts/build-artifacts.mjs` (8 call sites). That build:
- `fs.rm`s the entire shared R2 staging dir `dist/metagraph-r2/metagraph` (`build-artifacts.mjs:201`) and only re-writes `registry-summary.json` ~1500 lines later (`:1772`), and
- the tampering tests `writeFileSync` forged JSON into **committed** `public/metagraph` files, restoring them in `finally`.

`registry-summary.json` (and other R2-only artifacts) are **not committed** to `public/metagraph`, so during the rebuild window they're absent from *both* the staging and public paths. Reader tests that serve them via `createLocalArtifactEnv` (`subnet-overview`, `mcp-server`, `api-coverage`, +~12 more) then hit `readArtifact`'s R2 404. Vitest's default forks pool runs files **in parallel sharing one working dir** (no isolation in `vitest.config.mjs`), so the mutator races the readers.

## Fix
`fileParallelism: false` — files run sequentially, each still in its own isolated fork (module-state isolation preserved; only filesystem-race concurrency removed). The build output root resolves from the script's own location and the tampering mutates shared **inputs**, so redirecting the build to a temp dir would need a full input+output tree copy — serializing is the clean, low-risk fix.

## Verification (reproduced + disproved)
A throwaway probe hammering `/api/v1/registry/summary` while `artifacts.test.mjs` rebuilds:
- **Parallelism forced on:** `232/800`, `212/800`, `217/800` requests returned **404** (~27%) — the flake, on demand.
- **Serial (this fix):** **0** non-200 across repeated runs.

Full suite **843/843**, coverage gate green. Cost: ~10–15s (full suite ~39s serial locally).