### PR TITLE
fix(discovery): absolute canonical refs in the Link header (apex-safe)

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1378,8 +1378,10 @@ describe("Agent discovery surfaces", () => {
   });
 
   test("api-catalog hrefs are canonical (api.metagraph.sh), not the request host", async () => {
-    // The apex (metagraph.sh) routes /.well-known/* to this worker too, so the
-    // catalog must reference the real API host regardless of which host served it.
+    // The apex (metagraph.sh) routes /.well-known/* to this worker too, so both
+    // the linkset body AND the HTTP Link header must reference the real API host
+    // regardless of which host served the request — origin-relative refs would
+    // resolve to metagraph.sh (the wrong host).
     const response = await handleRequest(
       new Request("https://metagraph.sh/.well-known/api-catalog"),
       {},
@@ -1391,5 +1393,12 @@ describe("Agent discovery surfaces", () => {
       body.linkset[0]["service-desc"][0].href,
       "https://api.metagraph.sh/metagraph/openapi.json",
     );
+    const link = response.headers.get("link");
+    assert.match(
+      link,
+      /<https:\/\/api\.metagraph\.sh\/metagraph\/openapi\.json>; rel="service-desc"/,
+    );
+    // No origin-relative refs that would resolve to the apex host.
+    assert.doesNotMatch(link, /<\/[a-z.]/);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3121,19 +3121,22 @@ function corsPreflight(request) {
 }
 
 // RFC 8288 Link header advertising the machine entrypoints, mirrored as
-// `<link>` elements in the homepage HTML below. Relative refs resolve against
-// the request URL, so the same value is correct on any deployment host. The
-// relation set mirrors the authoritative RFC 9264 linkset served at
-// /.well-known/api-catalog (service-desc, both service-doc targets, status,
-// describedby) so an agent bootstrapping from the header alone sees the same
-// entrypoints as the catalog body.
+// `<link>` elements in the homepage HTML below. These discovery paths are also
+// served on the apex (metagraph.sh) via zone routes, where origin-relative refs
+// would resolve against metagraph.sh — the wrong host (the canonical API is
+// api.metagraph.sh). So the Link header uses ABSOLUTE canonical refs, matching
+// the authoritative RFC 9264 linkset body (which is already absolute). The
+// relation set mirrors that body (service-desc, both service-doc targets,
+// status, describedby) so an agent bootstrapping from the header alone sees the
+// same entrypoints as the catalog.
+const DISCOVERY_LINK_BASE = `https://${PRIMARY_DOMAIN}`;
 const DISCOVERY_LINK_HEADER = [
-  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
-  '</metagraph/openapi.json>; rel="service-desc"; type="application/json"',
-  '</llms.txt>; rel="service-doc"; type="text/plain"',
-  '</agent.md>; rel="service-doc"; type="text/markdown"',
-  '</health>; rel="status"; type="application/json"',
-  '</.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"',
+  `<${DISCOVERY_LINK_BASE}/.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"`,
+  `<${DISCOVERY_LINK_BASE}/metagraph/openapi.json>; rel="service-desc"; type="application/json"`,
+  `<${DISCOVERY_LINK_BASE}/llms.txt>; rel="service-doc"; type="text/plain"`,
+  `<${DISCOVERY_LINK_BASE}/agent.md>; rel="service-doc"; type="text/markdown"`,
+  `<${DISCOVERY_LINK_BASE}/health>; rel="status"; type="application/json"`,
+  `<${DISCOVERY_LINK_BASE}/.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"`,
 ].join(", ");
 
 const HOMEPAGE_HTML = `<!doctype html>


### PR DESCRIPTION
Reapplies the valid insight from the closed #514 on current main.

**Bug:** `DISCOVERY_LINK_HEADER` used origin-relative refs (`</metagraph/openapi.json>`). The backend serves these discovery paths on the **apex** (`metagraph.sh`) too via zone routes — and a relative ref there resolves against `metagraph.sh`, the wrong host (`metagraph.sh/metagraph/*` 404s on the UI worker; the canonical API is `api.metagraph.sh`). So an agent following the `Link` header on the apex-served `/.well-known/api-catalog` got dead URLs.

**Fix:** absolute canonical refs (`https://api.metagraph.sh/…`), matching the RFC 9264 linkset body (already absolute) and the apex UI worker's own homepage `Link` header (#65). Relation set unchanged (the 6-member set from #516). Test extended to assert the header is absolute with no origin-relative refs.

(#514 had the right idea but was built on a pre-#516 tree, so it couldn't merge cleanly — closed in favor of this.)

Verified: 29 worker-runtime tests pass, `validate:mcp` green, eslint + prettier clean. No contract/artifact change (HTTP header only).