### PR TITLE
registry(providers): record Byzantium's verified GitHub org (safe-scan-ai)

### DIFF
--- a/registry/providers/byzantium.json
+++ b/registry/providers/byzantium.json
@@ -4,6 +4,7 @@
   "name": "Byzantium",
   "kind": "subnet-team",
   "website_url": "https://www.byzantiumai.net/",
+  "github_url": "https://github.com/safe-scan-ai",
   "authority": "official",
-  "notes": "Provider entry for Byzantium SN76 website. Public docs/API/common-path candidates are currently 404 and are not promoted."
+  "notes": "Provider entry for Byzantium SN76. The team operates under the Safe Scan brand (safe-scan.ai / @SAFESCAN_AI); its GitHub org is safe-scan-ai (verified via the SN76 source repo README + taostats/CoinGecko/subnetalpha)."
 }


### PR DESCRIPTION
Re-review of the SN76 (Byzantium) source-repo merge under the hardened owner-identity gate.

The merged repo `github.com/safe-scan-ai/cancer-ai` is genuinely SN76's official code — its README declares *Bittensor Subnet 76*, and the team operates under the **Safe Scan** brand (safe-scan.ai / @SAFESCAN_AI), independently corroborated by taostats, CoinGecko, and subnetalpha. The merge was content-correct but cleared the *old* gate via a self-satisfiable signal (no owner/freshness check).

Recording `github_url=https://github.com/safe-scan-ai` makes the owner link explicit so the new gate's owner-match resolves it cleanly (`safe-scan-ai` ⊇ provider identity) instead of flagging an apparent `byzantiumai.net` ↔ `safe-scan-ai` mismatch. Content stays merged; provenance is now trustworthy rather than accidentally-correct.