### PR TITLE
fix(api): populate response-body published_at from the live KV pointer

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -75,6 +75,33 @@ describe("Worker runtime", () => {
     assert.notEqual(body.meta.generated_at, publishedAt);
   });
 
+  test("/api/v1/build populates the body's published_at from the KV pointer (generated_at stays the marker)", async () => {
+    const publishedAt = "2026-06-12T21:06:24.956Z";
+    const controlEnv = {
+      ...env,
+      METAGRAPH_CONTROL: {
+        async get(key, options) {
+          assert.equal(key, "metagraph:latest");
+          assert.equal(options?.type, "json");
+          return { latest_prefix: "latest/", published_at: publishedAt };
+        },
+      },
+    };
+    const response = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/build"),
+      controlEnv,
+      {},
+    );
+    assert.equal(response.status, 200);
+    const body = await response.json();
+    // The committed build-summary body carries published_at:null; serve overlays
+    // the real publish pointer so a body-reading agent sees genuine freshness.
+    assert.equal(body.data.published_at, publishedAt);
+    assert.equal(body.meta.published_at, publishedAt);
+    // generated_at stays the deterministic content marker (issue #349).
+    assert.equal(body.data.generated_at, "1970-01-01T00:00:00.000Z");
+  });
+
   test("serves a health readiness probe", async () => {
     const response = await handleRequest(
       new Request("https://metagraph.sh/health"),

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -968,19 +968,37 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
       parameter: transformed.error.parameter,
     });
   }
+  // Real publish time from the KV latest pointer (null until a publish has
+  // populated it). Unlike generated_at — a deterministic content marker that is
+  // intentionally the 1970 epoch in committed/local builds (issue #349) — this
+  // is the genuine "last updated" timestamp.
+  const pub = await publishedAt(env);
+  // Static-asset artifacts that DECLARE a `published_at` field (e.g.
+  // build-summary, agent-catalog) carry it as null in the committed
+  // deterministic build, so an agent reading the response BODY (not just the
+  // envelope meta) sees no freshness signal. Populate it at serve from the same
+  // pointer that feeds meta.published_at; generated_at stays the marker.
+  let responseData = transformed.data;
+  if (
+    pub &&
+    responseData &&
+    typeof responseData === "object" &&
+    !Array.isArray(responseData) &&
+    "published_at" in responseData &&
+    !responseData.published_at
+  ) {
+    responseData = { ...responseData, published_at: pub };
+  }
   return envelopeResponse(
     request,
     {
-      data: transformed.data,
+      data: responseData,
       meta: {
         artifact_path: artifactPath,
         cache: matched.cache,
         contract_version: contractVersion(env),
         generated_at: baseData?.generated_at || null,
-        // Real publish time from the KV latest pointer; null until a publish has
-        // populated it. Unlike generated_at (a deterministic content marker),
-        // this is safe to render as a human "last updated" timestamp.
-        published_at: await publishedAt(env),
+        published_at: pub,
         source: baseSource,
         ...(baseData?.operational_observed_at
           ? { operational_observed_at: baseData.operational_observed_at }


### PR DESCRIPTION
**Reported:** `/api/v1/build` `data.generated_at` is the epoch-zero placeholder `1970-01-01T00:00:00.000Z`, which makes a freshness-checking agent conclude the registry is decades stale.

**Investigation:** the `1970` is *intentional* — `generated_at` is a deterministic content marker (epoch in committed/local builds, for reproducible-build verification + stable hashing; issue #349), and `tests/worker-runtime.test.mjs` explicitly asserts `generated_at ≠ published_at`. The genuine gap is different: the build-summary **body** carries `published_at: null` too (the committed artifact is deterministic), so the real freshness timestamp existed *only* in the envelope `meta.published_at` (overlaid at serve from the KV pointer). An agent reading the **body** got no real timestamp at all.

**Fix:** the serve layer now overlays the body's `published_at` from the same KV pointer that feeds `meta.published_at` — but only for artifacts that already declare a `published_at` field and left it null (build-summary, agent-catalog). `generated_at` is left as the deterministic marker, so the tested `generated_at ≠ published_at` invariant holds.

**Result:** `/api/v1/build` body now carries a real `published_at` (the publish time) for body-reading agents; `generated_at` stays the deterministic marker (documented, with `meta.published_at`/`data.published_at` as the freshness signal).

Test added; 28 worker-runtime tests pass; eslint + prettier clean. Serve-only; no build/artifact/schema change.