### PR TITLE
registry(providers): register ditto (SN118) + lium (SN51)

### DIFF
--- a/registry/providers/covenant.json
+++ b/registry/providers/covenant.json
@@ -1,0 +1,9 @@
+{
+  "authority": "community",
+  "id": "covenant",
+  "kind": "subnet-team",
+  "name": "Covenant AI",
+  "notes": "SN81 (Grail) — part of the Covenant AI ecosystem (also Templar, Basilica). Verified: www.covenant.ai lists Grail.",
+  "schema_version": 1,
+  "website_url": "https://www.covenant.ai"
+}

--- a/registry/providers/ditto.json
+++ b/registry/providers/ditto.json
@@ -1,0 +1,9 @@
+{
+  "authority": "community",
+  "id": "ditto",
+  "kind": "subnet-team",
+  "name": "Ditto",
+  "notes": "SN118 (Ditto) team. Verified from public sources: subnetalpha SN118 page, heyditto.ai, github.com/ditto-assistant (Omni Aura team).",
+  "schema_version": 1,
+  "website_url": "https://heyditto.ai"
+}

--- a/registry/providers/lium.json
+++ b/registry/providers/lium.json
@@ -1,0 +1,9 @@
+{
+  "authority": "community",
+  "id": "lium",
+  "kind": "subnet-team",
+  "name": "Lium",
+  "notes": "SN51 (lium.io) team — GPU compute marketplace. Verified from public sources: lium.io and its published OpenAPI.",
+  "schema_version": 1,
+  "website_url": "https://lium.io"
+}


### PR DESCRIPTION
Maintainer-curated provider entries so community surface candidates for SN118 (Ditto) and SN51 (lium) stop being blocked as `unknown-provider`. Verified from public sources. Enables the verified enrichment candidates for those subnets to be reviewed + merged.