### PR TITLE
enrich(sn76): add source-repo for Byzantium (Safe Scan)

### DIFF
--- a/registry/candidates/community/community-sn-76-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-76-source-repo-github-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-76-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "Byzantium community source-repo",
+      "netuid": 76,
+      "provider": "byzantium",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/safe-scan-ai/cancer-ai",
+      "source_urls": ["https://github.com/safe-scan-ai/cancer-ai"],
+      "state": "schema-valid",
+      "url": "https://github.com/safe-scan-ai/cancer-ai"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
Adds one verified `source-repo` surface for SN76. The repository README explicitly declares the netuid. Single `registry/candidates/community/*.json` file, no generated artifacts.