### PR TITLE
fix(mcp): overlay published_at on the served MCP server card

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -102,6 +102,45 @@ describe("Worker runtime", () => {
     assert.equal(body.data.generated_at, "1970-01-01T00:00:00.000Z");
   });
 
+  test("/.well-known/mcp/server-card.json overlays published_at from the KV pointer", async () => {
+    const publishedAt = "2026-06-12T21:06:24.956Z";
+    const controlEnv = {
+      ...env,
+      METAGRAPH_CONTROL: {
+        async get(key, options) {
+          assert.equal(key, "metagraph:latest");
+          assert.equal(options?.type, "json");
+          return { latest_prefix: "latest/", published_at: publishedAt };
+        },
+      },
+    };
+    const response = await handleRequest(
+      new Request("https://api.metagraph.sh/.well-known/mcp/server-card.json"),
+      controlEnv,
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "application/json");
+    assert.ok(response.headers.get("etag"));
+    const card = await response.json();
+    // The committed card carries published_at:null; serve overlays the real
+    // publish pointer. generated_at stays the deterministic marker; the
+    // content_hash + serverInfo are preserved.
+    assert.equal(card.published_at, publishedAt);
+    assert.equal(card.generated_at, "1970-01-01T00:00:00.000Z");
+    assert.ok(card.content_hash, "card must keep its content_hash");
+    assert.ok(card.serverInfo?.name, "card must keep serverInfo");
+
+    // Cold (no KV pointer): published_at stays null, card still serves.
+    const cold = await handleRequest(
+      new Request("https://api.metagraph.sh/.well-known/mcp/server-card.json"),
+      env,
+      {},
+    );
+    assert.equal(cold.status, 200);
+    assert.equal((await cold.json()).published_at, null);
+  });
+
   test("serves a health readiness probe", async () => {
     const response = await handleRequest(
       new Request("https://metagraph.sh/health"),

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -253,6 +253,10 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     return apiCatalogResponse(request);
   }
 
+  if (url.pathname === "/.well-known/mcp/server-card.json") {
+    return mcpServerCardResponse(request, env);
+  }
+
   if (url.pathname === "/health") {
     return handleHealthRequest(request, env);
   }
@@ -3223,6 +3227,43 @@ function apiCatalogResponse(request) {
     return new Response(null, { headers });
   }
   return new Response(`${JSON.stringify(linkset, null, 2)}\n`, { headers });
+}
+
+// The MCP server card (SEP-1649) is build-generated and shipped as a static
+// asset with a deterministic `published_at: null` (committed builds can't carry
+// a real publish time). Serve it worker-first (see wrangler `run_worker_first`)
+// so we can overlay the real publish time from the KV latest pointer — the same
+// freshness the /api/v1 envelope exposes. `generated_at` stays the deterministic
+// content marker (issue #349); `content_hash` + the contract version remain the
+// integrity/version signals.
+async function mcpServerCardResponse(request, env) {
+  const assetUrl = new URL(
+    "/.well-known/mcp/server-card.json",
+    request.url,
+  ).toString();
+  const asset = env.ASSETS?.fetch
+    ? await env.ASSETS.fetch(new Request(assetUrl))
+    : null;
+  if (!asset || !asset.ok) {
+    return errorResponse("not_found", "MCP server card is unavailable.", 404, {
+      artifact_path: "/.well-known/mcp/server-card.json",
+    });
+  }
+  const card = await asset.json();
+  const pub = await publishedAt(env);
+  if (pub && !card.published_at) {
+    card.published_at = pub;
+  }
+  const body = `${JSON.stringify(card, null, 2)}\n`;
+  const headers = discoveryHeaders("application/json");
+  headers.set("etag", await weakEtag(body));
+  if (request.headers.get("if-none-match") === headers.get("etag")) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
 }
 
 function apiHeaders(cacheProfile) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -26,6 +26,7 @@
     "run_worker_first": [
       "/",
       "/.well-known/api-catalog",
+      "/.well-known/mcp/server-card.json",
       "/api/*",
       "/rpc/*",
       "/metagraph/*",


### PR DESCRIPTION
Closes the last `published_at: null` discovery gap (companion to #518).

The MCP server card at `/.well-known/mcp/server-card.json` was a static asset with a deterministic `published_at: null` — an agent reading the card got no freshness timestamp. It's now served **worker-first** (`mcpServerCardResponse`), reading the build-generated asset via the ASSETS binding and overlaying the real publish time from the KV latest pointer (the same mechanism behind `/api/v1` `meta.published_at` and the build-summary body in #518).

- `generated_at` stays the deterministic content marker (issue #349)
- `content_hash` + `serverInfo` + contract version preserved untouched
- Cold store → `published_at` stays `null`, card still serves (200)
- Added `/.well-known/mcp/server-card.json` to `run_worker_first`; etag + 304 supported

Verified: 29 worker-runtime tests pass (warm overlay + cold), eslint + prettier clean, `worker-deploy-dry-run` passes. Serve-only; no build/schema change.