### PR TITLE
feat(discovery): serve apex metagraph.sh discovery from the backend worker

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1311,13 +1311,19 @@ describe("Agent discovery surfaces", () => {
     assert.equal(context.status[0].href, "https://api.metagraph.sh/health");
   });
 
-  test("api-catalog hrefs follow the request origin", async () => {
+  test("api-catalog hrefs are canonical (api.metagraph.sh), not the request host", async () => {
+    // The apex (metagraph.sh) routes /.well-known/* to this worker too, so the
+    // catalog must reference the real API host regardless of which host served it.
     const response = await handleRequest(
-      new Request("https://preview.example.com/.well-known/api-catalog"),
+      new Request("https://metagraph.sh/.well-known/api-catalog"),
       {},
       {},
     );
     const body = await response.json();
-    assert.equal(body.linkset[0].anchor, "https://preview.example.com/api/v1");
+    assert.equal(body.linkset[0].anchor, "https://api.metagraph.sh/api/v1");
+    assert.equal(
+      body.linkset[0]["service-desc"][0].href,
+      "https://api.metagraph.sh/metagraph/openapi.json",
+    );
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -4,6 +4,7 @@ import {
   PUBLIC_ARTIFACTS,
   CACHE_SECONDS,
   CONTRACT_VERSION,
+  PRIMARY_DOMAIN,
   artifactPathFromTemplate,
   compileRoutePattern,
 } from "../src/contracts.mjs";
@@ -246,7 +247,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   }
 
   if (url.pathname === "/.well-known/api-catalog") {
-    return apiCatalogResponse(request, url);
+    return apiCatalogResponse(request);
   }
 
   if (url.pathname === "/health") {
@@ -3090,10 +3091,12 @@ function homepageResponse(request) {
   return new Response(HOMEPAGE_HTML, { headers });
 }
 
-// RFC 9727 API catalog as an RFC 9264 linkset+json document. Absolute hrefs are
-// built from the request origin so the catalog is correct on any deploy host.
-function apiCatalogResponse(request, url) {
-  const base = url.origin;
+// RFC 9727 API catalog as an RFC 9264 linkset+json document. Hrefs point at the
+// canonical API host (api.metagraph.sh) regardless of which host served this —
+// the apex (metagraph.sh) routes /.well-known/* here too, and its catalog must
+// reference the real API, not the apex.
+function apiCatalogResponse(request) {
+  const base = `https://${PRIMARY_DOMAIN}`;
   const linkset = {
     linkset: [
       {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -43,7 +43,22 @@
     // return 503 ai_unavailable. Flip to "false" to instantly disable.
     "METAGRAPH_ENABLE_AI": "true",
   },
-  "routes": [{ "pattern": "api.metagraph.sh", "custom_domain": true }],
+  // api.metagraph.sh is the backend worker's custom domain (the canonical agent
+  // surface). The apex metagraph.sh is the metagraphed-ui worker, but the
+  // machine/agent-discovery PATHS are routed here too so the SAME backend serves
+  // them on both hosts (single source of truth — no redirect/proxy/duplication).
+  // These specific routes win over the UI worker's apex domain; the UI keeps
+  // serving `/` and all human pages. (`/` is intentionally NOT routed here so the
+  // apex homepage stays the UI; its Link header belongs in the UI worker.)
+  "routes": [
+    { "pattern": "api.metagraph.sh", "custom_domain": true },
+    { "pattern": "metagraph.sh/.well-known/*", "zone_name": "metagraph.sh" },
+    { "pattern": "metagraph.sh/sitemap.xml", "zone_name": "metagraph.sh" },
+    { "pattern": "metagraph.sh/llms.txt", "zone_name": "metagraph.sh" },
+    { "pattern": "metagraph.sh/llms-full.txt", "zone_name": "metagraph.sh" },
+    { "pattern": "metagraph.sh/auth.md", "zone_name": "metagraph.sh" },
+    { "pattern": "metagraph.sh/agent.md", "zone_name": "metagraph.sh" },
+  ],
   "kv_namespaces": [
     {
       "binding": "METAGRAPH_CONTROL",


### PR DESCRIPTION
The **proper** apex fix (replacing the redirect/proxy/token idea). `api.metagraph.sh` is correctly a custom domain on the `metagraphed` backend worker; this routes the apex's machine-discovery **paths** to that same worker — single source of truth, no redirect, no proxy, no duplicated files.

- **`wrangler.jsonc`**: `metagraph.sh` routes for `/.well-known/*`, `/sitemap.xml`, `/llms.txt`, `/llms-full.txt`, `/auth.md`, `/agent.md` → the `metagraphed` worker. The apex `/` and UI pages stay on `metagraphed-ui` (specific routes win over its apex domain).
- **`workers/api.mjs`**: the api-catalog references the canonical `api.metagraph.sh` host (not the request origin), so the apex-served catalog points at the real API instead of duplicating the API onto the apex.

**Residual:** the apex `/` homepage `Link` header belongs in the `metagraphed-ui` repo (`/` must keep serving the UI). All *file*-based checks (api-catalog, sitemap, llms, agent-skills, mcp-card, auth.md) are served on the apex via these routes.

**Deploy note:** registering `metagraph.sh` routes requires the Workers Builds deploy to have rights on that zone. If it lacks them, the deploy no-ops on route registration (`api.metagraph.sh` unaffected — low risk) and this is reverted. Verified: `wrangler deploy --dry-run` + config validation pass; full suite + coverage green.