### PR TITLE
fix(health): serve live per-endpoint health on the endpoint routes (close the live-only-health gap)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1405,7 +1405,7 @@ export interface components {
             classification?: components["schemas"]["Classification"];
             error?: string | null;
             /** @enum {unknown} */
-            health_source: "probe-derived" | "missing-probe" | "not-monitored";
+            health_source: "probe-derived" | "missing-probe" | "not-monitored" | "live-cron-prober" | "unavailable";
             health_stale: boolean;
             id: string;
             kind: components["schemas"]["SurfaceKind"];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -1735,7 +1735,9 @@
             "enum": [
               "probe-derived",
               "missing-probe",
-              "not-monitored"
+              "not-monitored",
+              "live-cron-prober",
+              "unavailable"
             ]
           },
           "health_stale": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1405,7 +1405,7 @@ export interface components {
             classification?: components["schemas"]["Classification"];
             error?: string | null;
             /** @enum {unknown} */
-            health_source: "probe-derived" | "missing-probe" | "not-monitored";
+            health_source: "probe-derived" | "missing-probe" | "not-monitored" | "live-cron-prober" | "unavailable";
             health_stale: boolean;
             id: string;
             kind: components["schemas"]["SurfaceKind"];

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -1721,7 +1721,9 @@
             "enum": [
               "probe-derived",
               "missing-probe",
-              "not-monitored"
+              "not-monitored",
+              "live-cron-prober",
+              "unavailable"
             ]
           },
           "health_stale": {

--- a/schemas/components/07-endpoints-rpc.schema.json
+++ b/schemas/components/07-endpoints-rpc.schema.json
@@ -408,7 +408,13 @@
             "type": ["string", "null"]
           },
           "health_source": {
-            "enum": ["probe-derived", "missing-probe", "not-monitored"]
+            "enum": [
+              "probe-derived",
+              "missing-probe",
+              "not-monitored",
+              "live-cron-prober",
+              "unavailable"
+            ]
           },
           "health_stale": {
             "type": "boolean"

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -756,4 +756,84 @@ export function overlayCatalogIndex(staticIndex, live) {
   };
 }
 
+// Replace one EndpointResource's operational health with the live probe row,
+// or mark it `unknown` when the surface has no live reading. Structural and
+// capability fields are preserved; only the freshness-bearing fields (status,
+// classification, latency, the observed_* timestamps, health_source/stale, and
+// pool eligibility) are overwritten so a build-time value is never served as
+// fresh.
+function overlayEndpointHealth(endpoint, liveRow) {
+  if (!liveRow) {
+    return {
+      ...endpoint,
+      status: "unknown",
+      classification: "unknown",
+      latency_ms: null,
+      observed_at: null,
+      last_checked: null,
+      last_ok: null,
+      health_source: "unavailable",
+      health_stale: true,
+      pool_eligible: false,
+      error: null,
+    };
+  }
+  return {
+    ...endpoint,
+    status: liveRow.status,
+    classification:
+      liveRow.classification ?? endpoint.classification ?? "unknown",
+    latency_ms: Number.isFinite(liveRow.latency_ms) ? liveRow.latency_ms : null,
+    observed_at: liveRow.last_checked || null,
+    last_checked: liveRow.last_checked || null,
+    last_ok: liveRow.last_ok || null,
+    health_source: "live-cron-prober",
+    health_stale: false,
+    pool_eligible: liveRow.status === "ok",
+    error: liveRow.status === "ok" ? null : (endpoint.error ?? null),
+  };
+}
+
+function countEndpointStatuses(endpoints) {
+  const counts = {};
+  for (const endpoint of endpoints) {
+    counts[endpoint.status] = (counts[endpoint.status] || 0) + 1;
+  }
+  return counts;
+}
+
+// Overlay live per-endpoint operational health onto any artifact that embeds the
+// shared EndpointResource list (subnet detail, profile, the endpoints
+// collection, provider endpoints, the composed overview). Each endpoint is
+// joined to the live snapshot by surface_id; surfaces absent from the live store
+// become `unknown` (never the baked build-time value). The artifact's status
+// histogram is recomputed when present. Returns null only when the artifact
+// carries no endpoints array (the caller then serves it untouched).
+export function overlayArtifactEndpoints(staticData, live) {
+  if (!staticData || !Array.isArray(staticData.endpoints)) return null;
+  const liveById = new Map();
+  if (live && Array.isArray(live.surfaces)) {
+    for (const row of live.surfaces) liveById.set(row.surface_id, row);
+  }
+  const endpoints = staticData.endpoints.map((endpoint) =>
+    overlayEndpointHealth(endpoint, liveById.get(endpoint.surface_id) || null),
+  );
+  const result = {
+    ...staticData,
+    endpoints,
+    operational_observed_at: live?.last_run_at || null,
+    health_source: live?.health_source || "unavailable",
+  };
+  if (staticData.summary && typeof staticData.summary === "object") {
+    result.summary = {
+      ...staticData.summary,
+      by_status: countEndpointStatuses(endpoints),
+      pool_eligible_count: endpoints.filter(
+        (endpoint) => endpoint.pool_eligible,
+      ).length,
+    };
+  }
+  return result;
+}
+
 export { OPERATIONAL_KINDS };

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -6,6 +6,7 @@ import {
   formatTrends,
   mergeFreshness,
   mergeRpcEndpoints,
+  overlayArtifactEndpoints,
   overlayCatalogDetail,
   overlayCatalogIndex,
   overlayOverviewHealth,
@@ -959,6 +960,128 @@ describe("composed-artifact health overlays", () => {
     assert.equal(out.subnets[0].callable_count, 2); // structural count untouched
     assert.equal(out.operational_observed_at, live.last_run_at);
   });
+
+  test("overlayArtifactEndpoints replaces baked per-endpoint health with live", () => {
+    const artifact = {
+      netuid: 7,
+      summary: { by_status: { ok: 2 }, pool_eligible_count: 2 },
+      endpoints: [
+        {
+          surface_id: "7:subnet-api:x",
+          url: "https://x",
+          status: "ok",
+          classification: "live",
+          health_source: "probe-derived",
+          health_stale: false,
+          observed_at: "BUILD",
+          last_ok: "BUILD",
+          latency_ms: 999,
+          pool_eligible: true,
+          error: null,
+        },
+        {
+          surface_id: "7:docs:absent",
+          url: "https://absent",
+          status: "ok",
+          health_source: "probe-derived",
+          health_stale: false,
+          observed_at: "BUILD",
+          pool_eligible: true,
+        },
+      ],
+    };
+    const out = overlayArtifactEndpoints(artifact, live);
+    // surface present in the live snapshot → live values, never the baked ones.
+    const a = out.endpoints[0];
+    assert.equal(a.status, "failed");
+    assert.equal(a.health_source, "live-cron-prober");
+    assert.equal(a.health_stale, false);
+    assert.equal(a.observed_at, live.last_run_at ? a.observed_at : null);
+    assert.equal(a.last_checked, "2026-06-13T00:00:00.000Z");
+    assert.equal(a.pool_eligible, false); // live status failed → not eligible
+    assert.equal(a.url, "https://x"); // structural kept
+    // surface absent from the live snapshot → unknown, never the baked value.
+    const b = out.endpoints[1];
+    assert.equal(b.status, "unknown");
+    assert.equal(b.health_source, "unavailable");
+    assert.equal(b.health_stale, true);
+    assert.equal(b.pool_eligible, false);
+    assert.equal(b.url, "https://absent"); // structural kept
+    // freshness + recomputed histogram surface at the top level.
+    assert.equal(out.operational_observed_at, live.last_run_at);
+    assert.equal(out.health_source, "live-cron-prober");
+    assert.deepEqual(out.summary.by_status, { failed: 1, unknown: 1 });
+    assert.equal(out.summary.pool_eligible_count, 0);
+  });
+
+  test("overlayArtifactEndpoints blanks endpoints to unknown when the store is cold", () => {
+    const artifact = {
+      endpoints: [
+        {
+          surface_id: "7:subnet-api:x",
+          status: "ok",
+          health_source: "probe-derived",
+          latency_ms: 10,
+          pool_eligible: true,
+        },
+      ],
+    };
+    const out = overlayArtifactEndpoints(artifact, null);
+    assert.equal(out.endpoints[0].status, "unknown");
+    assert.equal(out.endpoints[0].health_source, "unavailable");
+    assert.equal(out.endpoints[0].health_stale, true);
+    assert.equal(out.endpoints[0].latency_ms, null);
+    assert.equal(out.endpoints[0].pool_eligible, false);
+    assert.equal(out.operational_observed_at, null);
+    assert.equal(out.health_source, "unavailable");
+  });
+
+  test("overlayArtifactEndpoints returns null when there is no endpoints array", () => {
+    assert.equal(overlayArtifactEndpoints({ netuid: 7 }, live), null);
+    assert.equal(overlayArtifactEndpoints(null, live), null);
+  });
+
+  test("overlayArtifactEndpoints keeps a live-ok endpoint eligible and preserves a non-ok error", () => {
+    const liveOk = {
+      last_run_at: "2026-06-13T00:00:00.000Z",
+      health_source: "live-cron-prober",
+      surfaces: [
+        {
+          surface_id: "ok-one",
+          status: "ok",
+          classification: "live",
+          latency_ms: 42,
+          last_ok: "2026-06-13T00:00:00.000Z",
+          last_checked: "2026-06-13T00:00:00.000Z",
+        },
+        {
+          surface_id: "deg-one",
+          status: "degraded",
+          classification: "slow",
+          latency_ms: null,
+          last_ok: null,
+          last_checked: "2026-06-13T00:00:00.000Z",
+        },
+      ],
+    };
+    const out = overlayArtifactEndpoints(
+      {
+        endpoints: [
+          { surface_id: "ok-one", status: "failed", pool_eligible: false },
+          { surface_id: "deg-one", status: "ok", error: "prev-error" },
+        ],
+      },
+      liveOk,
+    );
+    assert.equal(out.endpoints[0].status, "ok");
+    assert.equal(out.endpoints[0].pool_eligible, true);
+    assert.equal(out.endpoints[0].latency_ms, 42);
+    assert.equal(out.endpoints[0].error, null); // ok → error cleared
+    // non-ok live status keeps the static error and stays ineligible.
+    assert.equal(out.endpoints[1].status, "degraded");
+    assert.equal(out.endpoints[1].pool_eligible, false);
+    assert.equal(out.endpoints[1].error, "prev-error");
+  });
 });
 
 describe("worker live health overlay on composed routes", () => {
@@ -1019,6 +1142,155 @@ describe("worker live health overlay on composed routes", () => {
     const res = await handleRequest(req("/api/v1/subnets/7/overview"), env, {});
     assert.equal(res.status, 200);
     assert.notEqual((await res.json()).meta.source, "live-cron-prober");
+  });
+
+  const seedDetailArchive = (detail) => ({
+    async get(key) {
+      if (!String(key).includes("subnets/7.json")) return null;
+      return {
+        async json() {
+          return detail;
+        },
+        async text() {
+          return JSON.stringify(detail);
+        },
+      };
+    },
+  });
+
+  test("/api/v1/subnets/7 overlays per-endpoint health live (no longer baked)", async () => {
+    const detail = {
+      schema_version: 1,
+      generated_at: "2026-06-12T21:00:00.000Z",
+      subnet: { netuid: 7 },
+      summary: { by_status: { ok: 1 }, pool_eligible_count: 1 },
+      endpoints: [
+        {
+          id: "endpoint-s1",
+          surface_id: "s1",
+          netuid: 7,
+          kind: "subnet-api",
+          url: "https://s1",
+          provider: "p",
+          status: "ok",
+          classification: "live",
+          health_source: "probe-derived",
+          health_stale: false,
+          observed_at: "2026-06-12T21:00:00.000Z",
+          last_ok: "2026-06-12T21:00:00.000Z",
+          last_checked: "2026-06-12T21:00:00.000Z",
+          latency_ms: 900,
+          pool_eligible: true,
+        },
+      ],
+    };
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: kvWith({
+        "health:current": {
+          last_run_at: "2026-06-13T00:00:00.000Z",
+          health_source: "live-cron-prober",
+          surfaces: [
+            {
+              surface_id: "s1",
+              netuid: 7,
+              status: "failed",
+              classification: "down",
+              latency_ms: 5,
+              last_ok: "2026-06-12T23:00:00.000Z",
+              last_checked: "2026-06-13T00:00:00.000Z",
+            },
+          ],
+        },
+      }),
+      METAGRAPH_ARCHIVE: seedDetailArchive(detail),
+    });
+    const res = await handleRequest(req("/api/v1/subnets/7"), env, {});
+    assert.equal(res.status, 200);
+    const ep = (await res.clone().json()).data.endpoints[0];
+    assert.equal(ep.status, "failed"); // live status, not the baked "ok"
+    assert.equal(ep.health_source, "live-cron-prober");
+    assert.equal(ep.health_stale, false);
+    assert.equal(ep.pool_eligible, false); // live failed → ineligible
+    assert.equal(ep.observed_at, "2026-06-13T00:00:00.000Z");
+    assert.equal((await res.json()).meta.source, "live-cron-prober");
+  });
+
+  test("/api/v1/subnets/7 endpoints read `unknown` when the live store is cold", async () => {
+    const detail = {
+      subnet: { netuid: 7 },
+      endpoints: [
+        {
+          id: "endpoint-s1",
+          surface_id: "s1",
+          netuid: 7,
+          kind: "subnet-api",
+          url: "https://s1",
+          provider: "p",
+          status: "ok",
+          health_source: "probe-derived",
+          health_stale: false,
+          observed_at: "2026-06-12T21:00:00.000Z",
+          pool_eligible: true,
+        },
+      ],
+    };
+    const env = createLocalArtifactEnv({
+      METAGRAPH_ARCHIVE: seedDetailArchive(detail),
+    });
+    const res = await handleRequest(req("/api/v1/subnets/7"), env, {});
+    assert.equal(res.status, 200);
+    const ep = (await res.json()).data.endpoints[0];
+    assert.equal(ep.status, "unknown"); // never the baked "ok"
+    assert.equal(ep.health_source, "unavailable");
+    assert.equal(ep.health_stale, true);
+  });
+
+  test("raw /metagraph/subnets/7.json overlays per-endpoint health live too", async () => {
+    const detail = {
+      subnet: { netuid: 7 },
+      endpoints: [
+        {
+          id: "endpoint-s1",
+          surface_id: "s1",
+          netuid: 7,
+          kind: "subnet-api",
+          url: "https://s1",
+          provider: "p",
+          status: "ok",
+          health_source: "probe-derived",
+          health_stale: false,
+          observed_at: "2026-06-12T21:00:00.000Z",
+          pool_eligible: true,
+        },
+      ],
+    };
+    const env = createLocalArtifactEnv({
+      METAGRAPH_CONTROL: kvWith({
+        "health:current": {
+          last_run_at: "2026-06-13T00:00:00.000Z",
+          health_source: "live-cron-prober",
+          surfaces: [
+            {
+              surface_id: "s1",
+              netuid: 7,
+              status: "degraded",
+              classification: "slow",
+              latency_ms: 50,
+              last_ok: "2026-06-12T23:00:00.000Z",
+              last_checked: "2026-06-13T00:00:00.000Z",
+            },
+          ],
+        },
+      }),
+      METAGRAPH_ARCHIVE: seedDetailArchive(detail),
+    });
+    const res = await handleRequest(req("/metagraph/subnets/7.json"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    // Raw artifact path is no longer byte-identical: operational health is live.
+    assert.equal(body.endpoints[0].status, "degraded");
+    assert.equal(body.endpoints[0].health_source, "live-cron-prober");
+    assert.equal(body.endpoints[0].health_stale, false);
   });
 
   test("/api/v1/health serves `unknown` when the live store is cold (live-only)", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -45,6 +45,7 @@ import {
   LEADERBOARD_BOARDS,
   mergeFreshness,
   mergeRpcEndpoints,
+  overlayArtifactEndpoints,
   overlayCatalogDetail,
   overlayCatalogIndex,
   overlayOverviewHealth,
@@ -487,12 +488,32 @@ async function handleRawArtifactRequest(
       artifact_path: networkPath,
     });
   }
+  // Live per-endpoint health overlay: raw artifacts that embed the shared
+  // EndpointResource list (endpoints.json, subnets/{n}.json, profiles/{n}.json,
+  // provider endpoints) must not serve build-time operational health as fresh.
+  // Overlay the 2-minute cron snapshot so direct /metagraph/*.json fetchers see
+  // the same live status the /api/v1 routes do; surfaces with no live reading
+  // read `unknown`. Mainnet-only (live store is mainnet) and gated to artifacts
+  // that actually carry probed endpoints.
+  let data = artifact.data;
+  if (
+    network.isDefault &&
+    Array.isArray(data?.endpoints) &&
+    data.endpoints.some((endpoint) => endpoint?.surface_id)
+  ) {
+    const liveSnapshot = await resolveLiveHealth({
+      readHealthKv,
+      env,
+      db: env.METAGRAPH_HEALTH_DB,
+    });
+    data = overlayArtifactEndpoints(data, liveSnapshot) ?? data;
+  }
   // The raw artifact path has no envelope, so direct fetchers of
   // /metagraph/*.json have no freshness signal — the body's generated_at is the
   // deterministic epoch content marker by design. Expose the real publish time
-  // as a header; the body stays byte-identical to the committed artifact.
+  // as a header; the operational-health fields are overlaid live (above).
   const pub = await publishedAt(env);
-  const body = JSON.stringify(artifact.data);
+  const body = JSON.stringify(data);
   const headers = apiHeaders("standard");
   headers.set("content-type", JSON_CONTENT_TYPE);
   headers.set("x-metagraph-artifact-source", artifact.source);
@@ -2662,69 +2683,91 @@ function unknownSubnetHealth(netuid) {
 
 // Overlay the 2-minute cron snapshot onto a static health/rpc artifact. Returns
 // { data } when a live snapshot is available, else null (caller serves static).
+// Health-overlay routes whose live composition is keyed on surfaces/services
+// (not the shared EndpointResource list) — excluded from the generic per-endpoint
+// overlay below so it does not double-process them.
+const ENDPOINT_OVERLAY_EXCLUDED_IDS = new Set([
+  "subnet-health",
+  "rpc-endpoints",
+  "freshness",
+  "agent-catalog",
+  "agent-catalog-subnet",
+]);
+
 async function liveHealthOverlay(env, matched, staticData) {
+  let resolved;
+  const getLive = async () => {
+    if (resolved === undefined) {
+      resolved =
+        (await resolveLiveHealth({
+          readHealthKv,
+          env,
+          db: env.METAGRAPH_HEALTH_DB,
+        })) || null;
+    }
+    return resolved;
+  };
+
+  let data;
   switch (matched.id) {
     case "subnet-health": {
-      const liveSnapshot = await resolveLiveHealth({
-        readHealthKv,
-        env,
-        db: env.METAGRAPH_HEALTH_DB,
-      });
-      const data = overlaySubnetHealth(
+      data = overlaySubnetHealth(
         staticData,
-        liveSnapshot,
+        await getLive(),
         Number(matched.params.netuid),
       );
-      return data ? { data } : null;
+      break;
     }
     case "rpc-endpoints": {
       const pool = await readHealthKv(env, KV_HEALTH_RPC_POOL);
-      const data = mergeRpcEndpoints(staticData, pool);
-      return data ? { data } : null;
+      data = mergeRpcEndpoints(staticData, pool);
+      break;
     }
     case "freshness": {
       const meta = await readHealthKv(env, KV_HEALTH_META);
-      const data = mergeFreshness(staticData, meta);
-      return data ? { data } : null;
+      data = mergeFreshness(staticData, meta);
+      break;
     }
     case "subnet-overview": {
-      const liveSnapshot = await resolveLiveHealth({
-        readHealthKv,
-        env,
-        db: env.METAGRAPH_HEALTH_DB,
-      });
-      const data = overlayOverviewHealth(
+      data = overlayOverviewHealth(
         staticData,
-        liveSnapshot,
+        await getLive(),
         Number(matched.params.netuid),
       );
-      return data ? { data } : null;
+      break;
     }
     case "agent-catalog-subnet": {
-      const liveSnapshot = await resolveLiveHealth({
-        readHealthKv,
-        env,
-        db: env.METAGRAPH_HEALTH_DB,
-      });
-      const data = overlayCatalogDetail(
+      data = overlayCatalogDetail(
         staticData,
-        liveSnapshot,
+        await getLive(),
         Number(matched.params.netuid),
       );
-      return data ? { data } : null;
+      break;
     }
     case "agent-catalog": {
-      const liveSnapshot = await resolveLiveHealth({
-        readHealthKv,
-        env,
-        db: env.METAGRAPH_HEALTH_DB,
-      });
-      const data = overlayCatalogIndex(staticData, liveSnapshot);
-      return data ? { data } : null;
+      data = overlayCatalogIndex(staticData, await getLive());
+      break;
     }
     default:
-      return null;
+      data = null;
   }
+
+  // Generic live overlay for any artifact embedding the shared EndpointResource
+  // list (subnet detail, profile, endpoints collection, provider endpoints, and
+  // the composed overview's endpoints[]). Each endpoint's operational health is
+  // replaced from the 2-minute cron snapshot; surfaces with no live reading
+  // become `unknown` — so per-endpoint health is never the baked build value.
+  const base = data ?? staticData;
+  if (
+    !ENDPOINT_OVERLAY_EXCLUDED_IDS.has(matched.id) &&
+    Array.isArray(base?.endpoints) &&
+    base.endpoints.some((endpoint) => endpoint?.surface_id)
+  ) {
+    const overlaid = overlayArtifactEndpoints(base, await getLive());
+    if (overlaid) data = overlaid;
+  }
+
+  return data ? { data } : null;
 }
 
 // Real publish timestamp for envelope meta, read from the KV latest pointer.


### PR DESCRIPTION
## The bug (high severity, found by the AI-readiness audit)

The live-only-health migration (#479/#490) overlaid live health onto `subnet-health`, `agent-catalog`, the overview's **top-level** health, `rpc-endpoints`, and `freshness` — but **missed the shared `EndpointResource` list**. So these routes served the **build-time per-endpoint health verbatim**, flagged `health_stale:false` with an ~11h-old `observed_at`, while the dedicated `/health` routes returned fresh `live-cron-prober` data:

- `GET /api/v1/endpoints`
- `GET /api/v1/subnets/{netuid}` (subnet detail)
- `GET /api/v1/subnets/{netuid}/profile`
- `GET /api/v1/providers/{slug}/endpoints` (+ provider detail)
- the raw `/metagraph/{endpoints,subnets/{n},profiles/{n}}.json` copies

(The audit labelled this "the overview route"; the overview's *top-level* health was already live — the real gap is the `EndpointResource` list shared across the detail/profile/endpoints/provider routes. Confirmed live: detail `endpoints[].health_source = "probe-derived"`, `observed_at` ~11h old, vs `/health` `source: live-cron-prober` seconds old.)

## Fix

- **`overlayArtifactEndpoints()`** (`src/health-serving.mjs`): join each endpoint to the 2-minute cron snapshot by `surface_id` and replace only the freshness-bearing fields (`status`, `classification`, `latency_ms`, `observed_at`/`last_checked`/`last_ok`, `health_source`, `health_stale`, `pool_eligible`, `error`). Structural + capability fields are preserved; the status histogram is recomputed. Surfaces absent from the live store read **`unknown`** — never the baked value.
- **Wired generically** into `liveHealthOverlay` — covers subnet-detail, profiles, endpoints, provider endpoints/detail, and the overview's `endpoints[]`; the surfaces/services health routes are explicitly excluded so they aren't double-processed.
- **`handleRawArtifactRequest`** overlays the same way, so direct `/metagraph/*.json` fetchers get live status too.
- **Cold store → `unknown`** on every path, so operational health is never served from a build artifact (the migration's core invariant, now upheld everywhere).
- **Schema**: add `live-cron-prober` + `unavailable` to `EndpointResource.health_source`; regenerated bundled components + OpenAPI + types.

## Verification

- New tests cover the overlay (warm / cold / missing-surface / eligibility / error handling) and the live API + raw-artifact routes — `tests/health-serving.test.mjs` (81 pass).
- `test:coverage` (excl. the pre-existing flaky `artifacts.test` registry-staleness, which CI rebuilds past): **894 pass, 98.04% stmts / 90.07% branches** (gate 98/90).
- `validate:{contract-drift,schemas,schema-enums,api,openapi,mcp,types,generated-client,openapi-examples,docs}` all pass; eslint + prettier clean.

Backend-only; no registry/data-artifact changes. Will live-verify the detail/endpoints routes show `live-cron-prober` after deploy.