### PR TITLE
fix(security): require submitted URL owner match

### DIFF
--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -1136,15 +1136,10 @@ export function validateCandidateForSubmission({
       (provider) => provider.id === candidate.provider,
     );
     const identityTokens = providerIdentityTokens(providerRecord);
-    const claimTokens = [
-      ...new Set([
-        ...urlOwnerTokens(candidate.url),
-        ...urlOwnerTokens(candidate.source_url),
-      ]),
-    ];
+    const claimTokens = urlOwnerTokens(candidate.url);
     if (!ownerTokensMatch(claimTokens, identityTokens)) {
       manual_reasons.push(
-        "candidate url/source_url owner does not match its registered provider's identity — needs review to confirm it is the subnet's own surface",
+        "candidate url owner does not match its registered provider's identity — needs review to confirm it is the subnet's own surface",
       );
     }
     if (

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -449,6 +449,32 @@ describe("Metagraphed submission gate policy", () => {
     );
   });
 
+  test("routes an ownership-sensitive surface with mismatched url even when source_url matches provider to manual review", () => {
+    const document = structuredClone(validCandidateDocument);
+    Object.assign(document.candidates[0], {
+      id: "community-sn-7-source-repo-masked-mismatch",
+      kind: "source-repo",
+      url: "https://github.com/random-stranger/some-repo",
+      source_url: "https://all-ways.io/",
+      source_urls: ["https://all-ways.io/"],
+    });
+    const report = buildPrSubmissionReport({
+      changedFiles: ["registry/candidates/community/masked-mismatch.json"],
+      candidateDocument: document,
+      native,
+      providers,
+      existingSubnets: subnets,
+      submitter: "jsonbored",
+    });
+    assert.equal(report.public_state, "manual_review");
+    assert.equal(
+      report.manual_reasons.some((reason) =>
+        reason.includes("url owner does not match its registered provider"),
+      ),
+      true,
+    );
+  });
+
   test("accepts an ownership-sensitive surface whose owner matches its provider", () => {
     const document = structuredClone(validCandidateDocument);
     Object.assign(document.candidates[0], {


### PR DESCRIPTION
### Motivation
- The ownership-sensitive prefilter previously accepted a submission if either `candidate.url` or `candidate.source_url` matched the registered provider, which allowed a provider-owned `source_url` to mask an unrelated (attacker-controlled) `candidate.url` and bypass manual review.
- The goal is to ensure the submitted FIRST-PARTY surface (`candidate.url`) itself plausibly belongs to the declared provider for ownership-sensitive kinds, while still preserving the independent-proof checks for non-repo kinds.

### Description
- Update `scripts/submission-policy.mjs` to compute claim tokens only from `candidate.url` by replacing the union of `urlOwnerTokens(candidate.url)` and `urlOwnerTokens(candidate.source_url)` with `urlOwnerTokens(candidate.url)`, and adjust the manual-reason message accordingly.
- Add a regression test in `tests/submission-gate.test.mjs` that submits a mismatched `candidate.url` (attacker repo) while `source_url` is provider-owned, and asserts the result routes to `manual_review`.
- Preserve the existing independent-proof check for non-repo kinds that flags identical `url` and `source_url` via `sameResourceUrl`.

### Testing
- Ran `npx vitest run tests/submission-gate.test.mjs` and the test suite passed (`46 passed`).
- Ran `npm run validate:private-boundary` and the private-boundary validation passed.
- Ran `npx prettier --check scripts/submission-policy.mjs tests/submission-gate.test.mjs` and formatting checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ce506008c832ab27d58929072cb77)