### PR TITLE
feat(mcp): submit MCP server to the canonical MCP Registry

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -1,0 +1,73 @@
+name: Publish MCP Registry
+
+# Publishes metagraphed's hosted MCP server to the canonical MCP Registry
+# (registry.modelcontextprotocol.io) from the repo-root `server.json`. Uses
+# GitHub OIDC for the `io.github.jsonbored/*` namespace — no token, no secret,
+# no DNS. Manual trigger; the registry rejects a re-publish of an existing
+# version, so bump `version` in server.json before re-running.
+#
+# This is a remote server (remotes[].url -> https://api.metagraph.sh/mcp), so
+# there is no package artifact to build/publish — only the metadata listing.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mcp-registry-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      id-token: write # OIDC: proves the io.github.jsonbored namespace
+      contents: read
+    env:
+      # Pinned mcp-publisher release + the SHA256 of its linux/amd64 tarball
+      # (from registry_1.7.9_checksums.txt). Hardcoding the digest means we
+      # never trust a fetched checksums file at runtime.
+      MCP_PUBLISHER_VERSION: v1.7.9
+      MCP_PUBLISHER_SHA256: ab128162b0616090b47cf245afe0a23f3ef08936fdce19074f5ba0a4469281ac
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Validate server.json
+        run: |
+          set -euo pipefail
+          node --input-type=module -e '
+            import { readFileSync } from "node:fs";
+            const s = JSON.parse(readFileSync("server.json", "utf8"));
+            if (s.name !== "io.github.jsonbored/metagraphed") {
+              throw new Error(`unexpected name: ${s.name}`);
+            }
+            if (!s.version || typeof s.version !== "string") {
+              throw new Error("server.json is missing a string version");
+            }
+            const remote = (s.remotes ?? [])[0];
+            if (remote?.type !== "streamable-http" || !remote?.url?.startsWith("https://api.metagraph.sh/")) {
+              throw new Error(`unexpected remote: ${JSON.stringify(remote)}`);
+            }
+            console.log(`server.json ok — ${s.name} v${s.version} -> ${remote.url}`);
+          '
+
+      - name: Install mcp-publisher (pinned + checksum-verified)
+        run: |
+          set -euo pipefail
+          url="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_linux_amd64.tar.gz"
+          curl -fsSL "$url" -o mcp-publisher.tar.gz
+          echo "${MCP_PUBLISHER_SHA256}  mcp-publisher.tar.gz" | sha256sum -c -
+          tar -xzf mcp-publisher.tar.gz mcp-publisher
+          chmod +x mcp-publisher
+          ./mcp-publisher --version || true
+
+      - name: Authenticate to MCP Registry (GitHub OIDC)
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server to MCP Registry
+        run: ./mcp-publisher publish

--- a/docs/apex-agent-discovery.md
+++ b/docs/apex-agent-discovery.md
@@ -67,6 +67,15 @@ backend routes are ever removed); the backend routes above win for the paths
 they cover, so the backend is the live source for everything except `/` and
 `/sitemap.xml`.
 
+## Canonical MCP Registry listing
+
+Beyond the self-hosted surfaces, metagraphed's hosted MCP server is listed in the
+canonical [MCP Registry](https://registry.modelcontextprotocol.io) as
+`io.github.jsonbored/metagraphed`, pointing at the live `streamable-http` remote
+`https://api.metagraph.sh/mcp`. Registry-aware clients can resolve the server by
+name; the published listing is `server.json` at the repo root, shipped via GitHub
+OIDC (no secret). See [docs/mcp-registry.md](mcp-registry.md).
+
 ## Optional: AI-bot crawl policy
 
 The apex `robots.txt` is Cloudflare **Managed robots.txt**: `User-agent: *` is

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -1,0 +1,67 @@
+# MCP Registry submission
+
+metagraphed's hosted MCP server is listed in the canonical
+[MCP Registry](https://registry.modelcontextprotocol.io) so that MCP-aware
+clients (Claude, IDEs, agent runtimes) can discover and add it by name instead
+of being handed a URL out of band.
+
+This complements — it does not replace — the self-hosted discovery surfaces
+(`/.well-known/mcp/server-card.json`, `/.well-known/mcp.json`, the api-catalog
+linkset, and the `POST /mcp` endpoint itself). The registry is one more front
+door; the server-card remains the authoritative, always-current description.
+
+## The listing
+
+- **Manifest:** [`server.json`](../server.json) at the repo root, validated
+  against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`.
+- **Name (namespace):** `io.github.jsonbored/metagraphed`. The `io.github.*`
+  namespace is proven by **GitHub OIDC** from this repo — no DNS record, no
+  Ed25519 key, no stored secret. (The branded reverse-DNS alternative
+  `sh.metagraph/*` would require a DNS `TXT` record + a signing key held as a CI
+  secret; not worth the operational surface for an equivalent listing.)
+- **Transport:** a single `remotes[]` entry —
+  `{ "type": "streamable-http", "url": "https://api.metagraph.sh/mcp" }`. There
+  is **no package** (npm/PyPI) to publish; this is a hosted remote server, so
+  the registry stores only the metadata pointing at the live endpoint.
+
+## Publishing
+
+`mcp-publisher` is run from CI by
+[`.github/workflows/publish-mcp-registry.yml`](../.github/workflows/publish-mcp-registry.yml):
+
+1. **Trigger:** manual (`workflow_dispatch`) — Actions → _Publish MCP Registry_
+   → _Run workflow_. Mirrors the Python SDK release flow.
+2. **Auth:** `mcp-publisher login github-oidc` using the job's `id-token: write`
+   OIDC token. The registry maps the token's repo owner (`JSONbored`) to the
+   `io.github.jsonbored/*` namespace. **No secret to configure.**
+3. **Supply chain:** the `mcp-publisher` binary is pinned to a release tag and
+   verified against a hardcoded SHA256 before it runs.
+4. **Publish:** `mcp-publisher publish` reads `server.json` and submits it.
+
+### Re-publishing / version bumps
+
+The registry **rejects a re-publish of an existing `version`**. To ship a
+change, bump `version` in `server.json` (it is an independent listing version —
+not the live `serverInfo.version`, which tracks the API contract) and re-run the
+workflow. Editing `server.json` without bumping the version will fail the
+publish step, by design.
+
+## Verifying a published listing
+
+```
+curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.jsonbored/metagraphed" | jq .
+```
+
+The returned record should show the `streamable-http` remote at
+`https://api.metagraph.sh/mcp` and the current `version`.
+
+## Adding the server in a client
+
+Most MCP clients accept the remote URL directly:
+
+```
+https://api.metagraph.sh/mcp
+```
+
+Registry-aware clients can instead resolve it by name —
+`io.github.jsonbored/metagraphed` — and pick up the transport automatically.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.jsonbored/metagraphed",
+  "title": "metagraphed — Bittensor subnet operational registry",
+  "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
+  "version": "0.1.0",
+  "websiteUrl": "https://metagraph.sh",
+  "repository": {
+    "url": "https://github.com/JSONbored/metagraphed",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://api.metagraph.sh/mcp"
+    }
+  ]
+}


### PR DESCRIPTION
## What

Lists metagraphed's hosted MCP server in the canonical [MCP Registry](https://registry.modelcontextprotocol.io) so MCP-aware clients can discover and add it **by name** instead of being handed a URL out of band.

- **`server.json`** (repo root) — remote server `io.github.jsonbored/metagraphed`, single `streamable-http` remote at `https://api.metagraph.sh/mcp`. Validated against the `2025-12-11` server schema (`name`/`version`/`remotes`/`repository`/`websiteUrl`, description ≤100 chars). No `packages` — this is a hosted remote, not a published package.
- **`.github/workflows/publish-mcp-registry.yml`** — `workflow_dispatch`, **GitHub OIDC** for the `io.github.*` namespace (no secret, no DNS, no Ed25519 key). `mcp-publisher` pinned to `v1.7.9` and **SHA256-verified** before it runs. Mirrors the hardened house style (`persist-credentials: false`, minimal perms, concurrency guard, SHA-pinned `actions/checkout`).
- **Docs** — `docs/mcp-registry.md` (namespace rationale, publish + version-bump flow, client install, verification) + a pointer from `docs/apex-agent-discovery.md`.

## Why `io.github.jsonbored/metagraphed`

GitHub-OIDC namespace auth is fully CI-automatable with zero owner setup. The branded `sh.metagraph/*` reverse-DNS alternative would need a DNS `TXT` record + a signing key in CI secrets for an equivalent listing — not worth the operational surface.

## Shipping

This PR only lands the files. The registry submission itself is **owner-triggered** (outward-facing publish): run **Actions → Publish MCP Registry → Run workflow** once. Re-publishing requires bumping `server.json.version` first (the registry rejects duplicate versions).

## Validation

- `server.json` validates clean against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json` (ajv, draft-07).
- `validate:workflows`, `validate:docs`, `scan:public-safety` all pass; new files are prettier-clean.