### PR TITLE
enrich(sn13): add example surface for Data Universe SDK

### DIFF
--- a/registry/candidates/community/community-sn-13-example-github-com.json
+++ b/registry/candidates/community/community-sn-13-example-github-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-13-example-github-com",
+      "kind": "example",
+      "name": "Data Universe community example",
+      "netuid": 13,
+      "provider": "macrocosmos",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/macrocosm-os/data-universe",
+      "source_urls": ["https://github.com/macrocosm-os/data-universe"],
+      "state": "schema-valid",
+      "url": "https://github.com/macrocosm-os/macrocosmos-py/blob/main/examples/sn13_on_demand_data.py"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
Reference GOOD example for the `example` content type — a verified, gate-passing surface for SN13 (resolves 200, serves the kind, names the netuid in content, owner-matched where required). Single candidate file.