### PR TITLE
feat(health): add GET /api/v1/subnets/{netuid}/uptime — daily uptime history route

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -74,6 +74,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/health/percentiles/{netuid}.json`: schema for per-surface latency percentiles (p50/p95/p99) served live from D1 at `GET /api/v1/subnets/{netuid}/health/percentiles` (no static file).
 - `/metagraph/health/incidents/{netuid}.json`: schema for per-surface SLA + reconstructed downtime incidents served live from D1 at `GET /api/v1/subnets/{netuid}/health/incidents` (no static file).
 - `/metagraph/subnets/{netuid}/trajectory.json`: schema for the week-over-week structural trajectory served live from D1 at `GET /api/v1/subnets/{netuid}/trajectory` (no static file).
+- `/metagraph/subnets/{netuid}/uptime.json`: schema for the long-term daily uptime history per operational surface (90d/1y window), served live from the `surface_uptime_daily` D1 rollup at `GET /api/v1/subnets/{netuid}/uptime` (no static file).
 - `/metagraph/registry/leaderboards.json`: schema for the registry leaderboards served live from D1 + registry projections at `GET /api/v1/registry/leaderboards` (no static file).
 - `/metagraph/schema-drift.json`: OpenAPI snapshot/drift status.
 - `/metagraph/schemas/index.json`: captured machine-readable schema index.
@@ -108,6 +109,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/subnets/{netuid}/health/percentiles`: fetch p50/p95/p99 latency percentiles per operational surface over a 7d/30d window (live from D1).
 - `/api/v1/subnets/{netuid}/health/incidents`: fetch SLA (uptime ratio) + reconstructed downtime incidents per operational surface over a 7d/30d window (live from D1).
 - `/api/v1/subnets/{netuid}/trajectory`: fetch the week-over-week structural trajectory (completeness + counts) from daily snapshots (live from D1).
+- `/api/v1/subnets/{netuid}/uptime`: fetch long-term daily uptime history per operational surface over a 90d/1y window (live from the `surface_uptime_daily` D1 rollup).
 - `/api/v1/registry/leaderboards`: fetch registry leaderboards (`board=healthiest|fastest-rpc|most-complete|fastest-growing`, or omit for all).
 - `/api/v1/surfaces`: list curated public surfaces.
 - `/api/v1/subnets/{netuid}/surfaces`: list curated public surfaces for one subnet.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -922,6 +922,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/uptime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). */
+        get: operations["subnetUptime"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/surfaces": {
         parameters: {
             query?: never;
@@ -2965,6 +2982,31 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        UptimeArtifact: {
+            netuid: number;
+            schema_version: number;
+            source: string;
+            surfaces: ({
+                day_count: number;
+                days: ({
+                    avg_latency_ms?: number | null;
+                    day: string;
+                    samples: number;
+                    status: string;
+                    uptime_ratio: number | null;
+                } & {
+                    [key: string]: unknown;
+                })[];
+                samples: number;
+                surface_id: string;
+                uptime_ratio: number | null;
+            } & {
+                [key: string]: unknown;
+            })[];
+            window?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         VerificationArtifact: components["schemas"]["ArtifactBase"] & ({
             candidate_count: number;
             /** Format: date-time */
@@ -6973,6 +7015,78 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetTrajectoryArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetUptime: {
+        parameters: {
+            query?: {
+                window?: "90d" | "1y";
+            };
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["UptimeArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -324,6 +324,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "subnet-uptime",
+      "path": "/metagraph/subnets/{netuid}/uptime.json",
+      "schema_ref": "#/components/schemas/UptimeArtifact",
+      "storage_tier": "git"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
       "schema_ref": "#/components/schemas/RegistryLeaderboardsArtifact",
@@ -3397,6 +3404,29 @@
       "query_collection": null,
       "query_filter_names": [],
       "query_parameters": []
+    },
+    {
+      "artifact_path": "/metagraph/subnets/{netuid}/uptime.json",
+      "cache": "short",
+      "description": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+      "id": "subnet-uptime",
+      "method": "GET",
+      "path": "/api/v1/subnets/{netuid}/uptime",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "window",
+          "schema": {
+            "enum": [
+              "90d",
+              "1y"
+            ],
+            "type": "string"
+          }
+        }
+      ]
     },
     {
       "artifact_path": "/metagraph/registry/leaderboards.json",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -417,6 +417,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
+      "id": "subnet-uptime",
+      "path": "/metagraph/subnets/{netuid}/uptime.json",
+      "schema_ref": "#/components/schemas/UptimeArtifact",
+      "storage_tier": "git"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing), computed live from D1 + registry projections at /api/v1/registry/leaderboards (no static file).",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -8375,6 +8375,104 @@
           }
         ]
       },
+      "UptimeArtifact": {
+        "additionalProperties": true,
+        "properties": {
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "surfaces": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "day_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "days": {
+                  "items": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "avg_latency_ms": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "day": {
+                        "type": "string"
+                      },
+                      "samples": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "uptime_ratio": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "day",
+                      "samples",
+                      "uptime_ratio",
+                      "status"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "samples": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "surface_id": {
+                  "type": "string"
+                },
+                "uptime_ratio": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "surface_id",
+                "day_count",
+                "samples",
+                "uptime_ratio",
+                "days"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "window": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "source",
+          "surfaces"
+        ],
+        "type": "object"
+      },
       "VerificationArtifact": {
         "allOf": [
           {
@@ -16761,6 +16859,118 @@
         },
         "summary": "Fetch the week-over-week structural trajectory (completeness + surface/endpoint counts) for one subnet from daily snapshots (computed live from D1).",
         "tags": [
+          "subnets",
+          "analytics"
+        ]
+      }
+    },
+    "/api/v1/subnets/{netuid}/uptime": {
+      "get": {
+        "operationId": "subnetUptime",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "netuid",
+            "required": true,
+            "schema": {
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "enum": [
+                "90d",
+                "1y"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/UptimeArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+        "tags": [
+          "health",
           "subnets",
           "analytics"
         ]

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -922,6 +922,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/subnets/{netuid}/uptime": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup). */
+        get: operations["subnetUptime"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/surfaces": {
         parameters: {
             query?: never;
@@ -2965,6 +2982,31 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        UptimeArtifact: {
+            netuid: number;
+            schema_version: number;
+            source: string;
+            surfaces: ({
+                day_count: number;
+                days: ({
+                    avg_latency_ms?: number | null;
+                    day: string;
+                    samples: number;
+                    status: string;
+                    uptime_ratio: number | null;
+                } & {
+                    [key: string]: unknown;
+                })[];
+                samples: number;
+                surface_id: string;
+                uptime_ratio: number | null;
+            } & {
+                [key: string]: unknown;
+            })[];
+            window?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         VerificationArtifact: components["schemas"]["ArtifactBase"] & ({
             candidate_count: number;
             /** Format: date-time */
@@ -6973,6 +7015,78 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetTrajectoryArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    subnetUptime: {
+        parameters: {
+            query?: {
+                window?: "90d" | "1y";
+            };
+            header?: never;
+            path: {
+                netuid: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["UptimeArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -8353,6 +8353,104 @@
           }
         ]
       },
+      "UptimeArtifact": {
+        "additionalProperties": true,
+        "properties": {
+          "netuid": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "surfaces": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "day_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "days": {
+                  "items": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "avg_latency_ms": {
+                        "type": [
+                          "integer",
+                          "null"
+                        ]
+                      },
+                      "day": {
+                        "type": "string"
+                      },
+                      "samples": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "uptime_ratio": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "day",
+                      "samples",
+                      "uptime_ratio",
+                      "status"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "samples": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "surface_id": {
+                  "type": "string"
+                },
+                "uptime_ratio": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                }
+              },
+              "required": [
+                "surface_id",
+                "day_count",
+                "samples",
+                "uptime_ratio",
+                "days"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "window": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "netuid",
+          "source",
+          "surfaces"
+        ],
+        "type": "object"
+      },
       "VerificationArtifact": {
         "allOf": [
           {

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -564,6 +564,52 @@
         },
         "additionalProperties": true
       },
+      "UptimeArtifact": {
+        "type": "object",
+        "required": ["schema_version", "netuid", "source", "surfaces"],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "netuid": { "type": "integer", "minimum": 0 },
+          "window": { "type": ["string", "null"] },
+          "source": { "type": "string" },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "surface_id",
+                "day_count",
+                "samples",
+                "uptime_ratio",
+                "days"
+              ],
+              "properties": {
+                "surface_id": { "type": "string" },
+                "day_count": { "type": "integer", "minimum": 0 },
+                "samples": { "type": "integer", "minimum": 0 },
+                "uptime_ratio": { "type": ["number", "null"] },
+                "days": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["day", "samples", "uptime_ratio", "status"],
+                    "properties": {
+                      "day": { "type": "string" },
+                      "samples": { "type": "integer", "minimum": 0 },
+                      "uptime_ratio": { "type": ["number", "null"] },
+                      "avg_latency_ms": { "type": ["integer", "null"] },
+                      "status": { "type": "string" }
+                    },
+                    "additionalProperties": true
+                  }
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      },
       "RegistryLeaderboardsArtifact": {
         "type": "object",
         "required": ["schema_version", "source", "boards"],

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -69,6 +69,14 @@ const checks = [
     },
   ],
   [
+    "/api/v1/subnets/7/uptime",
+    (body) => {
+      assert.equal(body.data.netuid, 7);
+      assert.equal(Array.isArray(body.data.surfaces), true);
+      assert.equal(body.data.source, "live-cron-prober");
+    },
+  ],
+  [
     "/api/v1/registry/leaderboards",
     (body) => {
       assert.equal(typeof body.data.boards, "object");

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -25,6 +25,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "health-percentiles",
   "health-incidents",
   "subnet-trajectory",
+  "subnet-uptime",
   "registry-leaderboards",
   // Live-only operational health (served from KV/D1, no static file on disk).
   "health-latest",

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -804,6 +804,12 @@ export const PUBLIC_ARTIFACTS = [
     "SubnetTrajectoryArtifact",
   ),
   artifact(
+    "subnet-uptime",
+    "/metagraph/subnets/{netuid}/uptime.json",
+    "Long-term daily uptime history per operational surface for one subnet (90d/1y window), served live from the surface_uptime_daily D1 rollup (no static file).",
+    "UptimeArtifact",
+  ),
+  artifact(
     "registry-leaderboards",
     "/metagraph/registry/leaderboards.json",
     "Registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing), computed live from D1 + registry projections at /api/v1/registry/leaderboards (no static file).",
@@ -1336,6 +1342,17 @@ export const API_ROUTES = [
     "short",
     ["subnets", "analytics"],
     [],
+    [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
+  ),
+  route(
+    "subnet-uptime",
+    "GET",
+    "/api/v1/subnets/{netuid}/uptime",
+    "/metagraph/subnets/{netuid}/uptime.json",
+    "Fetch long-term daily uptime history per operational surface for one subnet over a 90d or 1y window (computed live from the surface_uptime_daily D1 rollup).",
+    "short",
+    ["health", "subnets", "analytics"],
+    [{ name: "window", schema: { type: "string", enum: ["90d", "1y"] } }],
     [{ name: "netuid", schema: { type: "integer", minimum: 0 } }],
   ),
   route(

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -549,6 +549,57 @@ function shiftDate(isoDate, days) {
   return new Date(base).toISOString().slice(0, 10);
 }
 
+// Long-term daily uptime series per surface, from surface_uptime_daily rows
+// {surface_id, day, samples, ok_count, uptime_ratio, avg_latency_ms, status}.
+// Groups by surface, sorts days ascending, and rolls a window-wide uptime_ratio
+// from the summed ok_count/samples (exact, not an average of ratios).
+export function formatUptime({ netuid, window, rows }) {
+  const bySurface = new Map();
+  for (const row of rows || []) {
+    const list = bySurface.get(row.surface_id) || [];
+    list.push({
+      day: row.day,
+      samples: Number(row.samples) || 0,
+      ok_count: Number(row.ok_count) || 0,
+      uptime_ratio: row.uptime_ratio == null ? null : Number(row.uptime_ratio),
+      avg_latency_ms:
+        row.avg_latency_ms == null
+          ? null
+          : Math.round(Number(row.avg_latency_ms)),
+      status: row.status || "unknown",
+    });
+    bySurface.set(row.surface_id, list);
+  }
+  const surfaces = [...bySurface.entries()]
+    .map(([surfaceId, days]) => {
+      days.sort((a, b) => String(a.day).localeCompare(String(b.day)));
+      const samples = days.reduce((sum, d) => sum + d.samples, 0);
+      const okCount = days.reduce((sum, d) => sum + d.ok_count, 0);
+      return {
+        surface_id: surfaceId,
+        day_count: days.length,
+        samples,
+        uptime_ratio: samples ? Number((okCount / samples).toFixed(4)) : null,
+        // Per-day series without the internal ok_count (uptime_ratio covers it).
+        days: days.map((d) => ({
+          day: d.day,
+          samples: d.samples,
+          uptime_ratio: d.uptime_ratio,
+          avg_latency_ms: d.avg_latency_ms,
+          status: d.status,
+        })),
+      };
+    })
+    .sort((a, b) => a.surface_id.localeCompare(b.surface_id));
+  return {
+    schema_version: 1,
+    netuid,
+    window: window || null,
+    source: "live-cron-prober",
+    surfaces,
+  };
+}
+
 // --- Live-everywhere health resolution + composed-artifact overlays ----------
 // Health must never be served from a build-time artifact. resolveLiveHealth
 // returns the freshest live snapshot — KV health:current first, then a

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -11,6 +11,7 @@ import {
   overlayOverviewHealth,
   overlayRpcPoolEligibility,
   overlaySubnetHealth,
+  formatUptime,
   parseLive,
   resolveLiveHealth,
   subnetBadgeStatus,
@@ -1045,5 +1046,134 @@ describe("worker live health overlay on composed routes", () => {
     const res = await handleRequest(req("/api/v1/subnets/7/overview"), env, {});
     const body = await res.json();
     assert.equal(body.data.health, null);
+  });
+});
+
+describe("formatUptime (daily uptime history)", () => {
+  test("groups by surface, sorts days, rolls window uptime from ok_count/samples", () => {
+    const out = formatUptime({
+      netuid: 7,
+      window: "90d",
+      rows: [
+        {
+          surface_id: "b",
+          day: "2026-06-12",
+          samples: 100,
+          ok_count: 100,
+          uptime_ratio: 1,
+          avg_latency_ms: 50,
+          status: "ok",
+        },
+        {
+          surface_id: "a",
+          day: "2026-06-13",
+          samples: 100,
+          ok_count: 90,
+          uptime_ratio: 0.9,
+          avg_latency_ms: 70,
+          status: "degraded",
+        },
+        {
+          surface_id: "a",
+          day: "2026-06-12",
+          samples: 100,
+          ok_count: 80,
+          uptime_ratio: 0.8,
+          avg_latency_ms: 60,
+          status: "degraded",
+        },
+      ],
+    });
+    assert.equal(out.netuid, 7);
+    assert.equal(out.window, "90d");
+    assert.equal(out.source, "live-cron-prober");
+    // sorted by surface_id (a before b)
+    assert.equal(out.surfaces[0].surface_id, "a");
+    assert.equal(out.surfaces[0].day_count, 2);
+    assert.equal(out.surfaces[0].samples, 200);
+    // window uptime = (80+90)/200 = 0.85, from summed counts (not avg of ratios)
+    assert.equal(out.surfaces[0].uptime_ratio, 0.85);
+    // days sorted ascending; internal ok_count dropped from the per-day series
+    assert.equal(out.surfaces[0].days[0].day, "2026-06-12");
+    assert.equal(out.surfaces[0].days[0].ok_count, undefined);
+    assert.equal(out.surfaces[0].days[0].uptime_ratio, 0.8);
+  });
+
+  test("returns an empty series for no rows", () => {
+    assert.deepEqual(
+      formatUptime({ netuid: 7, window: "1y", rows: [] }).surfaces,
+      [],
+    );
+  });
+
+  test("handles null ratios/latency, missing status, zero samples, and no window", () => {
+    const out = formatUptime({
+      netuid: 7,
+      rows: [
+        {
+          surface_id: "z",
+          day: "2026-06-13",
+          samples: 0,
+          ok_count: 0,
+          uptime_ratio: null,
+          avg_latency_ms: null,
+        },
+      ],
+    });
+    assert.equal(out.window, null); // window omitted → null
+    assert.equal(out.surfaces[0].uptime_ratio, null); // samples 0 → null ratio
+    assert.equal(out.surfaces[0].days[0].uptime_ratio, null);
+    assert.equal(out.surfaces[0].days[0].avg_latency_ms, null);
+    assert.equal(out.surfaces[0].days[0].status, "unknown"); // missing → unknown
+  });
+});
+
+describe("worker /api/v1/subnets/{netuid}/uptime route", () => {
+  test("serves the live daily uptime rollup from D1", async () => {
+    const env = createLocalArtifactEnv({
+      METAGRAPH_HEALTH_DB: d1With([
+        {
+          surface_id: "7:subnet-api:x",
+          day: "2026-06-13",
+          samples: 700,
+          ok_count: 700,
+          uptime_ratio: 1,
+          avg_latency_ms: 40,
+          status: "ok",
+        },
+      ]),
+    });
+    const res = await handleRequest(
+      req("/api/v1/subnets/7/uptime?window=1y"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.netuid, 7);
+    assert.equal(body.data.window, "1y");
+    assert.equal(body.data.surfaces[0].surface_id, "7:subnet-api:x");
+    assert.equal(body.data.surfaces[0].uptime_ratio, 1);
+    assert.equal(body.meta.source, "live-cron-prober");
+  });
+
+  test("defaults to 90d and returns an empty series when D1 is cold", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(req("/api/v1/subnets/7/uptime"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.data.window, "90d");
+    assert.deepEqual(body.data.surfaces, []);
+  });
+
+  test("rejects an invalid window with 400", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      req("/api/v1/subnets/7/uptime?window=5y"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 400);
+    assert.equal((await res.json()).error.code, "invalid_query");
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -39,6 +39,7 @@ import {
   formatPercentiles,
   formatTrajectory,
   formatTrends,
+  formatUptime,
   INCIDENT_GAP_MS,
   LEADERBOARD_BOARDS,
   mergeFreshness,
@@ -74,6 +75,9 @@ const PERCENTILES_PATH_PATTERN =
   /^\/api\/v1\/subnets\/(\d+)\/health\/percentiles$/;
 const INCIDENTS_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/health\/incidents$/;
 const TRAJECTORY_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/trajectory$/;
+const UPTIME_PATH_PATTERN = /^\/api\/v1\/subnets\/(\d+)\/uptime$/;
+const UPTIME_WINDOWS = { "90d": 90, "1y": 365 };
+const MAX_UPTIME_ROWS = 10000;
 const ANALYTICS_WINDOWS = { "7d": 7, "30d": 30 };
 const ANALYTICS_WINDOW_PARAM = "window";
 const MAX_INCIDENT_ROWS = 1000;
@@ -304,6 +308,10 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     if (trajectoryMatch) {
       return handleTrajectory(request, env, Number(trajectoryMatch[1]));
     }
+    const uptimeMatch = UPTIME_PATH_PATTERN.exec(resolved.url.pathname);
+    if (uptimeMatch) {
+      return handleUptime(request, env, Number(uptimeMatch[1]), resolved.url);
+    }
     return handleApiRequest(request, env, resolved.url);
   }
 
@@ -342,7 +350,8 @@ function isMainnetOnlyApiPath(pathname) {
     TRENDS_PATH_PATTERN.test(pathname) ||
     PERCENTILES_PATH_PATTERN.test(pathname) ||
     INCIDENTS_PATH_PATTERN.test(pathname) ||
-    TRAJECTORY_PATH_PATTERN.test(pathname)
+    TRAJECTORY_PATH_PATTERN.test(pathname) ||
+    UPTIME_PATH_PATTERN.test(pathname)
   );
 }
 
@@ -1189,6 +1198,48 @@ async function handleTrajectory(request, env, netuid) {
       meta: analyticsMeta(
         env,
         `/metagraph/subnets/${netuid}/trajectory.json`,
+        null,
+      ),
+    },
+    "short",
+  );
+}
+
+// Long-term daily uptime history for one subnet's operational surfaces, served
+// live from the surface_uptime_daily rollup (PR3). 90d/1y window. Returns a
+// schema-stable empty payload when D1 is unbound/cold or no history has accrued
+// yet (mirrors the other D1-backed analytics routes).
+async function handleUptime(request, env, netuid, url) {
+  const windowParam = url.searchParams.get("window") || "90d";
+  const days = UPTIME_WINDOWS[windowParam];
+  if (!days) {
+    return errorResponse(
+      "invalid_query",
+      "Query parameter `window` must be one of: 90d, 1y.",
+      400,
+      { parameter: "window" },
+    );
+  }
+  const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const rows = await d1All(
+    env,
+    `SELECT surface_id, day, samples, ok_count, uptime_ratio, avg_latency_ms, status
+     FROM surface_uptime_daily
+     WHERE netuid = ? AND day >= ?
+     ORDER BY day DESC
+     LIMIT ?`,
+    [netuid, cutoff, MAX_UPTIME_ROWS],
+  );
+  const data = formatUptime({ netuid, window: windowParam, rows });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: analyticsMeta(
+        env,
+        `/metagraph/subnets/${netuid}/uptime.json`,
         null,
       ),
     },


### PR DESCRIPTION
Makes the PR3 `surface_uptime_daily` rollup **queryable** — a live dynamic route (90d/1y window) over the daily rollup, mirroring the trends/trajectory pattern (no static artifact). Completes the uptime-history feature ([plan](.claude/plans/delightful-inventing-seahorse.md) PR3's deferred read route).

- **`workers/api.mjs`**: `UPTIME_PATH_PATTERN` + `handleUptime` — reads `surface_uptime_daily` by netuid + window cutoff, formats a per-surface daily series; 90d default, invalid window → 400, empty when D1 is cold / no history yet.
- **`src/health-serving.mjs`**: `formatUptime` — groups by surface, sorts days ascending, rolls a window `uptime_ratio` from summed `ok_count`/`samples` (exact, not an average of ratios).
- **Contract**: `contracts.mjs` route + artifact, `UptimeArtifact` schema, `COMPUTED_ARTIFACTS`, `validate-api` check, `docs/backend-artifact-contracts.md`; openapi/types/bundle regenerated. Route count 55 → 56.

Tests: `formatUptime` unit (grouping, null/zero-sample/empty paths) + route (D1 rows, cold-empty, invalid-window 400). Coverage gate green (branches 90.1%). The D1 migration is already applied + verified producing real rows, so this route returns live data once the hourly rollup runs.

> Cleanly rebased onto current main (incl. #497 D1-fallback fix — different function, auto-merged).