### PR TITLE
fix(api): bound D1 health-analytics queries with a timeout (Wave A)

### DIFF
--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -418,6 +418,31 @@ describe("analytics routes (cold local D1)", () => {
     );
     assert.equal(body.data.point_count, 0);
   });
+  test("a hung D1 query times out and degrades to empty (never blocks the isolate)", async () => {
+    // METAGRAPH_HEALTH_DB whose .all() never resolves + a 50ms D1 timeout: each
+    // route must still return its normal cold/empty envelope. Without the
+    // withTimeout wrap this test would hang until the test runner kills it.
+    const hangingDb = {
+      prepare: () => ({ bind: () => ({ all: () => new Promise(() => {}) }) }),
+    };
+    const hungEnv = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: hangingDb,
+      METAGRAPH_D1_TIMEOUT_MS: "50",
+    };
+    // percentiles → d1All (shared helper); trends → handleHealthTrends (inline query)
+    const pct = await getJson(
+      "https://api.metagraph.sh/api/v1/subnets/7/health/percentiles",
+      hungEnv,
+    );
+    assert.equal(pct.status, 200);
+    assert.deepEqual(pct.body.data.surfaces, []);
+    const trends = await getJson(
+      "https://api.metagraph.sh/api/v1/subnets/7/health/trends",
+      hungEnv,
+    );
+    assert.equal(trends.status, 200);
+  });
   test("leaderboards returns most-complete from profiles even with cold D1", async () => {
     const { body } = await getJson(
       "https://api.metagraph.sh/api/v1/registry/leaderboards",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1003,18 +1003,21 @@ async function handleHealthTrends(request, env, netuid) {
     let rows = [];
     if (db?.prepare) {
       try {
-        const result = await db
-          .prepare(
-            `SELECT surface_id,
+        const result = await withTimeout(
+          db
+            .prepare(
+              `SELECT surface_id,
                     COUNT(*) AS total,
                     SUM(ok) AS ok_count,
                     AVG(latency_ms) AS avg_latency_ms
              FROM surface_checks
              WHERE netuid = ? AND checked_at >= ?
              GROUP BY surface_id`,
-          )
-          .bind(netuid, nowMs - days * DAY_MS)
-          .all();
+            )
+            .bind(netuid, nowMs - days * DAY_MS)
+            .all(),
+          d1TimeoutMs(env),
+        );
         rows = result?.results || [];
       } catch {
         rows = [];
@@ -1081,10 +1084,13 @@ async function d1All(env, sql, params) {
   const db = env.METAGRAPH_HEALTH_DB;
   if (!db?.prepare) return [];
   try {
-    const result = await db
-      .prepare(sql)
-      .bind(...params)
-      .all();
+    const result = await withTimeout(
+      db
+        .prepare(sql)
+        .bind(...params)
+        .all(),
+      d1TimeoutMs(env),
+    );
     return result?.results || [];
   } catch {
     return [];
@@ -1985,6 +1991,17 @@ function logEvent(env, level, event, fields = {}) {
 function r2TimeoutMs(env) {
   const raw = Number(env.METAGRAPH_R2_TIMEOUT_MS);
   return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_R2_TIMEOUT_MS;
+}
+
+const DEFAULT_D1_TIMEOUT_MS = 5000;
+
+// Health-analytics D1 reads (trends/percentiles/incidents/uptime) can scan large
+// time-series. Bound them so a slow/degraded query degrades to the route's normal
+// empty-result path instead of holding the isolate until the CPU limit kills it.
+// Tunable via METAGRAPH_D1_TIMEOUT_MS.
+function d1TimeoutMs(env) {
+  const raw = Number(env.METAGRAPH_D1_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_D1_TIMEOUT_MS;
 }
 
 // R2's get() takes no AbortSignal, so bound it with a race: a slow/degraded


### PR DESCRIPTION
**Wave A** of the 🛡️ hardening roadmap (#512), part of #509.

The request-path D1 reads (trends; percentiles/incidents/uptime/leaderboards via the shared `d1All`) had **no time bound** — a slow/degraded query could hold the isolate until the CPU limit kills it.

**Fix:** wrap both `.all()` sites in the existing `withTimeout` helper (default **5s**, tunable via `METAGRAPH_D1_TIMEOUT_MS`, mirroring `r2TimeoutMs`). Both sites already `catch → []`, so a timeout now degrades to the route's normal cold/empty envelope — **no success-path behavior change**.

**Test:** a never-resolving `.all()` + 50ms timeout returns the empty-but-valid envelope for both the `d1All` and `handleHealthTrends` paths (would hang without the wrap).

> Note from verifying #509: the audit over-claimed several Wave A items — `?limit` is already capped at 1000, KV reads are already parse-guarded, and the R2-fallback default is deliberate (R2-only artifacts aren't in ASSETS). Details in the issue. This PR is the one genuinely-missing bound.