### PR TITLE
fix(webhooks): exponential backoff between delivery retries (Wave A)

### DIFF
--- a/src/webhooks.mjs
+++ b/src/webhooks.mjs
@@ -377,6 +377,8 @@ export async function deliverChangeEvent({
   now,
   timeoutMs = 8000,
   maxAttempts = 3,
+  backoffBaseMs = 500,
+  sleepFn = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
   resolveHostnames,
 }) {
   if (!subscription || typeof subscription.url !== "string") {
@@ -423,38 +425,46 @@ export async function deliverChangeEvent({
       });
     } catch (error) {
       lastReason = error?.name === "TimeoutError" ? "timeout" : "network-error";
-      continue; // transient — retry
+      response = null; // transient — fall through to backoff + retry
     }
-    const status = response.status;
-    if (status >= 200 && status < 300) {
-      return {
-        id: subscription.id,
-        status: "delivered",
-        status_code: status,
-        attempts: attempt,
-      };
+    if (response) {
+      const status = response.status;
+      if (status >= 200 && status < 300) {
+        return {
+          id: subscription.id,
+          status: "delivered",
+          status_code: status,
+          attempts: attempt,
+        };
+      }
+      lastReason = `http-${status}`;
+      if (status >= 300 && status < 400) {
+        return {
+          id: subscription.id,
+          status: "failed",
+          status_code: status,
+          reason: "redirect-not-followed",
+          attempts: attempt,
+        };
+      }
+      // 4xx (except 429) is a deterministic rejection — do not retry.
+      if (status >= 400 && status < 500 && status !== 429) {
+        return {
+          id: subscription.id,
+          status: "failed",
+          status_code: status,
+          reason: lastReason,
+          attempts: attempt,
+        };
+      }
+      // 5xx / 429 — fall through to backoff + retry.
     }
-    lastReason = `http-${status}`;
-    if (status >= 300 && status < 400) {
-      return {
-        id: subscription.id,
-        status: "failed",
-        status_code: status,
-        reason: "redirect-not-followed",
-        attempts: attempt,
-      };
+    // Transient failure (network/timeout/5xx/429): exponential backoff before
+    // the next attempt — 500ms, 1s, 2s… — skipped after the final attempt so a
+    // permanently-down endpoint doesn't add a trailing wait.
+    if (attempt < maxAttempts) {
+      await sleepFn(backoffBaseMs * 2 ** (attempt - 1));
     }
-    // 4xx (except 429) is a deterministic rejection — do not retry.
-    if (status >= 400 && status < 500 && status !== 429) {
-      return {
-        id: subscription.id,
-        status: "failed",
-        status_code: status,
-        reason: lastReason,
-        attempts: attempt,
-      };
-    }
-    // 5xx / 429 — retry.
   }
   return {
     id: subscription.id,

--- a/tests/webhooks.test.mjs
+++ b/tests/webhooks.test.mjs
@@ -361,6 +361,24 @@ describe("deliverChangeEvent", () => {
     assert.equal(res.attempts, 2);
   });
 
+  test("applies exponential backoff between retries, none after the last", async () => {
+    const delays = [];
+    const fetchFn = async () => new Response("", { status: 503 }); // always retryable
+    const res = await deliverChangeEvent({
+      subscription: sub(),
+      event,
+      fetchFn,
+      now,
+      sleepFn: async (ms) => {
+        delays.push(ms);
+      },
+    });
+    assert.equal(res.status, "failed");
+    assert.equal(res.attempts, 3);
+    // 2 backoffs for 3 attempts (500ms, 1s); no trailing wait after the last.
+    assert.deepEqual(delays, [500, 1000]);
+  });
+
   test("does NOT retry a 4xx rejection", async () => {
     let n = 0;
     const fetchFn = async () => {


### PR DESCRIPTION
**Wave A** of the 🛡️ hardening roadmap (#512), part of #509.

`deliverChangeEvent` already retried transient failures (network/timeout/5xx/429) up to `maxAttempts=3`, but with **no delay between attempts** — immediate retries can hammer a briefly-flaky subscriber.

**Fix:** exponential backoff (500ms, 1s, …; `backoffBaseMs`) before each retry, **skipped after the final attempt** so a permanently-down endpoint adds no trailing wait. `sleepFn` is injectable (default real timer) so tests stay deterministic and fast.

**Test:** a recording `sleepFn` + always-503 `fetchFn` asserts `delays === [500, 1000]` across 3 attempts (2 backoffs, none after the last). All 28 webhooks tests pass.

Completes the actionable scope of #509 (DLQ assessed as low-value for this current-state, 6h-republished, already-logged webhook model — see the issue).