### PR TITLE
feat(security): pre-filter ownership-sensitive submissions on owner/provider identity

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -1,4 +1,5 @@
 import {
+  clusterDomainFromUrl,
   flattenSurfaces,
   normalizePublicUrl,
   registrySurfaceKey,
@@ -873,6 +874,134 @@ function validateCandidateSchemaShape(candidate) {
   return errors;
 }
 
+// Ownership-sensitive kinds purport to be the subnet's OWN first-party surface, so the URL owner must
+// plausibly belong to the registered provider. Third-party/aggregator kinds (dashboard/docs/etc.)
+// legitimately have a different owner and are not owner-checked here.
+const OWNER_SENSITIVE_KINDS = new Set([
+  "source-repo",
+  "website",
+  "subnet-api",
+  "openapi",
+  "sse",
+]);
+const CODE_HOST_RE = /^(github\.com|gitlab\.com|bitbucket\.org)$/i;
+const normIdentToken = (value) =>
+  String(value || "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+
+/** Owner token(s) a URL claims — a code host (github/gitlab/bitbucket) contributes its ORG; any other
+ *  host contributes its registrable-domain label. Normalized to alnum, ≥4 chars (a 1-3 char slug
+ *  matches anywhere). */
+export function urlOwnerTokens(value) {
+  if (typeof value !== "string" || !value) return [];
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return [];
+  }
+  const host = url.hostname.toLowerCase().replace(/^www\./, "");
+  const out = [];
+  if (CODE_HOST_RE.test(host)) {
+    const org = url.pathname.replace(/^\/+/, "").split("/")[0];
+    if (org) out.push(normIdentToken(org));
+  } else {
+    const domain = clusterDomainFromUrl(value);
+    if (domain) out.push(normIdentToken(domain.split(".")[0]));
+  }
+  return out.filter((token) => token.length >= 4);
+}
+
+/** Identity tokens for a candidate's declared provider — its name, id, and the owner tokens of its
+ *  official website/docs/github. Used to check an ownership-sensitive candidate's URL belongs to it. */
+export function providerIdentityTokens(provider) {
+  if (!provider || typeof provider !== "object") return [];
+  const out = new Set();
+  for (const field of ["name", "id"]) {
+    const token = normIdentToken(provider[field]);
+    if (token.length >= 4) out.add(token);
+  }
+  for (const field of ["website_url", "docs_url", "github_url"]) {
+    for (const token of urlOwnerTokens(provider[field])) out.add(token);
+  }
+  return [...out];
+}
+
+/** Two identity tokens are "related" — EXACTLY equal, or one contains the other with the shorter
+ *  (discriminating) token ≥8 chars, so a short generic/forgeable token (sn76, vision, data, network)
+ *  can only match by exact equality, never by being a substring of an attacker org. (adversarial) */
+export function ownerTokensRelated(a, b) {
+  if (!a || !b) return false;
+  if (a === b) return true;
+  const [shorter, longer] = a.length <= b.length ? [a, b] : [b, a];
+  return shorter.length >= 8 && longer.includes(shorter);
+}
+
+/** github org "luminarnetwork" matches provider name token "luminarnetwork" (exact); "safescanai" does
+ *  not match "byzantium". Empty token set → can't determine → don't block. */
+export function ownerTokensMatch(claimTokens, identityTokens) {
+  if (claimTokens.length === 0 || identityTokens.length === 0) return true;
+  return claimTokens.some((claim) =>
+    identityTokens.some((identity) => ownerTokensRelated(claim, identity)),
+  );
+}
+
+/** True when two URLs are the same resource ignoring scheme + www + trailing slash — so http↔https and
+ *  www↔apex variants of one url do not read as an "independent" proof source. (adversarial) */
+export function sameResourceUrl(a, b) {
+  const canon = (value) => {
+    try {
+      const url = new URL(value);
+      return `${url.hostname.replace(/^www\./, "")}${url.pathname.replace(/\/+$/, "")}${url.search}`.toLowerCase();
+    } catch {
+      return null;
+    }
+  };
+  const left = canon(a);
+  const right = canon(b);
+  return left != null && left === right;
+}
+
+/** Anchored placeholder/example-URL detection — avoids substring false-positives (notexample.com,
+ *  example.company.com, "/deprecated-endpoints"). Flags example.com/.org/.net as the registrable host,
+ *  the github username/repo stub, or "deprecated" as a whole host/path label. (adversarial) */
+export function isPlaceholderUrl(value) {
+  if (typeof value !== "string" || !value) return false;
+  let url;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  const host = url.hostname.toLowerCase().replace(/^www\./, "");
+  if (
+    ["com", "org", "net"].some(
+      (tld) => host === `example.${tld}` || host.endsWith(`.example.${tld}`),
+    )
+  ) {
+    return true;
+  }
+  const segments = url.pathname
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter(Boolean);
+  if (
+    /^(github|gitlab)\.com$/.test(host) &&
+    segments[0] === "username" &&
+    (segments[1] || "").replace(/\.git$/i, "") === "repo"
+  ) {
+    return true;
+  }
+  if (
+    host === "deprecated" ||
+    segments.some((s) => s.toLowerCase() === "deprecated")
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function validateCandidateForSubmission({
   candidate,
   document = {},
@@ -983,6 +1112,51 @@ export function validateCandidateForSubmission({
       category: "unsupported-shape",
       message: `candidate provider ${candidate.provider || "<missing>"} is not registered`,
     });
+  }
+  // Placeholder/example identity URLs (example.com, github.com/username/repo, "deprecated") are never
+  // a real surface — reject rather than feed the review gate a fake. (hardening preflight)
+  if (isPlaceholderUrl(candidate.url)) {
+    errors.push({
+      category: "private-or-unsafe-url",
+      message: "candidate url is a placeholder/example URL",
+    });
+  }
+  if (isPlaceholderUrl(candidate.source_url)) {
+    errors.push({
+      category: "private-or-unsafe-url",
+      message: "candidate source_url is a placeholder/example URL",
+    });
+  }
+  // Ownership-sensitive surfaces must be the subnet's OWN: the URL owner (code org / domain) must
+  // plausibly match the registered provider's identity, and — for non-repo kinds — the proof source
+  // must be INDEPENDENT of the url. Mismatches route to maintainer review: a deterministic pre-filter
+  // that reinforces the private review gate's owner-match in depth (identity facts, no scoring rubric).
+  if (OWNER_SENSITIVE_KINDS.has(candidate.kind)) {
+    const providerRecord = providers.find(
+      (provider) => provider.id === candidate.provider,
+    );
+    const identityTokens = providerIdentityTokens(providerRecord);
+    const claimTokens = [
+      ...new Set([
+        ...urlOwnerTokens(candidate.url),
+        ...urlOwnerTokens(candidate.source_url),
+      ]),
+    ];
+    if (!ownerTokensMatch(claimTokens, identityTokens)) {
+      manual_reasons.push(
+        "candidate url/source_url owner does not match its registered provider's identity — needs review to confirm it is the subnet's own surface",
+      );
+    }
+    if (
+      candidate.kind !== "source-repo" &&
+      normalizedUrl &&
+      normalizedSourceUrl &&
+      sameResourceUrl(candidate.url, candidate.source_url)
+    ) {
+      manual_reasons.push(
+        "candidate source_url is identical to its url — an independent proof source is needed for this kind",
+      );
+    }
   }
   if (candidate.public_safe !== true) {
     errors.push({

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -14,6 +14,12 @@ import {
   buildIssueIntakeReport,
   buildPrSubmissionReport,
   classifyPrScope,
+  isPlaceholderUrl,
+  ownerTokensMatch,
+  ownerTokensRelated,
+  providerIdentityTokens,
+  sameResourceUrl,
+  urlOwnerTokens,
 } from "../scripts/submission-policy.mjs";
 import {
   buildNotificationKey,
@@ -405,7 +411,7 @@ describe("Metagraphed submission gate policy", () => {
 
     const rpcDocument = structuredClone(validCandidateDocument);
     rpcDocument.candidates[0].kind = "subtensor-rpc";
-    rpcDocument.candidates[0].url = "https://rpc.example.com";
+    rpcDocument.candidates[0].url = "https://rpc.subtensor.io";
     const rpcReport = buildPrSubmissionReport({
       changedFiles: ["registry/candidates/community/rpc.json"],
       candidateDocument: rpcDocument,
@@ -415,6 +421,145 @@ describe("Metagraphed submission gate policy", () => {
       submitter: "jsonbored",
     });
     assert.equal(rpcReport.public_state, "manual_review");
+  });
+
+  test("routes an ownership-sensitive surface whose owner does not match its provider to manual review", () => {
+    const document = structuredClone(validCandidateDocument);
+    Object.assign(document.candidates[0], {
+      id: "community-sn-7-source-repo-mismatch",
+      kind: "source-repo",
+      url: "https://github.com/random-stranger/some-repo",
+      source_url: "https://github.com/random-stranger/some-repo",
+      source_urls: ["https://github.com/random-stranger/some-repo"],
+    });
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/mismatch.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(report.public_state, "manual_review");
+    assert.equal(
+      report.manual_reasons.some((reason) =>
+        reason.includes("does not match its registered provider"),
+      ),
+      true,
+    );
+  });
+
+  test("accepts an ownership-sensitive surface whose owner matches its provider", () => {
+    const document = structuredClone(validCandidateDocument);
+    Object.assign(document.candidates[0], {
+      id: "community-sn-7-source-repo-allways",
+      kind: "source-repo",
+      url: "https://github.com/all-ways/subnet",
+      source_url: "https://github.com/all-ways/subnet",
+      source_urls: ["https://github.com/all-ways/subnet"],
+    });
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/allways-repo.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(report.public_state, "submit_pr");
+  });
+
+  test("rejects placeholder/example identity URLs", () => {
+    const document = structuredClone(validCandidateDocument);
+    document.candidates[0].url = "https://example.com/app";
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/placeholder.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(report.public_state, "fix_required");
+    assert.equal(
+      report.errors.includes("candidate url is a placeholder/example URL"),
+      true,
+    );
+  });
+
+  test("routes a non-repo surface whose source_url equals its url (no independent proof) to manual review", () => {
+    const document = structuredClone(validCandidateDocument);
+    Object.assign(document.candidates[0], {
+      id: "community-sn-7-website-selfproof",
+      kind: "website",
+      url: "https://status.all-ways.io/",
+      source_url: "https://status.all-ways.io/",
+      source_urls: ["https://status.all-ways.io/"],
+    });
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/selfproof.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(report.public_state, "manual_review");
+    assert.equal(
+      report.manual_reasons.some((reason) =>
+        reason.includes("independent proof source"),
+      ),
+      true,
+    );
+  });
+
+  test("does not false-flag a legit host that merely contains 'example.com' as a substring", () => {
+    const document = structuredClone(validCandidateDocument);
+    Object.assign(document.candidates[0], {
+      id: "community-sn-7-docs-notexample",
+      kind: "docs",
+      url: "https://notexample.com/docs",
+      source_url: "https://notexample.com/proof",
+      source_urls: ["https://notexample.com/proof"],
+    });
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/notexample.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(
+      report.errors.includes("candidate url is a placeholder/example URL"),
+      false,
+    );
+  });
+
+  test("independent-proof check sees through www/protocol variants of the same resource", () => {
+    const document = structuredClone(validCandidateDocument);
+    Object.assign(document.candidates[0], {
+      id: "community-sn-7-website-wwwself",
+      kind: "website",
+      url: "https://status.all-ways.io/",
+      source_url: "https://www.status.all-ways.io/",
+      source_urls: ["https://www.status.all-ways.io/"],
+    });
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/wwwself.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(report.public_state, "manual_review");
+    assert.equal(
+      report.manual_reasons.some((reason) =>
+        reason.includes("independent proof source"),
+      ),
+      true,
+    );
   });
 
   test("blocks duplicate curated surfaces", () => {
@@ -1054,5 +1199,92 @@ describe("Metagraphed submission gate policy", () => {
       ),
       "prefix Public evidence OK.",
     );
+  });
+});
+
+describe("submission-policy owner-identity + placeholder helpers", () => {
+  test("urlOwnerTokens extracts code-host org, domain label, and tolerates junk", () => {
+    assert.deepEqual(
+      urlOwnerTokens("https://github.com/safe-scan-ai/cancer-ai"),
+      ["safescanai"],
+    );
+    assert.deepEqual(urlOwnerTokens("https://status.all-ways.io/x"), [
+      "allways",
+    ]);
+    assert.deepEqual(urlOwnerTokens("not a url"), []);
+    assert.deepEqual(urlOwnerTokens(42), []);
+    // a sub-4-char org is filtered out
+    assert.deepEqual(urlOwnerTokens("https://github.com/ab/repo"), []);
+  });
+
+  test("providerIdentityTokens pulls name/id/url tokens, empty for missing provider", () => {
+    const tokens = providerIdentityTokens({
+      id: "luminar-network",
+      name: "Luminar Network",
+      website_url: "https://luminar.network/",
+    });
+    assert.equal(tokens.includes("luminarnetwork"), true);
+    assert.equal(tokens.includes("luminar"), true);
+    assert.deepEqual(providerIdentityTokens(null), []);
+    assert.deepEqual(providerIdentityTokens("nope"), []);
+  });
+
+  test("ownerTokensRelated: exact OR >=8-char containment, never short substrings", () => {
+    assert.equal(ownerTokensRelated("luminarnetwork", "luminarnetwork"), true); // exact
+    assert.equal(ownerTokensRelated("tensorplexlabs", "tensorplex"), true); // 10-char containment
+    assert.equal(ownerTokensRelated("sn76mirror", "sn76"), false); // short token, no substring match
+    assert.equal(ownerTokensRelated("visiontools", "vision"), false); // 6-char, no substring match
+    assert.equal(ownerTokensRelated("", "luminar"), false); // empty guard
+    assert.equal(ownerTokensRelated("luminar", ""), false);
+  });
+
+  test("ownerTokensMatch: empty set is non-blocking; otherwise any related pair matches", () => {
+    assert.equal(ownerTokensMatch([], ["byzantium"]), true);
+    assert.equal(ownerTokensMatch(["safescanai"], []), true);
+    assert.equal(
+      ownerTokensMatch(["luminarnetwork"], ["luminarnetwork", "luminar"]),
+      true,
+    );
+    assert.equal(
+      ownerTokensMatch(["safescanai"], ["byzantium", "byzantiumai"]),
+      false,
+    );
+  });
+
+  test("sameResourceUrl: same resource through www/protocol, false on differ or junk", () => {
+    assert.equal(
+      sameResourceUrl(
+        "https://status.all-ways.io/",
+        "https://www.status.all-ways.io/",
+      ),
+      true,
+    );
+    assert.equal(sameResourceUrl("https://x.io/a", "http://www.x.io/a/"), true);
+    assert.equal(sameResourceUrl("https://x.io/a", "https://x.io/b"), false);
+    assert.equal(sameResourceUrl("not a url", "https://x.io/a"), false);
+  });
+
+  test("isPlaceholderUrl: anchored example/github-stub/deprecated detection, no substring false-positives", () => {
+    assert.equal(isPlaceholderUrl("https://example.com/app"), true);
+    assert.equal(isPlaceholderUrl("https://docs.example.org/x"), true);
+    assert.equal(isPlaceholderUrl("https://github.com/username/repo"), true);
+    assert.equal(
+      isPlaceholderUrl("https://github.com/username/repo.git"),
+      true,
+    );
+    assert.equal(isPlaceholderUrl("https://api.realsite.io/deprecated"), true);
+    // NOT placeholders (the false-positive fixes)
+    assert.equal(isPlaceholderUrl("https://notexample.com/app"), false);
+    assert.equal(isPlaceholderUrl("https://example.company.com/app"), false);
+    assert.equal(
+      isPlaceholderUrl("https://github.com/realorg/realrepo"),
+      false,
+    );
+    assert.equal(
+      isPlaceholderUrl("https://site.io/deprecated-endpoints"),
+      false,
+    );
+    assert.equal(isPlaceholderUrl("not a url"), false);
+    assert.equal(isPlaceholderUrl(99), false);
   });
 });


### PR DESCRIPTION
## What
Deterministic UGC-preflight hardening in `scripts/submission-policy.mjs` — defense-in-depth that mirrors the private reviewbot gate's owner-match, so weak surfaces are routed to maintainer review *before* the AI gate ever runs.

- **Owner/provider identity match** for ownership-sensitive kinds (`source-repo`, `website`, `subnet-api`, `openapi`, `sse`): the url/source_url owner (code org / domain) must match the registered provider's identity. Tolerant token match — exact, or ≥8-char containment so short/generic tokens (`sn76`, `vision`) can't be forged into a match.
- **Independent proof** for non-repo kinds: `source_url` must differ from `url` (seen through www/protocol variants).
- **Placeholder/example URLs** rejected — anchored to host/path boundaries (no `notexample.com` / `example.company.com` false-positives).

## Why
A submission auto-merged that shouldn't have (SN76 Byzantium → `github.com/safe-scan-ai/cancer-ai`, owner ≠ the subnet's registered identity). This pre-filters that class deterministically.

## Tests / safety
- `tests/submission-gate.test.mjs`: +6 cases (owner mismatch→manual, owner match→submit, placeholder reject, placeholder false-positive avoided, independent-proof incl. www/protocol). 39 pass.
- `npm run validate:private-boundary` passes — no private scoring rubric encoded.
- prettier + eslint clean.