### PR TITLE
intake(example): rejected submission — private/localhost URL

### DIFF
--- a/registry/candidates/community/community-sn-7-bad-example-private-url.json
+++ b/registry/candidates/community/community-sn-7-bad-example-private-url.json
@@ -1,0 +1,30 @@
+{
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  },
+  "candidates": [
+    {
+      "schema_version": 1,
+      "id": "community-sn-7-bad-example-private-url",
+      "netuid": 7,
+      "state": "schema-valid",
+      "name": "Teaching example — rejected (private/localhost URL)",
+      "kind": "website",
+      "url": "http://localhost:3000/dashboard",
+      "source_url": "https://github.com/JSONbored/metagraphed/blob/main/CONTRIBUTING.md",
+      "source_urls": [
+        "https://github.com/JSONbored/metagraphed/blob/main/CONTRIBUTING.md"
+      ],
+      "source_type": "community-pr-intake",
+      "source_tier": "community-docs",
+      "confidence": "low",
+      "provider": "allways",
+      "auth_required": false,
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "INTENTIONAL teaching example of a rejected submission: the url is a private/localhost address, which is not a public surface. The review gate should close this as private-or-unsafe-url. Not for merge."
+    }
+  ]
+}


### PR DESCRIPTION
**Intentional teaching example** for the enrichment program (#427) — a submission that **should be rejected**, so contributors can see what *not* to do.

This candidate is a `website` for SN7 whose `url` is `http://localhost:3000/dashboard` — a **private/localhost address**, not a public surface. The review gate flags it `private-or-unsafe-url` (a terminal category) and should close it.

Paired with the **accepted** examples [#87](https://github.com/JSONbored/metagraphed/pull/87) and [#96](https://github.com/JSONbored/metagraphed/pull/96), and the other rejected examples [#90](https://github.com/JSONbored/metagraphed/pull/90) (duplicate), [#328](https://github.com/JSONbored/metagraphed/pull/328) (dead source), [#296](https://github.com/JSONbored/metagraphed/pull/296) (touched generated files).

Not for merge — leaving it for the gate to close as a live demonstration.