### PR TITLE
docs: relicense to AGPL-3.0 (Apache-2.0 SDKs) + contributor-ready docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the maintainers privately via the repository's confidential reporting channel — open a [GitHub security advisory](https://github.com/JSONbored/metagraphed/security/advisories/new) or contact the maintainer [@JSONbored](https://github.com/JSONbored). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,223 +1,82 @@
-# Contributing To Metagraphed
+# Contributing to Metagraphed
 
-Metagraphed is a backend-first operational registry for Bittensor subnet interfaces. The source of truth is reviewed JSON in this repo; generated artifacts under `public/metagraph` are projections of that source.
+Metagraphed is the Bittensor subnet integration registry — every subnet, metagraphed. This is the backend: a Cloudflare Worker API plus Node build scripts. **JSON Schema is the canonical contract** → OpenAPI → typed clients. Generated artifacts under `public/metagraph/` are projections of reviewed source, never hand-authored truth.
 
-## Local Checks
+Live: [metagraph.sh](https://metagraph.sh) · API [api.metagraph.sh](https://api.metagraph.sh) · License AGPL-3.0 (Apache-2.0 client SDKs)
+
+Two kinds of contribution, two paths:
+
+- **Code / schema changes** → normal feature PR, run the gates below.
+- **Community data** → one candidate JSON file, see [Community submissions](#community-submissions).
+
+## Setup & gates
 
 Use Node 22.
 
 ```bash
-npm ci
-npm run pipeline:check
-```
-
-Before opening a PR that changes public contracts, also run:
-
-```bash
-npm run test:coverage
-git diff --check
-```
-
-For smaller changes, run the focused checks that match the files you touched:
-
-```bash
+npm install
+npm test
 npm run validate
-npm run validate:schemas
-npm run validate:api
-npm run validate:openapi
-npm run worker:test
-npm run scan:public-safety
+npm run build
 ```
 
-## Registry Data Rules
+`npm run validate` runs schema, API, and OpenAPI checks. For a full local data pipeline run, use `npm run pipeline:check`. Match focused checks to what you touch (`npm run validate:schemas`, `validate:api`, `validate:openapi`, `worker:test`) rather than running everything.
 
-- Native subnet existence comes from the Bittensor/Finney chain snapshot.
-- Public interface metadata comes from curated overlays or reviewed candidate records.
-- Third-party directories, docs, GitHub READMEs, and websites are enrichment sources only.
-- Do not add secrets, PATs, wallet paths, private dashboards, private URLs, validator-local state, or credentialed API flows.
-- Do not invent API/status surfaces for subnets that do not publish them.
-- Preserve raw native chain values separately from curated display metadata.
-- Treat duplicate `netuid + kind + URL` records as data-quality bugs.
+## Schema-first rule
 
-## Community Intake
+The contract is generated, so you never edit it by hand:
 
-Community submissions can become candidates, not direct registry truth. There are
-two supported paths:
+1. Edit the source under `schemas/` or `schemas/components/`.
+2. Run `npm run build` to regenerate `openapi.json` and the types/clients.
+3. **Commit the regenerated artifacts in the same PR.**
 
-- PR-first: add exactly one `registry/candidates/community/*.json` candidate
-  document or exactly one `registry/providers/community/*.json` provider
-  profile document and no other files.
-- Issue-first: submit an `interface-submission`, `profile-correction`,
-  `endpoint-submission`, `provider-submission`, or `status-report` issue and
-  let the import/review workflow create the candidate PR after approval.
-- Endpoint/provider/status issues: submit endpoint resources, provider profiles,
-  or status reports through the matching issue template. These create review or
-  re-probe work; they do not directly change observed health.
+Skipping the rebuild trips `validate:contract-drift` in CI. Schemas are the source of truth; everything downstream follows.
 
-## What To Submit First
+## Where to start
 
-The most useful contributions are public operational facts that close real
-registry gaps:
+- **Issues** labeled [`good first issue`](https://github.com/JSONbored/metagraphed/labels/good%20first%20issue) and [`help wanted`](https://github.com/JSONbored/metagraphed/labels/help%20wanted) are scoped and ready.
+- **Data gaps** — generate the current curation queue: `npm run curation:brief` (add `-- --limit 20` for more, `-- --json` for machine-readable). Start with profile-light subnets: directory-only entries, missing websites or source repos, public APIs with no OpenAPI metadata yet. See [`docs/curation-playbook.md`](docs/curation-playbook.md).
 
-- official docs;
-- official website;
-- source repository;
-- dashboard or explorer;
-- OpenAPI/Swagger schema URL;
-- public subnet API URL;
-- SSE endpoint;
-- public data artifact;
-- SDK or example repository.
+## Community submissions
 
-Start with subnets that are still profile-light: directory-only entries,
-subnets missing websites or source repos, and subnets with public APIs that do
-not yet have OpenAPI/schema metadata in Metagraphed.
+Community data becomes a reviewed **candidate**, not direct registry truth. PR-first is the simplest path:
 
-Generate the current queue with:
+> Add **exactly one** file — `registry/candidates/community/*.json` (a candidate) **or** `registry/providers/community/*.json` (a provider profile) — and **nothing else**. No generated artifacts.
+
+Generate a candidate locally:
 
 ```bash
-npm run curation:brief
+npm run candidate:new -- \
+  --netuid 7 --kind docs \
+  --url https://docs.example.com \
+  --source-url https://github.com/example/project \
+  --provider community --submitted-by <github-login> --write
 ```
 
-The curation playbook is in `docs/curation-playbook.md`.
+A good candidate PR is small: one public URL, one source URL proving the claim, one active netuid, no generated files. Best kinds (these can be auto-reviewed): `docs`, `website`, `source-repo`, `dashboard`, `openapi`, `subnet-api`, `sse`, `data-artifact`, `sdk`, `example`.
 
-Good direct candidate PRs are small: exactly one public URL, one public source
-URL proving the claim, one active netuid, and no generated artifacts.
+**Routes to manual review** (still welcome, just won't auto-merge): provider/operator profiles, base-layer `subtensor-rpc`/`subtensor-wss`/`archive` endpoints, authenticated or paid APIs, unknown providers, adapter requests, status reports, identity disputes.
 
-## Auto-Reviewed vs Manual
+**Hard boundaries:**
 
-Safe direct candidate PRs can be AI-reviewed by the private Metagraphed gate and
-may be merged automatically by the GitHub App after public checks pass. These
-are usually app-layer or docs/data surfaces such as `docs`, `website`,
-`source-repo`, `dashboard`, `openapi`, `subnet-api`, `sse`, `data-artifact`,
-`sdk`, `example`, and `repo-registry`.
+- Health, uptime, latency, incidents, and pool eligibility are **probe-derived only**. Reports can trigger a re-probe; they can never set observed state.
+- No secrets, PATs, wallet paths, private URLs, or validator-local data.
+- Don't invent API/status surfaces a subnet doesn't publish.
+- Schema-valid ≠ accepted. A private review gate makes the final call.
 
-The gate still routes higher-risk or ambiguous submissions to manual review:
+Prefer issues? Use the `interface-submission`, `profile-correction`, `endpoint-submission`, `provider-submission`, or `status-report` template — an approved issue opens the candidate PR for you. Full contract in [`docs/submission-gate.md`](docs/submission-gate.md).
 
-- provider/operator profiles;
-- Bittensor base-layer `subtensor-rpc`, `subtensor-wss`, or `archive`
-  endpoints;
-- authenticated or paid APIs;
-- unknown providers/operators;
-- adapter requests;
-- endpoint status reports;
-- identity disputes or conflicting official sources.
+## Pull requests
 
-Do not submit health, uptime, latency, incident, or pool-eligibility values.
-Those are generated only from Metagraphed probes and adapters. Status reports
-can trigger review or a future re-probe, but they cannot change observed
-operational state directly.
+- Short and focused, Conventional Commit-style titles.
+- Include the validation commands you ran in the PR body.
+- No local paths, machine-specific setup, env dumps, or private notes.
+- Keep UI/frontend work out of this repo — it owns backend data contracts and generated JSON. The web app lives at [metagraphed-ui](https://github.com/JSONbored/metagraphed-ui).
 
-You can generate a direct candidate PR file locally:
+## Deeper docs
 
-```bash
-npm run candidate:new -- --netuid 7 --kind docs --url https://docs.all-ways.io/community-submission-example --source-url https://docs.all-ways.io/how-it-works.html --provider allways --submitted-by <github-login> --write
-```
+- [`docs/submission-gate.md`](docs/submission-gate.md) — full community submission contract.
+- [`docs/curation-playbook.md`](docs/curation-playbook.md) — what to curate and in what order.
+- [`docs/api-stability.md`](docs/api-stability.md) — API/contract stability guarantees.
 
-You can generate a direct provider profile review file locally:
-
-```bash
-npm run provider:new -- --id example-operator --name "Example Operator" --kind infrastructure-provider --website-url https://example.com --docs-url https://docs.example.com --github-url https://github.com/example --contact-url https://example.com/contact --submitted-by <github-login> --write
-```
-
-Example payloads live under `docs/examples/submissions`.
-Useful examples include direct candidates, endpoint resources, OpenAPI/schema
-URLs, provider profiles, profile/source corrections, and status reports.
-
-Live PR references:
-
-- AI-merged safe candidate example:
-  https://github.com/JSONbored/metagraphed/pull/96
-- Manual-review direct candidate example:
-  https://github.com/JSONbored/metagraphed/pull/84
-- Closed duplicate candidate example:
-  https://github.com/JSONbored/metagraphed/pull/105
-
-Do not include generated `public/metagraph/**` artifacts, native snapshots,
-workflow/script changes, secrets, wallet/PAT material, private URLs, or
-validator-local data in UGC submissions.
-
-The public submission gate performs deterministic checks first:
-
-- active Finney netuid;
-- supported surface kind;
-- registered provider;
-- public-safe interface and source URLs;
-- one candidate per submission;
-- one provider profile per provider submission;
-- no duplicate curated surface or candidate;
-- submitter provenance for direct PRs;
-- no generated artifact edits.
-
-Provider profile submissions are review inputs only. They cannot claim official
-authority, cannot make endpoints pool-eligible, and cannot directly edit
-canonical `registry/providers/*.json` entries.
-
-Passing public preflight routes the submission into private gate review. The
-private reviewer may merge/import clean submissions, close hard failures, or
-route rare edge cases to manual review. Public comments expose broad reason
-categories only; private scoring prompts, thresholds, and corpus weights are not
-part of the public repo.
-
-Maintainer automation branches such as `codex/*` are intentionally ignored by
-the private UGC gate. Contributor examples should use normal feature branches
-with one candidate or provider file.
-
-Status reports never set uptime, latency, health status, incident state, or pool
-eligibility. They can only trigger review or a future re-probe; operational state
-comes from Metagraphed probes and adapters.
-
-Profile/source corrections are welcome for official websites, docs, source
-repos, dashboards, OpenAPI/schema URLs, SDKs, examples, or public data artifacts.
-Approved corrections improve profile completeness and gap reports; they do not
-override native chain state or observed endpoint health.
-
-The issue import flow is:
-
-1. Submit an `interface-submission` issue.
-2. `intake:dry-run` parses and validates the issue.
-3. The submission gate reviews source facts and safety.
-4. The gate or a maintainer applies `metagraphed-import-approved`.
-5. The import workflow opens a PR.
-6. Normal validation plus gate review decide whether it merges.
-
-Schema-valid does not mean accepted.
-
-## Generated Artifacts
-
-Avoid hand-editing `public/metagraph` unless you are correcting a stale derived artifact that cannot be regenerated without unrelated live-probe churn. Prefer changing canonical registry source and rebuilding.
-
-Use:
-
-```bash
-npm run pipeline:refresh
-```
-
-for full local refreshes. Set `METAGRAPH_WRITE_PROBE_RESULTS=1` only when you intentionally want live probe artifacts updated.
-
-Production publishes can require freshness gates:
-
-```bash
-METAGRAPH_REQUIRE_PROBE_HEALTH=1 METAGRAPH_REQUIRE_FRESHNESS=1 npm run validate
-```
-
-Freshness is exposed in `/metagraph/freshness.json` and `/api/v1/freshness`.
-Required publish lanes include native subnet data, candidate discovery,
-candidate verification, probe-derived health, and adapter snapshots.
-
-### Publish timing
-
-When your change merges, Cloudflare Workers Builds deploys the Worker and the
-compact contract artifacts in `public/metagraph` immediately. The high-churn data
-— `search`, `profiles`, `surfaces`, `evidence-ledger`, `freshness`, `curation` —
-is **R2-only** and republished on a ~6h schedule, so a newly imported subnet can
-take up to ~6 hours to appear in those indexes and in the completeness
-leaderboard (`/api/v1/profiles?sort=completeness_score`). The compact
-`subnets`/`coverage` digests refresh with the build.
-
-## Pull Requests
-
-- Use short, focused PRs with Conventional Commit-style titles.
-- Include the relevant validation commands in the PR body.
-- Do not include local paths, machine-specific setup, raw environment dumps, or private research notes.
-- Keep UI/frontend work out of this repo; this repo owns backend data contracts and generated JSON.
+By contributing you agree your work is released under the repository's [AGPL-3.0 License](LICENSE) — or Apache-2.0 for contributions to the client SDKs under `packages/client/` and `python/`.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,661 @@
-MIT License
+                    GNU AFFERO GENERAL PUBLIC LICENSE
+                       Version 3, 19 November 2007
 
-Copyright (c) 2026 JSONbored
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+                            Preamble
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+  The GNU Affero General Public License is a free, copyleft license for
+software and other kinds of works, specifically designed to ensure
+cooperation with the community in the case of network server software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+our General Public Licenses are intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  Developers that use our General Public Licenses protect your rights
+with two steps: (1) assert copyright on the software, and (2) offer
+you this License which gives you legal permission to copy, distribute
+and/or modify the software.
+
+  A secondary benefit of defending all users' freedom is that
+improvements made in alternate versions of the program, if they
+receive widespread use, become available for other developers to
+incorporate.  Many developers of free software are heartened and
+encouraged by the resulting cooperation.  However, in the case of
+software used on network servers, this result may fail to come about.
+The GNU General Public License permits making a modified version and
+letting the public access it on a server without ever releasing its
+source code to the public.
+
+  The GNU Affero General Public License is designed specifically to
+ensure that, in such cases, the modified source code becomes available
+to the community.  It requires the operator of a network server to
+provide the source code of the modified version running there to the
+users of that server.  Therefore, public use of a modified version, on
+a publicly accessible server, gives the public access to the source
+code of the modified version.
+
+  An older license, called the Affero General Public License and
+published by Affero, was designed to accomplish similar goals.  This is
+a different license, not a version of the Affero GPL, but Affero has
+released a new version of the Affero GPL which permits relicensing under
+this license.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU Affero General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Remote Network Interaction; Use with the GNU General Public License.
+
+  Notwithstanding any other provision of this License, if you modify the
+Program, your modified version must prominently offer all users
+interacting with it remotely through a computer network (if your version
+supports such interaction) an opportunity to receive the Corresponding
+Source of your version by providing access to the Corresponding Source
+from a network server at no charge, through some standard or customary
+means of facilitating copying of software.  This Corresponding Source
+shall include the Corresponding Source for any work covered by version 3
+of the GNU General Public License that is incorporated pursuant to the
+following paragraph.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the work with which it is combined will remain governed by version
+3 of the GNU General Public License.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU Affero General Public License from time to time.  Such new versions
+will be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU Affero General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU Affero General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU Affero General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If your software can interact with users remotely through a computer
+network, you should also make sure that it provides a way for users to
+get its source.  For example, if your program is a web application, its
+interface could display a "Source" link that leads users to an archive
+of the code.  There are many ways you could offer source, and different
+solutions will be better for different programs; see section 13 for the
+specific requirements.
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU AGPL, see
+<https://www.gnu.org/licenses/>.

--- a/README.md
+++ b/README.md
@@ -1,309 +1,105 @@
+<div align="center">
+
 # Metagraphed
 
-Every subnet, metagraphed.
+### Every subnet, metagraphed.
 
-Metagraphed is an unofficial operational registry for Bittensor subnet interfaces, health, schemas, and public access metadata.
+The Bittensor subnet integration registry. For every subnet it answers: **what does it expose** (public APIs, docs, schemas), **is it healthy**, and **how do I call it** — machine-readable, for AI agents and developers alike.
 
-The native Bittensor metagraph tells you what is happening at the subnet protocol layer. Metagraphed adds the missing builder-facing layer around it: public APIs, OpenAPI/Swagger surfaces, dashboards, repositories, endpoint health, probe history, schema drift, and access notes.
+[![Website](https://img.shields.io/badge/website-metagraph.sh-111?logo=cloudflare&logoColor=white)](https://metagraph.sh)
+[![MCP](https://img.shields.io/badge/MCP-api.metagraph.sh%2Fmcp-7c3aed)](https://api.metagraph.sh/mcp)
+[![npm](https://img.shields.io/npm/v/@jsonbored/metagraphed?logo=npm&label=npm)](https://www.npmjs.com/package/@jsonbored/metagraphed)
+[![PyPI](https://img.shields.io/pypi/v/metagraphed?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/metagraphed/)
+[![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)
 
-## Domains
+</div>
 
-- `metagraph.sh` is the main product and public artifact surface.
-- `subnet.health` is not used for Metagraphed v1.
+---
 
-Example routes:
+## What it is
 
-- `https://metagraph.sh/subnets/7`
-- `https://api.metagraph.sh/metagraph/subnets.json`
-- `https://api.metagraph.sh/metagraph/health/subnets/7.json`
-- `https://api.metagraph.sh/metagraph/health/badges/7.json`
+The native Bittensor metagraph tells you what's happening at the protocol layer. Metagraphed adds the **builder-facing layer it lacks** — a registry of public subnet interfaces, endpoint health, and machine-readable schemas, built for **integration developers** (often reached through their AI agents) who need to discover and call subnet APIs.
 
-## What This Is
+> **Not** an official OpenTensor/Bittensor project · **not** a replacement for the native metagraph · **not** an alpha/price dashboard · **not** a wallet, validator, or credential tool.
 
-- a registry of public subnet interfaces;
-- a deterministic JSON artifact generator;
-- a probe surface for safe public endpoints;
-- a status layer for APIs, schemas, and public data surfaces;
-- a Cloudflare-backed API/cache/history layer;
-- a foundation for future hosted/cache/load-balanced subnet access.
+The web UI lives at **[metagraph.sh](https://metagraph.sh)**. The API is served from **`https://api.metagraph.sh`** (REST under `/api/v1`, artifacts under `/metagraph`).
 
-## What This Is Not
+## Quickstart
 
-- not an official OpenTensor or Bittensor project;
-- not a replacement for the native Bittensor metagraph;
-- not another alpha dashboard, docs encyclopedia, or generic RPC provider;
-- not a validator credential, wallet, or private scoring mirror.
+Three ways to use Metagraphed. Pick one.
 
-## Use It From An Agent (MCP)
+#### 🤖 AI agent (MCP)
 
-metagraphed is agent-native. Point any MCP client at the public, read-only
-Streamable-HTTP endpoint and your agent can query the registry as tools:
+Agent-native, public, read-only, Streamable-HTTP. 14 tools to discover a subnet, check if it's up, and learn how to call it.
 
-```
+```bash
 claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp
 ```
 
-For Cursor / other clients, add an MCP server with url
-`https://api.metagraph.sh/mcp` and transport `streamable-http`. The nine tools
-(`search_subnets`, `find_subnets_by_capability`, `get_subnet`,
-`get_subnet_health`, `list_subnet_apis`, `get_api_schema`, `get_agent_catalog`,
-`get_best_rpc_endpoint`, `registry_summary`) let an agent discover a subnet,
-check whether it's up, and learn how to call its API.
+> Cursor / other clients: add an MCP server with url `https://api.metagraph.sh/mcp`, transport `streamable-http`.
+>
+> Tools: `search_subnets` · `find_subnets_by_capability` · `get_subnet` · `get_subnet_health` · `list_subnet_apis` · `get_api_schema` · `get_fixture` · `get_agent_catalog` · `get_best_rpc_endpoint` · `registry_summary` · `semantic_search` · `ask` · `find_subnet_for_task` · `how_do_i_call`
 
-- Server descriptor: `https://api.metagraph.sh/.well-known/mcp/server-card.json`
-- Drop-in "bittensor in a box" skill: `https://api.metagraph.sh/skills/bittensor/SKILL.md`
-- Machine index for any LLM/crawler: `https://api.metagraph.sh/llms.txt`
+#### 📦 Typed client
 
-## Registry Coverage
-
-Metagraphed is chain-first:
-
-- every active Finney netuid gets a native chain entry from decoded Bittensor/Subtensor data;
-- root `netuid: 0` is included and labeled as root/system;
-- root `netuid: 0` carries Bittensor base-layer RPC/WSS endpoint surfaces;
-- generalized endpoint resources normalize base-layer RPC/WSS and subnet-app/API/docs/data surfaces without pretending every subnet has Cosmos-style RPC/API/gRPC/seed endpoints;
-- curated overlays add public interface metadata after machine verification or maintainer review;
-- third-party APIs are enrichment/candidate sources, not canonical existence sources.
-- generated candidates capture public-source leads, but only live/redirected public-safe candidates become promoted surfaces.
-
-Coverage levels:
-
-- `native-only`: chain-derived subnet entry, no verified public interface metadata yet;
-- `manifested`: curated interface metadata exists, but no default probe is enabled;
-- `probed`: curated interface metadata exists and at least one safe read-only probe is configured.
-
-Curation levels:
-
-- `native`: chain-derived only;
-- `candidate-discovered`: public-source leads exist but are not verified;
-- `machine-verified`: live public surfaces were safely probed and promoted;
-- `maintainer-reviewed`: a human reviewed the overlay;
-- `adapter-backed`: subnet-specific public data dimensions are modeled.
-
-## Pilot Overlays
-
-The initial rich overlays track:
-
-- Allways SN7: API health, protocol state, network overview, miners, leaderboard, reliability, events, crown data, and SSE.
-- Gittensor SN74: public docs, repository registration surfaces, public master repository weights, bounty/contribution metadata concepts, maintainer-cut metadata, and public-safe aggregate registry surfaces.
-
-Credentialed flows, wallet paths, validator-sensitive internals, private dashboards, and token-gated data are intentionally out of scope.
-
-## Artifact Contract
-
-Generated public artifact routes live under `/metagraph/*`. Compact indexes and contracts are checked in under `public/metagraph`; high-churn detail, health, verification, schema, adapter, and per-subnet files are written to the ignored R2 staging tree under `dist/metagraph-r2/metagraph` and uploaded to R2. The Worker keeps the same public paths either way.
-
-- `/metagraph/contracts.json`
-- `/metagraph/providers.json`
-- `/metagraph/providers/{slug}.json`
-- `/metagraph/providers/{slug}/endpoints.json`
-- `/metagraph/api-index.json`
-- `/metagraph/openapi.json`
-- `/metagraph/types.d.ts`
-- `/metagraph/changelog.json`
-- `/metagraph/subnets.json`
-- `/metagraph/subnets/{netuid}.json`
-- `/metagraph/surfaces.json`
-- `/metagraph/surfaces/{netuid}.json`
-- `/metagraph/endpoints.json`
-- `/metagraph/endpoints/{netuid}.json`
-- `/metagraph/candidates.json`
-- `/metagraph/candidates/{netuid}.json`
-- `/metagraph/review-queue.json`
-- `/metagraph/search.json`
-- `/metagraph/coverage.json`
-- `/metagraph/curation.json`
-- `/metagraph/gaps.json`
-- `/metagraph/verification/latest.json`
-- `/metagraph/verification/subnets/{netuid}.json`
-- `/metagraph/freshness.json`
-- `/metagraph/source-health.json`
-- `/metagraph/source-snapshots.json`
-- `/metagraph/evidence-ledger.json`
-- `/metagraph/health/latest.json`
-- `/metagraph/health/summary.json`
-- `/metagraph/health/history/{date}.json`
-- `/metagraph/health/subnets/{netuid}.json`
-- `/metagraph/health/badges/{netuid}.json`
-- `/metagraph/rpc-endpoints.json`
-- `/metagraph/rpc/pools.json`
-- `/metagraph/endpoint-pools.json`
-- `/metagraph/schema-drift.json`
-- `/metagraph/schemas/index.json`
-- `/metagraph/adapters/{slug}.json`
-- `/metagraph/r2-manifest.json`
-- `/metagraph/review/curation.json`
-- `/metagraph/review/gap-priorities.json`
-- `/metagraph/review/adapter-candidates.json`
-- `/metagraph/review/maintainer-decisions.json`
-- `/metagraph/build-summary.json`
-
-The generated files are deterministic and suitable for static hosting, R2-backed serving, CI review, and downstream consumption. Artifact contracts include `storage_tier` so validators, OpenAPI generation, R2 upload, and Worker loading agree on where each artifact belongs.
-
-## Status Badges
-
-Every subnet has a self-hosted SVG health badge (no third-party badge service):
-
-```markdown
-![Allways SN7 health](https://api.metagraph.sh/metagraph/health/badges/7.svg)
-```
-
-Badges render from the published `/metagraph/health/badges/{netuid}.json`
-artifact (`ok`/`degraded`/`failed`/`unknown`, probe-derived). Embedding one in a
-subnet README links back to its Metagraphed coverage.
-
-## Contract Source Of Truth
-
-Metagraphed uses JSON Schema as the canonical public/runtime contract. Contributors should edit modular schemas under `schemas/components/*.schema.json`, then run `npm run schemas:bundle` and `npm run build`.
-
-The contract chain is:
-
-- modular JSON Schema components are canonical;
-- `schemas/api-components.schema.json` is a generated bundle;
-- `/metagraph/openapi.json` is generated from the schema bundle plus route metadata;
-- `/metagraph/types.d.ts` and `generated/metagraphed-api.d.ts` are generated from OpenAPI;
-- `generated/metagraphed-client.ts` is a generated TypeScript frontend handoff helper.
-
-Zod is not the backend source of truth in v1. If Zod helpers are added later, they should be generated consumer tooling for frontend/runtime form validation, not canonical registry authority.
-
-API consumers (including the separate `metagraphed-ui` frontend) should start from `docs/api-stability.md` — the `/api/v1` stability contract covering the response envelope, pagination/sort/filter, cache profiles, `x-metagraph-*` headers, error codes, `meta.published_at` freshness, versioning guarantees, and copy-paste example queries. Generate a typed client from `/metagraph/openapi.json`, or consume the checked-in `generated/metagraphed-api.d.ts` and `generated/metagraphed-client.ts`.
-
-Worker API routes expose stable envelopes over the same canonical artifacts:
-
-- `/api/v1`
-- `/api/v1/subnets`
-- `/api/v1/subnets/{netuid}`
-- `/api/v1/profiles`
-- `/api/v1/subnets/{netuid}/profile`
-- `/api/v1/surfaces`
-- `/api/v1/subnets/{netuid}/surfaces`
-- `/api/v1/endpoints`
-- `/api/v1/subnets/{netuid}/endpoints`
-- `/api/v1/candidates`
-- `/api/v1/subnets/{netuid}/candidates`
-- `/api/v1/providers`
-- `/api/v1/providers/{slug}`
-- `/api/v1/providers/{slug}/endpoints`
-- `/api/v1/coverage`
-- `/api/v1/curation`
-- `/api/v1/gaps`
-- `/api/v1/review/gaps`
-- `/api/v1/review/profile-completeness`
-- `/api/v1/review/adapter-candidates`
-- `/api/v1/health`
-- `/api/v1/health/history/{date}`
-- `/api/v1/subnets/{netuid}/health`
-- `/api/v1/freshness`
-- `/api/v1/source-health`
-- `/api/v1/evidence`
-- `/api/v1/changelog`
-- `/api/v1/source-snapshots`
-- `/api/v1/rpc/endpoints`
-- `/api/v1/rpc/pools`
-- `/api/v1/endpoint-pools`
-- `/api/v1/endpoint-incidents`
-- `/api/v1/schemas`
-- `/api/v1/adapters/{slug}`
-- `/api/v1/search`
-- `/api/v1/contracts`
-- `/api/v1/openapi.json`
-- `/api/v1/build`
-
-## Local Commands
+Generated from the OpenAPI contract, published with provenance.
 
 ```bash
-npm run validate
-npm test
-npm run build
-npm run scan:public-safety
-npm run sync:subnets:dry-run
-npm run discover:candidates:dry-run
-npm run verify:candidates:dry-run
-npm run curate:baseline:dry-run
-npm run review:promote:dry-run
-npm run schemas:snapshot:dry-run
-npm run schemas:bundle
-npm run adapters:snapshot:dry-run
-npm run validate:schemas
-npm run validate:api
-npm run validate:contract-drift
-npm run validate:schema-enums
-npm run validate:openapi-examples
-npm run validate:generated-client
-npm run contract:summary
-npm run validate:docs
-npm run validate:intake
-npm run validate:workflows
-npm run submission:pr -- --changed-files changed-files.txt
-npm run curation:brief
-npm run endpoint:brief
-npm run endpoint:ops:brief
-npm run r2:manifest:dry-run
-npm run r2:download:dry-run
-npm run kv:publish:dry-run
-npm run worker:deploy:dry-run
-npm run probes:smoke
+npm i @jsonbored/metagraphed   # JS/TS
+pip install metagraphed        # Python
 ```
 
-`sync:subnets` uses the Bittensor Python SDK through `uvx` to fetch decoded native Finney subnet metadata without committing Python dependencies to this repo.
+#### 🌐 REST
 
-`discover:candidates` reads public enrichment sources and writes unverified candidate surfaces into `registry/candidates/generated/public-sources.json`. Current sources include TaoMarketCap, Tensorplex subnet-docs, Taopedia articles, Backprop Finance dTAO dashboard routes, Taostats metagraph dashboard routes, GitHub README links, and public project websites. Third-party dashboards are enrichment candidates only, not chain or identity authority. GitHub README-derived links are intentionally capped, de-duplicated by kind/domain, and limited to project-affiliated provenance so broad reference docs do not flood refresh PRs.
+Stable JSON envelope `{ ok, data, meta, error }`. OpenAPI at [`/metagraph/openapi.json`](https://api.metagraph.sh/metagraph/openapi.json).
 
-`verify:candidates` safely checks candidate URLs, writes a compact promotion snapshot to `registry/verification/promotions.json`, and stages the full volatile verification run outside Git for R2.
+```bash
+curl https://api.metagraph.sh/api/v1/subnets
+```
 
-`curate:baseline` derives generated baseline overlays for every active netuid that does not already have a hand-curated overlay. Git stores only a compact checksum summary; the expanded generated overlay bundle is staged outside Git for R2.
+## For agents
 
-`review:promote` applies public-safe maintainer review decisions from `registry/reviews/maintainer-reviewed.json`.
+| Resource              | URL                                                                                          |
+| --------------------- | -------------------------------------------------------------------------------------------- |
+| Copyable agent prompt | [`/agent.md`](https://api.metagraph.sh/agent.md)                                             |
+| Machine index         | [`/llms.txt`](https://api.metagraph.sh/llms.txt)                                             |
+| Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)           |
+| Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json) |
 
-`curation:brief` summarizes the lowest-completeness subnets, highest-priority curation gaps, and adapter candidates for GitHub-native contributor targeting.
+## This repo
 
-`endpoint:brief` summarizes monitored endpoint resources, root RPC/WSS/archive advisory pools, provider scores, active incidents, and the disabled proxy contract. It is an operator aid over existing artifacts, not a separate API or health authority.
-
-`schemas:snapshot` captures machine-readable OpenAPI/Swagger schema summaries and drift state.
-
-Local generated artifacts use a deterministic timestamp by default. Set `METAGRAPH_BUILD_TIMESTAMP=<iso-8601>` only when a refresh needs an explicit shared timestamp across discovery, build, schema, and R2 manifest steps.
-
-`schemas:bundle` bundles canonical modular JSON Schema components into `schemas/api-components.schema.json`.
-
-`validate:contract-drift`, `validate:schema-enums`, `validate:openapi-examples`, and `validate:generated-client` enforce schema/OpenAPI/type/client parity.
-
-`contract:summary` compares the bundled schema against a base ref and classifies contract changes as additive, risky, or breaking for PR review.
-
-`adapters:snapshot` captures safe Allways/Gittensor public adapter summaries without raw wallet, miner, PAT, or validator-local payloads.
-
-`probes:smoke` performs read-only checks against public surfaces. It does not submit transactions, mutate subnet state, send wallet data, or use credentials.
-
-`r2:manifest` generates the Cloudflare R2 upload manifest from compact Git artifacts plus the ignored R2 staging tree. `r2:upload` is delta-based by default, using `latest/r2-manifest.json` to skip unchanged artifacts while refreshing R2 control files on full uploads. Smoke uploads with `METAGRAPH_R2_UPLOAD_LIMIT` upload only the limited artifact subset and intentionally skip control files so `latest/r2-manifest.json` never advertises artifacts that were not uploaded. `r2:upload`, `r2:download`, and `kv:publish` require explicit write flags so local validation cannot accidentally publish or restore.
-
-## Community Submissions
-
-Metagraphed supports PR-first and issue-first UGC for public subnet interface corrections. Direct UGC PRs must change exactly one `registry/candidates/community/*.json` file and no generated artifacts. Public preflight returns broad states (`submit_pr`, `fix_required`, `route_away`, `manual_review`); private gate scoring and merge heuristics are intentionally not committed.
-
-Use `npm run curation:brief` to generate a current Markdown curation queue from
-the existing profile completeness, gap priority, adapter candidate, and coverage
-artifacts. The curation playbook lives in `docs/curation-playbook.md`.
-
-See `docs/submission-gate.md` and `CONTRIBUTING.md` for the submission contract.
-
-## Repository Layout
+Cloudflare Worker API + Node build scripts. **Schema-first**: JSON Schema is the canonical contract → OpenAPI → types/clients. Artifacts are deterministic JSON; data refreshes on a schedule to R2/KV.
 
 ```text
-docs/                 product and operating notes
-registry/native/      generated chain-derived subnet snapshots
-registry/candidates/  unverified interface candidates pending review
-registry/providers/   provider metadata
-registry/reviews/     public-safe maintainer review decisions
-registry/subnets/     curated subnet interface overlays
-registry/verification/ generated candidate verification snapshots
-schemas/              public JSON schema contracts
-scripts/              validation, artifact generation, probe, and safety scripts
-generated/            generated TypeScript handoff types and client helpers
-workers/              Cloudflare Worker API routes over static artifacts
-public/metagraph/     compact generated JSON artifacts and public contracts
-dist/metagraph-r2/    ignored R2 staging tree for volatile/detail artifacts
-tests/                node test runner checks
+docs/              product + operating notes (start here)
+registry/          subnet overlays, candidates, community submissions
+schemas/           canonical JSON Schema components
+scripts/           validation, generation, probe, safety
+workers/           Cloudflare Worker API routes
+public/metagraph/  compact generated artifacts + contracts
+generated/         generated TypeScript types + client
 ```
+
+Deeper docs: [`docs/api-stability.md`](docs/api-stability.md) (the `/api/v1` contract), [`docs/submission-gate.md`](docs/submission-gate.md), [`docs/curation-playbook.md`](docs/curation-playbook.md).
+
+## Contributing
+
+Issues are labeled `good first issue` and `help wanted` — start there.
+
+- **Schema-first edits** require `npm run build` (regenerates `openapi.json` + types).
+- **Community submissions** are PR-first: touch exactly one `registry/candidates/community/*.json` file, no generated artifacts.
+
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) and [`docs/submission-gate.md`](docs/submission-gate.md).
+
+## Related
+
+- **Frontend** — [JSONbored/metagraphed-ui](https://github.com/JSONbored/metagraphed-ui): the web app at [metagraph.sh](https://metagraph.sh). Vite + React 19 + TanStack Start, deployed as a Cloudflare Worker. Holds no subnet data — it renders what this backend serves.
 
 ## License
 
-MIT
+The backend (Cloudflare Worker + build pipeline) is **[AGPL-3.0](./LICENSE)**. The
+published client SDKs are permissively licensed so you can embed them freely —
+[`packages/client`](./packages/client) (npm) and [`python/`](./python) (PyPI) are
+**[Apache-2.0](./packages/client/LICENSE)**.
+
+© 2026 JSONbored

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,26 @@
 
 Metagraphed publishes public operational metadata only.
 
+## Reporting a Vulnerability
+
+**Report security vulnerabilities privately** via GitHub's "Report a vulnerability" (private security advisories):
+
+**https://github.com/JSONbored/metagraphed/security/advisories/new**
+
+Never open a public issue for anything that could expose secrets, credentials, wallets, private infrastructure, or unsafe write access. The private advisory channel lets us triage and ship a fix before details are public.
+
+For **non-sensitive** public endpoint/status corrections (e.g. a stale URL or a wrong health status), use the status issue template instead.
+
+## Supported Versions
+
+Metagraphed is a continuously deployed service. Security fixes land on `main` and ship via the standard deploy pipeline; only the latest release of the published clients (`@jsonbored/metagraphed` on npm, `metagraphed` on PyPI) is supported.
+
 ## Do Not Submit
 
 - secrets, tokens, PATs, API keys, signed URLs, or webhook URLs;
 - wallet paths, seed phrases, hotkeys, coldkeys, keypairs, validator-local state, or private scoring inputs;
 - private dashboards, private IPs, localhost URLs, internal hostnames, or credentialed endpoints;
 - write/mutating RPC examples.
-
-## Reporting Issues
-
-For public endpoint/status corrections, use the status issue template.
-
-For anything that could expose secrets, credentials, wallets, private infrastructure, or unsafe write access, do not paste sensitive details into a public issue. Open a minimal public issue that says sensitive details are available privately, or contact the maintainer directly.
 
 ## RPC Proxy Boundary
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,20 @@
+# Support
+
+Need help using or building on Metagraphed? Here's where to go.
+
+## Using the registry
+
+- **Browse** — the web app at [metagraph.sh](https://metagraph.sh).
+- **API & contract** — the [API stability guide](./docs/api-stability.md); OpenAPI at [`/metagraph/openapi.json`](https://api.metagraph.sh/metagraph/openapi.json).
+- **AI agents** — add the MCP server (`claude mcp add --transport http metagraphed https://api.metagraph.sh/mcp`), grab the [copyable agent](https://api.metagraph.sh/agent.md), or point any LLM at [`/llms.txt`](https://api.metagraph.sh/llms.txt).
+- **Clients** — [`@jsonbored/metagraphed`](https://www.npmjs.com/package/@jsonbored/metagraphed) (npm) · [`metagraphed`](https://pypi.org/project/metagraphed/) (PyPI).
+
+## Questions, bugs, and data fixes
+
+- **Bug or feature request** — open an [issue](https://github.com/JSONbored/metagraphed/issues) using a template.
+- **Wrong or missing subnet data** — a small candidate PR is the fastest fix; see [CONTRIBUTING.md](./CONTRIBUTING.md) and the submission templates.
+- **Security** — don't open a public issue; follow [SECURITY.md](./SECURITY.md).
+
+## Docs
+
+Start in [`docs/`](./docs) — product notes, the submission gate, and the curation playbook.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "metagraphed",
       "version": "0.0.0",
-      "license": "MIT",
+      "license": "AGPL-3.0-or-later",
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@vitest/coverage-v8": "^4.1.8",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "type": "git",
     "url": "git+https://github.com/JSONbored/metagraphed.git"
   },
-  "license": "MIT",
+  "license": "AGPL-3.0-or-later",
   "engines": {
     "node": ">=22"
   },

--- a/packages/client/LICENSE
+++ b/packages/client/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -45,3 +45,8 @@ for the envelope, pagination, caching, error codes, and `x-metagraph-*` headers.
 
 The package tracks the `/api/v1` contract; changes within v1 are additive. The
 exported types are regenerated from `openapi.json` on each release.
+
+## License
+
+Apache-2.0 — see [LICENSE](./LICENSE). (The metagraphed backend itself is
+AGPL-3.0; this client SDK is permissively licensed so you can embed it freely.)

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -2,7 +2,7 @@
   "name": "@jsonbored/metagraphed",
   "version": "0.2.0",
   "description": "Typed TypeScript client for the metagraph.sh backend API — operational metadata, health, schemas, and interface discovery for Bittensor subnets.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "type": "module",
   "homepage": "https://metagraph.sh",
   "repository": {

--- a/python/LICENSE
+++ b/python/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/python/README.md
+++ b/python/README.md
@@ -54,4 +54,4 @@ backend's [API stability policy](https://github.com/JSONbored/metagraphed/blob/m
 
 ## License
 
-MIT
+Apache-2.0 — see [LICENSE](./LICENSE). (The metagraphed backend itself is AGPL-3.0; this client SDK is permissively licensed so you can embed it freely.)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,13 +7,13 @@ name = "metagraphed"
 version = "0.1.0"
 description = "Thin Python client for metagraphed — the operational + integration registry for Bittensor subnets (api.metagraph.sh)."
 readme = "README.md"
-license = { text = "MIT" }
+license = { text = "Apache-2.0" }
 requires-python = ">=3.9"
 authors = [{ name = "JSONbored" }]
 keywords = ["bittensor", "metagraph", "subnet", "registry", "api-client"]
 classifiers = [
   "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: MIT License",
+  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Typing :: Typed",
 ]

--- a/scripts/validate-docs.mjs
+++ b/scripts/validate-docs.mjs
@@ -24,25 +24,17 @@ for (const route of API_ROUTES) {
   );
 }
 
+// The README is intentionally minimal + quickstart-first; the exhaustive route
+// and artifact coverage is enforced in docs/backend-artifact-contracts.md (the
+// checks above). Here we only guard that the key live-resource pointers a
+// reader needs stay present in the README.
 for (const requiredReadmeText of [
-  "/api/v1/openapi.json",
-  "/api/v1/endpoints",
-  "/api/v1/subnets/{netuid}/endpoints",
-  "/api/v1/providers/{slug}/endpoints",
-  "/api/v1/health/history/{date}",
-  "/api/v1/subnets/{netuid}/surfaces",
-  "/metagraph/endpoints.json",
-  "/metagraph/endpoint-pools.json",
-  "/metagraph/health/history/{date}.json",
-  "/metagraph/types.d.ts",
-  "generated/metagraphed-client.ts",
-  "npm run schemas:bundle",
-  "npm run validate:contract-drift",
-  "npm run validate:schema-enums",
-  "npm run validate:openapi-examples",
-  "npm run validate:generated-client",
-  "npm run contract:summary",
-  "Zod is not the backend source of truth",
+  "metagraph.sh",
+  "api.metagraph.sh/mcp",
+  "@jsonbored/metagraphed",
+  "pip install metagraphed",
+  "/metagraph/openapi.json",
+  "docs/api-stability.md",
 ]) {
   check(
     README_HAS(requiredReadmeText),


### PR DESCRIPTION
Makes the repo contributor-ready and relicenses to protect the hosted service while keeping the client SDKs adoptable.

## Relicense
| Component | Was | Now |
| --- | --- | --- |
| Backend (Worker + build pipeline) | MIT | **AGPL-3.0** |
| `packages/client` → npm `@jsonbored/metagraphed` | MIT | **Apache-2.0** |
| `python/` → PyPI `metagraphed` | MIT | **Apache-2.0** |

AGPL protects the server + data pipeline; the SDKs stay permissive so integrators can embed them without AGPL's copyleft reaching their apps. Already-published SDK versions (0.2.0 / 0.1.0) remain MIT; the next publish carries Apache-2.0. Each SDK gets its own `LICENSE` + `license` field + README note.

## Docs — minimal, quickstart-first, beautiful
- **README** — rewritten from a 309-line wall into a scannable quickstart: the three paths (🤖 MCP one-liner / 📦 typed npm+PyPI clients / 🌐 REST), a badge row, an agent-resources table, repo layout, and a licensing note. Links the website + every live resource.
- **CONTRIBUTING** — crisp setup/gates, the schema-first rule, and the one-file community-submission flow (verified every referenced `npm run` exists).
- **SECURITY** — adds a private GitHub security-advisory reporting channel; keeps the registry data-boundary policy.
- **New:** `SUPPORT.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1, confidential reporting contact).
- **`validate-docs.mjs`** — updated to guard the README's key live-resource pointers instead of forcing the exhaustive route/command dump (that coverage is already enforced in `docs/backend-artifact-contracts.md`).

## Verification
`npm run validate` ✓ · `npm run validate:docs` ✓ · docs are Prettier-clean · all internal links resolve · no stale MIT references remain (the root `package-lock.json` entry is synced; dependency licenses are untouched).

Companion frontend PR: relicense + docs for [metagraphed-ui](https://github.com/JSONbored/metagraphed-ui).