### PR TITLE
fix(discovery): self-host the agent-skills index schema (schemas.agentskills.io is dead)

### DIFF
--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+  "$schema": "https://api.metagraph.sh/.well-known/agent-skills/schema.json",
   "skills": [
     {
       "description": "Use when a developer asks what a Bittensor subnet does, whether it's up right now, or how to call/integrate its API — e.g. \"which subnet does image generation\", \"is subnet 7 healthy\", \"how do I call the Chutes API\", \"build on a Bittensor subnet\". Backed by metagraphed (api.metagraph.sh), the live operational + integration registry for ~129 subnets.",

--- a/public/.well-known/agent-skills/schema.json
+++ b/public/.well-known/agent-skills/schema.json
@@ -1,0 +1,54 @@
+{
+  "$id": "https://api.metagraph.sh/.well-known/agent-skills/schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": true,
+  "description": "Discovery index for Agent Skills (agentskills.io SKILL.md format): one entry per published skill, each with a sha256 content digest for integrity verification.",
+  "properties": {
+    "$schema": {
+      "format": "uri",
+      "type": "string"
+    },
+    "skills": {
+      "items": {
+        "additionalProperties": true,
+        "properties": {
+          "description": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "digest": {
+            "pattern": "^sha256:[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 64,
+            "minLength": 1,
+            "pattern": "^[a-z0-9-]+$",
+            "type": "string"
+          },
+          "type": {
+            "const": "skill-md"
+          },
+          "url": {
+            "format": "uri",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "type",
+          "description",
+          "url",
+          "digest"
+        ],
+        "type": "object"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "skills"
+  ],
+  "title": "Agent Skills Discovery Index",
+  "type": "object"
+}

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1434,10 +1434,54 @@ for (const skillDirName of skillDirNames) {
 await fs.mkdir(path.join(repoRoot, "public/.well-known/agent-skills"), {
   recursive: true,
 });
+// Self-hosted JSON Schema for the discovery index. The official agentskills.io
+// spec defines only the SKILL.md format — there is no published discovery-index
+// schema, and the previously-referenced schemas.agentskills.io host does not
+// resolve. Rather than point `$schema` at a non-dereferenceable URL (which a
+// strict JSON Schema validator fails to fetch), we host our own schema here so
+// the index is self-describing and validatable. Served as a static ASSET at
+// /.well-known/agent-skills/schema.json on both api.metagraph.sh and the apex.
+const agentSkillsSchemaUrl = `${llmsApiBase}/.well-known/agent-skills/schema.json`;
+await writeJson(
+  path.join(repoRoot, "public/.well-known/agent-skills/schema.json"),
+  {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $id: agentSkillsSchemaUrl,
+    title: "Agent Skills Discovery Index",
+    description:
+      "Discovery index for Agent Skills (agentskills.io SKILL.md format): one entry per published skill, each with a sha256 content digest for integrity verification.",
+    type: "object",
+    required: ["skills"],
+    additionalProperties: true,
+    properties: {
+      $schema: { type: "string", format: "uri" },
+      skills: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["name", "type", "description", "url", "digest"],
+          additionalProperties: true,
+          properties: {
+            name: {
+              type: "string",
+              pattern: "^[a-z0-9-]+$",
+              minLength: 1,
+              maxLength: 64,
+            },
+            type: { const: "skill-md" },
+            description: { type: "string", minLength: 1 },
+            url: { type: "string", format: "uri" },
+            digest: { type: "string", pattern: "^sha256:[0-9a-f]{64}$" },
+          },
+        },
+      },
+    },
+  },
+);
 await writeJson(
   path.join(repoRoot, "public/.well-known/agent-skills/index.json"),
   {
-    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    $schema: agentSkillsSchemaUrl,
     skills: agentSkills,
   },
 );

--- a/tests/discovery-artifacts.test.mjs
+++ b/tests/discovery-artifacts.test.mjs
@@ -7,6 +7,8 @@ import { createHash } from "node:crypto";
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 import { repoRoot } from "../scripts/lib.mjs";
 import { MCP_SERVER_INFO } from "../src/mcp-server.mjs";
 
@@ -26,11 +28,13 @@ describe("Discovery artifacts", () => {
     assert.ok(card.capabilities?.tools, "card must advertise tool capability");
   });
 
-  test("agent-skills index matches the Discovery RFC v0.2.0 shape", async () => {
+  test("agent-skills index matches the discovery shape", async () => {
     const index = await readJson(".well-known/agent-skills/index.json");
+    // Self-hosted, dereferenceable schema (the official agentskills.io spec has
+    // no discovery-index schema; the old schemas.agentskills.io host is dead).
     assert.equal(
       index.$schema,
-      "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+      "https://api.metagraph.sh/.well-known/agent-skills/schema.json",
     );
     assert.ok(Array.isArray(index.skills) && index.skills.length > 0);
     for (const skill of index.skills) {
@@ -45,6 +49,25 @@ describe("Discovery artifacts", () => {
       const expected = createHash("sha256").update(body).digest("hex");
       assert.equal(skill.digest, `sha256:${expected}`, skill.name);
     }
+  });
+
+  test("agent-skills index validates against its self-hosted schema", async () => {
+    const schema = await readJson(".well-known/agent-skills/schema.json");
+    const index = await readJson(".well-known/agent-skills/index.json");
+    // The schema is served at the exact URL the index's $schema points to, so a
+    // validator that dereferences $schema fetches this file and succeeds.
+    assert.equal(schema.$id, index.$schema);
+    assert.equal(
+      schema.$schema,
+      "https://json-schema.org/draft/2020-12/schema",
+    );
+    const ajv = new Ajv2020({ strict: false });
+    addFormats(ajv);
+    const validate = ajv.compile(schema);
+    assert.ok(
+      validate(index),
+      `index must validate: ${JSON.stringify(validate.errors)}`,
+    );
   });
 
   test("auth.md states the API is unauthenticated", async () => {


### PR DESCRIPTION
**Reported:** the agent-skills discovery index at `/.well-known/agent-skills/index.json` declares `$schema=https://schemas.agentskills.io/discovery/0.2.0/schema.json`, but that host doesn't resolve — a JSON Schema validator that dereferences `$schema` fails.

**Verified before changing:**
- `/usr/bin/curl https://schemas.agentskills.io/...` → `Could not resolve host` (dead).
- The **official** Agent Skills spec ([agentskills.io/specification](https://agentskills.io/specification) + its `llms.txt` index) defines **only the `SKILL.md` format** — there is *no* published discovery-index schema anywhere official, and the apex `agentskills.io/discovery/0.2.0/schema.json` 404s. The `/.well-known/agent-skills/index.json` discovery index is **metagraphed's own convention**, so the old URI pointed at a host *and* a schema that don't exist.

**Fix (self-host a real schema, per your call):** added a dereferenceable JSON Schema (draft 2020-12) at `public/.well-known/agent-skills/schema.json`, served as a static ASSET at `https://api.metagraph.sh/.well-known/agent-skills/schema.json` (and on the apex via the existing `metagraph.sh/.well-known/*` route). The index's `$schema` now points there, and the index **validates against its own served schema** (asserted with ajv in the test, mirroring the curl-verified result). `build-artifacts.mjs` emits both files deterministically.

Verified: `discovery-artifacts.test` (5 pass, incl. ajv compile+validate), `validate:docs` + `scan:public-safety` pass. The `.well-known/*` files are ASSETS-served (not `/metagraph` artifacts), so no artifact-contract/route gates apply.