### PR TITLE
feat(curation): make curation:brief work on a clean checkout + accepted/rejected guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,17 @@ A good candidate PR is small: one public URL, one source URL proving the claim, 
 - Don't invent API/status surfaces a subnet doesn't publish.
 - Schema-valid ≠ accepted. A private review gate makes the final call.
 
+**Accepted vs rejected at a glance** — the visible checklist (the final merge decision is the review gate's):
+
+| ✅ Tends to get accepted                                                                                             | ❌ Gets closed / routed to manual                                                                              |
+| -------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Exactly one `registry/candidates/community/*.json` (or `providers/community/*.json`)                                 | Touches generated artifacts, scripts, or workflows ([#296](https://github.com/JSONbored/metagraphed/pull/296)) |
+| A public `url` **plus** a `source_url` that proves the claim                                                         | `source_url` 404s or doesn't back the claim ([#328](https://github.com/JSONbored/metagraphed/pull/328))        |
+| An auto-review `kind` (docs, website, source-repo, openapi, subnet-api, dashboard, sse, data-artifact, sdk, example) | A surface the subnet already exposes — duplicate ([#90](https://github.com/JSONbored/metagraphed/pull/90))     |
+| `auth_required: false`, `public_safe: true`, an active netuid, a registered provider                                 | Secrets/PATs/wallet paths, private/localhost URLs, or base-layer RPC/WSS/archive                               |
+
+A clean accepted example to copy: [#87](https://github.com/JSONbored/metagraphed/pull/87).
+
 Prefer issues? Use the `interface-submission`, `profile-correction`, `endpoint-submission`, `provider-submission`, or `status-report` template — an approved issue opens the candidate PR for you. Full contract in [`docs/submission-gate.md`](docs/submission-gate.md).
 
 ## Pull requests

--- a/scripts/curation-brief.mjs
+++ b/scripts/curation-brief.mjs
@@ -1,7 +1,6 @@
 import { readFile } from "node:fs/promises";
-import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { repoRoot, stableStringify } from "./lib.mjs";
+import { artifactFilePath, stableStringify } from "./lib.mjs";
 
 const args = new Set(process.argv.slice(2));
 const jsonMode = args.has("--json");
@@ -294,11 +293,27 @@ function formatCandidateSamples(row) {
 }
 
 async function readArtifact(relativePath) {
-  return JSON.parse(
-    await readFile(path.join(repoRoot, "public/metagraph", relativePath), {
-      encoding: "utf8",
-    }),
-  );
+  // Resolve by storage tier: git-tier artifacts (coverage.json,
+  // review/profile-completeness.json) live in public/metagraph; the R2-only
+  // enrichment-queue artifacts (gap-priorities, adapter-candidates,
+  // enrichment-queue, enrichment-targets) are written to the dist staging tree
+  // during a build. artifactFilePath() prefers the staged copy and falls back
+  // to public, so a post-build run finds everything.
+  const filePath = artifactFilePath(relativePath);
+  try {
+    return JSON.parse(await readFile(filePath, { encoding: "utf8" }));
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      throw new Error(
+        `Curation brief artifact not found: ${relativePath}. Run \`npm run build\` ` +
+          `first — the enrichment-queue artifacts are generated into the R2 staging ` +
+          `tree (dist/metagraph-r2/metagraph). Or query the live queue at ` +
+          `https://api.metagraph.sh/api/v1/review/enrichment-targets.`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
 }
 
 function valueAfter(flag) {


### PR DESCRIPTION
Foundation for the content-enrichment contributor program.

## `curation:brief` now works on a clean checkout
It crashed with `ENOENT` on a fresh checkout: it read every input from `public/metagraph`, but four of its inputs (`gap-priorities`, `adapter-candidates`, `enrichment-queue`, `enrichment-targets`) are **R2-only** and live in the dist staging tree, not `public/`. Now it uses the tier-aware `artifactFilePath()` resolver (staged-then-public), so a post-`build` run finds them all — and emits a clear "run `npm run build`, or query `/api/v1/review/enrichment-targets`" message otherwise. This makes it usable as the **live contributor enrichment queue**.

## CONTRIBUTING — "accepted vs rejected at a glance"
A compact visible-only checklist distilled from real resolved PRs (✅ [#87](https://github.com/JSONbored/metagraphed/pull/87) · ❌ [#90](https://github.com/JSONbored/metagraphed/pull/90) duplicate, [#296](https://github.com/JSONbored/metagraphed/pull/296) artifact-tampering, [#328](https://github.com/JSONbored/metagraphed/pull/328) 404 source). It documents the deterministic guards only — the final merge decision stays the review gate's, and no private scoring is exposed.

Verified: `curation:brief` runs green and lists the live gaps (missing-website 16, missing-source-repo 20, …); lint + prettier clean.