### PR TITLE
enrich(sn76): add source-repo for Byzantium (Safe Scan)

### DIFF
--- a/registry/candidates/community/community-sn-76-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-76-source-repo-github-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-76-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "Byzantium community source-repo",
+      "netuid": 76,
+      "provider": "byzantium",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/safe-scan-ai/cancer-ai",
+      "source_urls": ["https://github.com/safe-scan-ai/cancer-ai"],
+      "state": "schema-valid",
+      "url": "https://github.com/safe-scan-ai/cancer-ai"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "{\n\t\"message\": \"api rate limit exceeded for user id 49853598. if you reach out to github support for help, please include the request id beac:25e9aa:3cc0230:e346fb7:6a2c64cf and timestamp 2026-06-12 19:58:07 utc. for more on scraping github and how it may affect your rights, please review our terms of service (https:\\/\\/docs.github.com\\/en\\/site-policy\\/github-terms\\/github-terms-of-service)\",\n\t\"documentation_url\": \"https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api#rate-limiting\",\n\t\"status\": \"403\"\n}",
+    "submitted_by_url": "https://github.com/{\n\t\"message\": \"api rate limit exceeded for user id 49853598. if you reach out to github support for help, please include the request id beac:25e9aa:3cc0230:e346fb7:6a2c64cf and timestamp 2026-06-12 19:58:07 utc. for more on scraping github and how it may affect your rights, please review our terms of service (https:\\/\\/docs.github.com\\/en\\/site-policy\\/github-terms\\/github-terms-of-service)\",\n\t\"documentation_url\": \"https://docs.github.com/en/rest/using-the-rest-api/getting-started-with-the-rest-api#rate-limiting\",\n\t\"status\": \"403\"\n}"
+  }
+}


### PR DESCRIPTION
Adds one verified `source-repo` surface for SN76.

- url: https://github.com/safe-scan-ai/cancer-ai
- source_url (proof): https://github.com/safe-scan-ai/cancer-ai
- provider: `byzantium` (registered)

Single `registry/candidates/community/*.json` file, no generated artifacts. URL verified live (200).