### PR TITLE
feat(health): serve live operational health on every REST + MCP surface

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -545,4 +545,167 @@ function shiftDate(isoDate, days) {
   return new Date(base).toISOString().slice(0, 10);
 }
 
+// --- Live-everywhere health resolution + composed-artifact overlays ----------
+// Health must never be served from a build-time artifact. resolveLiveHealth
+// returns the freshest live snapshot — KV health:current first, then a
+// reconstruction from D1 surface_status (latest per-surface) when KV is cold —
+// or null when no live source exists (callers then serve `unknown`, never a
+// baked value). The overlay helpers below are pure: they take the resolved
+// snapshot and replace the embedded health on composed artifacts.
+
+function liveFromD1Rows(rows) {
+  const surfaces = rows.map((r) => ({
+    surface_id: r.surface_id,
+    netuid: r.netuid,
+    kind: r.kind,
+    provider: r.provider,
+    url: r.url,
+    status: r.status,
+    classification: r.classification,
+    latency_ms: Number.isFinite(r.latency_ms) ? r.latency_ms : null,
+    status_code: Number.isInteger(r.status_code) ? r.status_code : null,
+    last_checked: Number.isFinite(r.last_checked)
+      ? new Date(r.last_checked).toISOString()
+      : null,
+    last_ok: Number.isFinite(r.last_ok)
+      ? new Date(r.last_ok).toISOString()
+      : null,
+  }));
+  const byNetuid = new Map();
+  for (const row of surfaces) {
+    const group = byNetuid.get(row.netuid) || [];
+    group.push(row);
+    byNetuid.set(row.netuid, group);
+  }
+  const subnets = [...byNetuid.entries()]
+    .map(([netuid, group]) => ({ netuid, ...summarizeRows(group) }))
+    .sort((a, b) => a.netuid - b.netuid);
+  const lastRun = latestIso(surfaces.map((s) => s.last_checked));
+  return {
+    schema_version: 1,
+    generated_at: lastRun,
+    last_run_at: lastRun,
+    source: "live-d1-fallback",
+    health_source: "live-d1-fallback",
+    summary: { surface_count: surfaces.length },
+    subnets,
+    surfaces,
+  };
+}
+
+export async function resolveLiveHealth({ readHealthKv, env, db } = {}) {
+  if (typeof readHealthKv === "function" && env) {
+    try {
+      const current = await readHealthKv(env, "health:current");
+      if (current && Array.isArray(current.surfaces)) {
+        return { ...current, health_source: "live-cron-prober" };
+      }
+    } catch {
+      // fall through to D1
+    }
+  }
+  const database = db || env?.METAGRAPH_HEALTH_DB;
+  if (database?.prepare) {
+    try {
+      const { results } = await database
+        .prepare(
+          `SELECT surface_id, netuid, kind, provider, url, status, classification,
+                  latency_ms, status_code, last_checked, last_ok
+           FROM surface_status`,
+        )
+        .all();
+      if (Array.isArray(results) && results.length) {
+        return liveFromD1Rows(results);
+      }
+    } catch {
+      // fall through to null (caller serves `unknown`)
+    }
+  }
+  return null;
+}
+
+// Overlay the live per-subnet operational rollup onto a composed overview
+// artifact's `health`. Returns null only when there is no live snapshot at all
+// (caller falls back); when the snapshot exists but the subnet has no probed
+// surfaces, health is `unknown` — never the baked value.
+export function overlayOverviewHealth(staticOverview, live, netuid) {
+  if (!live || !Array.isArray(live.subnets)) return null;
+  const summary = live.subnets.find((entry) => entry.netuid === netuid) || null;
+  return {
+    ...(staticOverview || { netuid }),
+    health: summary
+      ? { netuid, ...summary, observed_by: "live-cron-prober" }
+      : { netuid, status: "unknown", surface_count: 0 },
+    operational_observed_at: live.last_run_at || null,
+    health_source: live.health_source || "live-cron-prober",
+  };
+}
+
+// Overlay live per-service health + recomputed call eligibility onto an agent
+// catalog detail artifact. Structural fields (base_url, auth, schema) are kept;
+// `health` and `eligibility.callable` become live (callable now = live status
+// not failed AND not classified dead/unsafe). Catalog services are already a
+// public-safe subset at build time, so structural callability is implied.
+export function overlayCatalogDetail(staticDetail, live, netuid) {
+  if (!live || !Array.isArray(live.surfaces)) return null;
+  const liveById = new Map();
+  for (const row of live.surfaces) {
+    if (row.netuid === netuid) liveById.set(row.surface_id, row);
+  }
+  const services = (staticDetail?.services || []).map((service) => {
+    const row = liveById.get(service.surface_id) || null;
+    const status = row ? row.status : "unknown";
+    const classification = row
+      ? row.classification
+      : (service.health?.classification ?? null);
+    const callableNow =
+      Boolean(row) &&
+      status !== "failed" &&
+      classification !== "dead" &&
+      classification !== "unsafe";
+    return {
+      ...service,
+      health: {
+        status,
+        classification,
+        latency_ms: row ? row.latency_ms : null,
+        last_ok: row ? row.last_ok : null,
+        last_checked: row ? row.last_checked : null,
+        stale: false,
+        observed_by: row ? "live-cron-prober" : "unavailable",
+      },
+      eligibility: {
+        ...(service.eligibility || {}),
+        callable: callableNow,
+        live_status: status,
+      },
+    };
+  });
+  return {
+    ...staticDetail,
+    services,
+    operational_observed_at: live.last_run_at || null,
+    health_source: live.health_source || "live-cron-prober",
+  };
+}
+
+// Overlay each agent-catalog index entry's `health` (a per-subnet status string)
+// from the live snapshot. Structural counts are left untouched.
+export function overlayCatalogIndex(staticIndex, live) {
+  if (!live || !Array.isArray(live.subnets)) return null;
+  const statusByNetuid = new Map(
+    live.subnets.map((entry) => [entry.netuid, entry.status]),
+  );
+  const subnets = (staticIndex?.subnets || []).map((entry) => ({
+    ...entry,
+    health: statusByNetuid.get(entry.netuid) ?? "unknown",
+  }));
+  return {
+    ...staticIndex,
+    subnets,
+    operational_observed_at: live.last_run_at || null,
+    health_source: live.health_source || "live-cron-prober",
+  };
+}
+
 export { OPERATIONAL_KINDS };

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -13,7 +13,14 @@
 import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.mjs";
-import { overlayRpcPoolEligibility } from "./health-serving.mjs";
+import {
+  overlayCatalogDetail,
+  overlayCatalogIndex,
+  overlayOverviewHealth,
+  overlayRpcPoolEligibility,
+  overlaySubnetHealth,
+  resolveLiveHealth,
+} from "./health-serving.mjs";
 import {
   aiEnabled,
   askQuestion,
@@ -89,6 +96,29 @@ async function loadArtifactData(ctx, artifactPath) {
     );
   }
   return result.data;
+}
+
+// Freshest live operational snapshot (KV health:current → D1 surface_status),
+// so MCP tools serve live health like the REST routes do — never a build-time
+// value. Returns null when no live source is available (caller renders
+// `unknown`). Mirrors workers/api.mjs liveHealthOverlay.
+function mcpLiveHealth(ctx) {
+  return resolveLiveHealth({
+    readHealthKv: ctx.readHealthKv,
+    env: ctx.env,
+    db: ctx.env?.METAGRAPH_HEALTH_DB,
+  });
+}
+
+// Best-effort static artifact read that yields null instead of throwing, so a
+// tool can fall through to a live-only / `unknown` payload once the static
+// health artifacts are removed (PR2).
+async function loadArtifactDataOrNull(ctx, artifactPath) {
+  try {
+    return await loadArtifactData(ctx, artifactPath);
+  } catch {
+    return null;
+  }
 }
 
 // AI-dependent tools (semantic_search, ask) need the VECTORIZE + AI bindings and
@@ -324,10 +354,12 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const capability = requireString(args, "capability");
       const limit = clampLimit(args?.limit, 10, 50);
-      const catalog = await loadArtifactData(
+      const staticCatalog = await loadArtifactData(
         ctx,
         "/metagraph/agent-catalog.json",
       );
+      const live = await mcpLiveHealth(ctx);
+      const catalog = overlayCatalogIndex(staticCatalog, live) || staticCatalog;
       const terms = queryTerms(capability);
       const subnets = Array.isArray(catalog.subnets) ? catalog.subnets : [];
       const ranked = subnets
@@ -384,7 +416,12 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      return loadArtifactData(ctx, `/metagraph/overview/${netuid}.json`);
+      const overview = await loadArtifactData(
+        ctx,
+        `/metagraph/overview/${netuid}.json`,
+      );
+      const live = await mcpLiveHealth(ctx);
+      return overlayOverviewHealth(overview, live, netuid) || overview;
     },
   },
   {
@@ -403,7 +440,22 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      return loadArtifactData(ctx, `/metagraph/health/subnets/${netuid}.json`);
+      const live = await mcpLiveHealth(ctx);
+      const staticHealth = await loadArtifactDataOrNull(
+        ctx,
+        `/metagraph/health/subnets/${netuid}.json`,
+      );
+      const overlaid = overlaySubnetHealth(staticHealth, live, netuid);
+      if (overlaid) return overlaid;
+      if (staticHealth) return staticHealth;
+      return {
+        schema_version: 1,
+        netuid,
+        summary: { status: "unknown", surface_count: 0 },
+        operational_observed_at: null,
+        health_source: "unavailable",
+        surfaces: [],
+      };
     },
   },
   {
@@ -423,14 +475,19 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      const data = await loadArtifactData(
+      const staticDetail = await loadArtifactData(
         ctx,
         `/metagraph/agent-catalog/${netuid}.json`,
       );
+      const live = await mcpLiveHealth(ctx);
+      const data =
+        overlayCatalogDetail(staticDetail, live, netuid) || staticDetail;
       return {
         netuid: data.netuid ?? netuid,
         service_count: Array.isArray(data.services) ? data.services.length : 0,
         services: data.services || [],
+        operational_observed_at: data.operational_observed_at ?? null,
+        health_source: data.health_source ?? "unavailable",
       };
     },
   },
@@ -521,11 +578,20 @@ export const MCP_TOOLS = [
       additionalProperties: false,
     },
     async handler(args, ctx) {
+      const live = await mcpLiveHealth(ctx);
       if (args?.netuid === undefined || args?.netuid === null) {
-        return loadArtifactData(ctx, "/metagraph/agent-catalog.json");
+        const index = await loadArtifactData(
+          ctx,
+          "/metagraph/agent-catalog.json",
+        );
+        return overlayCatalogIndex(index, live) || index;
       }
       const netuid = requireNetuid(args);
-      return loadArtifactData(ctx, `/metagraph/agent-catalog/${netuid}.json`);
+      const detail = await loadArtifactData(
+        ctx,
+        `/metagraph/agent-catalog/${netuid}.json`,
+      );
+      return overlayCatalogDetail(detail, live, netuid) || detail;
     },
   },
   {
@@ -777,10 +843,13 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const netuid = await resolveNetuid(ctx, args);
-      const detail = await loadArtifactData(
+      const staticDetail = await loadArtifactData(
         ctx,
         `/metagraph/agent-catalog/${netuid}.json`,
       );
+      const live = await mcpLiveHealth(ctx);
+      const detail =
+        overlayCatalogDetail(staticDetail, live, netuid) || staticDetail;
       const services = Array.isArray(detail.services) ? detail.services : [];
       const callable = services.filter((s) => s.eligibility?.callable);
       const steps = (callable.length > 0 ? callable : services).map((s) => ({
@@ -806,7 +875,8 @@ export const MCP_TOOLS = [
           : { available: false, schema_url: s.schema_url || null },
         health: {
           status: s.health?.status ?? "unknown",
-          stale: s.health?.stale ?? true,
+          stale: s.health?.stale ?? false,
+          observed_by: s.health?.observed_by ?? null,
         },
       }));
       const isCallable = callable.length > 0;
@@ -816,6 +886,8 @@ export const MCP_TOOLS = [
         name: detail.name,
         slug: detail.slug,
         integration_readiness: detail.integration_readiness,
+        operational_observed_at: detail.operational_observed_at ?? null,
+        health_source: detail.health_source ?? "unavailable",
         callable: isCallable,
         callable_count: callable.length,
         guidance: isCallable

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -6,9 +6,13 @@ import {
   formatTrends,
   mergeFreshness,
   mergeRpcEndpoints,
+  overlayCatalogDetail,
+  overlayCatalogIndex,
+  overlayOverviewHealth,
   overlayRpcPoolEligibility,
   overlaySubnetHealth,
   parseLive,
+  resolveLiveHealth,
   subnetBadgeStatus,
   summarizeRows,
 } from "../src/health-serving.mjs";
@@ -695,5 +699,252 @@ describe("worker live health serving", () => {
     assert.equal(body.data.netuid, 0);
     assert.equal(body.data.windows["7d"].uptime_ratio, 0.99);
     assert.equal(body.data.source, "live-cron-prober");
+  });
+});
+
+describe("resolveLiveHealth (KV → D1 → null)", () => {
+  const liveKv = {
+    last_run_at: "2026-06-13T00:00:00.000Z",
+    surfaces: [{ surface_id: "7:subnet-api:x", netuid: 7, status: "ok" }],
+    subnets: [{ netuid: 7, status: "ok" }],
+  };
+
+  test("prefers KV health:current and labels the source", async () => {
+    const live = await resolveLiveHealth({
+      readHealthKv: async (_e, key) =>
+        key === "health:current" ? liveKv : null,
+      env: {},
+    });
+    assert.equal(live.health_source, "live-cron-prober");
+    assert.equal(live.surfaces[0].status, "ok");
+  });
+
+  test("falls back to D1 surface_status when KV is cold", async () => {
+    const db = {
+      prepare: () => ({
+        all: async () => ({
+          results: [
+            {
+              surface_id: "7:subnet-api:x",
+              netuid: 7,
+              kind: "subnet-api",
+              provider: "x",
+              url: "https://x",
+              status: "failed",
+              classification: "down",
+              latency_ms: null,
+              status_code: 503,
+              last_checked: 1_700_000_000_000,
+              last_ok: 1_699_000_000_000,
+            },
+          ],
+        }),
+      }),
+    };
+    const live = await resolveLiveHealth({
+      readHealthKv: async () => null,
+      env: {},
+      db,
+    });
+    assert.equal(live.health_source, "live-d1-fallback");
+    assert.equal(live.surfaces[0].status, "failed");
+    assert.equal(live.subnets[0].netuid, 7);
+    assert.equal(live.subnets[0].status, "failed");
+    // ms → ISO conversion for D1 timestamps.
+    assert.match(live.surfaces[0].last_checked, /^20\d\d-/);
+  });
+
+  test("returns null when neither KV nor D1 has data", async () => {
+    assert.equal(
+      await resolveLiveHealth({ readHealthKv: async () => null, env: {} }),
+      null,
+    );
+  });
+
+  test("KV throwing or returning a non-snapshot falls through to D1/null", async () => {
+    // KV read throws → D1 (cold) → null.
+    assert.equal(
+      await resolveLiveHealth({
+        readHealthKv: async () => {
+          throw new Error("kv down");
+        },
+        env: {},
+      }),
+      null,
+    );
+    // KV returns an object without a surfaces array → falls through to null.
+    assert.equal(
+      await resolveLiveHealth({
+        readHealthKv: async () => ({ not: "a snapshot" }),
+        env: {},
+      }),
+      null,
+    );
+  });
+
+  test("D1 query throwing degrades to null (never a baked value)", async () => {
+    const db = {
+      prepare: () => ({
+        all: async () => {
+          throw new Error("d1 down");
+        },
+      }),
+    };
+    assert.equal(
+      await resolveLiveHealth({ readHealthKv: async () => null, env: {}, db }),
+      null,
+    );
+  });
+});
+
+describe("composed-artifact health overlays", () => {
+  const live = {
+    last_run_at: "2026-06-13T00:00:00.000Z",
+    health_source: "live-cron-prober",
+    subnets: [{ netuid: 7, status: "failed", surface_count: 1, ok_count: 0 }],
+    surfaces: [
+      {
+        surface_id: "7:subnet-api:x",
+        netuid: 7,
+        status: "failed",
+        classification: "down",
+        latency_ms: null,
+        last_ok: "2026-06-12T00:00:00.000Z",
+        last_checked: "2026-06-13T00:00:00.000Z",
+      },
+    ],
+  };
+
+  test("overlayOverviewHealth replaces baked health with live (or unknown)", () => {
+    const overview = { netuid: 7, health: { netuid: 7, status: "ok" } };
+    const out = overlayOverviewHealth(overview, live, 7);
+    assert.equal(out.health.status, "failed");
+    assert.equal(out.health.observed_by, "live-cron-prober");
+    assert.equal(out.operational_observed_at, live.last_run_at);
+    assert.equal(out.health_source, "live-cron-prober");
+    // subnet with no live rows → unknown, never the baked value.
+    const unknown = overlayOverviewHealth(
+      { netuid: 9, health: { status: "ok" } },
+      live,
+      9,
+    );
+    assert.equal(unknown.health.status, "unknown");
+    // no live snapshot → null (caller falls back).
+    assert.equal(overlayOverviewHealth(overview, null, 7), null);
+  });
+
+  test("overlayCatalogDetail makes per-service health + callable live", () => {
+    const detail = {
+      netuid: 7,
+      services: [
+        {
+          surface_id: "7:subnet-api:x",
+          base_url: "https://x",
+          health: { status: "ok", stale: true },
+          eligibility: { callable: true, reasons: [] },
+        },
+      ],
+    };
+    const out = overlayCatalogDetail(detail, live, 7);
+    assert.equal(out.services[0].health.status, "failed");
+    assert.equal(out.services[0].health.stale, false);
+    // live status failed → not callable now, even though baked said callable.
+    assert.equal(out.services[0].eligibility.callable, false);
+    assert.equal(out.services[0].base_url, "https://x"); // structural kept
+    assert.equal(out.health_source, "live-cron-prober");
+    assert.equal(overlayCatalogDetail(detail, null, 7), null);
+  });
+
+  test("overlayCatalogDetail marks a service with no live row as unknown", () => {
+    const detail = {
+      netuid: 7,
+      services: [
+        {
+          surface_id: "7:subnet-api:other",
+          base_url: "https://other",
+          health: { status: "ok", classification: "live", stale: true },
+          eligibility: { callable: true },
+        },
+      ],
+    };
+    const out = overlayCatalogDetail(detail, live, 7);
+    assert.equal(out.services[0].health.status, "unknown");
+    assert.equal(out.services[0].health.observed_by, "unavailable");
+    // classification falls back to the static value when no live row exists.
+    assert.equal(out.services[0].health.classification, "live");
+    assert.equal(out.services[0].eligibility.callable, false);
+  });
+
+  test("overlayCatalogIndex returns null without a live snapshot", () => {
+    assert.equal(overlayCatalogIndex({ subnets: [] }, null), null);
+  });
+
+  test("overlayCatalogIndex overlays per-subnet status", () => {
+    const index = { subnets: [{ netuid: 7, health: "ok", callable_count: 2 }] };
+    const out = overlayCatalogIndex(index, live);
+    assert.equal(out.subnets[0].health, "failed");
+    assert.equal(out.subnets[0].callable_count, 2); // structural count untouched
+    assert.equal(out.operational_observed_at, live.last_run_at);
+  });
+});
+
+describe("worker live health overlay on composed routes", () => {
+  test("/api/v1/subnets/7/overview overlays live health from KV", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: kvWith({
+        "health:current": {
+          last_run_at: "2026-06-13T00:00:00.000Z",
+          subnets: [
+            { netuid: 7, status: "failed", surface_count: 1, ok_count: 0 },
+          ],
+          surfaces: [],
+        },
+      }),
+    });
+    const res = await handleRequest(req("/api/v1/subnets/7/overview"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.health.status, "failed");
+    assert.equal(body.meta.source, "live-cron-prober");
+    assert.equal(body.meta.operational_observed_at, "2026-06-13T00:00:00.000Z");
+  });
+
+  test("/api/v1/agent-catalog/7 carries the live freshness contract", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: kvWith({
+        "health:current": {
+          last_run_at: "2026-06-13T00:00:00.000Z",
+          subnets: [{ netuid: 7, status: "ok" }],
+          surfaces: [],
+        },
+      }),
+    });
+    const res = await handleRequest(req("/api/v1/agent-catalog/7"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.meta.source, "live-cron-prober");
+    assert.equal(body.meta.operational_observed_at, "2026-06-13T00:00:00.000Z");
+  });
+
+  test("/api/v1/agent-catalog overlays the index per-subnet status", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: kvWith({
+        "health:current": {
+          last_run_at: "2026-06-13T00:00:00.000Z",
+          subnets: [{ netuid: 7, status: "degraded" }],
+          surfaces: [],
+        },
+      }),
+    });
+    const res = await handleRequest(req("/api/v1/agent-catalog"), env, {});
+    assert.equal(res.status, 200);
+    assert.equal((await res.json()).meta.source, "live-cron-prober");
+  });
+
+  test("composed routes fall back to the static artifact when KV+D1 are cold", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(req("/api/v1/subnets/7/overview"), env, {});
+    assert.equal(res.status, 200);
+    assert.notEqual((await res.json()).meta.source, "live-cron-prober");
   });
 });

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -1387,4 +1387,94 @@ describe("MCP goal-shaped tools — branch coverage", () => {
     assert.equal(res.body.result.structuredContent.count, 0);
   });
 
+  describe("live health overlay (warm KV overrides stale static)", () => {
+    const staticHealth = {
+      schema_version: 1,
+      netuid: 7,
+      summary: { status: "ok", surface_count: 1 },
+      surfaces: [{ surface_id: "7:subnet-api:x", netuid: 7, status: "ok" }],
+    };
+    const staticCatalog = {
+      netuid: 7,
+      services: [
+        {
+          surface_id: "7:subnet-api:x",
+          base_url: "https://x",
+          health: { status: "ok", stale: true },
+          eligibility: { callable: true, reasons: [] },
+        },
+      ],
+    };
+    const liveKv = {
+      last_run_at: "2026-06-13T00:00:00.000Z",
+      surfaces: [
+        {
+          surface_id: "7:subnet-api:x",
+          netuid: 7,
+          status: "failed",
+          classification: "down",
+          latency_ms: null,
+          last_ok: "2026-06-12T00:00:00.000Z",
+          last_checked: "2026-06-13T00:00:00.000Z",
+        },
+      ],
+      subnets: [{ netuid: 7, status: "failed", surface_count: 1, ok_count: 0 }],
+    };
+
+    test("get_subnet_health returns LIVE status, not the static artifact", async () => {
+      const deps = makeDeps(
+        { "/metagraph/health/subnets/7.json": staticHealth },
+        { "health:current": liveKv },
+      );
+      const res = await callTool("get_subnet_health", { netuid: 7 }, { deps });
+      const out = res.body.result.structuredContent;
+      assert.equal(out.surfaces[0].status, "failed");
+      assert.equal(out.summary.status, "failed");
+      assert.equal(out.operational_observed_at, "2026-06-13T00:00:00.000Z");
+    });
+
+    test("list_subnet_apis overlays live health + recomputes callable", async () => {
+      const deps = makeDeps(
+        { "/metagraph/agent-catalog/7.json": staticCatalog },
+        { "health:current": liveKv },
+      );
+      const res = await callTool("list_subnet_apis", { netuid: 7 }, { deps });
+      const out = res.body.result.structuredContent;
+      assert.equal(out.services[0].health.status, "failed");
+      assert.equal(out.services[0].health.stale, false);
+      assert.equal(out.services[0].eligibility.callable, false);
+      assert.equal(out.health_source, "live-cron-prober");
+    });
+
+    test("cold KV → tools still serve the static artifact (no regression)", async () => {
+      const deps = makeDeps({
+        "/metagraph/health/subnets/7.json": staticHealth,
+      });
+      const res = await callTool("get_subnet_health", { netuid: 7 }, { deps });
+      assert.equal(res.body.result.structuredContent.summary.status, "ok");
+    });
+
+    test("get_subnet_health with neither live nor static → unknown, never baked", async () => {
+      const res = await callTool(
+        "get_subnet_health",
+        { netuid: 7 },
+        { deps: makeDeps() },
+      );
+      const out = res.body.result.structuredContent;
+      assert.equal(out.summary.status, "unknown");
+      assert.equal(out.health_source, "unavailable");
+      assert.equal(out.operational_observed_at, null);
+    });
+
+    test("list_subnet_apis cold KV → static services + unavailable freshness", async () => {
+      const deps = makeDeps({
+        "/metagraph/agent-catalog/7.json": staticCatalog,
+      });
+      const res = await callTool("list_subnet_apis", { netuid: 7 }, { deps });
+      const out = res.body.result.structuredContent;
+      assert.equal(out.service_count, 1);
+      assert.equal(out.health_source, "unavailable");
+      assert.equal(out.operational_observed_at, null);
+    });
+  });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -42,8 +42,12 @@ import {
   LEADERBOARD_BOARDS,
   mergeFreshness,
   mergeRpcEndpoints,
+  overlayCatalogDetail,
+  overlayCatalogIndex,
+  overlayOverviewHealth,
   overlayRpcPoolEligibility,
   overlaySubnetHealth,
+  resolveLiveHealth,
   subnetBadgeStatus,
 } from "../src/health-serving.mjs";
 import { handleMcpRequest } from "../src/mcp-server.mjs";
@@ -888,7 +892,9 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
   }
 
   const baseData = live ? live.data : artifact.data;
-  const baseSource = live ? "live-cron-prober" : artifact.source;
+  const baseSource = live
+    ? baseData?.health_source || "live-cron-prober"
+    : artifact.source;
 
   const transformed = applyQueryFilters(
     baseData,
@@ -2555,6 +2561,41 @@ async function liveHealthOverlay(env, matched, staticData) {
     case "freshness": {
       const meta = await readHealthKv(env, KV_HEALTH_META);
       const data = mergeFreshness(staticData, meta);
+      return data ? { data } : null;
+    }
+    case "subnet-overview": {
+      const liveSnapshot = await resolveLiveHealth({
+        readHealthKv,
+        env,
+        db: env.METAGRAPH_HEALTH_DB,
+      });
+      const data = overlayOverviewHealth(
+        staticData,
+        liveSnapshot,
+        Number(matched.params.netuid),
+      );
+      return data ? { data } : null;
+    }
+    case "agent-catalog-subnet": {
+      const liveSnapshot = await resolveLiveHealth({
+        readHealthKv,
+        env,
+        db: env.METAGRAPH_HEALTH_DB,
+      });
+      const data = overlayCatalogDetail(
+        staticData,
+        liveSnapshot,
+        Number(matched.params.netuid),
+      );
+      return data ? { data } : null;
+    }
+    case "agent-catalog": {
+      const liveSnapshot = await resolveLiveHealth({
+        readHealthKv,
+        env,
+        db: env.METAGRAPH_HEALTH_DB,
+      });
+      const data = overlayCatalogIndex(staticData, liveSnapshot);
       return data ? { data } : null;
     }
     default:


### PR DESCRIPTION
## Why

Health must never be served from a build-time (~6h) artifact. The 2-minute cron prober already writes live health to KV (`health:current`) + D1 (`surface_status`), but the live overlay was wired into only **3** REST routes. Every other per-subnet health surface served baked values — worst of all the MCP `get_subnet_health`, which advertised "probed every ~2 minutes" while returning a static artifact.

This is **PR 1 of the live-only health migration** ([plan](.claude/plans/delightful-inventing-seahorse.md)): wire the live overlay into every per-subnet health surface across REST + MCP, with a freshness contract. PR 2 removes the stored static health entirely (so the cold fallback becomes an explicit `unknown`); PR 3 adds durable daily uptime history.

## What

- **`src/health-serving.mjs`**: `resolveLiveHealth` (KV `health:current` → D1 `surface_status` fallback → `null`) + pure overlays `overlayOverviewHealth`, `overlayCatalogDetail` (recomputes `eligibility.callable` from live status), `overlayCatalogIndex`.
- **`workers/api.mjs`**: `liveHealthOverlay` now covers `subnet-overview`, `agent-catalog`, `agent-catalog-subnet`; the envelope `source` reflects the real `health_source` (`live-cron-prober` | `live-d1-fallback`).
- **`src/mcp-server.mjs`**: `get_subnet`, `get_subnet_health`, `list_subnet_apis`, `get_agent_catalog`, `how_do_i_call`, `find_subnets_by_capability` overlay live health; removed the hard-coded `stale: true`; tools now expose `operational_observed_at` + `health_source`.
- **Freshness contract** on every health response: `operational_observed_at` (probe time) + `health_source`.
- **Cold KV+D1** → falls back to the static artifact (unchanged behavior); PR 2 turns this into an explicit `unknown`.

## Scope note

PR 1 covers the **REST + MCP** per-subnet surfaces (the agent integration path). The AI-enrichment health (`ask`/`semantic_search` via `ai-search.mjs`) and the aggregate `subnets`-list / `registry-summary` views are folded into **PR 2** (which restructures those artifacts anyway).

## Tests

- `tests/health-serving.test.mjs`: unit tests for `resolveLiveHealth` (KV → D1 → null, error paths) + each overlay (live / unknown / null) + REST integration (warm KV overlays `subnet-overview`/`agent-catalog`; cold falls back).
- `tests/mcp-server.test.mjs`: warm KV makes `get_subnet_health`/`list_subnet_apis` live (overrides static); cold falls back; no-data → `unknown`.
- Full suite + coverage gate green (98.04% stmt / 90% branch); `validate:mcp`/`validate:api`/`validate:contract-drift` pass.