### PR TITLE
fix(health): block stale R2 current-health artifacts and serve live-only subnet health

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -64,39 +64,19 @@ export function summarizeRows(rows) {
   };
 }
 
-// Per-subnet overlay: replace the static artifact's operational surfaces with the
-// fresh live rows (matched by surface_id), keep informational surfaces static,
-// recompute the summary. Returns null when there is no live snapshot.
+// Per-subnet overlay: build the response from fresh live rows only. Static
+// metadata may supply non-operational identity fields, but stale static surface
+// rows are never preserved. Returns null when there is no live snapshot.
 export function overlaySubnetHealth(staticArtifact, liveCurrent, netuid) {
   if (!liveCurrent || !Array.isArray(liveCurrent.surfaces)) return null;
   const liveById = new Map();
   for (const row of liveCurrent.surfaces) {
     if (row.netuid === netuid) liveById.set(row.surface_id, row);
   }
-  if (liveById.size === 0 && !staticArtifact) return null;
+  if (liveById.size === 0) return null;
 
-  const staticSurfaces = Array.isArray(staticArtifact?.surfaces)
-    ? staticArtifact.surfaces
-    : [];
-  const seen = new Set();
-  const merged = staticSurfaces.map((surface) => {
-    const live = liveById.get(surface.surface_id);
-    if (!live) return surface;
-    seen.add(surface.surface_id);
-    return {
-      ...surface,
-      status: live.status,
-      classification: live.classification,
-      latency_ms: live.latency_ms,
-      status_code: live.status_code,
-      last_checked: live.last_checked,
-      last_ok: live.last_ok,
-      observed_by: "live-cron-prober",
-    };
-  });
-  // Live operational surfaces not (yet) in the static artifact.
+  const merged = [];
   for (const [id, live] of liveById) {
-    if (seen.has(id)) continue;
     merged.push({
       surface_id: id,
       netuid,

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -110,17 +110,6 @@ function mcpLiveHealth(ctx) {
   });
 }
 
-// Best-effort static artifact read that yields null instead of throwing, so a
-// tool can fall through to a live-only / `unknown` payload once the static
-// health artifacts are removed (PR2).
-async function loadArtifactDataOrNull(ctx, artifactPath) {
-  try {
-    return await loadArtifactData(ctx, artifactPath);
-  } catch {
-    return null;
-  }
-}
-
 // AI-dependent tools (semantic_search, ask) need the VECTORIZE + AI bindings and
 // the kill-switch on. In a cold/CI env they degrade to a graceful isError result
 // pointing at the keyword fallback, never a transport error.
@@ -214,7 +203,10 @@ async function rankSubnetsForTask(ctx, task, poolSize) {
   const docs = Array.isArray(index.documents) ? index.documents : [];
   const ranked = docs
     .filter((doc) => doc.type === "subnet")
-    .map((doc) => ({ netuid: doc.netuid, relevance: scoreDocument(doc, terms) }))
+    .map((doc) => ({
+      netuid: doc.netuid,
+      relevance: scoreDocument(doc, terms),
+    }))
     .filter((entry) => entry.relevance > 0)
     .sort((a, b) => b.relevance - a.relevance || a.netuid - b.netuid)
     .slice(0, poolSize);
@@ -441,13 +433,8 @@ export const MCP_TOOLS = [
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
       const live = await mcpLiveHealth(ctx);
-      const staticHealth = await loadArtifactDataOrNull(
-        ctx,
-        `/metagraph/health/subnets/${netuid}.json`,
-      );
-      const overlaid = overlaySubnetHealth(staticHealth, live, netuid);
+      const overlaid = overlaySubnetHealth(null, live, netuid);
       if (overlaid) return overlaid;
-      if (staticHealth) return staticHealth;
       return {
         schema_version: 1,
         netuid,
@@ -760,8 +747,7 @@ export const MCP_TOOLS = [
       properties: {
         task: {
           type: "string",
-          description:
-            "What you want to accomplish, in plain language.",
+          description: "What you want to accomplish, in plain language.",
         },
         limit: {
           type: "integer",

--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -435,16 +435,68 @@ describe("live health overlay (rpc-endpoints + freshness)", () => {
     assert.equal(body.meta.source, "live-cron-prober");
   });
 
-  test("/api/v1/health with KV bound but cold serves the static artifact", async () => {
-    // health:current absent → liveHealthOverlay returns null at the `!current`
-    // guard, so the static health summary artifact is served.
+  test("/api/v1/health with KV bound but cold serves unknown, not static", async () => {
     const env = createLocalArtifactEnv({
       METAGRAPH_CONTROL: makeKv({}),
     });
     const res = await handleRequest(req("/api/v1/health"), env, {});
     assert.equal(res.status, 200);
     const body = await res.json();
-    assert.notEqual(body.meta.source, "live-cron-prober");
+    assert.equal(body.meta.source, "unavailable");
+    assert.equal(body.data.global.status_counts.unknown, 0);
+  });
+
+  test("retired raw current-health artifacts return 410 before stale R2 reads", async () => {
+    let reads = 0;
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          reads += 1;
+          return {
+            async json() {
+              return { stale: true };
+            },
+          };
+        },
+      },
+    });
+    for (const path of [
+      "/metagraph/health/latest.json",
+      "/metagraph/health/summary.json",
+      "/metagraph/health/subnets/7.json",
+    ]) {
+      const res = await handleRequest(req(path), env, {});
+      assert.equal(res.status, 410);
+      assert.equal((await res.json()).error.code, "retired_artifact");
+    }
+    assert.equal(reads, 0);
+  });
+
+  test("/api/v1/subnets/:netuid/health ignores stale static R2 objects", async () => {
+    let reads = 0;
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          reads += 1;
+          return {
+            async json() {
+              return {
+                netuid: 7,
+                summary: { status: "ok" },
+                surfaces: [{ surface_id: "stale", status: "ok" }],
+              };
+            },
+          };
+        },
+      },
+      METAGRAPH_CONTROL: makeKv({}),
+    });
+    const res = await handleRequest(req("/api/v1/subnets/7/health"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.summary.status, "unknown");
+    assert.deepEqual(body.data.surfaces, []);
+    assert.equal(reads, 0);
   });
 
   test("readHealthKv swallows a throwing KV get (serves static)", async () => {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -20,7 +20,7 @@ import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
 describe("overlaySubnetHealth", () => {
-  test("replaces operational surfaces with live rows; keeps informational static", () => {
+  test("builds per-subnet health from live rows without stale static surfaces", () => {
     const staticArtifact = {
       schema_version: 1,
       netuid: 7,
@@ -59,12 +59,14 @@ describe("overlaySubnetHealth", () => {
     };
     const merged = overlaySubnetHealth(staticArtifact, liveCurrent, 7);
     const api = merged.surfaces.find((s) => s.surface_id === "sn7-api");
-    const docs = merged.surfaces.find((s) => s.surface_id === "sn7-docs");
     assert.equal(api.status, "ok"); // overlaid live
     assert.equal(api.observed_by, "live-cron-prober");
-    assert.equal(docs.status, "ok"); // static, untouched
-    assert.equal(merged.summary.status, "ok"); // recomputed over merged set
-    assert.equal(merged.summary.ok_count, 2);
+    assert.equal(
+      merged.surfaces.some((s) => s.surface_id === "sn7-docs"),
+      false,
+    );
+    assert.equal(merged.summary.status, "ok"); // recomputed over live set
+    assert.equal(merged.summary.ok_count, 1);
     assert.equal(merged.operational_observed_at, "2026-06-11T00:00:00.000Z");
   });
 
@@ -255,7 +257,10 @@ describe("summarizeRows / rollupStatus", () => {
     assert.equal(out.avg_latency_ms, null);
   });
   test("all-unknown → unknown", () => {
-    assert.equal(summarizeRows([row("unknown"), row("unknown")]).status, "unknown");
+    assert.equal(
+      summarizeRows([row("unknown"), row("unknown")]).status,
+      "unknown",
+    );
   });
   test("all-ok → ok", () => {
     assert.equal(summarizeRows([row("ok"), row("ok")]).status, "ok");
@@ -264,7 +269,10 @@ describe("summarizeRows / rollupStatus", () => {
     assert.equal(summarizeRows([row("ok"), row("failed")]).status, "degraded");
   });
   test("ok + degraded mix → degraded", () => {
-    assert.equal(summarizeRows([row("ok"), row("degraded")]).status, "degraded");
+    assert.equal(
+      summarizeRows([row("ok"), row("degraded")]).status,
+      "degraded",
+    );
   });
   test("degraded + failed (no ok) → degraded (right-hand OR operand)", () => {
     // ok=0 so the `(counts.ok||0)>0` left operand is false; degraded>0 carries it.
@@ -371,7 +379,12 @@ describe("overlaySubnetHealth (additional paths)", () => {
     const live = {
       last_run_at: null,
       surfaces: [
-        { surface_id: "sn7-rpc", netuid: 7, kind: "subtensor-rpc", status: "ok" },
+        {
+          surface_id: "sn7-rpc",
+          netuid: 7,
+          kind: "subtensor-rpc",
+          status: "ok",
+        },
       ],
     };
     const out = overlaySubnetHealth({ schema_version: 2 }, live, 7);
@@ -568,7 +581,9 @@ describe("overlayRpcPoolEligibility (additional paths)", () => {
   });
 
   test("sustained-down endpoint with explicit live latency drops eligibility", () => {
-    const pool = { endpoints: [{ id: "a", pool_eligible: true, latency_ms: 5 }] };
+    const pool = {
+      endpoints: [{ id: "a", pool_eligible: true, latency_ms: 5 }],
+    };
     const live = {
       endpoints: [
         { id: "a", status: "failed", consecutive_failures: 2, latency_ms: 70 },
@@ -616,9 +631,18 @@ describe("formatTrends (additional paths)", () => {
       w.surfaces.map((s) => s.surface_id),
       ["a", "m", "z"],
     );
-    assert.equal(w.surfaces.find((s) => s.surface_id === "z").avg_latency_ms, null);
-    assert.equal(w.surfaces.find((s) => s.surface_id === "a").avg_latency_ms, 13);
-    assert.equal(w.surfaces.find((s) => s.surface_id === "m").uptime_ratio, null);
+    assert.equal(
+      w.surfaces.find((s) => s.surface_id === "z").avg_latency_ms,
+      null,
+    );
+    assert.equal(
+      w.surfaces.find((s) => s.surface_id === "a").avg_latency_ms,
+      13,
+    );
+    assert.equal(
+      w.surfaces.find((s) => s.surface_id === "m").uptime_ratio,
+      null,
+    );
     assert.equal(w.samples, 14);
     assert.equal(w.uptime_ratio, Number((6 / 14).toFixed(4)));
   });

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -517,9 +517,12 @@ describe("MCP tools (injected deps)", () => {
     assert.ok(res.body.result.content[0].text.includes("artifact_not_found"));
   });
 
-  test("get_subnet_health returns the health artifact", async () => {
+  test("get_subnet_health is live-only — ignores the static artifact, reports unknown when the live store is cold", async () => {
+    // `deps` carries a static /metagraph/health/subnets/7.json (summary.status
+    // "ok"), but current health is live-only: the retired static artifact must
+    // never be served, so a cold live store yields `unknown`, not stale "ok".
     const res = await callTool("get_subnet_health", { netuid: 7 }, { deps });
-    assert.equal(res.body.result.structuredContent.summary.status, "ok");
+    assert.equal(res.body.result.structuredContent.summary.status, "unknown");
   });
 
   test("list_subnet_apis returns the per-subnet services", async () => {
@@ -1473,12 +1476,12 @@ describe("MCP goal-shaped tools — branch coverage", () => {
       assert.equal(out.health_source, "live-cron-prober");
     });
 
-    test("cold KV → tools still serve the static artifact (no regression)", async () => {
+    test("cold KV → static current-health is NOT served (live-only); reports unknown", async () => {
       const deps = makeDeps({
         "/metagraph/health/subnets/7.json": staticHealth,
       });
       const res = await callTool("get_subnet_health", { netuid: 7 }, { deps });
-      assert.equal(res.body.result.structuredContent.summary.status, "ok");
+      assert.equal(res.body.result.structuredContent.summary.status, "unknown");
     });
 
     test("get_subnet_health with neither live nor static → unknown, never baked", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -68,6 +68,8 @@ const HEALTH_PRUNE_CRON = "0 * * * *";
 // top-of-hour prune. Must match a wrangler.jsonc `triggers.crons` entry.
 const EMBEDDING_SYNC_CRON = "37 3 * * *";
 // Trend windows for /api/v1/subnets/{netuid}/health/trends.
+const RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN =
+  /^\/metagraph\/health\/(?:latest\.json|summary\.json|subnets\/\d+\.json)$/;
 const HEALTH_TREND_WINDOWS = { "7d": 7, "30d": 30 };
 const TRENDS_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/health\/trends$/;
 const PERCENTILES_PATH_PATTERN =
@@ -458,6 +460,17 @@ async function handleRawArtifactRequest(
   }
 
   const networkPath = artifactPathForNetwork(url.pathname, network);
+  if (
+    network.isDefault &&
+    RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN.test(networkPath)
+  ) {
+    return errorResponse(
+      "retired_artifact",
+      "Current-state health artifacts are retired; use the live API health endpoints instead.",
+      410,
+      { artifact_path: networkPath },
+    );
+  }
   const artifact = await readArtifact(env, networkPath);
   if (!artifact.ok) {
     return errorResponse(artifact.code, artifact.message, artifact.status, {
@@ -859,11 +872,9 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
   // read metagraph/{prefix}/… — see artifactPathForNetwork.
   const artifactPath = artifactPathForNetwork(matched.artifactPath, network);
 
-  // Live operational-health overlay (Phase 3): overlay the fresh 2-minute cron
-  // snapshot (KV/D1) onto the static artifact, falling back to static when the
-  // snapshot is cold/unbound — zero regression. Perf: the global `health` summary
-  // is built purely from KV, so it skips the otherwise-wasted static R2 read when
-  // the snapshot is warm (the hot path on the most-hit health endpoint).
+  // Live operational-health overlay (Phase 3): current health is live-only.
+  // Static current-health artifacts are not read for mainnet health routes, so
+  // stale R2 objects left behind by earlier publishes cannot affect responses.
   let artifact;
   let live = null;
   if (!network.isDefault) {
@@ -886,6 +897,14 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
       : null;
     live = { data: liveData || unknownGlobalHealth(contractVersion(env)) };
     artifact = { ok: false };
+  } else if (matched.id === "subnet-health") {
+    artifact = { ok: false };
+    live = await liveHealthOverlay(env, matched, null);
+    // Per-subnet health is live-only too: never 404 on a cold store — serve an
+    // explicit `unknown` payload instead of the (now absent) static artifact.
+    if (!live) {
+      live = { data: unknownSubnetHealth(Number(matched.params.netuid)) };
+    }
   } else {
     artifact = await readArtifact(env, artifactPath);
     live = await liveHealthOverlay(
@@ -893,11 +912,6 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
       matched,
       artifact.ok ? artifact.data : null,
     );
-    // Per-subnet health is live-only too: never 404 on a cold store — serve an
-    // explicit `unknown` payload instead of the (now absent) static artifact.
-    if (!live && matched.id === "subnet-health") {
-      live = { data: unknownSubnetHealth(Number(matched.params.netuid)) };
-    }
   }
 
   if (!artifact.ok && !live) {
@@ -2714,7 +2728,8 @@ function filterRows(rows, params, keys, csvFilters = {}, arrayFilters = {}) {
       if (arrayFields) {
         return arrayFields.some(
           (field) =>
-            Array.isArray(row[field]) && row[field].map(String).includes(expected),
+            Array.isArray(row[field]) &&
+            row[field].map(String).includes(expected),
         );
       }
       const value = row[key];


### PR DESCRIPTION
### Motivation
- Previously published static current-health artifacts under `latest/` could remain addressable and be returned as current public data, allowing stale operational health rows to leak into responses and undermining the live-only migration.
- The per-subnet overlay preserved unmatched static surface rows, so an old R2 `health/subnets/{netuid}.json` object could influence `/api/v1/subnets/{netuid}/health` responses.

### Description
- Return `410 retired_artifact` for retired raw current-health paths before any R2 read by adding `RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN` and an early check in `handleRawArtifactRequest` in `workers/api.mjs`.
- Make mainnet per-subnet health live-only by skipping static artifact reads for `matched.id === "subnet-health"` and falling back to `unknown` when the live store is cold in `workers/api.mjs`.
- Stop preserving stale static surfaces in overlays by changing `overlaySubnetHealth` to build per-subnet responses solely from live rows in `src/health-serving.mjs`.
- Update MCP tool `get_subnet_health` to avoid falling back to stale static artifacts by calling `overlaySubnetHealth(null, live, netuid)` in `src/mcp-server.mjs`.
- Add and adjust regression tests to assert retired raw artifact paths return `410` and that per-subnet health ignores stale static R2 objects, and update overlay expectations in `tests/api-coverage.test.mjs` and `tests/health-serving.test.mjs`.

### Testing
- Ran formatting and linting with `npx prettier --write ...` and `npx eslint ...` and fixed issues; these completed successfully.
- Executed targeted unit tests: `npm test -- tests/api-coverage.test.mjs -t "retired raw|ignores stale|KV bound" --run` and `npm test -- tests/health-serving.test.mjs -t "overlaySubnetHealth" --run`, both of which passed.
- A full test run of the entire suites produced unrelated 404s in this workspace due to missing generated/local artifact fixtures (e.g., `latest/overview/7.json`), so some unrelated tests failed in this environment but the regression tests covering the change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cfa581444832aabeef8d859b46637)