### PR TITLE
fix(discovery): canonicalize discovery Link headers

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1311,9 +1311,9 @@ describe("Agent discovery surfaces", () => {
     assert.equal(context.status[0].href, "https://api.metagraph.sh/health");
   });
 
-  test("api-catalog hrefs are canonical (api.metagraph.sh), not the request host", async () => {
-    // The apex (metagraph.sh) routes /.well-known/* to this worker too, so the
-    // catalog must reference the real API host regardless of which host served it.
+  test("api-catalog discovery links are canonical (api.metagraph.sh), not the request host", async () => {
+    // The apex (metagraph.sh) routes /.well-known/* to this worker too, so both
+    // the linkset body and HTTP Link header must reference the real API host.
     const response = await handleRequest(
       new Request("https://metagraph.sh/.well-known/api-catalog"),
       {},
@@ -1325,5 +1325,11 @@ describe("Agent discovery surfaces", () => {
       body.linkset[0]["service-desc"][0].href,
       "https://api.metagraph.sh/metagraph/openapi.json",
     );
+    const link = response.headers.get("link");
+    assert.match(
+      link,
+      /<https:\/\/api\.metagraph\.sh\/metagraph\/openapi\.json>; rel="service-desc"/,
+    );
+    assert.doesNotMatch(link, /<\/metagraph\/openapi\.json>/);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3038,15 +3038,17 @@ function corsPreflight(request) {
   return new Response(null, { status: 204, headers });
 }
 
-// RFC 8288 Link header advertising the machine entrypoints, mirrored as
-// `<link>` elements in the homepage HTML below. Relative refs resolve against
-// the request URL, so the same value is correct on any deployment host.
+// RFC 8288 Link header advertising the canonical machine entrypoints, mirrored
+// as `<link>` elements in the homepage HTML below. Discovery routes may be
+// served from the apex too, so the HTTP Link header uses absolute canonical API
+// URLs instead of origin-relative refs.
+const DISCOVERY_LINK_BASE = `https://${PRIMARY_DOMAIN}`;
 const DISCOVERY_LINK_HEADER = [
-  '</.well-known/api-catalog>; rel="api-catalog"',
-  '</metagraph/openapi.json>; rel="service-desc"; type="application/json"',
-  '</llms.txt>; rel="service-doc"; type="text/plain"',
-  '</llms.txt>; rel="describedby"; type="text/plain"',
-  '</.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"',
+  `<${DISCOVERY_LINK_BASE}/.well-known/api-catalog>; rel="api-catalog"`,
+  `<${DISCOVERY_LINK_BASE}/metagraph/openapi.json>; rel="service-desc"; type="application/json"`,
+  `<${DISCOVERY_LINK_BASE}/llms.txt>; rel="service-doc"; type="text/plain"`,
+  `<${DISCOVERY_LINK_BASE}/llms.txt>; rel="describedby"; type="text/plain"`,
+  `<${DISCOVERY_LINK_BASE}/.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"`,
 ].join(", ");
 
 const HOMEPAGE_HTML = `<!doctype html>


### PR DESCRIPTION
### Motivation
- Apex-served discovery responses exposed origin-relative RFC 8288 `Link` headers (e.g. `</metagraph/openapi.json>`) that resolve against `metagraph.sh` while the JSON api-catalog body points at the canonical API host, causing clients to resolve service descriptions to an unrouted apex path.
- The header/body mismatch is a discovery/integrity bug when the apex routes `/.well-known/*` to the backend worker and should be fixed by advertising canonical `api.metagraph.sh` URLs in the HTTP `Link` header.

### Description
- Replace origin-relative `DISCOVERY_LINK_HEADER` entries in `workers/api.mjs` with absolute canonical URLs built from `PRIMARY_DOMAIN` via a new `DISCOVERY_LINK_BASE` so the HTTP `Link` header always points at `https://api.metagraph.sh`.
- Keep the existing homepage HTML and link elements unchanged while ensuring the worker-owned discovery responses return consistent canonical Link headers.
- Update the runtime test in `tests/worker-runtime.test.mjs` to assert the HTTP `Link` header matches the canonical linkset body and does not contain the old origin-relative OpenAPI reference.

### Testing
- Ran the focused test for the change with `npm test -- tests/worker-runtime.test.mjs -t "api-catalog discovery links"`, which passed. 
- Ran `npx eslint workers/api.mjs tests/worker-runtime.test.mjs` and `git diff --check`, both of which passed for the modified files. 
- Ran the full worker runtime tests with `npm test -- tests/worker-runtime.test.mjs`, where the targeted discovery test passed but the full test run reported unrelated existing failures (several artifact-backed routes returning `404`), which are pre-existing and not caused by this change. 
- Ran repository lint `npm run lint -- --quiet`, which is failing on an unrelated `no-unused-vars` error for `mkdirSync` in `tests/artifacts.test.mjs` and is outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d169a75b8832a824d030f66e8ea86)