### PR TITLE
fix(mcp): match GitHub owner case in the registry namespace

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -2,7 +2,7 @@ name: Publish MCP Registry
 
 # Publishes metagraphed's hosted MCP server to the canonical MCP Registry
 # (registry.modelcontextprotocol.io) from the repo-root `server.json`. Uses
-# GitHub OIDC for the `io.github.jsonbored/*` namespace — no token, no secret,
+# GitHub OIDC for the `io.github.JSONbored/*` namespace — no token, no secret,
 # no DNS. Manual trigger; the registry rejects a re-publish of an existing
 # version, so bump `version` in server.json before re-running.
 #
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      id-token: write # OIDC: proves the io.github.jsonbored namespace
+      id-token: write # OIDC: proves the io.github.JSONbored namespace
       contents: read
     env:
       # Pinned mcp-publisher release + the SHA256 of its linux/amd64 tarball
@@ -43,7 +43,7 @@ jobs:
           node --input-type=module -e '
             import { readFileSync } from "node:fs";
             const s = JSON.parse(readFileSync("server.json", "utf8"));
-            if (s.name !== "io.github.jsonbored/metagraphed") {
+            if (s.name !== "io.github.JSONbored/metagraphed") {
               throw new Error(`unexpected name: ${s.name}`);
             }
             if (!s.version || typeof s.version !== "string") {

--- a/docs/apex-agent-discovery.md
+++ b/docs/apex-agent-discovery.md
@@ -71,7 +71,7 @@ they cover, so the backend is the live source for everything except `/` and
 
 Beyond the self-hosted surfaces, metagraphed's hosted MCP server is listed in the
 canonical [MCP Registry](https://registry.modelcontextprotocol.io) as
-`io.github.jsonbored/metagraphed`, pointing at the live `streamable-http` remote
+`io.github.JSONbored/metagraphed`, pointing at the live `streamable-http` remote
 `https://api.metagraph.sh/mcp`. Registry-aware clients can resolve the server by
 name; the published listing is `server.json` at the repo root, shipped via GitHub
 OIDC (no secret). See [docs/mcp-registry.md](mcp-registry.md).

--- a/docs/mcp-registry.md
+++ b/docs/mcp-registry.md
@@ -14,7 +14,7 @@ door; the server-card remains the authoritative, always-current description.
 
 - **Manifest:** [`server.json`](../server.json) at the repo root, validated
   against `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`.
-- **Name (namespace):** `io.github.jsonbored/metagraphed`. The `io.github.*`
+- **Name (namespace):** `io.github.JSONbored/metagraphed`. The `io.github.*`
   namespace is proven by **GitHub OIDC** from this repo — no DNS record, no
   Ed25519 key, no stored secret. (The branded reverse-DNS alternative
   `sh.metagraph/*` would require a DNS `TXT` record + a signing key held as a CI
@@ -33,7 +33,7 @@ door; the server-card remains the authoritative, always-current description.
    → _Run workflow_. Mirrors the Python SDK release flow.
 2. **Auth:** `mcp-publisher login github-oidc` using the job's `id-token: write`
    OIDC token. The registry maps the token's repo owner (`JSONbored`) to the
-   `io.github.jsonbored/*` namespace. **No secret to configure.**
+   `io.github.JSONbored/*` namespace. **No secret to configure.**
 3. **Supply chain:** the `mcp-publisher` binary is pinned to a release tag and
    verified against a hardcoded SHA256 before it runs.
 4. **Publish:** `mcp-publisher publish` reads `server.json` and submits it.
@@ -49,7 +49,7 @@ publish step, by design.
 ## Verifying a published listing
 
 ```
-curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.jsonbored/metagraphed" | jq .
+curl -s "https://registry.modelcontextprotocol.io/v0/servers?search=io.github.JSONbored/metagraphed" | jq .
 ```
 
 The returned record should show the `streamable-http` remote at
@@ -64,4 +64,4 @@ https://api.metagraph.sh/mcp
 ```
 
 Registry-aware clients can instead resolve it by name —
-`io.github.jsonbored/metagraphed` — and pick up the transport automatically.
+`io.github.JSONbored/metagraphed` — and pick up the transport automatically.

--- a/server.json
+++ b/server.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.jsonbored/metagraphed",
+  "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
   "version": "0.1.0",


### PR DESCRIPTION
The first `publish-mcp-registry.yml` dispatch ([run](https://github.com/JSONbored/metagraphed/actions/runs/27479359078)) got through checkout, the SHA256-verified `mcp-publisher` install, **and OIDC auth** — then `mcp-publisher publish` returned:

> 403 Forbidden — You have permission to publish: `io.github.JSONbored/*`. Attempting to publish: `io.github.jsonbored/metagraphed`.

The registry matches the OIDC namespace **case-sensitively** against the GitHub owner login (`JSONbored`). I'd used the reverse-DNS lowercase convention, which the registry rejects.

Fix: use the exact owner case `io.github.JSONbored/metagraphed` in `server.json`, the workflow's inline validation guard, and the docs. `server.json` still validates against the `2025-12-11` schema (the `name` pattern permits uppercase). The failed publish stored nothing, so re-publishing `0.1.0` after merge is clean.