### PR TITLE
feat(contract): deepen the 10 shallow OpenAPI response schemas (#531 part 1)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -961,8 +961,9 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         AdapterArtifact: components["schemas"]["ArtifactBase"] & ({
+            /** @description Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific. */
             extensions: {
-                [key: string]: unknown;
+                [key: string]: Record<string, never>;
             };
             netuid: number;
             slug: string;
@@ -1067,7 +1068,11 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description Headline counts across the agent-facing registry. */
             summary?: {
+                callable_service_count?: number;
+                subnet_count?: number;
+            } & {
                 [key: string]: unknown;
             };
         } & {
@@ -1584,7 +1589,16 @@ export interface components {
             probe_finished_at?: string | null;
             probe_started_at?: string | null;
             source?: string;
+            /** @description Aggregate probe outcome counts for the day. */
             summary: {
+                classification_counts?: {
+                    [key: string]: number;
+                };
+                status_counts?: {
+                    [key: string]: number;
+                };
+                surface_count?: number;
+            } & {
                 [key: string]: unknown;
             };
             surfaces: components["schemas"]["HealthHistorySurface"][];
@@ -1919,7 +1933,13 @@ export interface components {
         });
         ProviderEndpointsArtifact: components["schemas"]["ArtifactBase"] & ({
             endpoints: components["schemas"]["EndpointResource"][];
+            /** @description Identity summary of the provider these endpoints belong to. */
             provider: {
+                authority?: string;
+                id?: string;
+                kind?: string;
+                name?: string;
+            } & {
                 [key: string]: unknown;
             };
             summary: components["schemas"]["EndpointSummary"];
@@ -2383,7 +2403,20 @@ export interface components {
         };
         RpcEndpointsArtifact: components["schemas"]["ArtifactBase"] & ({
             endpoints: components["schemas"]["RpcEndpoint"][];
+            /** @description Roll-up counts across the base-layer RPC endpoint set. */
             summary: {
+                archive_supported_count?: number;
+                by_kind?: {
+                    [key: string]: number;
+                };
+                by_provider?: {
+                    [key: string]: number;
+                };
+                by_status?: {
+                    [key: string]: number;
+                };
+                endpoint_count?: number;
+            } & {
                 [key: string]: unknown;
             };
         } & {
@@ -2419,10 +2452,27 @@ export interface components {
             url: string;
         };
         RpcPoolsArtifact: components["schemas"]["ArtifactBase"] & ({
+            /** @description The read-only RPC proxy contract (disabled by default behind a feature flag). */
             disabled_proxy_contract?: {
+                allowed_methods?: string[];
+                denied_method_patterns?: string[];
+                enabled?: boolean;
+                feature_flag?: string;
+                rate_limit_required?: boolean;
+                waf_required?: boolean;
+            } & {
                 [key: string]: unknown;
             };
+            /** @description How endpoints qualify for a pool — derived from monitored state only. */
             eligibility_policy?: {
+                eligible_layers?: string[];
+                notes?: string;
+                required_status?: string;
+                requires_no_auth?: boolean;
+                requires_public_safe?: boolean;
+                source?: string;
+                user_reports_can_change_health?: boolean;
+            } & {
                 [key: string]: unknown;
             };
             pools: components["schemas"]["RpcPool"][];
@@ -2698,10 +2748,24 @@ export interface components {
             } & {
                 [key: string]: unknown;
             };
-            curation?: Record<string, never> | null;
+            curation?: components["schemas"]["CurationMetadata"] | null;
             gap_priorities?: unknown[];
             gaps?: components["schemas"]["Gaps"] | null;
-            health: Record<string, never> | null;
+            health: ({
+                avg_latency_ms?: number | null;
+                degraded_count?: number;
+                failed_count?: number;
+                last_checked?: string | null;
+                last_ok?: string | null;
+                netuid?: number;
+                observed_by?: string;
+                ok_count?: number;
+                status?: string;
+                surface_count?: number;
+                unknown_count?: number;
+            } & {
+                [key: string]: unknown;
+            }) | null;
             name?: string;
             netuid: number;
             profile: components["schemas"]["SubnetProfile"] | null;
@@ -2878,7 +2942,15 @@ export interface components {
         } | null;
         SubnetsArtifact: components["schemas"]["ArtifactBase"] & ({
             network: components["schemas"]["BittensorNetwork"];
+            /** @description Provenance of the native chain snapshot this index was built from. */
             source: {
+                identity_storage?: string;
+                kind?: string;
+                method?: string;
+                package?: string;
+                rpc_family?: string;
+                version?: string;
+            } & {
                 [key: string]: unknown;
             };
             subnets: components["schemas"]["SubnetIndexEntry"][];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -27,7 +27,10 @@
             "additionalProperties": true,
             "properties": {
               "extensions": {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "type": "object"
+                },
+                "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",
                 "type": "object"
               },
               "netuid": {
@@ -401,6 +404,17 @@
               },
               "summary": {
                 "additionalProperties": true,
+                "description": "Headline counts across the agent-facing registry.",
+                "properties": {
+                  "callable_service_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               }
             },
@@ -2543,6 +2557,27 @@
               },
               "summary": {
                 "additionalProperties": true,
+                "description": "Aggregate probe outcome counts for the day.",
+                "properties": {
+                  "classification_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "status_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "surface_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               },
               "surfaces": {
@@ -3776,6 +3811,21 @@
               },
               "provider": {
                 "additionalProperties": true,
+                "description": "Identity summary of the provider these endpoints belong to.",
+                "properties": {
+                  "authority": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
                 "type": "object"
               },
               "summary": {
@@ -5892,6 +5942,38 @@
               },
               "summary": {
                 "additionalProperties": true,
+                "description": "Roll-up counts across the base-layer RPC endpoint set.",
+                "properties": {
+                  "archive_supported_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "by_kind": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "by_provider": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "by_status": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "endpoint_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               }
             },
@@ -6049,10 +6131,64 @@
             "properties": {
               "disabled_proxy_contract": {
                 "additionalProperties": true,
+                "description": "The read-only RPC proxy contract (disabled by default behind a feature flag).",
+                "properties": {
+                  "allowed_methods": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "denied_method_patterns": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "feature_flag": {
+                    "type": "string"
+                  },
+                  "rate_limit_required": {
+                    "type": "boolean"
+                  },
+                  "waf_required": {
+                    "type": "boolean"
+                  }
+                },
                 "type": "object"
               },
               "eligibility_policy": {
                 "additionalProperties": true,
+                "description": "How endpoints qualify for a pool — derived from monitored state only.",
+                "properties": {
+                  "eligible_layers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "required_status": {
+                    "type": "string"
+                  },
+                  "requires_no_auth": {
+                    "type": "boolean"
+                  },
+                  "requires_public_safe": {
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "user_reports_can_change_health": {
+                    "type": "boolean"
+                  }
+                },
                 "type": "object"
               },
               "pools": {
@@ -7184,9 +7320,13 @@
                 "type": "object"
               },
               "curation": {
-                "type": [
-                  "object",
-                  "null"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CurationMetadata"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               },
               "gap_priorities": {
@@ -7203,9 +7343,65 @@
                 ]
               },
               "health": {
-                "type": [
-                  "object",
-                  "null"
+                "oneOf": [
+                  {
+                    "additionalProperties": true,
+                    "description": "Live per-subnet health summary from the cron prober; null when no probe data exists.",
+                    "properties": {
+                      "avg_latency_ms": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      },
+                      "degraded_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "failed_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "last_checked": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "last_ok": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "netuid": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "observed_by": {
+                        "type": "string"
+                      },
+                      "ok_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "surface_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "unknown_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               },
               "name": {
@@ -8008,6 +8204,27 @@
               },
               "source": {
                 "additionalProperties": true,
+                "description": "Provenance of the native chain snapshot this index was built from.",
+                "properties": {
+                  "identity_storage": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "method": {
+                    "type": "string"
+                  },
+                  "package": {
+                    "type": "string"
+                  },
+                  "rpc_family": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
                 "type": "object"
               },
               "subnets": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -961,8 +961,9 @@ export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
         AdapterArtifact: components["schemas"]["ArtifactBase"] & ({
+            /** @description Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific. */
             extensions: {
-                [key: string]: unknown;
+                [key: string]: Record<string, never>;
             };
             netuid: number;
             slug: string;
@@ -1067,7 +1068,11 @@ export interface components {
             } & {
                 [key: string]: unknown;
             })[];
+            /** @description Headline counts across the agent-facing registry. */
             summary?: {
+                callable_service_count?: number;
+                subnet_count?: number;
+            } & {
                 [key: string]: unknown;
             };
         } & {
@@ -1584,7 +1589,16 @@ export interface components {
             probe_finished_at?: string | null;
             probe_started_at?: string | null;
             source?: string;
+            /** @description Aggregate probe outcome counts for the day. */
             summary: {
+                classification_counts?: {
+                    [key: string]: number;
+                };
+                status_counts?: {
+                    [key: string]: number;
+                };
+                surface_count?: number;
+            } & {
                 [key: string]: unknown;
             };
             surfaces: components["schemas"]["HealthHistorySurface"][];
@@ -1919,7 +1933,13 @@ export interface components {
         });
         ProviderEndpointsArtifact: components["schemas"]["ArtifactBase"] & ({
             endpoints: components["schemas"]["EndpointResource"][];
+            /** @description Identity summary of the provider these endpoints belong to. */
             provider: {
+                authority?: string;
+                id?: string;
+                kind?: string;
+                name?: string;
+            } & {
                 [key: string]: unknown;
             };
             summary: components["schemas"]["EndpointSummary"];
@@ -2383,7 +2403,20 @@ export interface components {
         };
         RpcEndpointsArtifact: components["schemas"]["ArtifactBase"] & ({
             endpoints: components["schemas"]["RpcEndpoint"][];
+            /** @description Roll-up counts across the base-layer RPC endpoint set. */
             summary: {
+                archive_supported_count?: number;
+                by_kind?: {
+                    [key: string]: number;
+                };
+                by_provider?: {
+                    [key: string]: number;
+                };
+                by_status?: {
+                    [key: string]: number;
+                };
+                endpoint_count?: number;
+            } & {
                 [key: string]: unknown;
             };
         } & {
@@ -2419,10 +2452,27 @@ export interface components {
             url: string;
         };
         RpcPoolsArtifact: components["schemas"]["ArtifactBase"] & ({
+            /** @description The read-only RPC proxy contract (disabled by default behind a feature flag). */
             disabled_proxy_contract?: {
+                allowed_methods?: string[];
+                denied_method_patterns?: string[];
+                enabled?: boolean;
+                feature_flag?: string;
+                rate_limit_required?: boolean;
+                waf_required?: boolean;
+            } & {
                 [key: string]: unknown;
             };
+            /** @description How endpoints qualify for a pool — derived from monitored state only. */
             eligibility_policy?: {
+                eligible_layers?: string[];
+                notes?: string;
+                required_status?: string;
+                requires_no_auth?: boolean;
+                requires_public_safe?: boolean;
+                source?: string;
+                user_reports_can_change_health?: boolean;
+            } & {
                 [key: string]: unknown;
             };
             pools: components["schemas"]["RpcPool"][];
@@ -2698,10 +2748,24 @@ export interface components {
             } & {
                 [key: string]: unknown;
             };
-            curation?: Record<string, never> | null;
+            curation?: components["schemas"]["CurationMetadata"] | null;
             gap_priorities?: unknown[];
             gaps?: components["schemas"]["Gaps"] | null;
-            health: Record<string, never> | null;
+            health: ({
+                avg_latency_ms?: number | null;
+                degraded_count?: number;
+                failed_count?: number;
+                last_checked?: string | null;
+                last_ok?: string | null;
+                netuid?: number;
+                observed_by?: string;
+                ok_count?: number;
+                status?: string;
+                surface_count?: number;
+                unknown_count?: number;
+            } & {
+                [key: string]: unknown;
+            }) | null;
             name?: string;
             netuid: number;
             profile: components["schemas"]["SubnetProfile"] | null;
@@ -2878,7 +2942,15 @@ export interface components {
         } | null;
         SubnetsArtifact: components["schemas"]["ArtifactBase"] & ({
             network: components["schemas"]["BittensorNetwork"];
+            /** @description Provenance of the native chain snapshot this index was built from. */
             source: {
+                identity_storage?: string;
+                kind?: string;
+                method?: string;
+                package?: string;
+                rpc_family?: string;
+                version?: string;
+            } & {
                 [key: string]: unknown;
             };
             subnets: components["schemas"]["SubnetIndexEntry"][];

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -13,7 +13,10 @@
             "additionalProperties": true,
             "properties": {
               "extensions": {
-                "additionalProperties": true,
+                "additionalProperties": {
+                  "type": "object"
+                },
+                "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",
                 "type": "object"
               },
               "netuid": {
@@ -387,6 +390,17 @@
               },
               "summary": {
                 "additionalProperties": true,
+                "description": "Headline counts across the agent-facing registry.",
+                "properties": {
+                  "callable_service_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "subnet_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               }
             },
@@ -2521,6 +2535,27 @@
               },
               "summary": {
                 "additionalProperties": true,
+                "description": "Aggregate probe outcome counts for the day.",
+                "properties": {
+                  "classification_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "status_counts": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "surface_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               },
               "surfaces": {
@@ -3754,6 +3789,21 @@
               },
               "provider": {
                 "additionalProperties": true,
+                "description": "Identity summary of the provider these endpoints belong to.",
+                "properties": {
+                  "authority": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "name": {
+                    "type": "string"
+                  }
+                },
                 "type": "object"
               },
               "summary": {
@@ -5870,6 +5920,38 @@
               },
               "summary": {
                 "additionalProperties": true,
+                "description": "Roll-up counts across the base-layer RPC endpoint set.",
+                "properties": {
+                  "archive_supported_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  },
+                  "by_kind": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "by_provider": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "by_status": {
+                    "additionalProperties": {
+                      "minimum": 0,
+                      "type": "integer"
+                    },
+                    "type": "object"
+                  },
+                  "endpoint_count": {
+                    "minimum": 0,
+                    "type": "integer"
+                  }
+                },
                 "type": "object"
               }
             },
@@ -6027,10 +6109,64 @@
             "properties": {
               "disabled_proxy_contract": {
                 "additionalProperties": true,
+                "description": "The read-only RPC proxy contract (disabled by default behind a feature flag).",
+                "properties": {
+                  "allowed_methods": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "denied_method_patterns": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "enabled": {
+                    "type": "boolean"
+                  },
+                  "feature_flag": {
+                    "type": "string"
+                  },
+                  "rate_limit_required": {
+                    "type": "boolean"
+                  },
+                  "waf_required": {
+                    "type": "boolean"
+                  }
+                },
                 "type": "object"
               },
               "eligibility_policy": {
                 "additionalProperties": true,
+                "description": "How endpoints qualify for a pool — derived from monitored state only.",
+                "properties": {
+                  "eligible_layers": {
+                    "items": {
+                      "type": "string"
+                    },
+                    "type": "array"
+                  },
+                  "notes": {
+                    "type": "string"
+                  },
+                  "required_status": {
+                    "type": "string"
+                  },
+                  "requires_no_auth": {
+                    "type": "boolean"
+                  },
+                  "requires_public_safe": {
+                    "type": "boolean"
+                  },
+                  "source": {
+                    "type": "string"
+                  },
+                  "user_reports_can_change_health": {
+                    "type": "boolean"
+                  }
+                },
                 "type": "object"
               },
               "pools": {
@@ -7162,9 +7298,13 @@
                 "type": "object"
               },
               "curation": {
-                "type": [
-                  "object",
-                  "null"
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/CurationMetadata"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               },
               "gap_priorities": {
@@ -7181,9 +7321,65 @@
                 ]
               },
               "health": {
-                "type": [
-                  "object",
-                  "null"
+                "oneOf": [
+                  {
+                    "additionalProperties": true,
+                    "description": "Live per-subnet health summary from the cron prober; null when no probe data exists.",
+                    "properties": {
+                      "avg_latency_ms": {
+                        "type": [
+                          "number",
+                          "null"
+                        ]
+                      },
+                      "degraded_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "failed_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "last_checked": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "last_ok": {
+                        "type": [
+                          "string",
+                          "null"
+                        ]
+                      },
+                      "netuid": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "observed_by": {
+                        "type": "string"
+                      },
+                      "ok_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "status": {
+                        "type": "string"
+                      },
+                      "surface_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "unknown_count": {
+                        "minimum": 0,
+                        "type": "integer"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  {
+                    "type": "null"
+                  }
                 ]
               },
               "name": {
@@ -7986,6 +8182,27 @@
               },
               "source": {
                 "additionalProperties": true,
+                "description": "Provenance of the native chain snapshot this index was built from.",
+                "properties": {
+                  "identity_storage": {
+                    "type": "string"
+                  },
+                  "kind": {
+                    "type": "string"
+                  },
+                  "method": {
+                    "type": "string"
+                  },
+                  "package": {
+                    "type": "string"
+                  },
+                  "rpc_family": {
+                    "type": "string"
+                  },
+                  "version": {
+                    "type": "string"
+                  }
+                },
                 "type": "object"
               },
               "subnets": {

--- a/schemas/components/03-providers.schema.json
+++ b/schemas/components/03-providers.schema.json
@@ -134,6 +134,13 @@
             "properties": {
               "provider": {
                 "type": "object",
+                "description": "Identity summary of the provider these endpoints belong to.",
+                "properties": {
+                  "id": { "type": "string" },
+                  "name": { "type": "string" },
+                  "kind": { "type": "string" },
+                  "authority": { "type": "string" }
+                },
                 "additionalProperties": true
               },
               "summary": {

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -1026,6 +1026,15 @@
               },
               "source": {
                 "type": "object",
+                "description": "Provenance of the native chain snapshot this index was built from.",
+                "properties": {
+                  "kind": { "type": "string" },
+                  "method": { "type": "string" },
+                  "package": { "type": "string" },
+                  "version": { "type": "string" },
+                  "rpc_family": { "type": "string" },
+                  "identity_storage": { "type": "string" }
+                },
                 "additionalProperties": true
               },
               "subnets": {
@@ -1406,8 +1415,35 @@
                   { "type": "null" }
                 ]
               },
-              "health": { "type": ["object", "null"] },
-              "curation": { "type": ["object", "null"] },
+              "health": {
+                "oneOf": [
+                  {
+                    "type": "object",
+                    "description": "Live per-subnet health summary from the cron prober; null when no probe data exists.",
+                    "properties": {
+                      "netuid": { "type": "integer", "minimum": 0 },
+                      "status": { "type": "string" },
+                      "surface_count": { "type": "integer", "minimum": 0 },
+                      "ok_count": { "type": "integer", "minimum": 0 },
+                      "degraded_count": { "type": "integer", "minimum": 0 },
+                      "failed_count": { "type": "integer", "minimum": 0 },
+                      "unknown_count": { "type": "integer", "minimum": 0 },
+                      "last_checked": { "type": ["string", "null"] },
+                      "last_ok": { "type": ["string", "null"] },
+                      "avg_latency_ms": { "type": ["number", "null"] },
+                      "observed_by": { "type": "string" }
+                    },
+                    "additionalProperties": true
+                  },
+                  { "type": "null" }
+                ]
+              },
+              "curation": {
+                "oneOf": [
+                  { "$ref": "#/components/schemas/CurationMetadata" },
+                  { "type": "null" }
+                ]
+              },
               "gaps": {
                 "oneOf": [
                   { "$ref": "#/components/schemas/Gaps" },
@@ -1543,7 +1579,15 @@
             "properties": {
               "published_at": { "type": ["string", "null"] },
               "content_hash": { "type": "string" },
-              "summary": { "type": "object", "additionalProperties": true },
+              "summary": {
+                "type": "object",
+                "description": "Headline counts across the agent-facing registry.",
+                "properties": {
+                  "subnet_count": { "type": "integer", "minimum": 0 },
+                  "callable_service_count": { "type": "integer", "minimum": 0 }
+                },
+                "additionalProperties": true
+              },
               "copyable_agent": {
                 "type": "object",
                 "required": ["url"],

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -310,6 +310,18 @@
               },
               "summary": {
                 "type": "object",
+                "description": "Aggregate probe outcome counts for the day.",
+                "properties": {
+                  "surface_count": { "type": "integer", "minimum": 0 },
+                  "status_counts": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer", "minimum": 0 }
+                  },
+                  "classification_counts": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer", "minimum": 0 }
+                  }
+                },
                 "additionalProperties": true
               },
               "surfaces": {

--- a/schemas/components/07-endpoints-rpc.schema.json
+++ b/schemas/components/07-endpoints-rpc.schema.json
@@ -696,6 +696,26 @@
             "properties": {
               "summary": {
                 "type": "object",
+                "description": "Roll-up counts across the base-layer RPC endpoint set.",
+                "properties": {
+                  "endpoint_count": { "type": "integer", "minimum": 0 },
+                  "archive_supported_count": {
+                    "type": "integer",
+                    "minimum": 0
+                  },
+                  "by_kind": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer", "minimum": 0 }
+                  },
+                  "by_provider": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer", "minimum": 0 }
+                  },
+                  "by_status": {
+                    "type": "object",
+                    "additionalProperties": { "type": "integer", "minimum": 0 }
+                  }
+                },
                 "additionalProperties": true
               },
               "endpoints": {
@@ -720,10 +740,38 @@
             "properties": {
               "disabled_proxy_contract": {
                 "type": "object",
+                "description": "The read-only RPC proxy contract (disabled by default behind a feature flag).",
+                "properties": {
+                  "enabled": { "type": "boolean" },
+                  "feature_flag": { "type": "string" },
+                  "allowed_methods": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "denied_method_patterns": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "rate_limit_required": { "type": "boolean" },
+                  "waf_required": { "type": "boolean" }
+                },
                 "additionalProperties": true
               },
               "eligibility_policy": {
                 "type": "object",
+                "description": "How endpoints qualify for a pool — derived from monitored state only.",
+                "properties": {
+                  "source": { "type": "string" },
+                  "eligible_layers": {
+                    "type": "array",
+                    "items": { "type": "string" }
+                  },
+                  "required_status": { "type": "string" },
+                  "requires_no_auth": { "type": "boolean" },
+                  "requires_public_safe": { "type": "boolean" },
+                  "user_reports_can_change_health": { "type": "boolean" },
+                  "notes": { "type": "string" }
+                },
                 "additionalProperties": true
               },
               "provider_scores": {

--- a/schemas/components/09-schemas-adapters-r2.schema.json
+++ b/schemas/components/09-schemas-adapters-r2.schema.json
@@ -251,7 +251,8 @@
               },
               "extensions": {
                 "type": "object",
-                "additionalProperties": true
+                "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",
+                "additionalProperties": { "type": "object" }
               },
               "snapshot": {
                 "type": ["object", "null"],


### PR DESCRIPTION
**Part 1 of #531** (Wave 9 epic #534). The other 46 routes are already well-typed; this fills in the 10 nested fields that were `{ type: object, additionalProperties: true }` placeholders, typed to the **real served shapes** (each verified against the live artifact by `validate:openapi-examples`).

| Schema | Field(s) deepened |
| --- | --- |
| SubnetsArtifact | `source` (snapshot provenance) |
| SubnetOverviewArtifact | `health` (live summary), `curation` → reuses `CurationMetadata` |
| AgentResourcesArtifact | `summary` |
| RpcEndpointsArtifact | `summary` (by_kind/by_provider/by_status) |
| RpcPoolsArtifact | `disabled_proxy_contract`, `eligibility_policy` (also covers `EndpointPoolsArtifact`) |
| ProviderEndpointsArtifact | `provider` (identity summary) |
| HealthHistoryArtifact | `summary` (classification/status counts) |
| AdapterArtifact | `extensions` (documented map-of-objects) |

`additionalProperties` stays `true` so schemas remain forward-compatible and the live artifacts keep validating.

## Gates
Regenerated `openapi.json` + `types.d.ts` + `generated/metagraphed-api.d.ts` + the component bundle (no `build:artifacts`, so no data-artifact churn). All green: `validate:schemas`, `validate:contract-drift`, `validate:openapi` (56 routes), **`validate:openapi-examples` (56 routes — validates the deeper schemas against real artifacts)**, `validate:types`, `validate:generated-client`. Edited component schemas are prettier-clean.

## Part 2 (next PR)
Worked request/response examples on every operation + extend `validate:openapi-examples` to require ≥1 schema-valid example per op.