### PR TITLE
registry(providers): register bitcast-network (SN93)

### DIFF
--- a/registry/providers/bitcast-network.json
+++ b/registry/providers/bitcast-network.json
@@ -1,0 +1,9 @@
+{
+  "schema_version": 1,
+  "id": "bitcast-network",
+  "name": "Bitcast",
+  "kind": "subnet-team",
+  "website_url": "https://www.bitcast.network",
+  "authority": "community",
+  "notes": "SN93 (Bitcast) team. Verified from public sources: stats.bitcast.network (the subnet's stats dashboard, which names Subnet 93) under bitcast.network."
+}


### PR DESCRIPTION
Maintainer-curated provider for SN93 (Bitcast) so its dashboard surface can be reviewed. Verified: stats.bitcast.network names Subnet 93.