### PR TITLE
fix(health): keep not-monitored endpoints labelled not-monitored (not unavailable)

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -763,6 +763,17 @@ export function overlayCatalogIndex(staticIndex, live) {
 // pool eligibility) are overwritten so a build-time value is never served as
 // fresh.
 function overlayEndpointHealth(endpoint, liveRow) {
+  // Not-monitored endpoints (docs, dashboards, …) carry a stable structural
+  // classification, not a freshness signal — they are never probed, so their
+  // `not-monitored` status is permanent and honest. Leave them untouched;
+  // overlaying would mislabel an intentionally-unmonitored surface as
+  // `unavailable`/stale.
+  if (
+    endpoint?.monitoring_status === "not_monitored" ||
+    endpoint?.health_source === "not-monitored"
+  ) {
+    return endpoint;
+  }
   if (!liveRow) {
     return {
       ...endpoint,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1041,6 +1041,38 @@ describe("composed-artifact health overlays", () => {
     assert.equal(overlayArtifactEndpoints(null, live), null);
   });
 
+  test("overlayArtifactEndpoints leaves not-monitored endpoints untouched", () => {
+    const artifact = {
+      endpoints: [
+        {
+          surface_id: "docs-1",
+          monitoring_status: "not_monitored",
+          status: "unknown",
+          health_source: "not-monitored",
+          health_stale: false,
+          pool_eligible: false,
+          url: "https://docs",
+        },
+        {
+          surface_id: "mon-absent",
+          monitoring_status: "monitored",
+          status: "ok",
+          health_source: "probe-derived",
+          pool_eligible: true,
+          url: "https://mon",
+        },
+      ],
+    };
+    const out = overlayArtifactEndpoints(artifact, live);
+    // not-monitored is a stable classification, never overlaid to unavailable.
+    assert.equal(out.endpoints[0].health_source, "not-monitored");
+    assert.equal(out.endpoints[0].health_stale, false);
+    assert.equal(out.endpoints[0].status, "unknown");
+    // a monitored surface absent from the live snapshot does read unavailable.
+    assert.equal(out.endpoints[1].health_source, "unavailable");
+    assert.equal(out.endpoints[1].status, "unknown");
+  });
+
   test("overlayArtifactEndpoints keeps a live-ok endpoint eligible and preserves a non-ok error", () => {
     const liveOk = {
       last_run_at: "2026-06-13T00:00:00.000Z",


### PR DESCRIPTION
Follow-up to #515. The endpoint live overlay blanked **every** endpoint absent from the live snapshot to `unknown`/`unavailable`/`health_stale:true` — including endpoints that are intentionally **not monitored** (docs, dashboards). Not-monitored is a stable structural classification, not a freshness signal, so that mislabelled an unmonitored surface as a failed/stale probe.

`overlayEndpointHealth` now leaves `monitoring_status: "not_monitored"` (or `health_source: "not-monitored"`) endpoints untouched; only monitored endpoints are overlaid (live row → live status; absent from the live snapshot → `unavailable`, which is honest for a monitored surface the live cron doesn't cover).

Verified live on `/api/v1/subnets/7`: 11 monitored → `live-cron-prober`, 10 monitored-but-not-live-probed → `unavailable`, 1 `not_monitored` → was mislabelled `unavailable`, now stays `not-monitored`. Test added; 82 health-serving tests pass; lint + prettier clean. Pure serving logic — no schema/contract change.