### PR TITLE
Fix uptime artifact storage tier classification

### DIFF
--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -327,7 +327,7 @@
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
       "schema_ref": "#/components/schemas/UptimeArtifact",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "contract_version": "2026-06-06.1",

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -421,7 +421,7 @@
       "id": "subnet-uptime",
       "path": "/metagraph/subnets/{netuid}/uptime.json",
       "schema_ref": "#/components/schemas/UptimeArtifact",
-      "storage_tier": "git"
+      "storage_tier": "r2"
     },
     {
       "content_type": "application/json",

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -29,6 +29,7 @@ const R2_ONLY_PATTERNS = [
   /^health\/percentiles\/(?:\d+|\{netuid\})\.json$/,
   /^health\/incidents\/(?:\d+|\{netuid\})\.json$/,
   /^subnets\/(?:\d+|\{netuid\})\/trajectory\.json$/,
+  /^subnets\/(?:\d+|\{netuid\})\/uptime\.json$/,
   /^registry\/leaderboards\.json$/,
   // Per-subnet agent capability catalog (full service detail) — large, built.
   /^agent-catalog\/(?:\d+|\{netuid\})\.json$/,

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -597,6 +597,14 @@ describe("script utility contracts", () => {
       ARTIFACT_STORAGE_TIERS.r2,
     );
     assert.equal(
+      artifactStorageTierForPath("/metagraph/subnets/{netuid}/uptime.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
+      artifactStorageTierForPath("/metagraph/subnets/7/uptime.json"),
+      ARTIFACT_STORAGE_TIERS.r2,
+    );
+    assert.equal(
       artifactStorageTierForRelativePath("schemas/index.json"),
       ARTIFACT_STORAGE_TIERS.dual,
     );


### PR DESCRIPTION
### Motivation
- The new live-only uptime artifact `/metagraph/subnets/{netuid}/uptime.json` was being classified as `git` even though it is served live from D1 and has no static file, causing contract consumers to prefer static assets.
- Neighboring live-only artifacts (trends, incidents, trajectory, leaderboards) are marked R2-only but the uptime pattern was omitted from the R2-only list in `src/artifact-storage.mjs`.
- The goal is to ensure raw artifact resolution and generated public contracts correctly advertise `storage_tier: "r2"` for uptime artifacts.

### Description
- Add the uptime pattern to the R2-only list in `src/artifact-storage.mjs` by inserting `^subnets\/(?:\d+|\{netuid\})\/uptime\.json$` into `R2_ONLY_PATTERNS` so templated and concrete uptime paths classify as `r2`.
- Update `tests/script-utils.test.mjs` to assert both the templated path and a concrete path map to `ARTIFACT_STORAGE_TIERS.r2` to prevent regressions.
- Regenerate public contract outputs so `public/metagraph/api-index.json` and `public/metagraph/contracts.json` advertise `"storage_tier": "r2"` for `subnet-uptime`.

### Testing
- Ran `npm run build:artifacts` which completed successfully and rebuilt artifact manifests.
- Ran the unit/tests `npm test -- tests/script-utils.test.mjs` where the single test file passed (33 tests passed).
- Ran API validation `npm run validate:api` which validated `56` Worker API routes and verified `artifactStorageTierForPath` reports `r2` for both `/metagraph/subnets/{netuid}/uptime.json` and `/metagraph/subnets/7/uptime.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d0b761e94832a90f9b57c2b9e017c)