### PR TITLE
feat(security): add RFC 9116 /.well-known/security.txt (Wave C)

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,9 @@
+# Security policy for metagraphed — api.metagraph.sh / metagraph.sh
+# Format: RFC 9116 — https://www.rfc-editor.org/rfc/rfc9116
+# Metagraphed publishes public operational metadata only; report privately.
+
+Contact: https://github.com/JSONbored/metagraphed/security/advisories/new
+Expires: 2027-06-13T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://api.metagraph.sh/.well-known/security.txt
+Policy: https://github.com/JSONbored/metagraphed/blob/main/SECURITY.md

--- a/tests/discovery-artifacts.test.mjs
+++ b/tests/discovery-artifacts.test.mjs
@@ -52,4 +52,37 @@ describe("Discovery artifacts", () => {
     assert.match(authMd, /public and read-only/i);
     assert.match(authMd, /No authentication/i);
   });
+
+  test("security.txt follows RFC 9116 (contact, expires, canonical)", async () => {
+    const txt = await fs.readFile(
+      path.join(publicDir, ".well-known/security.txt"),
+      "utf8",
+    );
+    const field = (name) =>
+      txt.match(new RegExp(`^${name}:\\s*(.+)$`, "mi"))?.[1]?.trim();
+    // Contact is REQUIRED by RFC 9116; it must be the private advisory channel
+    // documented in SECURITY.md (never a public issue / personal address).
+    assert.equal(
+      field("Contact"),
+      "https://github.com/JSONbored/metagraphed/security/advisories/new",
+    );
+    // Expires is REQUIRED and must be a valid future ISO-8601 instant. Compared
+    // against a fixed baseline (not wall-clock) so the gate stays deterministic;
+    // renewing the date before it lapses is a calendar maintenance task.
+    const expires = field("Expires");
+    assert.ok(expires, "security.txt must declare Expires");
+    assert.ok(
+      !Number.isNaN(Date.parse(expires)),
+      "Expires must be ISO-8601 parseable",
+    );
+    assert.ok(
+      Date.parse(expires) > Date.parse("2026-06-13T00:00:00.000Z"),
+      "Expires must be in the future",
+    );
+    // Canonical must point at this backend's served copy.
+    assert.equal(
+      field("Canonical"),
+      "https://api.metagraph.sh/.well-known/security.txt",
+    );
+  });
 });


### PR DESCRIPTION
**Wave C** of the 🛡️ hardening & polish roadmap (#512). Closes #511.

Adds `public/.well-known/security.txt` (RFC 9116) — the one confirmed-missing discovery file (`api-catalog`/`Link` headers already exist). Served automatically by the ASSETS binding like the other `/.well-known/*` files; `Contact` is the private GitHub advisory channel from SECURITY.md.

```
Contact: https://github.com/JSONbored/metagraphed/security/advisories/new
Expires: 2027-06-13T00:00:00.000Z
Canonical: https://api.metagraph.sh/.well-known/security.txt
Policy: …/SECURITY.md
```

- New `discovery-artifacts` test guards contact/expires/canonical (deterministic).
- Public-safety scan passes.
- Note: `Canonical` lists only the backend copy; extending the apex (`metagraph.sh`) `.well-known` proxy to cover it can follow in a frontend PR.
- Optional follow-up: auto-generate `Expires` at build time so it never lapses.