### PR TITLE
enrich(sn14): add subnet-api surface for Cacheon

### DIFF
--- a/registry/candidates/community/community-sn-14-subnet-api-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-subnet-api-api-cacheon-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-14-subnet-api-api-cacheon-ai",
+      "kind": "subnet-api",
+      "name": "Cacheon community subnet-api",
+      "netuid": 14,
+      "provider": "cacheon",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://cacheon.ai/docs/miners/api-contract",
+      "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
+      "state": "schema-valid",
+      "url": "https://api.cacheon.ai/api/status"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
First-party SN14 monitoring API (api.cacheon.ai); the contract docs name Subnet 14. Re-verifies the gate now routes a borderline reviewer-'manual' verdict to **manual review**, not auto-close.