### PR TITLE
enrich(sn2): add website surface for Inference Labs (DSperse)

### DIFF
--- a/registry/candidates/community/community-sn-2-website-www-inferencelabs-com.json
+++ b/registry/candidates/community/community-sn-2-website-www-inferencelabs-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-2-website-www-inferencelabs-com",
+      "kind": "website",
+      "name": "Inference Labs (Subnet 2) website",
+      "netuid": 2,
+      "provider": "inference-labs",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/inference-labs-inc/subnet-2",
+      "source_urls": ["https://github.com/inference-labs-inc/subnet-2"],
+      "state": "schema-valid",
+      "url": "https://www.inferencelabs.com/"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jsonbored",
+    "submitted_by_url": "https://github.com/jsonbored"
+  }
+}


### PR DESCRIPTION
Gate-validation candidate for the redeployed reviewbot content gate (Cloudflare Workers Builds: success on reviewbot#78).

- **Netuid** 2 · **Kind** `website`
- **URL** https://www.inferencelabs.com/
- **Source** https://github.com/inference-labs-inc/subnet-2

Exercises the live content-review path (owner-match + grounding + dual-AI + the new reachability/degraded gates). Artifacts intentionally not regenerated, so this will not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)