### PR TITLE
docs: harden apex discovery proxy snippet

### DIFF
--- a/docs/apex-agent-discovery.md
+++ b/docs/apex-agent-discovery.md
@@ -26,12 +26,34 @@ scanner that does not follow cross-host redirects still sees it):
 // Snippet: apex-discovery-proxy
 export default {
   async fetch(request) {
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      return new Response("Method Not Allowed", {
+        status: 405,
+        headers: { allow: "GET, HEAD" },
+      });
+    }
+
     const url = new URL(request.url);
-    const upstream = new URL(
-      url.pathname + url.search,
-      "https://api.metagraph.sh",
-    );
-    const resp = await fetch(upstream, request);
+    const upstream = new URL("https://api.metagraph.sh");
+    upstream.pathname = url.pathname;
+    upstream.search = url.search;
+
+    const upstreamHeaders = new Headers();
+    for (const name of [
+      "accept",
+      "accept-language",
+      "if-none-match",
+      "if-modified-since",
+    ]) {
+      const value = request.headers.get(name);
+      if (value !== null) upstreamHeaders.set(name, value);
+    }
+
+    const resp = await fetch(upstream, {
+      method: request.method,
+      headers: upstreamHeaders,
+      redirect: "manual",
+    });
     // Preserve the API's Link/Content-Type headers; surface the proxy origin.
     const headers = new Headers(resp.headers);
     headers.set("x-served-by", "api.metagraph.sh");
@@ -44,8 +66,9 @@ Bind it with a **Snippet Rule** that matches the discovery paths only (so the UI
 keeps serving everything else):
 
 ```
-(http.request.uri.path in {"/sitemap.xml" "/robots.txt" "/llms.txt" "/llms-full.txt" "/auth.md" "/agent.md"}
- or starts_with(http.request.uri.path, "/.well-known/"))
+(http.request.method in {"GET" "HEAD"}
+ and (http.request.uri.path in {"/sitemap.xml" "/robots.txt" "/llms.txt" "/llms-full.txt" "/auth.md" "/agent.md"}
+      or starts_with(http.request.uri.path, "/.well-known/")))
 ```
 
 **Simpler alternative — Redirect Rules** (no Snippet; dashboard-only): a dynamic


### PR DESCRIPTION
### Motivation
- The Cloudflare Snippet in the apex runbook constructed an upstream URL from the request pathname and proxied the original `Request`, which can forward cookies/Authorization and allow an open-proxy via path normalization differences. 
- The change aims to remove credential-forwarding and reduce path-normalization attack surface while keeping the documented behavior of serving discovery surfaces under the apex. 

### Description
- Updated `docs/apex-agent-discovery.md` snippet to reject non-`GET`/`HEAD` methods and return `405 Method Not Allowed` for others. 
- Replaced `new URL(url.pathname + url.search, "https://api.metagraph.sh")` with a fixed `https://api.metagraph.sh` origin and explicit `upstream.pathname = url.pathname` and `upstream.search = url.search`. 
- Stop forwarding the original `Request` object and instead forward a minimal allowlist of non-credential headers (`accept`, `accept-language`, `if-none-match`, `if-modified-since`) and the request method, and use `redirect: "manual"` when calling `fetch`. 
- Tightened the Snippet Rule expression to only match discovery paths for `GET`/`HEAD` requests. 

### Testing
- Ran `npm run validate:docs` and the documentation contract validation passed. 
- Formatted and checked style with `npx prettier --check docs/apex-agent-discovery.md` (ran `prettier --write` as needed) and the file now passes Prettier. 
- Ran `git diff --check` and no diff errors were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d0011df98832a8480cd87ae7e33c6)