### PR TITLE
fix(health): preserve endpoint pool eligibility constraints

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -18,6 +18,30 @@ const OPERATIONAL_KINDS = new Set([
   "data-artifact",
 ]);
 
+function isBaseLayerEndpoint(kind) {
+  return kind === "subtensor-rpc" || kind === "subtensor-wss";
+}
+
+function endpointPoolEligibility(endpoint) {
+  const reasons = [];
+  if (!isBaseLayerEndpoint(endpoint.kind)) {
+    reasons.push("not-bittensor-base-layer");
+  }
+  if (endpoint.status !== "ok") {
+    reasons.push(`status-${endpoint.status || "unknown"}`);
+  }
+  if (endpoint.auth_required !== false) {
+    reasons.push("auth-required");
+  }
+  if (endpoint.public_safe !== true) {
+    reasons.push("not-public-safe");
+  }
+  return {
+    eligible: reasons.length === 0,
+    reasons: reasons.length ? reasons : ["eligible"],
+  };
+}
+
 export function parseLive(raw) {
   if (!raw) return null;
   if (typeof raw === "object") return raw;
@@ -762,6 +786,15 @@ export function overlayCatalogIndex(staticIndex, live) {
 // classification, latency, the observed_* timestamps, health_source/stale, and
 // pool eligibility) are overwritten so a build-time value is never served as
 // fresh.
+function withPoolEligibility(endpoint) {
+  const eligibility = endpointPoolEligibility(endpoint);
+  return {
+    ...endpoint,
+    pool_eligible: eligibility.eligible,
+    pool_eligibility_reasons: eligibility.reasons,
+  };
+}
+
 function overlayEndpointHealth(endpoint, liveRow) {
   // Not-monitored endpoints (docs, dashboards, …) carry a stable structural
   // classification, not a freshness signal — they are never probed, so their
@@ -775,7 +808,7 @@ function overlayEndpointHealth(endpoint, liveRow) {
     return endpoint;
   }
   if (!liveRow) {
-    return {
+    return withPoolEligibility({
       ...endpoint,
       status: "unknown",
       classification: "unknown",
@@ -785,11 +818,10 @@ function overlayEndpointHealth(endpoint, liveRow) {
       last_ok: null,
       health_source: "unavailable",
       health_stale: true,
-      pool_eligible: false,
       error: null,
-    };
+    });
   }
-  return {
+  return withPoolEligibility({
     ...endpoint,
     status: liveRow.status,
     classification:
@@ -800,9 +832,8 @@ function overlayEndpointHealth(endpoint, liveRow) {
     last_ok: liveRow.last_ok || null,
     health_source: "live-cron-prober",
     health_stale: false,
-    pool_eligible: liveRow.status === "ok",
     error: liveRow.status === "ok" ? null : (endpoint.error ?? null),
-  };
+  });
 }
 
 function countEndpointStatuses(endpoints) {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -1014,6 +1014,109 @@ describe("composed-artifact health overlays", () => {
     assert.equal(out.summary.pool_eligible_count, 0);
   });
 
+  test("overlayArtifactEndpoints recomputes pool eligibility from live health and static constraints", () => {
+    const liveOk = {
+      last_run_at: "2026-06-13T00:00:00.000Z",
+      health_source: "live-cron-prober",
+      surfaces: [
+        {
+          surface_id: "rpc-ok",
+          status: "ok",
+          last_checked: "2026-06-13T00:00:00.000Z",
+        },
+        {
+          surface_id: "api-ok",
+          status: "ok",
+          last_checked: "2026-06-13T00:00:00.000Z",
+        },
+        {
+          surface_id: "auth-ok",
+          status: "ok",
+          last_checked: "2026-06-13T00:00:00.000Z",
+        },
+        {
+          surface_id: "unsafe-ok",
+          status: "ok",
+          last_checked: "2026-06-13T00:00:00.000Z",
+        },
+      ],
+    };
+    const out = overlayArtifactEndpoints(
+      {
+        summary: { by_status: { failed: 4 }, pool_eligible_count: 0 },
+        endpoints: [
+          {
+            surface_id: "rpc-ok",
+            kind: "subtensor-rpc",
+            auth_required: false,
+            public_safe: true,
+            status: "failed",
+          },
+          {
+            surface_id: "api-ok",
+            kind: "subnet-api",
+            auth_required: false,
+            public_safe: true,
+            status: "failed",
+          },
+          {
+            surface_id: "auth-ok",
+            kind: "subtensor-rpc",
+            auth_required: true,
+            public_safe: true,
+            status: "failed",
+          },
+          {
+            surface_id: "unsafe-ok",
+            kind: "subtensor-wss",
+            auth_required: false,
+            public_safe: false,
+            status: "failed",
+          },
+        ],
+      },
+      liveOk,
+    );
+
+    assert.equal(
+      out.endpoints.find((e) => e.surface_id === "rpc-ok").pool_eligible,
+      true,
+    );
+    assert.deepEqual(
+      out.endpoints.find((e) => e.surface_id === "rpc-ok")
+        .pool_eligibility_reasons,
+      ["eligible"],
+    );
+    assert.equal(
+      out.endpoints.find((e) => e.surface_id === "api-ok").pool_eligible,
+      false,
+    );
+    assert.deepEqual(
+      out.endpoints.find((e) => e.surface_id === "api-ok")
+        .pool_eligibility_reasons,
+      ["not-bittensor-base-layer"],
+    );
+    assert.equal(
+      out.endpoints.find((e) => e.surface_id === "auth-ok").pool_eligible,
+      false,
+    );
+    assert.deepEqual(
+      out.endpoints.find((e) => e.surface_id === "auth-ok")
+        .pool_eligibility_reasons,
+      ["auth-required"],
+    );
+    assert.equal(
+      out.endpoints.find((e) => e.surface_id === "unsafe-ok").pool_eligible,
+      false,
+    );
+    assert.deepEqual(
+      out.endpoints.find((e) => e.surface_id === "unsafe-ok")
+        .pool_eligibility_reasons,
+      ["not-public-safe"],
+    );
+    assert.equal(out.summary.pool_eligible_count, 1);
+  });
+
   test("overlayArtifactEndpoints blanks endpoints to unknown when the store is cold", () => {
     const artifact = {
       endpoints: [
@@ -1099,7 +1202,14 @@ describe("composed-artifact health overlays", () => {
     const out = overlayArtifactEndpoints(
       {
         endpoints: [
-          { surface_id: "ok-one", status: "failed", pool_eligible: false },
+          {
+            surface_id: "ok-one",
+            status: "failed",
+            kind: "subtensor-rpc",
+            auth_required: false,
+            public_safe: true,
+            pool_eligible: false,
+          },
           { surface_id: "deg-one", status: "ok", error: "prev-error" },
         ],
       },


### PR DESCRIPTION
### Motivation
- Correct a regression where the live health overlay set `pool_eligible` solely from the live probe (`status === "ok"`) and thereby ignored static eligibility constraints such as endpoint `kind`, `auth_required`, and `public_safe`.
- Ensure public registry metadata and aggregate counts remain trustworthy by recomputing eligibility from the combined static + live view instead of exposing baked or incorrectly derived booleans.

### Description
- Add `isBaseLayerEndpoint` and `endpointPoolEligibility` helpers to encapsulate the static eligibility policy (base-layer kind, `status === "ok"`, `auth_required === false`, and `public_safe === true`).
- Add `withPoolEligibility` and change `overlayEndpointHealth` to apply it so each overlaid endpoint carries `pool_eligible` and `pool_eligibility_reasons` derived from the combined static properties and live health.
- Preserve structural fields and live freshness fields while removing the previous direct assignment of `pool_eligible` from the live row, and keep the summary histogram recomputation but now consistent with recomputed eligibility.
- Add regression tests to `tests/health-serving.test.mjs` that verify live-OK non-base-layer, auth-required, and non-public-safe endpoints remain ineligible while a valid live-OK RPC endpoint is eligible.

### Testing
- Ran `npm test -- tests/health-serving.test.mjs -t overlayArtifactEndpoints` and the targeted overlay tests passed (all selected tests succeeded).
- Ran `npm test -- tests/health-serving.test.mjs` where the full file run showed 83 tests with 2 failures in unrelated composed-route cold-overview fixtures (the targeted overlay assertions pass; the failing two are pre-existing environment/fixture expectations in this environment).
- Ran `npx eslint src/health-serving.mjs tests/health-serving.test.mjs` and linting of the modified files passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d24304880832a92162eea5622a622)