### PR TITLE
fix(apex): serve the human-page sitemap on metagraph.sh (stop shadowing it)

### DIFF
--- a/docs/apex-agent-discovery.md
+++ b/docs/apex-agent-discovery.md
@@ -20,33 +20,46 @@ routes (they win over the UI worker's apex domain; `/` and all UI pages stay on
 
 ```
 metagraph.sh/.well-known/*
-metagraph.sh/sitemap.xml
 metagraph.sh/llms.txt
 metagraph.sh/llms-full.txt
 metagraph.sh/auth.md
 metagraph.sh/agent.md
 ```
 
-So `metagraph.sh/.well-known/api-catalog`, `/sitemap.xml`, `/llms.txt`,
+So `metagraph.sh/.well-known/api-catalog`, `/llms.txt`, `/llms-full.txt`,
 `/auth.md`, `/agent.md`, `/.well-known/agent-skills/index.json`, and
 `/.well-known/mcp/server-card.json` are all served on the apex by the backend —
 **verified live**. The api-catalog references the canonical `api.metagraph.sh`
 host, so the apex advertises the real API rather than duplicating it.
 
-## The one remaining piece
+## Sitemap is host-scoped (NOT routed to the backend)
 
-The apex **homepage `/` `Link` header** can't live here — `/` must keep serving
-the UI (`metagraphed-ui`), so a request to `metagraph.sh/` is handled by that
-worker, not this one. To satisfy the "Link headers on homepage" check on the
-apex, add to the **`metagraphed-ui`** worker's `/` response:
+`metagraph.sh/sitemap.xml` is **not** routed here. A sitemap served at
+`metagraph.sh` must list `metagraph.sh` **human pages** (`/`, `/subnets`,
+`/providers`, per-subnet pages, …) — crawlers ignore cross-host `<loc>` entries.
+The **`metagraphed-ui`** worker builds that human-page sitemap on the apex
+(`src/server.ts` → `buildSitemap`). The backend serves its own API/agent sitemap
+on its own host at `api.metagraph.sh/sitemap.xml`. (An earlier revision routed
+the apex sitemap to the backend, which shadowed the human sitemap with 142
+cross-host `api.metagraph.sh` URLs — that route has been removed.)
+
+## Homepage `/` Link header — DONE (in `metagraphed-ui`)
+
+The apex **homepage `/` `Link` header** can't live in this repo — `/` must keep
+serving the UI, so `metagraph.sh/` is handled by the `metagraphed-ui` worker. It
+is **implemented there and verified live**: `metagraphed-ui/src/server.ts`
+(`injectAnalytics`) sets an RFC 8288 `Link` header on every HTML response,
+including `/`:
 
 ```
-Link: <https://api.metagraph.sh/.well-known/api-catalog>; rel="api-catalog", <https://api.metagraph.sh/llms.txt>; rel="service-doc", <https://api.metagraph.sh/metagraph/openapi.json>; rel="service-desc"
+Link: <https://api.metagraph.sh/.well-known/api-catalog>; rel="api-catalog", <https://api.metagraph.sh/metagraph/openapi.json>; rel="service-desc"; type="application/json", <https://api.metagraph.sh/llms.txt>; rel="service-doc"; type="text/plain", <https://api.metagraph.sh/.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"
 ```
 
-(Equivalent alternative, no UI change: a Cloudflare **Response Header Transform
-Rule** on `metagraph.sh` matching `http.request.uri.path eq "/"` that sets that
-same `Link` header — needs a zone token with `Transform Rules: Edit`.)
+That worker also independently proxies the discovery resources + builds the
+sitemap as a self-contained fallback (so apex discovery survives even if these
+backend routes are ever removed); the backend routes above win for the paths
+they cover, so the backend is the live source for everything except `/` and
+`/sitemap.xml`.
 
 ## Optional: AI-bot crawl policy
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -44,16 +44,24 @@
     "METAGRAPH_ENABLE_AI": "true",
   },
   // api.metagraph.sh is the backend worker's custom domain (the canonical agent
-  // surface). The apex metagraph.sh is the metagraphed-ui worker, but the
-  // machine/agent-discovery PATHS are routed here too so the SAME backend serves
-  // them on both hosts (single source of truth — no redirect/proxy/duplication).
-  // These specific routes win over the UI worker's apex domain; the UI keeps
-  // serving `/` and all human pages. (`/` is intentionally NOT routed here so the
-  // apex homepage stays the UI; its Link header belongs in the UI worker.)
+  // surface). The apex metagraph.sh is the metagraphed-ui worker. Agents hit the
+  // human-facing apex too, so the machine-discovery PATHS the backend generates
+  // canonically are routed here as well — these specific routes win over the UI
+  // worker's apex catch-all, so the SAME backend serves them on both hosts (no
+  // duplicated content). The UI keeps serving `/` and every human page.
+  //
+  // Deliberately NOT routed here (owned by the metagraphed-ui worker on the apex):
+  //   - `/`            — stays the UI app; the UI worker adds the homepage RFC 8288
+  //                      `Link` header (see metagraphed-ui src/server.ts).
+  //   - `/sitemap.xml` — host-scoped. A sitemap on metagraph.sh must list
+  //                      metagraph.sh human pages; the UI worker serves that. The
+  //                      backend serves its own API/agent sitemap at
+  //                      api.metagraph.sh/sitemap.xml. Routing the apex sitemap
+  //                      here would shadow the human sitemap with cross-host
+  //                      api.metagraph.sh URLs (which crawlers ignore).
   "routes": [
     { "pattern": "api.metagraph.sh", "custom_domain": true },
     { "pattern": "metagraph.sh/.well-known/*", "zone_name": "metagraph.sh" },
-    { "pattern": "metagraph.sh/sitemap.xml", "zone_name": "metagraph.sh" },
     { "pattern": "metagraph.sh/llms.txt", "zone_name": "metagraph.sh" },
     { "pattern": "metagraph.sh/llms-full.txt", "zone_name": "metagraph.sh" },
     { "pattern": "metagraph.sh/auth.md", "zone_name": "metagraph.sh" },


### PR DESCRIPTION
## Problem

`metagraph.sh/sitemap.xml` was routed to the **metagraphed backend worker** (added in #503). The backend's sitemap is for its own host — so the apex sitemap served **142 `<loc>` entries, all `https://api.metagraph.sh/...`, and zero `metagraph.sh` URLs**.

Sitemaps are host-scoped: crawlers ignore cross-host `<loc>` entries. So the human site's own pages (`/`, `/subnets`, `/providers`, per-subnet, …) were effectively missing from its sitemap, and every entry that *was* there is one a crawler would discard.

## Fix

Remove the `metagraph.sh/sitemap.xml` backend route. The apex request then falls through to the **`metagraphed-ui`** worker, which already builds the correct human-page sitemap (`src/server.ts` → `buildSitemap`, all `https://metagraph.sh/...`). The backend keeps its own API/agent sitemap on its own host at `api.metagraph.sh/sitemap.xml`.

Clean host-scoping:
- `metagraph.sh/sitemap.xml` → UI worker → metagraph.sh human pages
- `api.metagraph.sh/sitemap.xml` → backend → API/agent resources

The other apex discovery routes (`.well-known/*`, `llms.txt`, `llms-full.txt`, `auth.md`, `agent.md`) are **unchanged** — their content is identical across hosts, so the backend serving them on the apex is correct.

## Also

Documents in `docs/apex-agent-discovery.md` that the apex homepage `/` `Link` header (the previously-tracked "one remaining piece") is **implemented and live** in `metagraphed-ui/src/server.ts` (`injectAnalytics` sets the RFC 8288 `Link` header on every HTML response).

## Verification

- `node scripts/worker-deploy-dry-run.mjs` — passed
- `node scripts/cloudflare-verify.mjs` — passed
- `npm run validate:docs` — passed
- `prettier --check` on touched files — clean

Wrangler treats the config as the source of truth for routes and reconciles on deploy (Workers Builds runs `wrangler deploy`), so removing the route de-registers it. Will verify live after merge that `metagraph.sh/sitemap.xml` lists `metagraph.sh` URLs.

Config + docs only — no code/schema/artifact changes.