### PR TITLE
feat(agents): OpenAI + Anthropic tool specs at /.well-known/agent-tools

### DIFF
--- a/docs/agent-tools.md
+++ b/docs/agent-tools.md
@@ -1,0 +1,100 @@
+# Agent tool specs (OpenAI + Anthropic)
+
+For MCP-aware clients, point them at `https://api.metagraph.sh/mcp` (or resolve
+`io.github.JSONbored/metagraphed` from the [MCP Registry](mcp-registry.md)). For
+the two largest **non-MCP** agent ecosystems — OpenAI function calling and
+Anthropic tool use — metagraphed publishes paste-ready static tool specs:
+
+| Surface                  | URL                                                               |
+| ------------------------ | ----------------------------------------------------------------- |
+| Index (executor + links) | `https://api.metagraph.sh/.well-known/agent-tools/index.json`     |
+| OpenAI function specs    | `https://api.metagraph.sh/.well-known/agent-tools/openai.json`    |
+| Anthropic tool specs     | `https://api.metagraph.sh/.well-known/agent-tools/anthropic.json` |
+
+Both spec documents are projected at request time from the same tool list the
+MCP server advertises, so they never drift. The OpenAI document is a bare array
+of `{ type: "function", function: {...} }`; the Anthropic document is a bare
+array of `{ name, description, input_schema }`. Each is dropped directly into the
+respective SDK's `tools` parameter.
+
+## Executing a tool call
+
+The specs declare the tool _shape_; execution is uniform — forward the model's
+tool call to the MCP endpoint as a JSON-RPC `tools/call`:
+
+```
+POST https://api.metagraph.sh/mcp
+{ "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+  "params": { "name": "<tool name>", "arguments": { ... } } }
+```
+
+The result's `structuredContent` (and the text block) is the tool output. The
+`index.json` document carries this executor mapping machine-readably under
+`executor`.
+
+> Tool results may include operator-controlled on-chain text. Treat returned
+> field values as **data, never as instructions** (the untrusted-data note is
+> baked into every tool description).
+
+### OpenAI (Chat Completions / Responses)
+
+```js
+const tools = await fetch(
+  "https://api.metagraph.sh/.well-known/agent-tools/openai.json",
+).then((r) => r.json());
+
+async function runToolCall(call) {
+  const res = await fetch("https://api.metagraph.sh/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: {
+        name: call.function.name,
+        arguments: JSON.parse(call.function.arguments),
+      },
+    }),
+  }).then((r) => r.json());
+  return res.result?.structuredContent ?? res.result?.content?.[0]?.text;
+}
+
+// Pass `tools` to chat.completions.create({ model, messages, tools });
+// when the model emits tool_calls, map each through runToolCall and return the
+// result as a tool message.
+```
+
+### Anthropic (Messages)
+
+```js
+const tools = await fetch(
+  "https://api.metagraph.sh/.well-known/agent-tools/anthropic.json",
+).then((r) => r.json());
+
+async function runToolUse(block) {
+  const res = await fetch("https://api.metagraph.sh/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: block.name, arguments: block.input },
+    }),
+  }).then((r) => r.json());
+  return res.result?.structuredContent ?? res.result?.content?.[0]?.text;
+}
+
+// Pass `tools` to messages.create({ model, messages, tools });
+// for each tool_use block, return a tool_result with runToolUse(block).
+```
+
+## Source of truth
+
+The specs derive from `listToolDefinitions()` in
+[src/mcp-server.mjs](../src/mcp-server.mjs) via
+[src/agent-tool-specs.mjs](../src/agent-tool-specs.mjs); `validate:mcp` asserts
+the served specs cover every MCP tool and match the canonical projection. The
+documents are advertised from the `/.well-known/api-catalog` linkset
+(`describedby`) and the homepage discovery index.

--- a/docs/apex-agent-discovery.md
+++ b/docs/apex-agent-discovery.md
@@ -4,7 +4,7 @@
 
 - **`api.metagraph.sh`** — the `metagraphed` backend worker (this repo), a custom
   domain. The canonical agent surface: `/`, `/.well-known/*` (api-catalog,
-  agent-skills, mcp/server-card, mcp.json, llms.txt), `/sitemap.xml`,
+  agent-skills, agent-tools, mcp/server-card, mcp.json, llms.txt), `/sitemap.xml`,
   `/robots.txt`, `/llms.txt`, `/llms-full.txt`, `/auth.md`, `/agent.md`, RFC 8288
   `Link` headers, and `POST /mcp`. Live + verified.
 - **`metagraph.sh`** (apex) — the human web app, served by the separate
@@ -75,6 +75,14 @@ canonical [MCP Registry](https://registry.modelcontextprotocol.io) as
 `https://api.metagraph.sh/mcp`. Registry-aware clients can resolve the server by
 name; the published listing is `server.json` at the repo root, shipped via GitHub
 OIDC (no secret). See [docs/mcp-registry.md](mcp-registry.md).
+
+## Agent tool specs (non-MCP runtimes)
+
+For OpenAI function calling and Anthropic tool use (which consume static tool
+JSON, not MCP), the backend serves paste-ready specs at
+`/.well-known/agent-tools/{index,openai,anthropic}.json` — projected at request
+time from the same tool list the MCP server advertises, and advertised from the
+api-catalog linkset (`describedby`). See [docs/agent-tools.md](agent-tools.md).
 
 ## Optional: AI-bot crawl policy
 

--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -9,6 +9,10 @@ import assert from "node:assert/strict";
 import Ajv2020 from "ajv/dist/2020.js";
 import { handleRequest } from "../workers/api.mjs";
 import { MCP_TOOLS, listToolDefinitions } from "../src/mcp-server.mjs";
+import {
+  buildAnthropicToolSpecs,
+  buildOpenAIToolSpecs,
+} from "../src/agent-tool-specs.mjs";
 import { createLocalArtifactEnv } from "./lib.mjs";
 
 const env = createLocalArtifactEnv();
@@ -29,6 +33,15 @@ async function mcp(payload, { method = "POST" } = {}) {
     method,
     headers: { "content-type": "application/json" },
     body: method === "POST" ? JSON.stringify(payload) : undefined,
+  });
+  const response = await handleRequest(request, env, {});
+  const text = await response.text();
+  return { status: response.status, body: text ? JSON.parse(text) : null };
+}
+
+async function getJson(path) {
+  const request = new Request(`https://api.metagraph.sh${path}`, {
+    method: "GET",
   });
   const response = await handleRequest(request, env, {});
   const text = await response.text();
@@ -123,6 +136,80 @@ for (const tool of tools) {
     `${tool.name}: inputSchema must be an object schema`,
   );
 }
+
+// --- Agent tool specs (OpenAI + Anthropic) ---------------------------------
+// The /.well-known/agent-tools/* specs are projected at request time from the
+// same listToolDefinitions() the MCP server advertises, so they must cover
+// every tool and match the canonical projection byte-for-byte (no drift).
+
+const toolNames = new Set(MCP_TOOLS.map((tool) => tool.name));
+
+const openaiSpec = await getJson("/.well-known/agent-tools/openai.json");
+assert.equal(openaiSpec.status, 200, "openai.json must return HTTP 200");
+assert.deepEqual(
+  openaiSpec.body,
+  buildOpenAIToolSpecs(listToolDefinitions()),
+  "served openai.json must equal the canonical OpenAI projection",
+);
+assert.equal(
+  openaiSpec.body.length,
+  MCP_TOOLS.length,
+  "openai.json must expose every MCP tool",
+);
+for (const entry of openaiSpec.body) {
+  assert.equal(entry.type, "function", "openai entry must be a function tool");
+  assert.ok(
+    toolNames.has(entry.function?.name),
+    `openai entry references unknown tool ${entry.function?.name}`,
+  );
+  assert.equal(
+    entry.function?.parameters?.type,
+    "object",
+    `${entry.function?.name}: openai parameters must be an object schema`,
+  );
+  assert.equal(
+    typeof entry.function?.description,
+    "string",
+    `${entry.function?.name}: openai tool needs a description`,
+  );
+}
+
+const anthropicSpec = await getJson("/.well-known/agent-tools/anthropic.json");
+assert.equal(anthropicSpec.status, 200, "anthropic.json must return HTTP 200");
+assert.deepEqual(
+  anthropicSpec.body,
+  buildAnthropicToolSpecs(listToolDefinitions()),
+  "served anthropic.json must equal the canonical Anthropic projection",
+);
+for (const entry of anthropicSpec.body) {
+  assert.ok(
+    toolNames.has(entry.name),
+    `anthropic entry references unknown tool ${entry.name}`,
+  );
+  assert.equal(
+    entry.input_schema?.type,
+    "object",
+    `${entry.name}: anthropic input_schema must be an object schema`,
+  );
+}
+
+const toolsIndex = await getJson("/.well-known/agent-tools/index.json");
+assert.equal(toolsIndex.status, 200, "agent-tools index must return HTTP 200");
+assert.equal(
+  toolsIndex.body.executor?.endpoint,
+  "https://api.metagraph.sh/mcp",
+  "agent-tools index executor must point at the MCP endpoint",
+);
+assert.equal(
+  toolsIndex.body.executor?.jsonrpc_method,
+  "tools/call",
+  "agent-tools index executor must use tools/call",
+);
+assert.deepEqual(
+  [...toolsIndex.body.tools].sort(),
+  [...toolNames].sort(),
+  "agent-tools index must list every MCP tool",
+);
 
 // --- One tools/call per tool ----------------------------------------------
 

--- a/src/agent-tool-specs.mjs
+++ b/src/agent-tool-specs.mjs
@@ -1,0 +1,69 @@
+// Agent tool specs for NON-MCP agent runtimes.
+//
+// The canonical MCP server (src/mcp-server.mjs) exposes our tools over the MCP
+// `tools/list` projection. The two largest agent ecosystems — OpenAI function
+// calling and Anthropic tool use — consume *static* tool JSON instead, so we
+// project the same `listToolDefinitions()` output into their shapes. Building
+// from that single source means the OpenAI/Anthropic specs can never drift from
+// what the MCP server advertises (same names, descriptions, and JSON Schemas,
+// including the untrusted-data note baked into each description).
+//
+// Execution is uniform: every tool is run by forwarding the model's tool call
+// to the MCP endpoint as a JSON-RPC `tools/call` (see buildAgentToolsIndex).
+import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
+import { MCP_SERVER_INFO, listToolDefinitions } from "./mcp-server.mjs";
+
+const ORIGIN = `https://${PRIMARY_DOMAIN}`;
+const MCP_ENDPOINT = `${ORIGIN}/mcp`;
+const OPENAI_SPEC_URL = `${ORIGIN}/.well-known/agent-tools/openai.json`;
+const ANTHROPIC_SPEC_URL = `${ORIGIN}/.well-known/agent-tools/anthropic.json`;
+
+// OpenAI Chat Completions / Responses `tools[]` entries: a bare, paste-ready
+// array of `{ type: "function", function: { name, description, parameters } }`.
+export function buildOpenAIToolSpecs(tools = listToolDefinitions()) {
+  return tools.map((tool) => ({
+    type: "function",
+    function: {
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.inputSchema,
+    },
+  }));
+}
+
+// Anthropic Messages `tools[]` entries: `{ name, description, input_schema }`.
+export function buildAnthropicToolSpecs(tools = listToolDefinitions()) {
+  return tools.map((tool) => ({
+    name: tool.name,
+    description: tool.description,
+    input_schema: tool.inputSchema,
+  }));
+}
+
+// A small machine-readable hub: what the specs are, where they live, and the
+// single uniform executor (the MCP endpoint). Keeps the executor mapping out of
+// the spec arrays themselves (which must stay valid for their target SDK).
+export function buildAgentToolsIndex(
+  tools = listToolDefinitions(),
+  { contractVersion = CONTRACT_VERSION } = {},
+) {
+  return {
+    schema_version: 1,
+    title: `${MCP_SERVER_INFO.title} — agent tool specs`,
+    description:
+      "Paste-ready OpenAI + Anthropic tool specs derived from the metagraphed " +
+      "MCP tools. Execute any tool by forwarding the model's tool call to the " +
+      "MCP endpoint as a JSON-RPC tools/call.",
+    contract_version: contractVersion,
+    executor: {
+      transport: "mcp-streamable-http",
+      endpoint: MCP_ENDPOINT,
+      jsonrpc_method: "tools/call",
+    },
+    specs: {
+      openai: OPENAI_SPEC_URL,
+      anthropic: ANTHROPIC_SPEC_URL,
+    },
+    tools: tools.map((tool) => tool.name),
+  };
+}

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1401,4 +1401,92 @@ describe("Agent discovery surfaces", () => {
     // No origin-relative refs that would resolve to the apex host.
     assert.doesNotMatch(link, /<\/[a-z.]/);
   });
+
+  test("serves OpenAI tool specs as a paste-ready function array", async () => {
+    const response = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/.well-known/agent-tools/openai.json",
+      ),
+      {},
+      {},
+    );
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get("content-type"), "application/json");
+    assert.equal(response.headers.get("access-control-allow-origin"), "*");
+    const tools = await response.json();
+    assert.equal(Array.isArray(tools), true);
+    assert.ok(tools.length >= 14);
+    for (const tool of tools) {
+      assert.equal(tool.type, "function");
+      assert.equal(typeof tool.function.name, "string");
+      assert.equal(typeof tool.function.description, "string");
+      assert.equal(tool.function.parameters.type, "object");
+    }
+  });
+
+  test("serves Anthropic tool specs with input_schema", async () => {
+    const response = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/.well-known/agent-tools/anthropic.json",
+      ),
+      {},
+      {},
+    );
+    assert.equal(response.status, 200);
+    const tools = await response.json();
+    assert.equal(Array.isArray(tools), true);
+    for (const tool of tools) {
+      assert.equal(typeof tool.name, "string");
+      assert.equal(tool.input_schema.type, "object");
+      assert.equal("parameters" in tool, false);
+    }
+  });
+
+  test("agent-tools index points at the MCP executor and is discoverable", async () => {
+    const indexResponse = await handleRequest(
+      new Request(
+        "https://api.metagraph.sh/.well-known/agent-tools/index.json",
+      ),
+      {},
+      {},
+    );
+    assert.equal(indexResponse.status, 200);
+    const index = await indexResponse.json();
+    assert.equal(index.executor.endpoint, "https://api.metagraph.sh/mcp");
+    assert.equal(index.executor.jsonrpc_method, "tools/call");
+    assert.equal(
+      index.specs.openai,
+      "https://api.metagraph.sh/.well-known/agent-tools/openai.json",
+    );
+    assert.ok(Array.isArray(index.tools) && index.tools.length >= 14);
+
+    // The api-catalog linkset advertises the index under describedby.
+    const catalog = await (
+      await handleRequest(
+        new Request("https://api.metagraph.sh/.well-known/api-catalog"),
+        {},
+        {},
+      )
+    ).json();
+    const describedby = catalog.linkset[0].describedby.map(
+      (entry) => entry.href,
+    );
+    assert.ok(
+      describedby.includes(
+        "https://api.metagraph.sh/.well-known/agent-tools/index.json",
+      ),
+    );
+  });
+
+  test("agent-tools specs are served on the apex host too", async () => {
+    const response = await handleRequest(
+      new Request("https://metagraph.sh/.well-known/agent-tools/openai.json"),
+      {},
+      {},
+    );
+    assert.equal(response.status, 200);
+    const tools = await response.json();
+    assert.equal(Array.isArray(tools), true);
+    assert.ok(tools.length >= 14);
+  });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -54,7 +54,12 @@ import {
   resolveLiveHealth,
   subnetBadgeStatus,
 } from "../src/health-serving.mjs";
-import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.mjs";
+import {
+  buildAgentToolsIndex,
+  buildAnthropicToolSpecs,
+  buildOpenAIToolSpecs,
+} from "../src/agent-tool-specs.mjs";
 import {
   aiEnabled,
   askQuestion,
@@ -255,6 +260,19 @@ export async function handleRequest(request, env = {}, ctx = {}) {
 
   if (url.pathname === "/.well-known/mcp/server-card.json") {
     return mcpServerCardResponse(request, env);
+  }
+
+  // Agent tool specs for non-MCP runtimes (OpenAI function calling / Anthropic
+  // tool use), projected at request time from the same listToolDefinitions() the
+  // MCP server advertises — so they can't drift. Worker-owned (run_worker_first).
+  if (url.pathname === "/.well-known/agent-tools/index.json") {
+    return agentToolsResponse(request, env, "index");
+  }
+  if (url.pathname === "/.well-known/agent-tools/openai.json") {
+    return agentToolsResponse(request, env, "openai");
+  }
+  if (url.pathname === "/.well-known/agent-tools/anthropic.json") {
+    return agentToolsResponse(request, env, "anthropic");
   }
 
   if (url.pathname === "/health") {
@@ -3164,6 +3182,7 @@ const HOMEPAGE_HTML = `<!doctype html>
 <li><a href="/.well-known/api-catalog">API catalog</a> (RFC 9727 linkset)</li>
 <li><a href="/.well-known/mcp/server-card.json">MCP server card</a> — <code>POST /mcp</code></li>
 <li><a href="/.well-known/agent-skills/index.json">Agent Skills index</a></li>
+<li><a href="/.well-known/agent-tools/index.json">Agent tool specs</a> — paste-ready OpenAI + Anthropic tools</li>
 <li><a href="/api/v1">REST API index</a> · <a href="/sitemap.xml">sitemap.xml</a> · <a href="/auth.md">auth.md</a></li>
 <li><a href="https://metagraph.sh">metagraph.sh</a> — human web app</li>
 </ul>
@@ -3221,6 +3240,10 @@ function apiCatalogResponse(request) {
             href: `${base}/.well-known/mcp/server-card.json`,
             type: "application/json",
           },
+          {
+            href: `${base}/.well-known/agent-tools/index.json`,
+            type: "application/json",
+          },
         ],
       },
     ],
@@ -3258,6 +3281,33 @@ async function mcpServerCardResponse(request, env) {
     card.published_at = pub;
   }
   const body = `${JSON.stringify(card, null, 2)}\n`;
+  const headers = discoveryHeaders("application/json");
+  headers.set("etag", await weakEtag(body));
+  if (request.headers.get("if-none-match") === headers.get("etag")) {
+    return new Response(null, { status: 304, headers });
+  }
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
+}
+
+// Serve the OpenAI/Anthropic tool specs (and their index) computed live from
+// listToolDefinitions(). No static asset + no API_ROUTES entry: like the
+// api-catalog, these are worker-generated discovery documents whose body is
+// derived from the canonical MCP tool list, so there is nothing to bake or keep
+// in sync.
+async function agentToolsResponse(request, env, kind) {
+  const tools = listToolDefinitions();
+  const data =
+    kind === "openai"
+      ? buildOpenAIToolSpecs(tools)
+      : kind === "anthropic"
+        ? buildAnthropicToolSpecs(tools)
+        : buildAgentToolsIndex(tools, {
+            contractVersion: contractVersion(env),
+          });
+  const body = `${JSON.stringify(data, null, 2)}\n`;
   const headers = discoveryHeaders("application/json");
   headers.set("etag", await weakEtag(body));
   if (request.headers.get("if-none-match") === headers.get("etag")) {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -27,6 +27,7 @@
       "/",
       "/.well-known/api-catalog",
       "/.well-known/mcp/server-card.json",
+      "/.well-known/agent-tools/*",
       "/api/*",
       "/rpc/*",
       "/metagraph/*",


### PR DESCRIPTION
Closes #530 (Wave 9 epic #534).

## What

Widens agent reach beyond MCP. The two largest non-MCP agent ecosystems — **OpenAI function calling** and **Anthropic tool use** — consume *static* tool JSON, so we now publish paste-ready specs:

| Surface | URL |
| --- | --- |
| Index (executor + links) | `/.well-known/agent-tools/index.json` |
| OpenAI function specs | `/.well-known/agent-tools/openai.json` |
| Anthropic tool specs | `/.well-known/agent-tools/anthropic.json` |

Both are projected **at request time** from the same `listToolDefinitions()` the MCP server advertises → **zero drift by construction** (same names, descriptions incl. the untrusted-data note, and JSON Schemas).

## Design

Served **worker-side like `/.well-known/api-catalog`** — not as `/api/v1` contract routes — so this avoids the API_ROUTES → OpenAPI → contract-drift → regeneration machinery entirely, and matches the correct discovery semantics (well-known URIs). The specs are advertised from the api-catalog linkset (`describedby`) + the homepage discovery index.

**Uniform executor:** the specs declare tool *shape*; execution is forwarding the model's tool call to `https://api.metagraph.sh/mcp` as a JSON-RPC `tools/call`. `index.json` carries this mapping machine-readably; `docs/agent-tools.md` has copy-paste OpenAI + Anthropic executor snippets.

## Tests / gates

- `validate:mcp` asserts the served OpenAI/Anthropic specs cover every MCP tool and equal the canonical projection (drift gate).
- 4 new worker-runtime tests: OpenAI array shape, Anthropic `input_schema`, the index executor + linkset discoverability, and apex-host serving. Full worker suite green (37 tests).
- eslint + prettier clean; `validate:docs`, `scan:public-safety` pass. No contract/artifact regeneration needed (no API_ROUTES/PUBLIC_ARTIFACTS touched).

## Follow-up (with #531)

`llms.txt` / `agent.md` mentions of the tool specs will land alongside #531 (which regenerates build artifacts anyway), to keep this PR free of the build-artifact regeneration dance.