### PR TITLE
enrich(sn2): add SDK surface for DSperse (proof-of-weights, pypi)

### DIFF
--- a/registry/candidates/community/community-sn-2-sdk-pypi-org.json
+++ b/registry/candidates/community/community-sn-2-sdk-pypi-org.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-2-sdk-pypi-org",
+      "kind": "sdk",
+      "name": "DSperse community sdk",
+      "netuid": 2,
+      "provider": "inference-labs",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/inference-labs-inc/proof-of-weights-sdk",
+      "source_urls": [
+        "https://github.com/inference-labs-inc/proof-of-weights-sdk"
+      ],
+      "state": "schema-valid",
+      "url": "https://pypi.org/project/proof-of-weights"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
Reference GOOD example for the `sdk` content type — the published pypi package, verified via the registry JSON metadata (which names SN2). Re-tests the gate's new package-registry fetch.