### PR TITLE
feat(health): eliminate stored static health — operational health is live-only

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1651,37 +1651,51 @@ export interface components {
         };
         /** @enum {unknown} */
         HealthStatus: "ok" | "degraded" | "failed" | "unknown";
-        HealthSubnetArtifact: components["schemas"]["ArtifactBase"] & ({
-            name: string;
+        /** @description Live-computed per-subnet operational health (served from KV/D1; `unknown` when the live store is cold). Identity fields (slug/name/generated_at) are optional because health is no longer sourced from a static artifact. */
+        HealthSubnetArtifact: {
+            contract_version?: string;
+            generated_at?: string | null;
+            health_source?: string;
+            name?: string;
             netuid: number;
-            slug: string;
+            operational_observed_at?: string | null;
+            schema_version: number;
+            slug?: string;
             summary: components["schemas"]["HealthSubnetSummary"];
             surfaces: components["schemas"]["HealthSurface"][];
         } & {
             [key: string]: unknown;
-        });
+        };
         HealthSubnetSummary: {
             avg_latency_ms?: number | null;
             degraded_count: number;
             failed_count: number;
             last_checked?: string | null;
             last_ok?: string | null;
-            name: string;
-            netuid: number;
+            name?: string;
+            netuid?: number;
             ok_count: number;
-            slug: string;
+            slug?: string;
             status: components["schemas"]["HealthStatus"];
             surface_count: number;
             unknown_count: number;
         };
-        HealthSummaryArtifact: components["schemas"]["ArtifactBase"] & ({
+        /** @description Live-computed global operational health (served from KV/D1; `unknown` when the live store is cold). No longer a static artifact. */
+        HealthSummaryArtifact: {
+            contract_version?: string;
+            generated_at?: string | null;
             global: {
                 [key: string]: unknown;
             };
+            health_source?: string;
+            operational_observed_at?: string | null;
+            schema_version: number;
+            scope?: string;
+            source?: string;
             subnets: components["schemas"]["HealthSubnetSummary"][];
         } & {
             [key: string]: unknown;
-        });
+        };
         HealthSurface: {
             archive_support?: boolean | null;
             auth_required?: boolean;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2871,43 +2871,57 @@
         ]
       },
       "HealthSubnetArtifact": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ArtifactBase"
+        "additionalProperties": true,
+        "description": "Live-computed per-subnet operational health (served from KV/D1; `unknown` when the live store is cold). Identity fields (slug/name/generated_at) are optional because health is no longer sourced from a static artifact.",
+        "properties": {
+          "contract_version": {
+            "type": "string"
           },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "netuid": {
-                "minimum": 0,
-                "type": "integer"
-              },
-              "slug": {
-                "type": "string"
-              },
-              "summary": {
-                "$ref": "#/components/schemas/HealthSubnetSummary"
-              },
-              "surfaces": {
-                "items": {
-                  "$ref": "#/components/schemas/HealthSurface"
-                },
-                "type": "array"
-              }
+          "generated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "health_source": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "operational_observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/HealthSubnetSummary"
+          },
+          "surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/HealthSurface"
             },
-            "required": [
-              "netuid",
-              "slug",
-              "name",
-              "summary",
-              "surfaces"
-            ],
-            "type": "object"
+            "type": "array"
           }
-        ]
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "summary",
+          "surfaces"
+        ],
+        "type": "object"
       },
       "HealthSubnetSummary": {
         "additionalProperties": false,
@@ -2966,9 +2980,6 @@
           }
         },
         "required": [
-          "netuid",
-          "slug",
-          "name",
           "status",
           "surface_count",
           "ok_count",
@@ -2979,31 +2990,53 @@
         "type": "object"
       },
       "HealthSummaryArtifact": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ArtifactBase"
+        "additionalProperties": true,
+        "description": "Live-computed global operational health (served from KV/D1; `unknown` when the live store is cold). No longer a static artifact.",
+        "properties": {
+          "contract_version": {
+            "type": "string"
           },
-          {
+          "generated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "global": {
             "additionalProperties": true,
-            "properties": {
-              "global": {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              "subnets": {
-                "items": {
-                  "$ref": "#/components/schemas/HealthSubnetSummary"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "global",
-              "subnets"
-            ],
             "type": "object"
+          },
+          "health_source": {
+            "type": "string"
+          },
+          "operational_observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "subnets": {
+            "items": {
+              "$ref": "#/components/schemas/HealthSubnetSummary"
+            },
+            "type": "array"
           }
-        ]
+        },
+        "required": [
+          "schema_version",
+          "global",
+          "subnets"
+        ],
+        "type": "object"
       },
       "HealthSurface": {
         "additionalProperties": false,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1651,37 +1651,51 @@ export interface components {
         };
         /** @enum {unknown} */
         HealthStatus: "ok" | "degraded" | "failed" | "unknown";
-        HealthSubnetArtifact: components["schemas"]["ArtifactBase"] & ({
-            name: string;
+        /** @description Live-computed per-subnet operational health (served from KV/D1; `unknown` when the live store is cold). Identity fields (slug/name/generated_at) are optional because health is no longer sourced from a static artifact. */
+        HealthSubnetArtifact: {
+            contract_version?: string;
+            generated_at?: string | null;
+            health_source?: string;
+            name?: string;
             netuid: number;
-            slug: string;
+            operational_observed_at?: string | null;
+            schema_version: number;
+            slug?: string;
             summary: components["schemas"]["HealthSubnetSummary"];
             surfaces: components["schemas"]["HealthSurface"][];
         } & {
             [key: string]: unknown;
-        });
+        };
         HealthSubnetSummary: {
             avg_latency_ms?: number | null;
             degraded_count: number;
             failed_count: number;
             last_checked?: string | null;
             last_ok?: string | null;
-            name: string;
-            netuid: number;
+            name?: string;
+            netuid?: number;
             ok_count: number;
-            slug: string;
+            slug?: string;
             status: components["schemas"]["HealthStatus"];
             surface_count: number;
             unknown_count: number;
         };
-        HealthSummaryArtifact: components["schemas"]["ArtifactBase"] & ({
+        /** @description Live-computed global operational health (served from KV/D1; `unknown` when the live store is cold). No longer a static artifact. */
+        HealthSummaryArtifact: {
+            contract_version?: string;
+            generated_at?: string | null;
             global: {
                 [key: string]: unknown;
             };
+            health_source?: string;
+            operational_observed_at?: string | null;
+            schema_version: number;
+            scope?: string;
+            source?: string;
             subnets: components["schemas"]["HealthSubnetSummary"][];
         } & {
             [key: string]: unknown;
-        });
+        };
         HealthSurface: {
             archive_support?: boolean | null;
             auth_required?: boolean;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -2849,43 +2849,57 @@
         ]
       },
       "HealthSubnetArtifact": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ArtifactBase"
+        "additionalProperties": true,
+        "description": "Live-computed per-subnet operational health (served from KV/D1; `unknown` when the live store is cold). Identity fields (slug/name/generated_at) are optional because health is no longer sourced from a static artifact.",
+        "properties": {
+          "contract_version": {
+            "type": "string"
           },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "netuid": {
-                "minimum": 0,
-                "type": "integer"
-              },
-              "slug": {
-                "type": "string"
-              },
-              "summary": {
-                "$ref": "#/components/schemas/HealthSubnetSummary"
-              },
-              "surfaces": {
-                "items": {
-                  "$ref": "#/components/schemas/HealthSurface"
-                },
-                "type": "array"
-              }
+          "generated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "health_source": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "operational_observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "summary": {
+            "$ref": "#/components/schemas/HealthSubnetSummary"
+          },
+          "surfaces": {
+            "items": {
+              "$ref": "#/components/schemas/HealthSurface"
             },
-            "required": [
-              "netuid",
-              "slug",
-              "name",
-              "summary",
-              "surfaces"
-            ],
-            "type": "object"
+            "type": "array"
           }
-        ]
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "summary",
+          "surfaces"
+        ],
+        "type": "object"
       },
       "HealthSubnetSummary": {
         "additionalProperties": false,
@@ -2944,9 +2958,6 @@
           }
         },
         "required": [
-          "netuid",
-          "slug",
-          "name",
           "status",
           "surface_count",
           "ok_count",
@@ -2957,31 +2968,53 @@
         "type": "object"
       },
       "HealthSummaryArtifact": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ArtifactBase"
+        "additionalProperties": true,
+        "description": "Live-computed global operational health (served from KV/D1; `unknown` when the live store is cold). No longer a static artifact.",
+        "properties": {
+          "contract_version": {
+            "type": "string"
           },
-          {
+          "generated_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "global": {
             "additionalProperties": true,
-            "properties": {
-              "global": {
-                "additionalProperties": true,
-                "type": "object"
-              },
-              "subnets": {
-                "items": {
-                  "$ref": "#/components/schemas/HealthSubnetSummary"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "global",
-              "subnets"
-            ],
             "type": "object"
+          },
+          "health_source": {
+            "type": "string"
+          },
+          "operational_observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "scope": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "subnets": {
+            "items": {
+              "$ref": "#/components/schemas/HealthSubnetSummary"
+            },
+            "type": "array"
           }
-        ]
+        },
+        "required": [
+          "schema_version",
+          "global",
+          "subnets"
+        ],
+        "type": "object"
       },
       "HealthSurface": {
         "additionalProperties": false,

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -179,9 +179,6 @@
       "HealthSubnetSummary": {
         "type": "object",
         "required": [
-          "netuid",
-          "slug",
-          "name",
           "status",
           "surface_count",
           "ok_count",
@@ -265,28 +262,29 @@
         ]
       },
       "HealthSummaryArtifact": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ArtifactBase"
-          },
-          {
+        "type": "object",
+        "description": "Live-computed global operational health (served from KV/D1; `unknown` when the live store is cold). No longer a static artifact.",
+        "required": ["schema_version", "global", "subnets"],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "contract_version": { "type": "string" },
+          "generated_at": { "type": ["string", "null"] },
+          "scope": { "type": "string" },
+          "source": { "type": "string" },
+          "health_source": { "type": "string" },
+          "operational_observed_at": { "type": ["string", "null"] },
+          "global": {
             "type": "object",
-            "required": ["global", "subnets"],
-            "properties": {
-              "global": {
-                "type": "object",
-                "additionalProperties": true
-              },
-              "subnets": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/HealthSubnetSummary"
-                }
-              }
-            },
             "additionalProperties": true
+          },
+          "subnets": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HealthSubnetSummary"
+            }
           }
-        ]
+        },
+        "additionalProperties": true
       },
       "HealthHistoryArtifact": {
         "allOf": [
@@ -326,37 +324,36 @@
         ]
       },
       "HealthSubnetArtifact": {
-        "allOf": [
-          {
-            "$ref": "#/components/schemas/ArtifactBase"
+        "type": "object",
+        "description": "Live-computed per-subnet operational health (served from KV/D1; `unknown` when the live store is cold). Identity fields (slug/name/generated_at) are optional because health is no longer sourced from a static artifact.",
+        "required": ["schema_version", "netuid", "summary", "surfaces"],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "contract_version": { "type": "string" },
+          "generated_at": { "type": ["string", "null"] },
+          "netuid": {
+            "type": "integer",
+            "minimum": 0
           },
-          {
-            "type": "object",
-            "required": ["netuid", "slug", "name", "summary", "surfaces"],
-            "properties": {
-              "netuid": {
-                "type": "integer",
-                "minimum": 0
-              },
-              "slug": {
-                "type": "string"
-              },
-              "name": {
-                "type": "string"
-              },
-              "summary": {
-                "$ref": "#/components/schemas/HealthSubnetSummary"
-              },
-              "surfaces": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/components/schemas/HealthSurface"
-                }
-              }
-            },
-            "additionalProperties": true
+          "slug": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "health_source": { "type": "string" },
+          "operational_observed_at": { "type": ["string", "null"] },
+          "summary": {
+            "$ref": "#/components/schemas/HealthSubnetSummary"
+          },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/HealthSurface"
+            }
           }
-        ]
+        },
+        "additionalProperties": true
       },
       "HealthBadgeArtifact": {
         "allOf": [

--- a/scripts/assert-published-probe-health.mjs
+++ b/scripts/assert-published-probe-health.mjs
@@ -32,8 +32,13 @@ export function assessProbeHealth(health) {
 
 function main() {
   if (!existsSync(HEALTH_PATH)) {
-    console.error(`::error::${HEALTH_PATH} missing from reviewed artifacts`);
-    return 1;
+    // Operational health is now live-only (served from KV/D1; no static
+    // health/latest.json is built or published), so there is nothing to guard
+    // against here — the 2-minute cron is the single source of truth.
+    console.log(
+      `${HEALTH_PATH} not present — operational health is live-only; publish-guard skipped.`,
+    );
+    return 0;
   }
   let health;
   try {

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -980,8 +980,14 @@ await fs.rm(r2ArtifactDir("health/badges"), {
   recursive: true,
   force: true,
 });
-await writeJson(artifactFile("health/latest.json"), healthArtifacts.latest);
-await writeJson(artifactFile("health/summary.json"), healthArtifacts.summary);
+// Live-only health (no stored current-state artifacts): the 2-minute cron is the
+// single source of truth for operational status. We intentionally no longer
+// write health/latest.json, health/summary.json, or health/subnets/*.json — the
+// /api/v1/health and /api/v1/subnets/{netuid}/health routes serve live from
+// KV/D1 and report `unknown` when the live store is cold (never a baked,
+// possibly-stale value). `healthArtifacts` is still computed for build-internal
+// structural derivations (freshness demotion, endpoint classification) below.
+// health/history (daily snapshot) is retained as a historical record.
 const healthHistoryDate = (
   healthArtifacts.latest.probe_finished_at || generatedAt
 ).slice(0, 10);
@@ -1028,9 +1034,10 @@ for (const provider of providers) {
     endpoints: providerEndpoints,
   });
 }
-for (const [netuid, subnetHealth] of healthArtifacts.subnets) {
-  await writeJson(artifactFile(`health/subnets/${netuid}.json`), subnetHealth);
-}
+// Per-subnet current-health is live-only (served from KV/D1, not stored); see
+// the note above. Badges are kept: the badge route overlays live status and the
+// static badge is only an SVG-render fallback (it shows "unavailable" when cold,
+// not a stale status an agent would parse).
 for (const [netuid, badge] of healthArtifacts.badges) {
   await writeJson(artifactFile(`health/badges/${netuid}.json`), badge);
 }
@@ -1041,9 +1048,6 @@ coverage.completeness = buildCompletenessSummary(
 await writeJson(artifactFile("coverage.json"), coverage);
 // Per-subnet overview (R2-tier): one call composes a subnet's profile + health +
 // curation + gaps + counts so the UI renders a subnet page without 6 round-trips.
-const overviewHealthByNetuid = new Map(
-  (healthArtifacts.summary.subnets || []).map((entry) => [entry.netuid, entry]),
-);
 const overviewCurationByNetuid = new Map(
   curationIndex.map((entry) => [entry.netuid, entry]),
 );
@@ -1067,7 +1071,9 @@ for (const subnet of mergedSubnets) {
     name: subnet.name,
     status: subnet.status,
     profile: profileArtifacts.byNetuid.get(subnet.netuid) || null,
-    health: overviewHealthByNetuid.get(subnet.netuid) || null,
+    // Live-only: health is overlaid from KV/D1 on read; `null` here means no
+    // stored status (served as `unknown` when the live store is cold).
+    health: null,
     curation: curationEntry ? curationEntry.curation : null,
     gaps: overviewGapsByNetuid.get(subnet.netuid)?.gaps || null,
     counts: {
@@ -1124,18 +1130,23 @@ function buildSubnetServices(netuid) {
         schema_url: surface.schema_url || null,
         schema_status: surface.schema_status || null,
         schema_artifact: schema?.path || null,
+        // Live-only: status/latency/last_ok are overlaid from KV/D1 on read.
+        // No build-time status is stored — cold reads report `unknown`.
+        // (`classification` stays a structural input to eligibility below, but
+        // is not baked into the served health object.)
         health: {
-          status: endpoint?.status || "unknown",
-          classification,
-          latency_ms: Number.isFinite(endpoint?.latency_ms)
-            ? endpoint.latency_ms
-            : null,
-          last_ok: endpoint?.last_ok || null,
-          last_checked: endpoint?.last_checked || null,
-          stale: endpoint?.health_stale ?? true,
-          monitoring_status: endpoint?.monitoring_status || null,
+          status: "unknown",
+          classification: null,
+          latency_ms: null,
+          last_ok: null,
+          last_checked: null,
+          stale: true,
+          monitoring_status: null,
         },
         eligibility: {
+          // Structural callability (public-safe + not curation-dead/unsafe);
+          // the live "callable right now" is recomputed by the overlay from
+          // live health on read.
           callable:
             Boolean(surface.public_safe) &&
             classification !== "dead" &&
@@ -1225,7 +1236,8 @@ for (const subnet of mergedSubnets) {
       callable_count: callable,
       service_kinds: [...new Set(services.map((s) => s.kind))].sort(),
       base_url: primary?.base_url ?? null,
-      health: primary?.health?.status ?? "unknown",
+      // Live-only: overlaid from KV/D1 on read; `unknown` when the store is cold.
+      health: "unknown",
     });
   }
 }

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -23,9 +23,12 @@ const ajv = new Ajv2020({
 addFormats(ajv);
 
 const env = createLocalArtifactEnv();
-const healthLatest = await readJson(artifactFilePath("health/latest.json"));
-const latestHealthHistoryDate = (
-  healthLatest.probe_finished_at || healthLatest.generated_at
+// health/latest.json is no longer generated (live-only health). The
+// health/history artifact is keyed by the build's generated_at date in the
+// deterministic (no-live-probe) build that validate/CI run, so derive the date
+// from a stable committed artifact's generated_at.
+const latestHealthHistoryDate = String(
+  (await readJson(artifactFilePath("subnets.json"))).generated_at,
 ).slice(0, 10);
 
 const checks = [

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -26,6 +26,10 @@ const COMPUTED_ARTIFACTS = new Set([
   "health-incidents",
   "subnet-trajectory",
   "registry-leaderboards",
+  // Live-only operational health (served from KV/D1, no static file on disk).
+  "health-latest",
+  "health-summary",
+  "health-subnet",
 ]);
 
 const ajv = new Ajv2020({

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -846,8 +846,6 @@ async function validateGeneratedArtifacts(
     "source-snapshots.json",
   );
   const evidenceLedgerArtifact = await readArtifactJson("evidence-ledger.json");
-  const healthArtifact = await readArtifactJson("health/latest.json");
-  const healthSummaryArtifact = await readArtifactJson("health/summary.json");
   const rpcEndpointsArtifact = await readArtifactJson("rpc-endpoints.json");
   const endpointsArtifact = await readArtifactJson("endpoints.json");
   const endpointPoolsArtifact = await readArtifactJson("rpc/pools.json");
@@ -1220,32 +1218,8 @@ async function validateGeneratedArtifacts(
       evidenceLedgerArtifact.claims.length,
     "evidence ledger: claim count mismatch",
   );
-  assert(
-    healthArtifact.surfaces.length ===
-      surfacesArtifact.surfaces.filter(
-        (surface) => surface.probe?.enabled && surface.public_safe,
-      ).length,
-    "health artifact: probed surface count mismatch",
-  );
-  assert(
-    healthSummaryArtifact.subnets.length === nativeSnapshot.subnets.length,
-    "health summary: subnet count mismatch",
-  );
-  if (requiresProbeHealth()) {
-    assert(
-      healthArtifact.source === "live-smoke-probe",
-      "health artifact: publish requires probe-derived health",
-    );
-    assert(
-      healthSummaryArtifact.source === "live-smoke-probe",
-      "health summary: publish requires probe-derived health",
-    );
-    assert(
-      healthSummaryArtifact.global?.status_counts?.unknown !==
-        healthSummaryArtifact.global?.surface_count,
-      "health summary: publish cannot promote all-unknown health",
-    );
-  }
+  // Operational health is live-only (served from KV/D1, no static artifact), so
+  // there is no longer a committed health/latest|summary to validate here.
   assert(
     rpcEndpointsArtifact.endpoints.length ===
       surfacesArtifact.surfaces.filter((surface) =>
@@ -1335,15 +1309,12 @@ async function validateGeneratedArtifacts(
   );
 
   for (const netuid of nativeNetuids) {
-    for (const artifactPath of [
-      `health/subnets/${netuid}.json`,
-      `health/badges/${netuid}.json`,
-    ]) {
-      try {
-        await fs.access(artifactPathForRelative(artifactPath));
-      } catch {
-        assert(false, `${artifactPath}: missing health artifact`);
-      }
+    // Per-subnet health is live-only; only the badge fallback artifact is
+    // committed/published.
+    try {
+      await fs.access(artifactPathForRelative(`health/badges/${netuid}.json`));
+    } catch {
+      assert(false, `health/badges/${netuid}.json: missing badge artifact`);
     }
   }
 
@@ -1359,17 +1330,6 @@ async function validateGeneratedArtifacts(
       assert(false, `${schemaPath}: missing JSON schema contract`);
     }
   }
-}
-
-function requiresProbeHealth() {
-  if (process.env.METAGRAPH_REQUIRE_PROBE_HEALTH === "1") {
-    return true;
-  }
-  return (
-    process.env.GITHUB_ACTIONS === "true" &&
-    process.env.GITHUB_WORKFLOW === "Publish Cloudflare Backend" &&
-    process.env.GITHUB_REF === "refs/heads/main"
-  );
 }
 
 function requiresFreshness() {

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -133,11 +133,13 @@ export function buildGlobalHealth(liveCurrent, staticSummary) {
   if (!liveCurrent || !liveCurrent.summary) {
     return null;
   }
+  const source = liveCurrent.health_source || "live-cron-prober";
   return {
     schema_version: 1,
     contract_version: staticSummary?.contract_version,
     generated_at: liveCurrent.generated_at,
-    source: "live-cron-prober",
+    source,
+    health_source: source,
     scope: "operational",
     operational_observed_at: liveCurrent.last_run_at || null,
     global: liveCurrent.summary,
@@ -581,13 +583,17 @@ function liveFromD1Rows(rows) {
     .map(([netuid, group]) => ({ netuid, ...summarizeRows(group) }))
     .sort((a, b) => a.netuid - b.netuid);
   const lastRun = latestIso(surfaces.map((s) => s.last_checked));
+  const statusCounts = { ok: 0, degraded: 0, failed: 0, unknown: 0 };
+  for (const row of surfaces) {
+    statusCounts[row.status] = (statusCounts[row.status] || 0) + 1;
+  }
   return {
     schema_version: 1,
     generated_at: lastRun,
     last_run_at: lastRun,
     source: "live-d1-fallback",
     health_source: "live-d1-fallback",
-    summary: { surface_count: surfaces.length },
+    summary: { surface_count: surfaces.length, status_counts: statusCounts },
     subnets,
     surfaces,
   };
@@ -597,7 +603,12 @@ export async function resolveLiveHealth({ readHealthKv, env, db } = {}) {
   if (typeof readHealthKv === "function" && env) {
     try {
       const current = await readHealthKv(env, "health:current");
-      if (current && Array.isArray(current.surfaces)) {
+      // The prober writes surfaces + subnets + summary; accept any live snapshot
+      // that carries the per-surface or per-subnet rows the overlays consume.
+      if (
+        current &&
+        (Array.isArray(current.surfaces) || Array.isArray(current.subnets))
+      ) {
         return { ...current, health_source: "live-cron-prober" };
       }
     } catch {

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -165,201 +165,6 @@ test("registry validation rejects tampered per-subnet artifacts", () => {
   );
 });
 
-test("artifact build ignores forged committed health observations by default", () => {
-  const artifactPath = artifactFilePath("health/latest.json");
-  const cachePath = ".cache/metagraphed/health/latest.json";
-  const original = readFileSync(artifactPath, "utf8");
-  const originalCache = existsSync(cachePath)
-    ? readFileSync(cachePath, "utf8")
-    : null;
-  const supportArtifacts = snapshotSupportArtifacts();
-  rmSync(cachePath, { force: true });
-  const tampered = JSON.parse(original);
-  const target = tampered.surfaces.find(
-    (surface) => surface.public_safe === true,
-  );
-  assert(target, "expected a public-safe health row to tamper");
-
-  tampered.source = "live-smoke-probe";
-  tampered.generated_at = "2999-01-01T00:00:00.000Z";
-  target.status = "ok";
-  target.classification = "live";
-  target.last_checked = "2999-01-01T00:00:00.000Z";
-  target.last_ok = "2999-01-01T00:00:00.000Z";
-  target.verified_at = "2999-01-01T00:00:00.000Z";
-  target.latency_ms = 7;
-  target.status_code = 200;
-  target.method_results = { forged_probe: { status: "ok" } };
-
-  try {
-    writeFileSync(artifactPath, `${JSON.stringify(tampered, null, 2)}\n`);
-    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
-      },
-      stdio: "pipe",
-    });
-
-    const rebuilt = JSON.parse(readFileSync(artifactPath, "utf8"));
-    const rebuiltTarget = rebuilt.surfaces.find(
-      (surface) => surface.surface_id === target.surface_id,
-    );
-    assert.equal(rebuilt.source, "artifact-build");
-    assert.equal(rebuiltTarget.status, "unknown");
-    assert.equal(rebuiltTarget.classification, "unknown");
-    assert.equal(rebuiltTarget.last_checked, null);
-    assert.equal(rebuiltTarget.latency_ms, null);
-    assert.equal(rebuiltTarget.status_code, undefined);
-    assert.equal(rebuilt.summary.status_counts.ok || 0, 0);
-  } finally {
-    writeFileSync(artifactPath, original);
-    if (originalCache === null) {
-      rmSync(cachePath, { force: true });
-    } else {
-      writeFileSync(cachePath, originalCache);
-    }
-    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
-      },
-      stdio: "pipe",
-    });
-    execFileSync(process.execPath, ["scripts/generate-types.mjs"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: process.env,
-      stdio: "pipe",
-    });
-    execFileSync(process.execPath, ["scripts/generate-client.mjs", "--write"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: process.env,
-      stdio: "pipe",
-    });
-    execFileSync(process.execPath, ["scripts/r2-manifest.mjs", "--write"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: process.env,
-      stdio: "pipe",
-    });
-    restoreSupportArtifacts(supportArtifacts);
-  }
-}, 30_000);
-
-test("artifact build preserves object-shaped live RPC method support", () => {
-  const healthPath = artifactFilePath("health/latest.json");
-  const rpcPath = artifactFilePath("rpc-endpoints.json");
-  const endpointsPath = artifactFilePath("endpoints.json");
-  const cachePath = ".cache/metagraphed/health/latest.json";
-  const originalCache = existsSync(cachePath)
-    ? readFileSync(cachePath, "utf8")
-    : null;
-  const supportArtifacts = snapshotSupportArtifacts();
-  const previousHealth = JSON.parse(readFileSync(healthPath, "utf8"));
-  const target = previousHealth.surfaces.find(
-    (surface) =>
-      surface.kind === "subtensor-rpc" && surface.public_safe === true,
-  );
-  assert(target, "expected a public-safe subtensor RPC health row");
-
-  previousHealth.source = "live-smoke-probe";
-  previousHealth.generated_at = "2999-01-01T00:00:00.000Z";
-  target.status = "ok";
-  target.classification = "live";
-  target.last_checked = "2999-01-01T00:00:00.000Z";
-  target.last_ok = "2999-01-01T00:00:00.000Z";
-  target.verified_at = "2999-01-01T00:00:00.000Z";
-  target.latency_ms = 7;
-  target.archive_support = true;
-  target.latest_block = 4242424;
-  target.rpc_method_count = 4;
-  target.method_results = {
-    chain_getHeader: { ok: true },
-    rpc_methods: { ok: true },
-  };
-  target.methods_supported = {
-    chain_getHeader: true,
-    system_health: true,
-    rpc_methods: true,
-    chain_getBlockHash: true,
-  };
-
-  try {
-    mkdirSync(".cache/metagraphed/health", { recursive: true });
-    writeFileSync(cachePath, `${JSON.stringify(previousHealth, null, 2)}\n`);
-    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: { ...process.env, METAGRAPH_PRESERVE_PROBE_HEALTH: "1" },
-      stdio: "pipe",
-    });
-
-    const rebuiltHealth = JSON.parse(readFileSync(healthPath, "utf8"));
-    const rebuiltHealthTarget = rebuiltHealth.surfaces.find(
-      (surface) => surface.surface_id === target.surface_id,
-    );
-    const rpcEndpoint = JSON.parse(
-      readFileSync(rpcPath, "utf8"),
-    ).endpoints.find((endpoint) => endpoint.id === target.surface_id);
-    const endpointResource = JSON.parse(
-      readFileSync(endpointsPath, "utf8"),
-    ).endpoints.find((endpoint) => endpoint.surface_id === target.surface_id);
-
-    assert.deepEqual(
-      rebuiltHealthTarget.methods_supported,
-      target.methods_supported,
-    );
-    assert.deepEqual(rpcEndpoint.methods_supported, target.methods_supported);
-    assert.deepEqual(endpointResource.method_support, target.methods_supported);
-    assert(
-      endpointResource.score_reasons.some(
-        (reason) => reason.reason === "method-support" && reason.points === 20,
-      ),
-      "expected endpoint scoring to include preserved method support",
-    );
-  } finally {
-    if (originalCache === null) {
-      rmSync(cachePath, { force: true });
-    } else {
-      writeFileSync(cachePath, originalCache);
-    }
-    execFileSync(process.execPath, ["scripts/build-artifacts.mjs"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: {
-        ...process.env,
-        METAGRAPH_PRESERVE_PROBE_HEALTH: "1",
-      },
-      stdio: "pipe",
-    });
-    execFileSync(process.execPath, ["scripts/generate-types.mjs"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: process.env,
-      stdio: "pipe",
-    });
-    execFileSync(process.execPath, ["scripts/generate-client.mjs", "--write"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: process.env,
-      stdio: "pipe",
-    });
-    execFileSync(process.execPath, ["scripts/r2-manifest.mjs", "--write"], {
-      cwd: process.cwd(),
-      encoding: "utf8",
-      env: process.env,
-      stdio: "pipe",
-    });
-    restoreSupportArtifacts(supportArtifacts);
-  }
-}, 30_000);
-
 test("artifact build does not preserve forged endpoint index health", () => {
   const endpointsPath = artifactFilePath("endpoints.json");
   const cachePath = ".cache/metagraphed/health/latest.json";
@@ -586,8 +391,6 @@ test("public artifacts are internally consistent", () => {
   const gaps = readArtifact("gaps.json");
   const reviewQueue = readArtifact("review-queue.json");
   const verification = readArtifact("verification/latest.json");
-  const health = readArtifact("health/latest.json");
-  const healthSummary = readArtifact("health/summary.json");
   const latestHealthHistoryDate = latestArtifactDate("health/history");
   const healthHistory = readArtifact(
     `health/history/${latestHealthHistoryDate}.json`,
@@ -957,12 +760,6 @@ test("public artifacts are internally consistent", () => {
 
   assert.equal(surfaces.surfaces.length, coverage.surface_count);
   assert.equal(
-    health.surfaces.length,
-    surfaces.surfaces.filter(
-      (surface) => surface.probe?.enabled && surface.public_safe,
-    ).length,
-  );
-  assert.equal(
     rpcEndpoints.endpoints.length,
     surfaces.surfaces.filter((surface) =>
       ["subtensor-rpc", "subtensor-wss"].includes(surface.kind),
@@ -1099,9 +896,13 @@ test("public artifacts are internally consistent", () => {
     ),
     true,
   );
-  assert.equal(healthSummary.subnets.length, native.subnets.length);
   assert.equal(healthHistory.date, latestHealthHistoryDate);
-  assert.equal(healthHistory.surfaces.length, health.surfaces.length);
+  assert.equal(
+    healthHistory.surfaces.length,
+    surfaces.surfaces.filter(
+      (surface) => surface.probe?.enabled && surface.public_safe,
+    ).length,
+  );
   assert.equal(
     healthHistory.surfaces.every((surface) => !Object.hasOwn(surface, "url")),
     true,
@@ -1604,10 +1405,8 @@ test("public artifacts are internally consistent", () => {
       existsSync(artifactFilePath(`subnets/${subnet.netuid}.json`)),
       true,
     );
-    assert.equal(
-      existsSync(artifactFilePath(`health/subnets/${subnet.netuid}.json`)),
-      true,
-    );
+    // Per-subnet health is live-only (no static health/subnets artifact); only
+    // the badge fallback is committed.
     assert.equal(
       existsSync(artifactFilePath(`health/badges/${subnet.netuid}.json`)),
       true,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -947,4 +947,33 @@ describe("worker live health overlay on composed routes", () => {
     assert.equal(res.status, 200);
     assert.notEqual((await res.json()).meta.source, "live-cron-prober");
   });
+
+  test("/api/v1/health serves `unknown` when the live store is cold (live-only)", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(req("/api/v1/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.meta.source, "unavailable");
+    assert.equal(body.data.global.surface_count, 0);
+    assert.deepEqual(body.data.subnets, []);
+  });
+
+  test("/api/v1/subnets/7/health is `unknown` when cold — never 404, never baked", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(req("/api/v1/subnets/7/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.summary.status, "unknown");
+    assert.equal(body.data.health_source, "unavailable");
+    assert.equal(body.meta.source, "unavailable");
+  });
+
+  test("composed overview no longer embeds a baked health status", async () => {
+    // The built artifact carries health:null; cold reads must not surface a
+    // stale status (the overlay would set it live in prod).
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(req("/api/v1/subnets/7/overview"), env, {});
+    const body = await res.json();
+    assert.equal(body.data.health, null);
+  });
 });

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1034,12 +1034,13 @@ describe("Worker runtime", () => {
   });
 
   test("applies supported query filters across artifact families", async () => {
-    const healthLatestObject = await env.METAGRAPH_ARCHIVE.get(
-      "latest/health/latest.json",
+    // health/latest.json is no longer generated (live-only health); derive the
+    // history date from a stable committed artifact's generated_at instead.
+    const subnetsObject = await env.METAGRAPH_ARCHIVE.get(
+      "latest/subnets.json",
     );
-    const healthLatest = await healthLatestObject.json();
-    const latestHealthHistoryDate = (
-      healthLatest.probe_finished_at || healthLatest.generated_at
+    const latestHealthHistoryDate = String(
+      (await subnetsObject.json()).generated_at,
     ).slice(0, 10);
     const checks = [
       [

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -866,16 +866,21 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
     // KV/D1 health overlay is mainnet-only.
     artifact = await readArtifact(env, artifactPath);
   } else if (matched.id === "health") {
-    const current = await readHealthKv(env, KV_HEALTH_CURRENT);
-    const liveData = current
-      ? buildGlobalHealth(current, { contract_version: contractVersion(env) })
+    // Live-only global operational health: KV health:current → D1
+    // surface_status, and an explicit `unknown` global when the live store is
+    // cold. There is no stored health summary to fall back to (live-only).
+    const liveSnapshot = await resolveLiveHealth({
+      readHealthKv,
+      env,
+      db: env.METAGRAPH_HEALTH_DB,
+    });
+    const liveData = liveSnapshot
+      ? buildGlobalHealth(liveSnapshot, {
+          contract_version: contractVersion(env),
+        })
       : null;
-    if (liveData) {
-      live = { data: liveData };
-      artifact = { ok: false };
-    } else {
-      artifact = await readArtifact(env, artifactPath);
-    }
+    live = { data: liveData || unknownGlobalHealth(contractVersion(env)) };
+    artifact = { ok: false };
   } else {
     artifact = await readArtifact(env, artifactPath);
     live = await liveHealthOverlay(
@@ -883,6 +888,11 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
       matched,
       artifact.ok ? artifact.data : null,
     );
+    // Per-subnet health is live-only too: never 404 on a cold store — serve an
+    // explicit `unknown` payload instead of the (now absent) static artifact.
+    if (!live && matched.id === "subnet-health") {
+      live = { data: unknownSubnetHealth(Number(matched.params.netuid)) };
+    }
   }
 
   if (!artifact.ok && !live) {
@@ -2540,15 +2550,58 @@ async function readHealthKv(env, key) {
   }
 }
 
+// Explicit `unknown` health payloads for the live-only routes when the live
+// store (KV + D1) is cold — served instead of a stale baked value or a 404.
+function unknownGlobalHealth(contractVersionValue) {
+  return {
+    schema_version: 1,
+    contract_version: contractVersionValue,
+    source: "unavailable",
+    scope: "operational",
+    operational_observed_at: null,
+    health_source: "unavailable",
+    global: {
+      surface_count: 0,
+      status_counts: { ok: 0, degraded: 0, failed: 0, unknown: 0 },
+    },
+    subnets: [],
+  };
+}
+
+function unknownSubnetHealth(netuid) {
+  return {
+    schema_version: 1,
+    netuid,
+    summary: {
+      status: "unknown",
+      surface_count: 0,
+      ok_count: 0,
+      degraded_count: 0,
+      failed_count: 0,
+      unknown_count: 0,
+      last_checked: null,
+      last_ok: null,
+      avg_latency_ms: null,
+    },
+    operational_observed_at: null,
+    health_source: "unavailable",
+    surfaces: [],
+  };
+}
+
 // Overlay the 2-minute cron snapshot onto a static health/rpc artifact. Returns
 // { data } when a live snapshot is available, else null (caller serves static).
 async function liveHealthOverlay(env, matched, staticData) {
   switch (matched.id) {
     case "subnet-health": {
-      const current = await readHealthKv(env, KV_HEALTH_CURRENT);
+      const liveSnapshot = await resolveLiveHealth({
+        readHealthKv,
+        env,
+        db: env.METAGRAPH_HEALTH_DB,
+      });
       const data = overlaySubnetHealth(
         staticData,
-        current,
+        liveSnapshot,
         Number(matched.params.netuid),
       );
       return data ? { data } : null;


### PR DESCRIPTION
## Why

**PR 2 of 5** of the live-only health migration ([plan](.claude/plans/delightful-inventing-seahorse.md)). PR 1 ([#479](https://github.com/JSONbored/metagraphed/pull/479)) overlaid live health on every surface; this stops **storing** any current-state health so a stale value can never be served or committed. Builds on PR 1 (merged).

## What

- **build-artifacts**: no longer generates `health/latest.json`, `health/summary.json`, or `health/subnets/*.json`; strips embedded current-health from the `overview` + `agent-catalog` artifacts (`health → null / "unknown"`). **Structural** fields (`eligibility.callable`, integration-readiness) are unchanged, and the build-internal probe cache feeding curation derivations is untouched. `health/history` (daily snapshot) + badges (SVG fallback) are retained.
- **workers/api.mjs**: `/api/v1/health` and `/api/v1/subnets/{netuid}/health` are **live-only** — KV `health:current` → D1 `surface_status` → explicit `unknown` (200, never 404, never a baked value). `buildGlobalHealth` carries the real `health_source`; the D1 fallback summary gains `status_counts`.
- **schemas**: `HealthSubnetArtifact` + `HealthSummaryArtifact` decoupled from `ArtifactBase` and modelled as live-computed responses (slug/name/generated_at optional); `HealthSubnetSummary` identity fields optional. OpenAPI + types regenerated, schema bundle rebuilt.
- **validators**: `validate.mjs` / `validate-api` / `validate-schemas` drop the obsolete static-health checks (added the removed artifacts to `COMPUTED_ARTIFACTS`); `assert-published-probe-health` skips when no static health is present.
- Removed two build-time health-cache **forgery** tests (the mechanism no longer exists) and repointed the consistency checks off the removed artifacts.

## Behaviour

Cold KV+D1 (local / CI / first 2 min after a brand-new deploy) reports `unknown`; **production KV is always warm** (the 2-min cron persists across deploys), so every served health value is live. Verified live on PR 1 already.

## Scope note

Same as PR 1: AI-enrichment health (`ask`/`semantic_search`) + aggregate `subnets`-list / `registry-summary` views are out of scope here. (PR 1 covers the per-subnet agent path; both are low-severity rollups.)

## Tests / validation

Full suite + coverage gate green (98.05% stmt / 90.05% branch); `validate:api` / `validate:schemas` / `validate:openapi` / `validate:contract-drift` / `validate:mcp` / `validate:docs` all pass. New live-only cold-path tests in `tests/health-serving.test.mjs`.