### PR TITLE
chore: gitignore .claude/ + refresh stale generated data artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,3 +179,6 @@ ops/private/
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# Claude Code session directory (local, per-developer)
+.claude/


### PR DESCRIPTION
**PR 5/5** (housekeeping) of the live-only health / AI-readiness work ([plan](.claude/plans/delightful-inventing-seahorse.md)).

- **`.gitignore`**: ignore the local `.claude/` Claude Code session directory.
- **Artifact refresh**: the committed data artifacts had drifted from the registry source (recent enrichment/provider PRs — sn2/13/39/90/93, bitcast — updated `registry/` without rebuilding the exports). Refreshed via a clean `npm run build` + `npm run r2:manifest`: `datasets/*`, `subnets.json`, `coverage.json`, `changelog.json`, `review/profile-completeness.json`, and the r2-manifest subset. Build-summary timestamp noise excluded. `validate.mjs` confirms internal consistency.