### PR TITLE
fix(contract): allow adapter extension metadata fields

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -963,7 +963,9 @@ export interface components {
         AdapterArtifact: components["schemas"]["ArtifactBase"] & ({
             /** @description Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific. */
             extensions: {
-                [key: string]: Record<string, never>;
+                [key: string]: {
+                    [key: string]: unknown;
+                };
             };
             netuid: number;
             slug: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -28,6 +28,7 @@
             "properties": {
               "extensions": {
                 "additionalProperties": {
+                  "additionalProperties": true,
                   "type": "object"
                 },
                 "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -963,7 +963,9 @@ export interface components {
         AdapterArtifact: components["schemas"]["ArtifactBase"] & ({
             /** @description Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific. */
             extensions: {
-                [key: string]: Record<string, never>;
+                [key: string]: {
+                    [key: string]: unknown;
+                };
             };
             netuid: number;
             slug: string;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -14,6 +14,7 @@
             "properties": {
               "extensions": {
                 "additionalProperties": {
+                  "additionalProperties": true,
                   "type": "object"
                 },
                 "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",

--- a/schemas/components/09-schemas-adapters-r2.schema.json
+++ b/schemas/components/09-schemas-adapters-r2.schema.json
@@ -252,7 +252,7 @@
               "extensions": {
                 "type": "object",
                 "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",
-                "additionalProperties": { "type": "object" }
+                "additionalProperties": { "type": "object", "additionalProperties": true }
               },
               "snapshot": {
                 "type": ["object", "null"],


### PR DESCRIPTION
### Motivation
- Fix a contract/type regression where `AdapterArtifact.extensions` map values were generated as `Record<string, never>`, which incorrectly implies extension objects are always empty and conflicts with real registry data.
- Ensure extension metadata remains forward-compatible and can contain adapter-specific fields such as `authority_notes` and `tracked_dimensions`.

### Description
- Update `schemas/components/09-schemas-adapters-r2.schema.json` to set the nested `extensions` value schema to `{ "type": "object", "additionalProperties": true }` so each map value explicitly allows arbitrary properties. 
- Rebundle the component schema into `schemas/api-components.schema.json` and regenerate the public OpenAPI document `public/metagraph/openapi.json` to carry the updated contract.
- Regenerate TypeScript declarations (`public/metagraph/types.d.ts` and `generated/metagraphed-api.d.ts`) so extension values are typed as open object maps (`[key: string]: { [key: string]: unknown }`) instead of `Record<string, never>`, preserving existing functionality.
- The change is minimal and preserves forward-compatibility of the API shape while matching served/registry data.

### Testing
- Ran `npm run -s validate:types`, which reported the generated API types are current (success).
- Ran `npm run -s validate:openapi`, which passed for the available routes (success).
- Ran `npm run -s validate:schemas`, which failed in this checkout due to a missing file (`public/metagraph/candidates.json`) unrelated to this schema change (environment issue).
- Ran `npm run -s schemas:bundle:check` and `npm run -s openapi:generate:dry-run`, both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dd957d538832ab63701796a0c57c3)