### PR TITLE
fix(MCP): MCP registry publish workflow authorization

### DIFF
--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -20,6 +20,8 @@ concurrency:
 
 jobs:
   publish:
+    # OIDC publishing must only run from the reviewed default branch.
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -35,6 +37,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
+          ref: refs/heads/main
           persist-credentials: false
 
       - name: Validate server.json
@@ -49,8 +52,20 @@ jobs:
             if (!s.version || typeof s.version !== "string") {
               throw new Error("server.json is missing a string version");
             }
-            const remote = (s.remotes ?? [])[0];
-            if (remote?.type !== "streamable-http" || !remote?.url?.startsWith("https://api.metagraph.sh/")) {
+            if (s.title !== "metagraphed — Bittensor subnet operational registry") {
+              throw new Error(`unexpected title: ${s.title}`);
+            }
+            if (s.websiteUrl !== "https://metagraph.sh") {
+              throw new Error(`unexpected websiteUrl: ${s.websiteUrl}`);
+            }
+            if (s.repository?.source !== "github" || s.repository?.url !== "https://github.com/JSONbored/metagraphed") {
+              throw new Error(`unexpected repository: ${JSON.stringify(s.repository)}`);
+            }
+            if (!Array.isArray(s.remotes) || s.remotes.length !== 1) {
+              throw new Error(`expected exactly one remote: ${JSON.stringify(s.remotes)}`);
+            }
+            const [remote] = s.remotes;
+            if (remote?.type !== "streamable-http" || remote?.url !== "https://api.metagraph.sh/mcp") {
               throw new Error(`unexpected remote: ${JSON.stringify(remote)}`);
             }
             console.log(`server.json ok — ${s.name} v${s.version} -> ${remote.url}`);


### PR DESCRIPTION
### Motivation
- The publish workflow allowed OIDC-authenticated publishing to run from a manually dispatched ref and read `server.json` from that ref, enabling an attacker with branch+dispatch rights to publish malicious registry metadata.
- The existing inline validation only checked the first remote with a loose prefix and could be bypassed by adding additional remotes or attacker-controlled fields.

### Description
- Gate the publish job with `if: github.ref == 'refs/heads/main'` so OIDC publishing only occurs from the reviewed default branch.
- Pin `actions/checkout` to `ref: refs/heads/main` so the workflow reads `server.json` from the reviewed main branch rather than the dispatched ref.
- Harden `server.json` validation to require the expected `title`, `websiteUrl`, exact `repository` object, exactly one `remotes` entry, and the exact `remotes[0].url`/`type` instead of accepting only a loose prefix.

### Testing
- Ran `npm run validate:workflows` which completed successfully and validated 8 workflow files.
- Ran `npx prettier --check .github/workflows/publish-mcp-registry.yml` which passed for the changed workflow file.
- Ran `git diff --check` which reported no problems in the modified file.
- Attempted `npm run format:check -- .github/workflows/publish-mcp-registry.yml` but the project `format:check` script checks the entire repository and reported pre-existing formatting warnings in unrelated files (not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dccc87c0c832a8d522f4f1256b30e)