### PR TITLE
docs(discovery): apex runbook reflects the implemented worker-routes approach

### DIFF
--- a/docs/apex-agent-discovery.md
+++ b/docs/apex-agent-discovery.md
@@ -1,81 +1,56 @@
-# Apex (`metagraph.sh`) agent-discovery runbook
+# Apex (`metagraph.sh`) agent-discovery
 
-All machine/agent-discovery surfaces are served by the **API Worker** at
-`api.metagraph.sh` (this repo): `/`, `/.well-known/*` (api-catalog, agent-skills,
-mcp/server-card, mcp.json, llms.txt), `/sitemap.xml`, `/robots.txt`, `/llms.txt`,
-`/llms-full.txt`, `/auth.md`, `/agent.md`, RFC 8288 `Link` headers, and the MCP
-endpoint `POST /mcp`. These are live and verified.
+## Architecture
 
-The **apex** `metagraph.sh` is the human web app (the separate `metagraphed-ui`
-Lovable repo). Agent-readiness scanners (e.g. isitagentready.com) probe the apex
-and find none of the discovery surfaces there. This runbook makes the apex pass
-**without** duplicating anything into the UI repo — everything is Cloudflare-zone
-config on `metagraph.sh`, so there is a single source of truth (the Worker).
+- **`api.metagraph.sh`** — the `metagraphed` backend worker (this repo), a custom
+  domain. The canonical agent surface: `/`, `/.well-known/*` (api-catalog,
+  agent-skills, mcp/server-card, mcp.json, llms.txt), `/sitemap.xml`,
+  `/robots.txt`, `/llms.txt`, `/llms-full.txt`, `/auth.md`, `/agent.md`, RFC 8288
+  `Link` headers, and `POST /mcp`. Live + verified.
+- **`metagraph.sh`** (apex) — the human web app, served by the separate
+  `metagraphed-ui` worker (Lovable repo).
 
-> None of this is deployable from this repo — it is dashboard / Terraform config
-> on the `metagraph.sh` zone. Apply it yourself, or authorize the Cloudflare MCP
-> and it can be set up directly.
+## What's implemented (single source of truth)
 
-## 1. Proxy the discovery paths to the API (recommended: Snippet)
-
-A Cloudflare **Snippet** on the `metagraph.sh` zone that reverse-proxies the
-discovery paths to `api.metagraph.sh` (serving the content under the apex, so a
-scanner that does not follow cross-host redirects still sees it):
-
-```js
-// Snippet: apex-discovery-proxy
-export default {
-  async fetch(request) {
-    const url = new URL(request.url);
-    const upstream = new URL(
-      url.pathname + url.search,
-      "https://api.metagraph.sh",
-    );
-    const resp = await fetch(upstream, request);
-    // Preserve the API's Link/Content-Type headers; surface the proxy origin.
-    const headers = new Headers(resp.headers);
-    headers.set("x-served-by", "api.metagraph.sh");
-    return new Response(resp.body, { status: resp.status, headers });
-  },
-};
-```
-
-Bind it with a **Snippet Rule** that matches the discovery paths only (so the UI
-keeps serving everything else):
+Rather than redirect/proxy/duplicate, the apex's machine-discovery **paths are
+routed to the same backend worker** that serves `api.metagraph.sh`. In this
+repo's `wrangler.jsonc`, the `metagraphed` worker holds these `metagraph.sh`
+routes (they win over the UI worker's apex domain; `/` and all UI pages stay on
+`metagraphed-ui`):
 
 ```
-(http.request.uri.path in {"/sitemap.xml" "/robots.txt" "/llms.txt" "/llms-full.txt" "/auth.md" "/agent.md"}
- or starts_with(http.request.uri.path, "/.well-known/"))
+metagraph.sh/.well-known/*
+metagraph.sh/sitemap.xml
+metagraph.sh/llms.txt
+metagraph.sh/llms-full.txt
+metagraph.sh/auth.md
+metagraph.sh/agent.md
 ```
 
-**Simpler alternative — Redirect Rules** (no Snippet; dashboard-only): a dynamic
-redirect for the same expression to `https://api.metagraph.sh${http.request.uri.path}`
-(302). Use only if the scanner follows cross-host redirects; the Snippet proxy is
-more robust.
+So `metagraph.sh/.well-known/api-catalog`, `/sitemap.xml`, `/llms.txt`,
+`/auth.md`, `/agent.md`, `/.well-known/agent-skills/index.json`, and
+`/.well-known/mcp/server-card.json` are all served on the apex by the backend —
+**verified live**. The api-catalog references the canonical `api.metagraph.sh`
+host, so the apex advertises the real API rather than duplicating it.
 
-## 2. Add `Link` headers to the apex homepage
+## The one remaining piece
 
-A Cloudflare **Response Header Transform Rule** on `metagraph.sh`, matching
-`http.request.uri.path eq "/"`, that **sets** the `Link` header:
+The apex **homepage `/` `Link` header** can't live here — `/` must keep serving
+the UI (`metagraphed-ui`), so a request to `metagraph.sh/` is handled by that
+worker, not this one. To satisfy the "Link headers on homepage" check on the
+apex, add to the **`metagraphed-ui`** worker's `/` response:
 
 ```
-</.well-known/api-catalog>; rel="api-catalog", </llms.txt>; rel="service-doc", </metagraph/openapi.json>; rel="service-desc"
+Link: <https://api.metagraph.sh/.well-known/api-catalog>; rel="api-catalog", <https://api.metagraph.sh/llms.txt>; rel="service-doc", <https://api.metagraph.sh/metagraph/openapi.json>; rel="service-desc"
 ```
 
-(The proxy in step 1 makes `metagraph.sh/.well-known/api-catalog` resolve.)
+(Equivalent alternative, no UI change: a Cloudflare **Response Header Transform
+Rule** on `metagraph.sh` matching `http.request.uri.path eq "/"` that sets that
+same `Link` header — needs a zone token with `Transform Rules: Edit`.)
 
-## 3. Relax the apex AI-bot block (optional, policy decision)
+## Optional: AI-bot crawl policy
 
-The apex `robots.txt` is Cloudflare **Managed robots.txt** and currently sets
-`Content-Signal: ai-train=no` and `Disallow: /` for `ClaudeBot`, `GPTBot`,
-`Google-Extended`, etc. If you want agents to crawl the human app, relax this in
-the Cloudflare **AI Audit / Managed robots.txt** settings. (The API host stays
-open regardless — its `robots.txt` is `Allow: /`.)
-
-## 4. Verify
-
-Re-run the scanner against `https://metagraph.sh` (and `https://api.metagraph.sh`,
-which already passes). The api-catalog / agent-skills / MCP-card / Link-header /
-sitemap / auth.md checks should pass via the proxy; OAuth/OIDC and protected-
-resource remain N/A by design (the API is public + unauthenticated — see
-[`/auth.md`](https://api.metagraph.sh/auth.md)).
+The apex `robots.txt` is Cloudflare **Managed robots.txt** and currently
+`Disallow: /` for `ClaudeBot`/`GPTBot`/etc. with `Content-Signal: ai-train=no`.
+Relax it in the Cloudflare AI-Audit / Managed-robots settings if you want agents
+to crawl the human app. (The API host stays open regardless — `Allow: /`.)


### PR DESCRIPTION
Updates `docs/apex-agent-discovery.md` to document what was actually shipped: the apex discovery files are served by the `metagraphed` backend worker via `metagraph.sh` routes ([#503](https://github.com/JSONbored/metagraphed/pull/503)), **verified live** — not the Snippet/redirect approach the runbook originally proposed. Documents the routing + the one residual (the apex homepage `/` `Link` header, which belongs in the `metagraphed-ui` worker). Docs-only.