### PR TITLE
feat(health): global cross-subnet incident ledger at /api/v1/incidents (#533)

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -75,6 +75,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/health/incidents/{netuid}.json`: schema for per-surface SLA + reconstructed downtime incidents served live from D1 at `GET /api/v1/subnets/{netuid}/health/incidents` (no static file).
 - `/metagraph/subnets/{netuid}/trajectory.json`: schema for the week-over-week structural trajectory served live from D1 at `GET /api/v1/subnets/{netuid}/trajectory` (no static file).
 - `/metagraph/subnets/{netuid}/uptime.json`: schema for the long-term daily uptime history per operational surface (90d/1y window), served live from the `surface_uptime_daily` D1 rollup at `GET /api/v1/subnets/{netuid}/uptime` (no static file).
+- `/metagraph/incidents.json`: schema for recent cross-subnet downtime incidents reconstructed from probe history, served live from D1 at `GET /api/v1/incidents` (no static file).
 - `/metagraph/registry/leaderboards.json`: schema for the registry leaderboards served live from D1 + registry projections at `GET /api/v1/registry/leaderboards` (no static file).
 - `/metagraph/schema-drift.json`: OpenAPI snapshot/drift status.
 - `/metagraph/schemas/index.json`: captured machine-readable schema index.
@@ -143,6 +144,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/rpc/pools`: fetch endpoint pool scores.
 - `/api/v1/endpoint-pools`: fetch generalized endpoint pool scores.
 - `/api/v1/endpoint-incidents`: fetch probe-derived endpoint incidents.
+- `/api/v1/incidents`: fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d/30d window (live from D1).
 - `/api/v1/schemas`: fetch captured schema index.
 - `/api/v1/adapters/{slug}`: fetch adapter-backed public metrics.
 - `/api/v1/search`: fetch compact search index.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -344,6 +344,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/incidents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window (computed live from D1). Pair with /api/v1/health for the overall status summary. */
+        get: operations["incidents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/lineage": {
         parameters: {
             query?: never;
@@ -1574,6 +1591,37 @@ export interface components {
             generated_at?: "1970-01-01T00:00:00.000Z";
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
+        /** @description Recent cross-subnet downtime incidents reconstructed from probe history; lists only surfaces that had an incident in the window. */
+        GlobalIncidentsArtifact: {
+            observed_at?: string | null;
+            schema_version: number;
+            source: string;
+            summary: {
+                affected_surface_count: number;
+                incident_count: number;
+            } & {
+                [key: string]: unknown;
+            };
+            surfaces: ({
+                downtime_ms?: number;
+                incident_count: number;
+                incidents: ({
+                    duration_ms: number;
+                    ended_at: number;
+                    failed_samples?: number;
+                    started_at: number;
+                } & {
+                    [key: string]: unknown;
+                })[];
+                netuid: number;
+                surface_id: string;
+            } & {
+                [key: string]: unknown;
+            })[];
+            window?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         HealthBadgeArtifact: components["schemas"]["ArtifactBase"] & ({
             color: string;
             label: string;
@@ -4563,6 +4611,76 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthHistoryArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    incidents: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["GlobalIncidentsArtifact"];
                     };
                 };
             };

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -331,6 +331,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "global-incidents",
+      "path": "/metagraph/incidents.json",
+      "schema_ref": "#/components/schemas/GlobalIncidentsArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",
       "schema_ref": "#/components/schemas/RegistryLeaderboardsArtifact",
@@ -4014,6 +4021,29 @@
               "asc",
               "desc"
             ]
+          }
+        }
+      ]
+    },
+    {
+      "artifact_path": "/metagraph/incidents.json",
+      "cache": "short",
+      "description": "Fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window (computed live from D1). Pair with /api/v1/health for the overall status summary.",
+      "id": "incidents",
+      "method": "GET",
+      "path": "/api/v1/incidents",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "window",
+          "schema": {
+            "enum": [
+              "7d",
+              "30d"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -426,6 +426,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "Recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window, served live from D1 at /api/v1/incidents (no static file).",
+      "id": "global-incidents",
+      "path": "/metagraph/incidents.json",
+      "schema_ref": "#/components/schemas/GlobalIncidentsArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing), computed live from D1 + registry projections at /api/v1/registry/leaderboards (no static file).",
       "id": "registry-leaderboards",
       "path": "/metagraph/registry/leaderboards.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -2487,6 +2487,113 @@
           }
         ]
       },
+      "GlobalIncidentsArtifact": {
+        "additionalProperties": true,
+        "description": "Recent cross-subnet downtime incidents reconstructed from probe history; lists only surfaces that had an incident in the window.",
+        "properties": {
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "summary": {
+            "additionalProperties": true,
+            "properties": {
+              "affected_surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "incident_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "incident_count",
+              "affected_surface_count"
+            ],
+            "type": "object"
+          },
+          "surfaces": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "downtime_ms": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "incident_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "incidents": {
+                  "items": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "duration_ms": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "ended_at": {
+                        "type": "integer"
+                      },
+                      "failed_samples": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "started_at": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "started_at",
+                      "ended_at",
+                      "duration_ms"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "netuid": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "surface_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "netuid",
+                "surface_id",
+                "incident_count",
+                "incidents"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "window": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "source",
+          "summary",
+          "surfaces"
+        ],
+        "type": "object"
+      },
       "HealthBadgeArtifact": {
         "allOf": [
           {
@@ -11646,6 +11753,108 @@
         "summary": "Fetch compact daily health history.",
         "tags": [
           "health"
+        ]
+      }
+    },
+    "/api/v1/incidents": {
+      "get": {
+        "operationId": "incidents",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "enum": [
+                "7d",
+                "30d"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/GlobalIncidentsArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window (computed live from D1). Pair with /api/v1/health for the overall status summary.",
+        "tags": [
+          "health",
+          "analytics"
         ]
       }
     },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -344,6 +344,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/incidents": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window (computed live from D1). Pair with /api/v1/health for the overall status summary. */
+        get: operations["incidents"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/lineage": {
         parameters: {
             query?: never;
@@ -1574,6 +1591,37 @@ export interface components {
             generated_at?: "1970-01-01T00:00:00.000Z";
         };
         GenericArtifact: components["schemas"]["ArtifactBase"];
+        /** @description Recent cross-subnet downtime incidents reconstructed from probe history; lists only surfaces that had an incident in the window. */
+        GlobalIncidentsArtifact: {
+            observed_at?: string | null;
+            schema_version: number;
+            source: string;
+            summary: {
+                affected_surface_count: number;
+                incident_count: number;
+            } & {
+                [key: string]: unknown;
+            };
+            surfaces: ({
+                downtime_ms?: number;
+                incident_count: number;
+                incidents: ({
+                    duration_ms: number;
+                    ended_at: number;
+                    failed_samples?: number;
+                    started_at: number;
+                } & {
+                    [key: string]: unknown;
+                })[];
+                netuid: number;
+                surface_id: string;
+            } & {
+                [key: string]: unknown;
+            })[];
+            window?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         HealthBadgeArtifact: components["schemas"]["ArtifactBase"] & ({
             color: string;
             label: string;
@@ -4563,6 +4611,76 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthHistoryArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    incidents: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["GlobalIncidentsArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -2465,6 +2465,113 @@
           }
         ]
       },
+      "GlobalIncidentsArtifact": {
+        "additionalProperties": true,
+        "description": "Recent cross-subnet downtime incidents reconstructed from probe history; lists only surfaces that had an incident in the window.",
+        "properties": {
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "summary": {
+            "additionalProperties": true,
+            "properties": {
+              "affected_surface_count": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "incident_count": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "incident_count",
+              "affected_surface_count"
+            ],
+            "type": "object"
+          },
+          "surfaces": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "downtime_ms": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "incident_count": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "incidents": {
+                  "items": {
+                    "additionalProperties": true,
+                    "properties": {
+                      "duration_ms": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "ended_at": {
+                        "type": "integer"
+                      },
+                      "failed_samples": {
+                        "minimum": 0,
+                        "type": "integer"
+                      },
+                      "started_at": {
+                        "type": "integer"
+                      }
+                    },
+                    "required": [
+                      "started_at",
+                      "ended_at",
+                      "duration_ms"
+                    ],
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "netuid": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "surface_id": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "netuid",
+                "surface_id",
+                "incident_count",
+                "incidents"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "window": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "source",
+          "summary",
+          "surfaces"
+        ],
+        "type": "object"
+      },
       "HealthBadgeArtifact": {
         "allOf": [
           {

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -576,6 +576,60 @@
         },
         "additionalProperties": true
       },
+      "GlobalIncidentsArtifact": {
+        "type": "object",
+        "description": "Recent cross-subnet downtime incidents reconstructed from probe history; lists only surfaces that had an incident in the window.",
+        "required": ["schema_version", "source", "summary", "surfaces"],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "window": { "type": ["string", "null"] },
+          "observed_at": { "type": ["string", "null"] },
+          "source": { "type": "string" },
+          "summary": {
+            "type": "object",
+            "required": ["incident_count", "affected_surface_count"],
+            "properties": {
+              "incident_count": { "type": "integer", "minimum": 0 },
+              "affected_surface_count": { "type": "integer", "minimum": 0 }
+            },
+            "additionalProperties": true
+          },
+          "surfaces": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "netuid",
+                "surface_id",
+                "incident_count",
+                "incidents"
+              ],
+              "properties": {
+                "netuid": { "type": "integer", "minimum": 0 },
+                "surface_id": { "type": "string" },
+                "incident_count": { "type": "integer", "minimum": 0 },
+                "downtime_ms": { "type": "integer", "minimum": 0 },
+                "incidents": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["started_at", "ended_at", "duration_ms"],
+                    "properties": {
+                      "started_at": { "type": "integer" },
+                      "ended_at": { "type": "integer" },
+                      "duration_ms": { "type": "integer", "minimum": 0 },
+                      "failed_samples": { "type": "integer", "minimum": 0 }
+                    },
+                    "additionalProperties": true
+                  }
+                }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      },
       "ReliabilityScore": {
         "type": "object",
         "description": "Composite reliability score (0-100) from durable uptime history: sample-weighted uptime with a mild latency penalty. Null when no probe data exists.",

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -324,6 +324,13 @@ const checks = [
     (body) => assert.equal(Array.isArray(body.data.subnets), true),
   ],
   [
+    "/api/v1/incidents",
+    (body) => {
+      assert.equal(Array.isArray(body.data.surfaces), true);
+      assert.equal(typeof body.data.summary.incident_count, "number");
+    },
+  ],
+  [
     `/api/v1/health/history/${latestHealthHistoryDate}?limit=2`,
     (body) => {
       assert.equal(Array.isArray(body.data.surfaces), true);

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -27,6 +27,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "subnet-trajectory",
   "subnet-uptime",
   "registry-leaderboards",
+  "global-incidents",
   // Live-only operational health (served from KV/D1, no static file on disk).
   "health-latest",
   "health-summary",

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -12,6 +12,9 @@ const R2_ONLY_PATTERNS = [
   /^candidates\/(?:\d+|\{netuid\})\.json$/,
   /^endpoint-incidents\.json$/,
   /^endpoint-pools\.json$/,
+  // Global cross-subnet incident ledger, computed live from D1 at
+  // /api/v1/incidents — never written as a file.
+  /^incidents\.json$/,
   /^endpoints\.json$/,
   /^endpoints\/(?:\d+|\{netuid\})\.json$/,
   /^evidence\/(?:\d+|\{netuid\})\.json$/,
@@ -138,7 +141,9 @@ export function artifactStorageTierForRelativePath(relativePath = "") {
   // Non-default network artifacts (testnet/…, local/…) are R2-only regardless of
   // what the unprefixed equivalent would be — secondary-network data is large and
   // sparse, so it is never committed to git.
-  if (NETWORK_KEY_PREFIXES.some((prefix) => normalized.startsWith(`${prefix}/`))) {
+  if (
+    NETWORK_KEY_PREFIXES.some((prefix) => normalized.startsWith(`${prefix}/`))
+  ) {
     return ARTIFACT_STORAGE_TIERS.r2;
   }
   if (R2_ONLY_PATTERNS.some((pattern) => pattern.test(normalized))) {

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -810,6 +810,12 @@ export const PUBLIC_ARTIFACTS = [
     "UptimeArtifact",
   ),
   artifact(
+    "global-incidents",
+    "/metagraph/incidents.json",
+    "Recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window, served live from D1 at /api/v1/incidents (no static file).",
+    "GlobalIncidentsArtifact",
+  ),
+  artifact(
     "registry-leaderboards",
     "/metagraph/registry/leaderboards.json",
     "Registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing), computed live from D1 + registry projections at /api/v1/registry/leaderboards (no static file).",
@@ -1476,6 +1482,16 @@ export const API_ROUTES = [
     "short",
     ["endpoints", "health"],
     listQuery("endpoint-incidents"),
+  ),
+  route(
+    "incidents",
+    "GET",
+    "/api/v1/incidents",
+    "/metagraph/incidents.json",
+    "Fetch recent cross-subnet downtime incidents reconstructed from probe history over a 7d or 30d window (computed live from D1). Pair with /api/v1/health for the overall status summary.",
+    "short",
+    ["health", "analytics"],
+    [{ name: "window", schema: { type: "string", enum: ["7d", "30d"] } }],
   ),
   route(
     "schemas",

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -398,6 +398,70 @@ export function formatIncidents({
   };
 }
 
+// Global, cross-subnet incident ledger from the same gap-island grouping as
+// formatIncidents, but keyed by netuid + surface_id and listing ONLY surfaces
+// that had an incident in the window (a "what's been down lately" feed, not a
+// full SLA table). `incidentRows`: [{ netuid, surface_id, started_at, ended_at,
+// failed_samples }], already capped + ordered by the SQL.
+export function formatGlobalIncidents({
+  window,
+  observedAt,
+  incidentRows,
+  maxIncidents,
+}) {
+  const incidentLimit = Number.isInteger(maxIncidents)
+    ? Math.max(0, maxIncidents)
+    : Infinity;
+  const bySurface = new Map();
+  let acceptedIncidents = 0;
+  for (const row of incidentRows || []) {
+    if (acceptedIncidents >= incidentLimit) {
+      break;
+    }
+    const netuid = Number(row.netuid);
+    const key = `${netuid}/${row.surface_id}`;
+    const entry = bySurface.get(key) || {
+      netuid,
+      surface_id: row.surface_id,
+      incidents: [],
+    };
+    const startedAt = Number(row.started_at);
+    const endedAt = Number(row.ended_at);
+    entry.incidents.push({
+      started_at: startedAt,
+      ended_at: endedAt,
+      duration_ms: endedAt - startedAt,
+      failed_samples: Number(row.failed_samples) || 0,
+    });
+    bySurface.set(key, entry);
+    acceptedIncidents += 1;
+  }
+
+  const surfaces = [...bySurface.values()]
+    .map((entry) => ({
+      netuid: entry.netuid,
+      surface_id: entry.surface_id,
+      incident_count: entry.incidents.length,
+      downtime_ms: entry.incidents.reduce((sum, i) => sum + i.duration_ms, 0),
+      incidents: entry.incidents,
+    }))
+    .sort(
+      (a, b) => a.netuid - b.netuid || a.surface_id.localeCompare(b.surface_id),
+    );
+
+  return {
+    schema_version: 1,
+    window: window || null,
+    observed_at: observedAt || null,
+    source: "live-cron-prober",
+    summary: {
+      incident_count: acceptedIncidents,
+      affected_surface_count: surfaces.length,
+    },
+    surfaces,
+  };
+}
+
 export const LEADERBOARD_BOARDS = [
   "healthiest",
   "fastest-rpc",

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -3,6 +3,7 @@ import { describe, test } from "vitest";
 import {
   OPERATIONAL_KINDS,
   buildGlobalHealth,
+  formatGlobalIncidents,
   formatTrends,
   mergeFreshness,
   mergeRpcEndpoints,
@@ -1762,5 +1763,90 @@ describe("loadSubnetReliability (D1-backed)", () => {
       await loadSubnetReliability({ db: uptimeDb([]), netuid: 7 }),
       null,
     );
+  });
+});
+
+describe("formatGlobalIncidents (cross-subnet ledger)", () => {
+  test("groups incidents by netuid+surface and summarizes", () => {
+    const out = formatGlobalIncidents({
+      window: "30d",
+      observedAt: "2026-06-13T00:00:00.000Z",
+      maxIncidents: 1000,
+      incidentRows: [
+        {
+          netuid: 7,
+          surface_id: "a",
+          started_at: 1000,
+          ended_at: 5000,
+          failed_samples: 3,
+        },
+        {
+          netuid: 7,
+          surface_id: "a",
+          started_at: 20000,
+          ended_at: 26000,
+          failed_samples: 2,
+        },
+        {
+          netuid: 23,
+          surface_id: "b",
+          started_at: 8000,
+          ended_at: 9000,
+          failed_samples: 1,
+        },
+      ],
+    });
+    assert.equal(out.summary.incident_count, 3);
+    assert.equal(out.summary.affected_surface_count, 2);
+    assert.equal(out.surfaces[0].netuid, 7); // sorted by netuid
+    const sn7 = out.surfaces.find((s) => s.netuid === 7);
+    assert.equal(sn7.incident_count, 2);
+    assert.equal(sn7.downtime_ms, 10000); // 4000 + 6000
+  });
+
+  test("empty rows -> empty ledger; caps at maxIncidents", () => {
+    assert.deepEqual(formatGlobalIncidents({ incidentRows: [] }).surfaces, []);
+    const capped = formatGlobalIncidents({
+      maxIncidents: 1,
+      incidentRows: [
+        {
+          netuid: 1,
+          surface_id: "x",
+          started_at: 1,
+          ended_at: 2,
+          failed_samples: 1,
+        },
+        {
+          netuid: 1,
+          surface_id: "x",
+          started_at: 3,
+          ended_at: 4,
+          failed_samples: 1,
+        },
+      ],
+    });
+    assert.equal(capped.summary.incident_count, 1);
+  });
+});
+
+describe("global incidents route", () => {
+  test("serves a schema-stable empty ledger when D1 is cold", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(req("/api/v1/incidents"), env, {});
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(Array.isArray(body.data.surfaces), true);
+    assert.equal(body.data.summary.incident_count, 0);
+    assert.equal(body.meta.source, "live-cron-prober");
+  });
+
+  test("rejects an unsupported window", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      req("/api/v1/incidents?window=5y"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 400);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -35,6 +35,7 @@ import {
 } from "../src/health-prober.mjs";
 import {
   buildGlobalHealth,
+  formatGlobalIncidents,
   formatIncidents,
   formatLeaderboards,
   formatPercentiles,
@@ -337,6 +338,9 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     const uptimeMatch = UPTIME_PATH_PATTERN.exec(resolved.url.pathname);
     if (uptimeMatch) {
       return handleUptime(request, env, Number(uptimeMatch[1]), resolved.url);
+    }
+    if (resolved.url.pathname === "/api/v1/incidents") {
+      return handleGlobalIncidents(request, env, resolved.url);
     }
     return handleApiRequest(request, env, resolved.url);
   }
@@ -1254,6 +1258,58 @@ async function handleHealthIncidents(request, env, netuid, url) {
         `/metagraph/health/incidents/${netuid}.json`,
         data.observed_at,
       ),
+    },
+    "short",
+  );
+}
+
+// Global, cross-subnet incident ledger — the same gap-island grouping as the
+// per-subnet route but with no netuid filter, grouped by (netuid, surface_id)
+// and capped. Powers a public status page's "recent incidents" feed. Returns a
+// schema-stable empty payload when D1 is unbound/cold.
+async function handleGlobalIncidents(request, env, url) {
+  const { label, days, error } = analyticsWindow(url);
+  if (error) {
+    return analyticsQueryError(error);
+  }
+  const since = Date.now() - days * DAY_MS;
+  const incidentRows = await d1All(
+    env,
+    `WITH failures AS (
+       SELECT netuid, surface_id, checked_at,
+              checked_at - LAG(checked_at)
+                OVER (PARTITION BY netuid, surface_id ORDER BY checked_at) AS gap
+       FROM surface_checks
+       WHERE checked_at >= ? AND ok = 0
+     ),
+     grouped AS (
+       SELECT netuid, surface_id, checked_at,
+              SUM(CASE WHEN gap IS NULL OR gap > ? THEN 1 ELSE 0 END)
+                OVER (PARTITION BY netuid, surface_id ORDER BY checked_at) AS grp
+       FROM failures
+     )
+     SELECT netuid, surface_id,
+            MIN(checked_at) AS started_at,
+            MAX(checked_at) AS ended_at,
+            COUNT(*) AS failed_samples
+     FROM grouped
+     GROUP BY netuid, surface_id, grp
+     ORDER BY started_at DESC
+     LIMIT ?`,
+    [since, INCIDENT_GAP_MS, MAX_INCIDENT_ROWS],
+  );
+  const meta = await readHealthKv(env, KV_HEALTH_META);
+  const data = formatGlobalIncidents({
+    window: label,
+    observedAt: meta?.last_run_at || null,
+    incidentRows,
+    maxIncidents: MAX_INCIDENT_ROWS,
+  });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: analyticsMeta(env, "/metagraph/incidents.json", data.observed_at),
     },
     "short",
   );


### PR DESCRIPTION
Closes #533 (Wave 9 epic #534).

## What

Adds the genuinely-missing backend piece for a public status page: a **global, cross-subnet incident feed**.

- **`GET /api/v1/incidents`** — reconstructs recent downtime incidents from `surface_checks` using the same gap-island SQL as the per-subnet route, but with no `netuid` filter, grouped by `(netuid, surface_id)`, over a 7d/30d window, capped at `MAX_INCIDENT_ROWS`. Lists only surfaces that had an incident (a "what's been down lately" ledger, not a full SLA table). Returns a schema-stable empty payload when D1 is cold.

What already existed (so this PR doesn't duplicate): per-subnet incidents (`/api/v1/subnets/{netuid}/health/incidents`), RPC-endpoint incidents (`/api/v1/endpoint-incidents`), and the overall **status summary** (`/api/v1/health` → counts + per-subnet rollups). So #533's "status" surface is `/api/v1/health`; the new addition is the incident ledger.

## Wiring
- `formatGlobalIncidents()` + `handleGlobalIncidents()`; `GlobalIncidentsArtifact` schema; `route()` + `artifact()` in contracts.
- `/metagraph/incidents.json` marked **R2-only** (live, no static file) + added to `COMPUTED_ARTIFACTS` so `validate-schemas` skips a non-existent file.
- `validate-api` per-route check + `backend-artifact-contracts.md` doc; regenerated `openapi.json`/`types.d.ts`/`api-index.json`/`contracts.json` (verified the diff is only the new route/artifact, no data churn).

## Tests
`formatGlobalIncidents` (grouping by netuid+surface, summary, empty, maxIncidents cap) + worker integration (cold D1 → empty ledger; unsupported `window` → 400). All contract validators green (57 routes); `validate:api`, `validate:openapi-examples`, `validate:schemas`, `validate:docs` pass.

## Follow-up
UI `/status` page consuming `/api/v1/health` + `/api/v1/incidents` — tracked separately in the `metagraphed-ui` repo.