### PR TITLE
enrich(sn39): add docs surface for Basilica

### DIFF
--- a/registry/candidates/community/community-sn-39-docs-docs-basilica-ai.json
+++ b/registry/candidates/community/community-sn-39-docs-docs-basilica-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-39-docs-docs-basilica-ai",
+      "kind": "docs",
+      "name": "deprecated community docs",
+      "netuid": 39,
+      "provider": "one-covenant",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://www.basilica.ai/",
+      "source_urls": ["https://www.basilica.ai/"],
+      "state": "schema-valid",
+      "url": "https://docs.basilica.ai/miners"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
Reference GOOD example for the `docs` content type — a verified, gate-passing surface for SN39 (resolves 200, serves the kind, names the netuid in content, owner-matched where required). Single candidate file.