### PR TITLE
intake(example): rejected submission — placeholder/example URL

### DIFF
--- a/registry/candidates/community/community-sn-7-website-status-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-website-status-all-ways-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-website-status-all-ways-io",
+      "kind": "website",
+      "name": "Allways community website",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/all-ways/subnet",
+      "source_urls": ["https://github.com/all-ways/subnet"],
+      "state": "schema-valid",
+      "url": "https://example.com/app"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
**Reference BAD example** (expected: closed by the gate). A `website` candidate whose `url` is a placeholder/example domain (`example.com`). The deterministic preflight rejects placeholder/example identity URLs (anchored to the host — real hosts like `notexample.com` are unaffected). Lesson: point at the subnet's **actual** surface, never a stand-in.