### PR TITLE
intake(example): rejected submission — duplicate surface

### DIFF
--- a/registry/candidates/community/community-sn-7-subnet-api-duplicate-bad-example.json
+++ b/registry/candidates/community/community-sn-7-subnet-api-duplicate-bad-example.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-subnet-api-duplicate-bad-example",
+      "kind": "subnet-api",
+      "name": "Allways swaps API (duplicate bad example)",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "INTENTIONAL teaching example: this re-submits an already-registered surface (api.all-ways.io/swaps). The gate should close it as a duplicate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.all-ways.io/swagger",
+      "source_urls": ["https://api.all-ways.io/swagger"],
+      "state": "schema-valid",
+      "url": "https://api.all-ways.io/swaps"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
**Intentional teaching example** for the enrichment program (#427) — a submission that **should be rejected**.

This re-submits a surface the registry already has (`api.all-ways.io/swaps`, SN7's swaps API). The review gate flags it `duplicate` (terminal) and should close it.

Paired with the other rejected examples [#434](https://github.com/JSONbored/metagraphed/pull/434) (private URL), [#90](https://github.com/JSONbored/metagraphed/pull/90), [#328](https://github.com/JSONbored/metagraphed/pull/328) (dead source), [#296](https://github.com/JSONbored/metagraphed/pull/296) (touched generated files) — and the accepted examples [#87](https://github.com/JSONbored/metagraphed/pull/87)/[#96](https://github.com/JSONbored/metagraphed/pull/96).

Not for merge — leaving it for the gate to close.