### PR TITLE
fix(discovery): canonicalize discovery Link header

### DIFF
--- a/scripts/worker-test.mjs
+++ b/scripts/worker-test.mjs
@@ -18,6 +18,28 @@ assert.equal(
   "API responses should set nosniff",
 );
 
+const apexCatalog = await handleRequest(
+  new Request("https://metagraph.sh/.well-known/api-catalog"),
+  env,
+  {},
+);
+assert.equal(apexCatalog.status, 200, "apex API catalog should be served");
+const apexCatalogLink = apexCatalog.headers.get("link") || "";
+assert.match(
+  apexCatalogLink,
+  /<https:\/\/api\.metagraph\.sh\/health>; rel="status"; type="application\/json"/,
+  "apex API catalog Link header should advertise canonical API health",
+);
+assert.ok(
+  !apexCatalogLink.includes("</health>"),
+  "apex API catalog Link header must not use a relative health target",
+);
+assert.equal(
+  (await apexCatalog.json()).linkset[0].status[0].href,
+  "https://api.metagraph.sh/health",
+  "apex API catalog body should continue to advertise canonical API health",
+);
+
 const apiOptions = await handleRequest(
   new Request("https://metagraph.sh/api/v1/subnets", { method: "OPTIONS" }),
   env,

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -3121,19 +3121,22 @@ function corsPreflight(request) {
 }
 
 // RFC 8288 Link header advertising the machine entrypoints, mirrored as
-// `<link>` elements in the homepage HTML below. Relative refs resolve against
-// the request URL, so the same value is correct on any deployment host. The
-// relation set mirrors the authoritative RFC 9264 linkset served at
-// /.well-known/api-catalog (service-desc, both service-doc targets, status,
-// describedby) so an agent bootstrapping from the header alone sees the same
-// entrypoints as the catalog body.
+// `<link>` elements in the homepage HTML below. Use the canonical API origin in
+// the header because this worker also owns selected discovery paths on the apex
+// host; relative refs from an apex request can otherwise resolve to routes that
+// are intentionally served only by api.metagraph.sh. The relation set mirrors
+// the authoritative RFC 9264 linkset served at /.well-known/api-catalog
+// (service-desc, both service-doc targets, status, describedby) so an agent
+// bootstrapping from the header alone sees the same entrypoints as the catalog
+// body.
+const DISCOVERY_LINK_BASE = `https://${PRIMARY_DOMAIN}`;
 const DISCOVERY_LINK_HEADER = [
-  '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
-  '</metagraph/openapi.json>; rel="service-desc"; type="application/json"',
-  '</llms.txt>; rel="service-doc"; type="text/plain"',
-  '</agent.md>; rel="service-doc"; type="text/markdown"',
-  '</health>; rel="status"; type="application/json"',
-  '</.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"',
+  `<${DISCOVERY_LINK_BASE}/.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"`,
+  `<${DISCOVERY_LINK_BASE}/metagraph/openapi.json>; rel="service-desc"; type="application/json"`,
+  `<${DISCOVERY_LINK_BASE}/llms.txt>; rel="service-doc"; type="text/plain"`,
+  `<${DISCOVERY_LINK_BASE}/agent.md>; rel="service-doc"; type="text/markdown"`,
+  `<${DISCOVERY_LINK_BASE}/health>; rel="status"; type="application/json"`,
+  `<${DISCOVERY_LINK_BASE}/.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"`,
 ].join(", ");
 
 const HOMEPAGE_HTML = `<!doctype html>


### PR DESCRIPTION
### Motivation
- The shared RFC 8288 `Link` header used relative references (e.g. `</health>`) which, when served from the apex host, resolve to `https://metagraph.sh/health` instead of the canonical API host used by the `/ .well-known/api-catalog` body, creating a discovery mismatch for apex clients. 
- The change ensures the header and the RFC 9264 linkset body advertise the same canonical API entrypoints so agents bootstrapping from headers get the authoritative API view.

### Description
- Replace the relative discovery `Link` header with absolute, canonical targets by adding `DISCOVERY_LINK_BASE = `https://${PRIMARY_DOMAIN}`` and building header entries from it in `workers/api.mjs` so header links (including `health`) point to the API origin. 
- Update `DISCOVERY_LINK_HEADER` to interpolate `DISCOVERY_LINK_BASE` into each relation (e.g. `<${DISCOVERY_LINK_BASE}/health>`). 
- Add a worker runtime assertion in `scripts/worker-test.mjs` that requests `https://metagraph.sh/.well-known/api-catalog` and asserts the response `Link` header advertises `https://api.metagraph.sh/health` and does not contain a relative `</health>`.

### Testing
- Ran `npm run worker:test` which executed the worker runtime tests and succeeded. 
- Ran `git diff --check` which reported no issues on the patched files. 
- Ran `npm run lint` which failed due to a pre-existing unrelated lint error (`tests/artifacts.test.mjs` unused `mkdirSync`). 
- Ran the full test suite with `npm test` which failed because many tests require generated artifacts under `public/metagraph` and `dist/metagraph-r2` and there are environment-dependent checks; these failures are unrelated to the discovery header change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d30cd39ec832a900228fb4523884f)