### PR TITLE
feat(health): durable daily uptime history (live-only retention)

### DIFF
--- a/migrations/0003_uptime_history.sql
+++ b/migrations/0003_uptime_history.sql
@@ -1,0 +1,23 @@
+-- Durable daily uptime history (live-only health, PR3).
+--
+-- The raw 2-minute surface_checks time-series is a 30-day hot window (powers the
+-- live trends/percentiles/incidents routes) and is pruned beyond that. To retain
+-- long-term uptime for analytics WITHOUT storing ~300M raw rows/yr, the hourly
+-- cron rolls each UTC day's raw checks into ONE row per (surface, day) here —
+-- ~420K rows/yr — and only then prunes the raw window. Retained indefinitely.
+
+CREATE TABLE IF NOT EXISTS surface_uptime_daily (
+  surface_id     TEXT    NOT NULL,
+  netuid         INTEGER NOT NULL,
+  day            TEXT    NOT NULL,            -- UTC date, YYYY-MM-DD
+  samples        INTEGER NOT NULL,           -- probe checks recorded that day
+  ok_count       INTEGER NOT NULL,           -- checks with status = 'ok'
+  uptime_ratio   REAL,                       -- ok_count / samples (4dp)
+  avg_latency_ms INTEGER,                    -- mean latency over the day
+  status         TEXT,                       -- ok | degraded | failed (daily rollup)
+  updated_at     INTEGER NOT NULL,           -- epoch ms of the last rollup write
+  PRIMARY KEY (surface_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_surface_uptime_daily_netuid_day
+  ON surface_uptime_daily (netuid, day);

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -538,6 +538,69 @@ async function persistToKv(kv, probed, runAt) {
   ]);
 }
 
+// UTC day bounds for a given epoch-ms instant: { date: "YYYY-MM-DD", start, end }.
+function utcDayBounds(ms) {
+  const d = new Date(ms);
+  const start = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+  return {
+    date: new Date(start).toISOString().slice(0, 10),
+    start,
+    end: start + 24 * 60 * 60 * 1000,
+  };
+}
+
+// Durable daily uptime rollup (PR3). Aggregates the raw 2-minute surface_checks
+// for a UTC day into ONE row per (surface, day) in surface_uptime_daily —
+// retained indefinitely for long-term uptime analytics — so the 30-day raw
+// prune never loses history. MUST run before pruneHealthHistory. Rolls up today
+// + yesterday each hour (the post-midnight fire finalizes the prior day; upsert
+// keeps it idempotent). No-ops when D1 is unbound/cold.
+export async function rollupDailyUptime(env, overrides = {}) {
+  const now = overrides.now || (() => Date.now());
+  const db = overrides.db || env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare) return { rolled: false };
+  const runAt = now();
+  const days = [utcDayBounds(runAt), utcDayBounds(runAt - 24 * 60 * 60 * 1000)];
+  const stmt = db.prepare(
+    `INSERT INTO surface_uptime_daily
+       (surface_id, netuid, day, samples, ok_count, uptime_ratio,
+        avg_latency_ms, status, updated_at)
+     SELECT
+       surface_id,
+       netuid,
+       ? AS day,
+       COUNT(*) AS samples,
+       SUM(ok) AS ok_count,
+       ROUND(CAST(SUM(ok) AS REAL) / COUNT(*), 4) AS uptime_ratio,
+       CAST(ROUND(AVG(latency_ms)) AS INTEGER) AS avg_latency_ms,
+       CASE
+         WHEN SUM(ok) = COUNT(*) THEN 'ok'
+         WHEN SUM(ok) = 0 THEN 'failed'
+         ELSE 'degraded'
+       END AS status,
+       ? AS updated_at
+     FROM surface_checks
+     WHERE checked_at >= ? AND checked_at < ?
+     GROUP BY surface_id, netuid
+     ON CONFLICT(surface_id, day) DO UPDATE SET
+       netuid = excluded.netuid,
+       samples = excluded.samples,
+       ok_count = excluded.ok_count,
+       uptime_ratio = excluded.uptime_ratio,
+       avg_latency_ms = excluded.avg_latency_ms,
+       status = excluded.status,
+       updated_at = excluded.updated_at`,
+  );
+  try {
+    await db.batch(
+      days.map(({ date, start, end }) => stmt.bind(date, runAt, start, end)),
+    );
+    return { rolled: true, days: days.map((d) => d.date) };
+  } catch {
+    return { rolled: false };
+  }
+}
+
 // Hourly maintenance cron: prune time-series rows older than the retention
 // window so the hot table stays lean.
 export async function pruneHealthHistory(env, overrides = {}) {

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -7,6 +7,7 @@ import {
   loadOperationalSurfaces,
   OPERATIONAL_SURFACES_PATH,
   pruneHealthHistory,
+  rollupDailyUptime,
   runHealthProber,
   workerResolvedUrlSafetyGuard,
   workerWebSocketConnector,
@@ -1222,5 +1223,85 @@ describe("pruneHealthHistory edge paths", () => {
     const result = await pruneHealthHistory({}, { now: () => 0, db });
     assert.equal(result.pruned, true);
     assert.equal(result.changes, null);
+  });
+});
+
+describe("rollupDailyUptime (durable daily history)", () => {
+  test("rolls up today + yesterday into surface_uptime_daily", async () => {
+    const db = makeDb();
+    const fixedNow = Date.UTC(2026, 5, 13, 10, 0, 0); // 2026-06-13T10:00Z
+    const result = await rollupDailyUptime(
+      { METAGRAPH_HEALTH_DB: db },
+      { now: () => fixedNow },
+    );
+    assert.equal(result.rolled, true);
+    assert.deepEqual(result.days, ["2026-06-13", "2026-06-12"]);
+    assert.equal(db.calls.batches.length, 1);
+    const stmts = db.calls.batches[0];
+    assert.equal(stmts.length, 2);
+    assert.match(stmts[0].sql, /INSERT INTO surface_uptime_daily/);
+    assert.match(stmts[0].sql, /ON CONFLICT\(surface_id, day\)/);
+    // binds: [day, updated_at, dayStart, dayEnd]
+    assert.deepEqual(stmts[0].binds, [
+      "2026-06-13",
+      fixedNow,
+      Date.UTC(2026, 5, 13),
+      Date.UTC(2026, 5, 14),
+    ]);
+    assert.equal(stmts[1].binds[0], "2026-06-12");
+    assert.equal(stmts[1].binds[2], Date.UTC(2026, 5, 12));
+  });
+
+  test("no-ops without a D1 binding", async () => {
+    assert.deepEqual(await rollupDailyUptime({}), { rolled: false });
+  });
+
+  test("degrades to { rolled: false } when the batch write throws", async () => {
+    const db = {
+      prepare: () => ({ bind: () => ({}) }),
+      async batch() {
+        throw new Error("d1 unavailable");
+      },
+    };
+    assert.deepEqual(await rollupDailyUptime({ METAGRAPH_HEALTH_DB: db }), {
+      rolled: false,
+    });
+  });
+
+  test("hourly cron rolls up BEFORE pruning the raw window", async () => {
+    const order = [];
+    const orderDb = {
+      prepare(sql) {
+        return {
+          sql,
+          bind: () => ({
+            sql,
+            async run() {
+              order.push(`run:${sql}`);
+              return { meta: { changes: 0 } };
+            },
+          }),
+        };
+      },
+      async batch(statements) {
+        order.push("batch:uptime-rollup");
+        return statements.map(() => ({ success: true }));
+      },
+    };
+    await handleScheduled(
+      { cron: "0 * * * *" },
+      { METAGRAPH_HEALTH_DB: orderDb },
+      {},
+    );
+    const rollupIdx = order.findIndex((o) => o === "batch:uptime-rollup");
+    const pruneIdx = order.findIndex((o) =>
+      o.includes("DELETE FROM surface_checks"),
+    );
+    assert.ok(rollupIdx >= 0, "rollup batch must run");
+    assert.ok(pruneIdx >= 0, "prune delete must run");
+    assert.ok(
+      rollupIdx < pruneIdx,
+      "daily rollup must run before the raw prune so history is never lost",
+    );
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -28,6 +28,7 @@ import {
   KV_HEALTH_META,
   KV_HEALTH_RPC_POOL,
   pruneHealthHistory,
+  rollupDailyUptime,
   runHealthProber,
   writeSubnetSnapshot,
 } from "../src/health-prober.mjs";
@@ -155,6 +156,10 @@ export default {
 export async function handleScheduled(controller, env = {}, ctx = {}) {
   const cron = controller?.cron || "";
   if (cron === HEALTH_PRUNE_CRON) {
+    // Roll the day's raw checks into the durable daily uptime table BEFORE
+    // pruning, so long-term history is never lost when 30-day raw rows are
+    // deleted (PR3). Then prune + snapshot.
+    await rollupDailyUptime(env);
     const [pruned] = await Promise.all([
       pruneHealthHistory(env),
       writeSubnetSnapshot(env, { readArtifact }),


### PR DESCRIPTION
## Why

**PR 3/5** of the live-only health migration ([plan](.claude/plans/delightful-inventing-seahorse.md)). With current health now live-only (PR 1+2), this retains **long-term uptime** for future analytics/charts — your explicit ask — stored as **daily aggregates only**, never the raw 2-minute series (~420K rows/yr vs ~300M/yr). Independent of PR 1/2.

## What

- **`migrations/0003_uptime_history.sql`**: new `surface_uptime_daily` table — one row per `(surface_id, day)` with `samples`, `ok_count`, `uptime_ratio`, `avg_latency_ms`, and a daily rollup `status`. Retained indefinitely.
- **`src/health-prober.mjs`**: `rollupDailyUptime()` aggregates the day's raw `surface_checks` into `surface_uptime_daily` (idempotent upsert; rolls up **today + yesterday** each hour so the post-midnight fire finalizes the prior day).
- **`workers/api.mjs`**: the hourly maintenance cron now **rolls up before pruning** the 30-day raw window, so long-term history is never lost. The raw `surface_checks` table is unchanged (still powers the live trends/percentiles/incidents routes).

## Not included (deliberate)

No raw long-term storage, no R2 archive (per your volume guardrail). The read route `/api/v1/subnets/{netuid}/uptime` is the **deferred, optional** consumer (the plan marks it "the chart route can land later") — the daily data accrues from the moment this deploys, so it's queryable whenever the route lands.

## Tests

`rollupDailyUptime` binds (today + yesterday day bounds), the no-D1 + write-error degradations, and the **roll-up-before-prune ordering** in the hourly cron. Clean full build → all 886 tests pass + coverage gate green (98.06% stmt / 90.06% branch).

> Note: `migrations/0003_uptime_history.sql` was force-added (`git add -f`) — a global gitignore ignores `*.sql`.