### PR TITLE
feat(health): per-subnet/per-endpoint reliability score (#532)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2014,6 +2014,21 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description Composite reliability score (0-100) from durable uptime history: sample-weighted uptime with a mild latency penalty. Null when no probe data exists. */
+        ReliabilityScore: {
+            avg_latency_ms?: number | null;
+            computed_at?: string | null;
+            day_count?: number;
+            /** @enum {string} */
+            grade: "A" | "B" | "C" | "D" | "F";
+            sample_count: number;
+            score: number;
+            surface_count?: number;
+            uptime_ratio: number | null;
+            window?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         ResponseEnvelopeContract: {
             /** @constant */
             error_schema_ref: "#/components/schemas/ErrorEnvelope";
@@ -3056,6 +3071,7 @@ export interface components {
         });
         UptimeArtifact: {
             netuid: number;
+            reliability?: components["schemas"]["ReliabilityScore"] | null;
             schema_version: number;
             source: string;
             surfaces: ({
@@ -3069,6 +3085,7 @@ export interface components {
                 } & {
                     [key: string]: unknown;
                 })[];
+                reliability?: components["schemas"]["ReliabilityScore"] | null;
                 samples: number;
                 surface_id: string;
                 uptime_ratio: number | null;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -4099,6 +4099,70 @@
           }
         ]
       },
+      "ReliabilityScore": {
+        "additionalProperties": true,
+        "description": "Composite reliability score (0-100) from durable uptime history: sample-weighted uptime with a mild latency penalty. Null when no probe data exists.",
+        "properties": {
+          "avg_latency_ms": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "computed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "day_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "grade": {
+            "enum": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "F"
+            ],
+            "type": "string"
+          },
+          "sample_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "surface_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "uptime_ratio": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "window": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "score",
+          "grade",
+          "uptime_ratio",
+          "sample_count"
+        ],
+        "type": "object"
+      },
       "ResponseEnvelopeContract": {
         "additionalProperties": false,
         "properties": {
@@ -8601,6 +8665,16 @@
             "minimum": 0,
             "type": "integer"
           },
+          "reliability": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReliabilityScore"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "schema_version": {
             "type": "integer"
           },
@@ -8651,6 +8725,16 @@
                     "type": "object"
                   },
                   "type": "array"
+                },
+                "reliability": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ReliabilityScore"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "samples": {
                   "minimum": 0,

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2014,6 +2014,21 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description Composite reliability score (0-100) from durable uptime history: sample-weighted uptime with a mild latency penalty. Null when no probe data exists. */
+        ReliabilityScore: {
+            avg_latency_ms?: number | null;
+            computed_at?: string | null;
+            day_count?: number;
+            /** @enum {string} */
+            grade: "A" | "B" | "C" | "D" | "F";
+            sample_count: number;
+            score: number;
+            surface_count?: number;
+            uptime_ratio: number | null;
+            window?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         ResponseEnvelopeContract: {
             /** @constant */
             error_schema_ref: "#/components/schemas/ErrorEnvelope";
@@ -3056,6 +3071,7 @@ export interface components {
         });
         UptimeArtifact: {
             netuid: number;
+            reliability?: components["schemas"]["ReliabilityScore"] | null;
             schema_version: number;
             source: string;
             surfaces: ({
@@ -3069,6 +3085,7 @@ export interface components {
                 } & {
                     [key: string]: unknown;
                 })[];
+                reliability?: components["schemas"]["ReliabilityScore"] | null;
                 samples: number;
                 surface_id: string;
                 uptime_ratio: number | null;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -4077,6 +4077,70 @@
           }
         ]
       },
+      "ReliabilityScore": {
+        "additionalProperties": true,
+        "description": "Composite reliability score (0-100) from durable uptime history: sample-weighted uptime with a mild latency penalty. Null when no probe data exists.",
+        "properties": {
+          "avg_latency_ms": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "computed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "day_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "grade": {
+            "enum": [
+              "A",
+              "B",
+              "C",
+              "D",
+              "F"
+            ],
+            "type": "string"
+          },
+          "sample_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "score": {
+            "maximum": 100,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "surface_count": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "uptime_ratio": {
+            "type": [
+              "number",
+              "null"
+            ]
+          },
+          "window": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "score",
+          "grade",
+          "uptime_ratio",
+          "sample_count"
+        ],
+        "type": "object"
+      },
       "ResponseEnvelopeContract": {
         "additionalProperties": false,
         "properties": {
@@ -8579,6 +8643,16 @@
             "minimum": 0,
             "type": "integer"
           },
+          "reliability": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/ReliabilityScore"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "schema_version": {
             "type": "integer"
           },
@@ -8629,6 +8703,16 @@
                     "type": "object"
                   },
                   "type": "array"
+                },
+                "reliability": {
+                  "oneOf": [
+                    {
+                      "$ref": "#/components/schemas/ReliabilityScore"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
                 },
                 "samples": {
                   "minimum": 0,

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -576,6 +576,23 @@
         },
         "additionalProperties": true
       },
+      "ReliabilityScore": {
+        "type": "object",
+        "description": "Composite reliability score (0-100) from durable uptime history: sample-weighted uptime with a mild latency penalty. Null when no probe data exists.",
+        "required": ["score", "grade", "uptime_ratio", "sample_count"],
+        "properties": {
+          "score": { "type": "integer", "minimum": 0, "maximum": 100 },
+          "grade": { "type": "string", "enum": ["A", "B", "C", "D", "F"] },
+          "uptime_ratio": { "type": ["number", "null"] },
+          "avg_latency_ms": { "type": ["integer", "null"] },
+          "sample_count": { "type": "integer", "minimum": 0 },
+          "window": { "type": ["string", "null"] },
+          "surface_count": { "type": "integer", "minimum": 0 },
+          "day_count": { "type": "integer", "minimum": 0 },
+          "computed_at": { "type": ["string", "null"] }
+        },
+        "additionalProperties": true
+      },
       "UptimeArtifact": {
         "type": "object",
         "required": ["schema_version", "netuid", "source", "surfaces"],
@@ -584,6 +601,12 @@
           "netuid": { "type": "integer", "minimum": 0 },
           "window": { "type": ["string", "null"] },
           "source": { "type": "string" },
+          "reliability": {
+            "oneOf": [
+              { "$ref": "#/components/schemas/ReliabilityScore" },
+              { "type": "null" }
+            ]
+          },
           "surfaces": {
             "type": "array",
             "items": {
@@ -600,6 +623,12 @@
                 "day_count": { "type": "integer", "minimum": 0 },
                 "samples": { "type": "integer", "minimum": 0 },
                 "uptime_ratio": { "type": ["number", "null"] },
+                "reliability": {
+                  "oneOf": [
+                    { "$ref": "#/components/schemas/ReliabilityScore" },
+                    { "type": "null" }
+                  ]
+                },
                 "days": {
                   "type": "array",
                   "items": {

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -7,6 +7,8 @@
 // serving zero-downtime and regression-proof. No I/O here: callers pass parsed
 // objects + D1 rows in.
 
+import { computeReliability } from "./reliability.mjs";
+
 const D1_HEALTH_FALLBACK_MAX_AGE_MS = 10 * 60 * 1000;
 
 const OPERATIONAL_KINDS = new Set([
@@ -557,7 +559,8 @@ function shiftDate(isoDate, days) {
 // {surface_id, day, samples, ok_count, uptime_ratio, avg_latency_ms, status}.
 // Groups by surface, sorts days ascending, and rolls a window-wide uptime_ratio
 // from the summed ok_count/samples (exact, not an average of ratios).
-export function formatUptime({ netuid, window, rows }) {
+export function formatUptime({ netuid, window, rows, now = null }) {
+  const reliability = computeReliability(rows, { window: window || null, now });
   const bySurface = new Map();
   for (const row of rows || []) {
     const list = bySurface.get(row.surface_id) || [];
@@ -584,6 +587,7 @@ export function formatUptime({ netuid, window, rows }) {
         day_count: days.length,
         samples,
         uptime_ratio: samples ? Number((okCount / samples).toFixed(4)) : null,
+        reliability: reliability.surfaces[surfaceId] || null,
         // Per-day series without the internal ok_count (uptime_ratio covers it).
         days: days.map((d) => ({
           day: d.day,
@@ -600,8 +604,48 @@ export function formatUptime({ netuid, window, rows }) {
     netuid,
     window: window || null,
     source: "live-cron-prober",
+    reliability: reliability.subnet,
     surfaces,
   };
+}
+
+// Load + score a subnet's reliability from surface_uptime_daily over a window.
+// Mirrors resolveLiveHealth's I/O posture (the caller passes the D1 binding);
+// returns null when D1 is unbound/cold or no history has accrued.
+export async function loadSubnetReliability({
+  db,
+  netuid,
+  windowDays = 30,
+  now = null,
+  limit = 5000,
+}) {
+  if (!db?.prepare) {
+    return null;
+  }
+  const nowMs = now ? Date.parse(now) : Date.now();
+  const cutoff = new Date(nowMs - windowDays * 24 * 60 * 60 * 1000)
+    .toISOString()
+    .slice(0, 10);
+  const computedAt = new Date(nowMs).toISOString();
+  try {
+    const result = await db
+      .prepare(
+        `SELECT surface_id, day, samples, ok_count, avg_latency_ms
+         FROM surface_uptime_daily
+         WHERE netuid = ? AND day >= ?
+         ORDER BY day DESC
+         LIMIT ?`,
+      )
+      .bind(netuid, cutoff, limit)
+      .all();
+    const rows = result?.results || [];
+    return computeReliability(rows, {
+      window: `${windowDays}d`,
+      now: computedAt,
+    }).subnet;
+  } catch {
+    return null;
+  }
 }
 
 // --- Live-everywhere health resolution + composed-artifact overlays ----------

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -14,6 +14,7 @@ import { CONTRACT_VERSION, PRIMARY_DOMAIN } from "./contracts.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.mjs";
 import {
+  loadSubnetReliability,
   overlayCatalogDetail,
   overlayCatalogIndex,
   overlayOverviewHealth,
@@ -457,15 +458,21 @@ export const MCP_TOOLS = [
     },
     async handler(args, ctx) {
       const netuid = requireNetuid(args);
-      const live = await mcpLiveHealth(ctx);
+      const [live, reliability] = await Promise.all([
+        mcpLiveHealth(ctx),
+        loadSubnetReliability({ db: ctx.env?.METAGRAPH_HEALTH_DB, netuid }),
+      ]);
       const overlaid = overlaySubnetHealth(null, live, netuid);
-      if (overlaid) return overlaid;
+      if (overlaid) {
+        return { ...overlaid, reliability };
+      }
       return {
         schema_version: 1,
         netuid,
         summary: { status: "unknown", surface_count: 0 },
         operational_observed_at: null,
         health_source: "unavailable",
+        reliability,
         surfaces: [],
       };
     },

--- a/src/reliability.mjs
+++ b/src/reliability.mjs
@@ -1,0 +1,120 @@
+// Reliability scoring over the durable daily uptime history (surface_uptime_daily).
+//
+// A reliability score (0–100) is a single, comparable signal of how dependable a
+// subnet's surfaces have been over a window. It is computed ONLY from real probe
+// history — `null` when there is no data (never a fabricated value).
+//
+// Formula (documented + stable so the score is reproducible and explainable):
+//   uptimeScore   = uptime_ratio * 100                     (sample-weighted, exact)
+//   latencyPenalty = clamp((avg_latency_ms - 500) / 100, 0, 15)
+//                     -> 0 at/under 500ms, +1 point per extra 100ms, capped at 15
+//   score         = round(max(0, uptimeScore - latencyPenalty))
+// Uptime dominates; latency is a mild secondary penalty. Grades: A>=99, B>=95,
+// C>=90, D>=75, else F.
+
+const LATENCY_FREE_MS = 500;
+const LATENCY_PENALTY_PER_MS = 1 / 100;
+const MAX_LATENCY_PENALTY = 15;
+
+function gradeFor(score) {
+  if (score >= 99) return "A";
+  if (score >= 95) return "B";
+  if (score >= 90) return "C";
+  if (score >= 75) return "D";
+  return "F";
+}
+
+// Score a single rolled-up window of stats. Returns null when there are no
+// samples (no probe data → no score, by design).
+export function scoreFromStats({ samples, okCount, avgLatencyMs }) {
+  if (!samples) {
+    return null;
+  }
+  const uptimeRatio = okCount / samples;
+  const uptimeScore = uptimeRatio * 100;
+  const latencyPenalty =
+    avgLatencyMs == null
+      ? 0
+      : Math.min(
+          MAX_LATENCY_PENALTY,
+          Math.max(
+            0,
+            (avgLatencyMs - LATENCY_FREE_MS) * LATENCY_PENALTY_PER_MS,
+          ),
+        );
+  const score = Math.max(0, Math.round(uptimeScore - latencyPenalty));
+  return {
+    score,
+    grade: gradeFor(score),
+    uptime_ratio: Number(uptimeRatio.toFixed(4)),
+    avg_latency_ms: avgLatencyMs == null ? null : Math.round(avgLatencyMs),
+    sample_count: samples,
+  };
+}
+
+// Aggregate surface_uptime_daily rows into a subnet-level score + a per-surface
+// score map. `rows`: [{ surface_id, day, samples, ok_count, avg_latency_ms }].
+// `subnet` is null when there are no samples across the window.
+export function computeReliability(rows, { window = null, now = null } = {}) {
+  const bySurface = new Map();
+  let totalSamples = 0;
+  let totalOk = 0;
+  let latencyWeighted = 0;
+  let latencySamples = 0;
+  const days = new Set();
+
+  for (const row of rows || []) {
+    const samples = Number(row.samples) || 0;
+    const okCount = Number(row.ok_count) || 0;
+    const latency =
+      row.avg_latency_ms == null ? null : Number(row.avg_latency_ms);
+    const surface = bySurface.get(row.surface_id) || {
+      samples: 0,
+      okCount: 0,
+      latencyWeighted: 0,
+      latencySamples: 0,
+    };
+    surface.samples += samples;
+    surface.okCount += okCount;
+    if (latency != null && Number.isFinite(latency)) {
+      surface.latencyWeighted += latency * samples;
+      surface.latencySamples += samples;
+      latencyWeighted += latency * samples;
+      latencySamples += samples;
+    }
+    bySurface.set(row.surface_id, surface);
+    totalSamples += samples;
+    totalOk += okCount;
+    if (row.day) {
+      days.add(row.day);
+    }
+  }
+
+  const surfaces = {};
+  for (const [surfaceId, surface] of bySurface) {
+    surfaces[surfaceId] = scoreFromStats({
+      samples: surface.samples,
+      okCount: surface.okCount,
+      avgLatencyMs: surface.latencySamples
+        ? surface.latencyWeighted / surface.latencySamples
+        : null,
+    });
+  }
+
+  const base = scoreFromStats({
+    samples: totalSamples,
+    okCount: totalOk,
+    avgLatencyMs: latencySamples ? latencyWeighted / latencySamples : null,
+  });
+  const subnet = base
+    ? {
+        ...base,
+        window,
+        surface_count: bySurface.size,
+        day_count: days.size,
+        computed_at: now,
+      }
+    : null;
+
+  return { subnet, surfaces };
+}

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -18,6 +18,7 @@ import {
   subnetBadgeStatus,
   summarizeRows,
 } from "../src/health-serving.mjs";
+import { computeReliability, scoreFromStats } from "../src/reliability.mjs";
 import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 import { handleRequest } from "../workers/api.mjs";
 
@@ -1513,13 +1514,18 @@ describe("formatUptime (daily uptime history)", () => {
     assert.equal(out.surfaces[0].days[0].day, "2026-06-12");
     assert.equal(out.surfaces[0].days[0].ok_count, undefined);
     assert.equal(out.surfaces[0].days[0].uptime_ratio, 0.8);
+    // reliability is attached at the subnet level + per surface
+    assert.equal(typeof out.reliability.score, "number");
+    assert.equal(out.reliability.window, "90d");
+    assert.equal(out.reliability.surface_count, 2);
+    assert.equal(typeof out.surfaces[0].reliability.score, "number");
+    assert.match(out.surfaces[0].reliability.grade, /^[A-F]$/);
   });
 
-  test("returns an empty series for no rows", () => {
-    assert.deepEqual(
-      formatUptime({ netuid: 7, window: "1y", rows: [] }).surfaces,
-      [],
-    );
+  test("returns an empty series + null reliability for no rows", () => {
+    const out = formatUptime({ netuid: 7, window: "1y", rows: [] });
+    assert.deepEqual(out.surfaces, []);
+    assert.equal(out.reliability, null);
   });
 
   test("handles null ratios/latency, missing status, zero samples, and no window", () => {
@@ -1591,5 +1597,73 @@ describe("worker /api/v1/subnets/{netuid}/uptime route", () => {
     );
     assert.equal(res.status, 400);
     assert.equal((await res.json()).error.code, "invalid_query");
+  });
+});
+
+describe("computeReliability (score from uptime history)", () => {
+  test("returns null subnet score when there is no probe data", () => {
+    assert.equal(computeReliability([]).subnet, null);
+    assert.deepEqual(computeReliability([]).surfaces, {});
+  });
+
+  test("scores sample-weighted uptime with a mild latency penalty", () => {
+    const out = computeReliability(
+      [
+        {
+          surface_id: "a",
+          day: "2026-06-12",
+          samples: 720,
+          ok_count: 720,
+          avg_latency_ms: 200,
+        },
+        {
+          surface_id: "a",
+          day: "2026-06-13",
+          samples: 720,
+          ok_count: 700,
+          avg_latency_ms: 300,
+        },
+        {
+          surface_id: "b",
+          day: "2026-06-12",
+          samples: 720,
+          ok_count: 360,
+          avg_latency_ms: 1500,
+        },
+      ],
+      { window: "30d", now: "2026-06-13T00:00:00.000Z" },
+    );
+    // subnet aggregate: (720+700+360)/2160 = 0.8241
+    assert.equal(out.subnet.uptime_ratio, 0.8241);
+    assert.equal(out.subnet.sample_count, 2160);
+    assert.equal(out.subnet.surface_count, 2);
+    assert.equal(out.subnet.window, "30d");
+    assert.equal(out.subnet.computed_at, "2026-06-13T00:00:00.000Z");
+    // healthy surface a -> high score; failing+slow surface b -> low
+    assert.ok(out.surfaces.a.score > out.surfaces.b.score);
+    assert.equal(out.surfaces.b.grade, "F");
+  });
+
+  test("latency penalty is bounded and only applies above 500ms", () => {
+    // perfect uptime, fast -> 100
+    assert.equal(
+      scoreFromStats({ samples: 100, okCount: 100, avgLatencyMs: 200 }).score,
+      100,
+    );
+    // perfect uptime, 1500ms -> 100 - (1000/100) = 90
+    assert.equal(
+      scoreFromStats({ samples: 100, okCount: 100, avgLatencyMs: 1500 }).score,
+      90,
+    );
+    // penalty caps at 15 even at extreme latency
+    assert.equal(
+      scoreFromStats({ samples: 100, okCount: 100, avgLatencyMs: 99999 }).score,
+      85,
+    );
+    // no samples -> null
+    assert.equal(
+      scoreFromStats({ samples: 0, okCount: 0, avgLatencyMs: 10 }),
+      null,
+    );
   });
 });

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -13,6 +13,7 @@ import {
   overlayRpcPoolEligibility,
   overlaySubnetHealth,
   formatUptime,
+  loadSubnetReliability,
   parseLive,
   resolveLiveHealth,
   subnetBadgeStatus,
@@ -1663,6 +1664,102 @@ describe("computeReliability (score from uptime history)", () => {
     // no samples -> null
     assert.equal(
       scoreFromStats({ samples: 0, okCount: 0, avgLatencyMs: 10 }),
+      null,
+    );
+  });
+
+  test("covers grade B, null latency, missing day, and nullish rows", () => {
+    // grade B (95-98)
+    assert.equal(
+      scoreFromStats({ samples: 100, okCount: 97, avgLatencyMs: 200 }).grade,
+      "B",
+    );
+    // null latency -> no penalty, avg_latency_ms reported null
+    const noLatency = scoreFromStats({
+      samples: 100,
+      okCount: 90,
+      avgLatencyMs: null,
+    });
+    assert.equal(noLatency.avg_latency_ms, null);
+    assert.equal(noLatency.score, 90);
+    // nullish rows -> empty result (no throw)
+    assert.equal(computeReliability(undefined).subnet, null);
+    assert.equal(computeReliability(null).subnet, null);
+    // a row with no day + no latency still scores from uptime
+    const out = computeReliability([
+      { surface_id: "a", samples: 100, ok_count: 100 },
+    ]);
+    assert.equal(out.subnet.score, 100);
+    assert.equal(out.subnet.avg_latency_ms, null);
+    assert.equal(out.subnet.day_count, 0);
+  });
+});
+
+describe("loadSubnetReliability (D1-backed)", () => {
+  function uptimeDb(rows) {
+    return {
+      prepare() {
+        return {
+          bind() {
+            return this;
+          },
+          async all() {
+            return { results: rows };
+          },
+        };
+      },
+    };
+  }
+
+  test("returns null when D1 is unbound", async () => {
+    assert.equal(
+      await loadSubnetReliability({ db: undefined, netuid: 7 }),
+      null,
+    );
+  });
+
+  test("scores from surface_uptime_daily rows", async () => {
+    const out = await loadSubnetReliability({
+      db: uptimeDb([
+        {
+          surface_id: "a",
+          day: "2026-06-12",
+          samples: 720,
+          ok_count: 720,
+          avg_latency_ms: 120,
+        },
+        {
+          surface_id: "b",
+          day: "2026-06-12",
+          samples: 720,
+          ok_count: 360,
+          avg_latency_ms: 900,
+        },
+      ]),
+      netuid: 7,
+      now: "2026-06-13T00:00:00.000Z",
+    });
+    assert.equal(out.window, "30d");
+    assert.equal(out.surface_count, 2);
+    assert.equal(out.uptime_ratio, 0.75); // (720+360)/1440
+    assert.equal(out.computed_at, "2026-06-13T00:00:00.000Z");
+  });
+
+  test("returns null (not throw) when the query fails", async () => {
+    const out = await loadSubnetReliability({
+      db: {
+        prepare() {
+          throw new Error("d1 down");
+        },
+      },
+      netuid: 7,
+    });
+    assert.equal(out, null);
+  });
+
+  test("returns null when there is no history yet", async () => {
+    assert.equal(
+      await loadSubnetReliability({ db: uptimeDb([]), netuid: 7 }),
       null,
     );
   });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1314,7 +1314,12 @@ async function handleUptime(request, env, netuid, url) {
      LIMIT ?`,
     [netuid, cutoff, MAX_UPTIME_ROWS],
   );
-  const data = formatUptime({ netuid, window: windowParam, rows });
+  const data = formatUptime({
+    netuid,
+    window: windowParam,
+    rows,
+    now: new Date().toISOString(),
+  });
   return envelopeResponse(
     request,
     {


### PR DESCRIPTION
Closes #532 (Wave 9 epic #534).

## What

Turns the durable daily uptime history (PR3 `surface_uptime_daily`) into a single, comparable **reliability score (0–100 + A–F grade)** per subnet and per surface, surfaced in REST + MCP.

**Formula** (documented in `src/reliability.mjs`, stable + reproducible):
```
uptimeScore    = uptime_ratio * 100              (sample-weighted, exact)
latencyPenalty = clamp((avg_latency_ms-500)/100, 0, 15)
score          = round(max(0, uptimeScore - latencyPenalty))
grades: A>=99, B>=95, C>=90, D>=75, else F
```
Uptime dominates; latency is a mild secondary penalty. **Scored only from real probe data — `null` when none exists** (honest scope; never fabricated).

## Surfaced in
- **REST** `GET /api/v1/subnets/{netuid}/uptime` → `reliability` (subnet-level) + per-surface `reliability`. `UptimeArtifact` schema gains a `ReliabilityScore` component.
- **MCP** `get_subnet_health` → `reliability` (queries `surface_uptime_daily`; the lenient `outputSchema` already permits it).

## Notes
- **No migration** — compute-on-read over the existing rollup. No new route.
- Regenerated `openapi.json` + `types.d.ts` (no `build:artifacts`, so no data-artifact churn).
- Unit tests: scoring math, the latency-penalty cap, grade boundaries, and the no-data → `null` path; `formatUptime` reliability attachment. All contract validators + `validate:mcp` + worker suite green.