### PR TITLE
feat(contract): worked example on every OpenAPI operation + enforcement (#531 part 2)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -3234,6 +3234,75 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "artifact_contracts": [
+                     *           {
+                     *             "contract_version": "2026-06-06.1",
+                     *             "id": "example",
+                     *             "path": "/metagraph/example.json",
+                     *             "schema_ref": "#/components/schemas/Example",
+                     *             "storage_tier": "dual"
+                     *           }
+                     *         ],
+                     *         "base_path": "/api/v1",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "openapi_url": "/api/v1/openapi.json",
+                     *         "primary_domain": "api.metagraph.sh",
+                     *         "response_envelope": {
+                     *           "error_schema_ref": "#/components/schemas/ErrorEnvelope",
+                     *           "fields": [
+                     *             "ok"
+                     *           ],
+                     *           "notes": "Example description.",
+                     *           "schema_version": 1,
+                     *           "success_schema_ref": "#/components/schemas/SuccessEnvelope"
+                     *         },
+                     *         "routes": [
+                     *           {
+                     *             "artifact_path": "/metagraph/example.json",
+                     *             "cache": "short",
+                     *             "description": "Example description.",
+                     *             "id": "example",
+                     *             "method": "GET",
+                     *             "path": "/api/v1/example",
+                     *             "public": true,
+                     *             "query_parameters": [
+                     *               {
+                     *                 "name": "Example Subnet",
+                     *                 "schema": {}
+                     *               }
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "type_definitions_url": "/metagraph/types.d.ts"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ApiIndexArtifact"];
                     };
@@ -3304,6 +3373,43 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "extensions": {
+                     *           "example": {}
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet",
+                     *         "snapshot": {},
+                     *         "subnet": "example"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AdapterArtifact"];
                     };
@@ -3372,6 +3478,45 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "callable_service_count": 1,
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "subnet_count": 1,
+                     *         "subnets": [
+                     *           {
+                     *             "netuid": 7,
+                     *             "service_count": 1
+                     *           }
+                     *         ],
+                     *         "total_subnet_count": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AgentCatalogArtifact"];
                     };
@@ -3442,6 +3587,58 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "categories": [
+                     *           "example"
+                     *         ],
+                     *         "completeness_score": 100,
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "integration_readiness": 1,
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "readiness": {
+                     *           "components": {},
+                     *           "readiness_version": 1,
+                     *           "score": 100
+                     *         },
+                     *         "schema_version": 1,
+                     *         "service_count": 1,
+                     *         "services": [
+                     *           {
+                     *             "base_url": "https://api.metagraph.sh/example",
+                     *             "kind": "example",
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "slug": "example-subnet",
+                     *         "subnet_type": "example"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AgentCatalogSubnetArtifact"];
                     };
@@ -3510,6 +3707,65 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "copyable_agent": {
+                     *           "description": "Example description.",
+                     *           "title": "Example Subnet",
+                     *           "url": "https://api.metagraph.sh/example"
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "mcp": {
+                     *           "endpoint": "https://api.metagraph.sh/example",
+                     *           "install": "example",
+                     *           "server_card": "https://api.metagraph.sh/example",
+                     *           "tools": [
+                     *             {
+                     *               "name": "Example Subnet"
+                     *             }
+                     *           ],
+                     *           "transport": "example"
+                     *         },
+                     *         "notes": "Example description.",
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "resources": [
+                     *           {
+                     *             "id": "example",
+                     *             "title": "Example Subnet",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "callable_service_count": 1,
+                     *           "subnet_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AgentResourcesArtifact"];
                     };
@@ -3578,6 +3834,52 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "artifact_budgets": [
+                     *           {
+                     *             "fail_bytes": 1,
+                     *             "path": "example",
+                     *             "size_bytes": 1,
+                     *             "status": "ok",
+                     *             "warn_bytes": 1
+                     *           }
+                     *         ],
+                     *         "artifact_count": 1,
+                     *         "artifact_size_bytes": 1,
+                     *         "candidate_count": 1,
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "provider_count": 1,
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "subnet_count": 1,
+                     *         "surface_count": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BuildSummaryArtifact"];
                     };
@@ -3655,6 +3957,51 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidates": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["CandidatesArtifact"];
                     };
@@ -3723,6 +4070,68 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "artifacts": {
+                     *           "added": [
+                     *             "example"
+                     *           ],
+                     *           "modified": [
+                     *             "example"
+                     *           ],
+                     *           "removed": [
+                     *             "example"
+                     *           ]
+                     *         },
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "source": "generated-artifact-diff",
+                     *         "subnets": {
+                     *           "added": [
+                     *             1
+                     *           ],
+                     *           "removed": [
+                     *             1
+                     *           ],
+                     *           "renamed": [
+                     *             {}
+                     *           ]
+                     *         },
+                     *         "summary": {
+                     *           "artifact_added_count": 1,
+                     *           "artifact_modified_count": 1,
+                     *           "artifact_removed_count": 1,
+                     *           "coverage_delta": {},
+                     *           "netuid_added_count": 7,
+                     *           "netuid_removed_count": 7,
+                     *           "netuid_renamed_count": 7
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChangelogArtifact"];
                     };
@@ -3791,6 +4200,51 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "artifacts": [
+                     *           {
+                     *             "contract_version": "2026-06-06.1",
+                     *             "id": "example",
+                     *             "path": "/metagraph/example.json",
+                     *             "schema_ref": "#/components/schemas/Example",
+                     *             "storage_tier": "dual"
+                     *           }
+                     *         ],
+                     *         "base_path": "/metagraph",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "name": "Example Subnet",
+                     *         "notes": "Example description.",
+                     *         "openapi_url": "/metagraph/openapi.json",
+                     *         "primary_domain": "api.metagraph.sh",
+                     *         "schema_version": 1,
+                     *         "status_domain": null,
+                     *         "type_definitions_url": "/metagraph/types.d.ts"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ContractsArtifact"];
                     };
@@ -3859,6 +4313,69 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "application_subnet_count": 1,
+                     *         "candidate_count": 1,
+                     *         "candidate_subnet_count": 1,
+                     *         "chain_subnet_count": 1,
+                     *         "completeness": {
+                     *           "average_score": 100,
+                     *           "dimension_coverage": {},
+                     *           "fully_complete_count": 1,
+                     *           "fully_complete_pct": 1,
+                     *           "median_score": 100,
+                     *           "methodology": "GET",
+                     *           "score_distribution": {},
+                     *           "scored_subnet_count": 1
+                     *         },
+                     *         "contract_version": "2026-06-06.1",
+                     *         "curated_overlay_count": 1,
+                     *         "curation_level_counts": {
+                     *           "example": 1
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "manifested_count": 1,
+                     *         "native_only_count": 1,
+                     *         "native_only_with_candidates": 1,
+                     *         "native_only_without_candidates": 1,
+                     *         "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+                     *         "network": "finney",
+                     *         "notes": "Example description.",
+                     *         "probed_count": 1,
+                     *         "probed_surface_count": 1,
+                     *         "root_subnet_count": 1,
+                     *         "schema_version": 1,
+                     *         "source": {
+                     *           "candidates": "example",
+                     *           "native": "example",
+                     *           "overlays": "example"
+                     *         },
+                     *         "surface_count": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["CoverageArtifact"];
                     };
@@ -3934,6 +4451,61 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "curation": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "coverage_level": "native-only",
+                     *             "curation": {
+                     *               "level": "native",
+                     *               "review_state": "unreviewed"
+                     *             },
+                     *             "gaps": {
+                     *               "gap_notes": [
+                     *                 "example"
+                     *               ],
+                     *               "missing_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "supported_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "slug": "example-subnet",
+                     *             "surface_count": 1
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["CurationArtifact"];
                     };
@@ -4013,6 +4585,71 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "incidents": [
+                     *           {
+                     *             "classification": "live",
+                     *             "detected_at": "2026-06-01T00:00:00.000Z",
+                     *             "endpoint_id": "https://api.metagraph.sh/example",
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_checked": "2026-06-01T00:00:00.000Z",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "reason": "example",
+                     *             "severity": "critical",
+                     *             "source": "probe-derived",
+                     *             "state": "active",
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "user_reported": false
+                     *           }
+                     *         ],
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "active_count": 1,
+                     *           "by_kind": {},
+                     *           "by_layer": {},
+                     *           "by_provider": {},
+                     *           "by_severity": {},
+                     *           "by_status": {},
+                     *           "incident_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EndpointIncidentsArtifact"];
                     };
@@ -4088,6 +4725,94 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "disabled_proxy_contract": {
+                     *           "allowed_methods": [
+                     *             "GET"
+                     *           ],
+                     *           "denied_method_patterns": [
+                     *             "GET"
+                     *           ],
+                     *           "enabled": true,
+                     *           "feature_flag": "example",
+                     *           "rate_limit_required": true,
+                     *           "waf_required": true
+                     *         },
+                     *         "eligibility_policy": {
+                     *           "eligible_layers": [
+                     *             "example"
+                     *           ],
+                     *           "notes": "Example description.",
+                     *           "required_status": "ok",
+                     *           "requires_no_auth": false,
+                     *           "requires_public_safe": true,
+                     *           "source": "live-cron-prober",
+                     *           "user_reports_can_change_health": false
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "pools": [
+                     *           {
+                     *             "eligible_count": 1,
+                     *             "endpoint_count": 1,
+                     *             "endpoints": [
+                     *               {
+                     *                 "health_source": "probe-derived",
+                     *                 "health_stale": false,
+                     *                 "id": "example",
+                     *                 "last_ok": "2026-06-01T00:00:00.000Z",
+                     *                 "observed_at": "2026-06-01T00:00:00.000Z",
+                     *                 "pool_eligible": false,
+                     *                 "provider": "example-provider",
+                     *                 "score": 100,
+                     *                 "status": "ok",
+                     *                 "url": "https://api.metagraph.sh/example"
+                     *               }
+                     *             ],
+                     *             "id": "example",
+                     *             "kind": "example"
+                     *           }
+                     *         ],
+                     *         "provider_scores": [
+                     *           {
+                     *             "average_score": 100,
+                     *             "degraded_count": 1,
+                     *             "endpoint_count": 1,
+                     *             "failed_count": 1,
+                     *             "monitored_count": 1,
+                     *             "ok_count": 1,
+                     *             "operational_score": 100,
+                     *             "pool_eligible_count": 1,
+                     *             "provider": "example-provider"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EndpointPoolsArtifact"];
                     };
@@ -4168,6 +4893,75 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "by_kind": {},
+                     *           "by_layer": {},
+                     *           "by_provider": {},
+                     *           "by_publication_state": {},
+                     *           "by_status": {},
+                     *           "endpoint_count": 1,
+                     *           "monitored_count": 1,
+                     *           "pool_eligible_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EndpointsArtifact"];
                     };
@@ -4242,6 +5036,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "claims": [
+                     *           {
+                     *             "claim": "example",
+                     *             "confidence": "low",
+                     *             "limits": "example",
+                     *             "source_tier": "native-chain",
+                     *             "source_type": "example",
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "subject": "example",
+                     *             "support_summary": "Example description."
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EvidenceLedgerArtifact"];
                     };
@@ -4310,6 +5146,44 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "fixture_count": 1,
+                     *         "fixtures": [
+                     *           {
+                     *             "netuid": 7,
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["FixturesIndexArtifact"];
                     };
@@ -4378,6 +5252,70 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "sources": [
+                     *           {
+                     *             "as_of": "example",
+                     *             "id": "example",
+                     *             "lane": "adapter-snapshot",
+                     *             "path": "example",
+                     *             "required_for_publish": true,
+                     *             "stale_after_hours": 1,
+                     *             "stale_behavior": "block",
+                     *             "status": "captured",
+                     *             "timestamp": "example",
+                     *             "timestamp_field": "example"
+                     *           }
+                     *         ],
+                     *         "summary": {
+                     *           "adapter_count": 1,
+                     *           "adapter_snapshot_as_of": "example",
+                     *           "blocking_source_count": 5000000,
+                     *           "candidate_discovery_as_of": "example",
+                     *           "health_probe_as_of": "example",
+                     *           "health_surface_count": 1,
+                     *           "missing_blocking_source_count": 5000000,
+                     *           "native_data_as_of": "example",
+                     *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+                     *           "openapi_surface_count": 1,
+                     *           "publish_ready_without_age_check": false,
+                     *           "schema_snapshot_as_of": "example",
+                     *           "stale_window_warnings": [
+                     *             "30d"
+                     *           ],
+                     *           "verification_as_of": "example",
+                     *           "verification_generated_at": "2026-06-01T00:00:00.000Z",
+                     *           "warning_source_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["FreshnessArtifact"];
                     };
@@ -4454,6 +5392,56 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "gaps": [
+                     *           {
+                     *             "coverage_level": "native-only",
+                     *             "curation_level": "native",
+                     *             "gaps": {
+                     *               "gap_notes": [
+                     *                 "example"
+                     *               ],
+                     *               "missing_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "supported_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "slug": "example-subnet"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["GapsArtifact"];
                     };
@@ -4529,6 +5517,50 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "global": {},
+                     *         "health_source": "probe-derived",
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "scope": "example",
+                     *         "source": "live-cron-prober",
+                     *         "subnets": [
+                     *           {
+                     *             "degraded_count": 1,
+                     *             "failed_count": 1,
+                     *             "ok_count": 1,
+                     *             "status": "ok",
+                     *             "surface_count": 1,
+                     *             "unknown_count": 1
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthSummaryArtifact"];
                     };
@@ -4609,6 +5641,55 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "date": "2026-06-01",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "probe_finished_at": "2026-06-01T00:00:00.000Z",
+                     *         "probe_started_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "summary": {
+                     *           "classification_counts": {},
+                     *           "status_counts": {},
+                     *           "surface_count": 1
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "classification": "live",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "status": "ok",
+                     *             "surface_id": "example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthHistoryArtifact"];
                     };
@@ -4679,6 +5760,54 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "summary": {
+                     *           "affected_surface_count": 1,
+                     *           "incident_count": 1
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "incident_count": 1,
+                     *             "incidents": [
+                     *               {
+                     *                 "duration_ms": 1,
+                     *                 "ended_at": 1,
+                     *                 "started_at": 1
+                     *               }
+                     *             ],
+                     *             "netuid": 7,
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["GlobalIncidentsArtifact"];
                     };
@@ -4747,6 +5876,52 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "graduated_subnet_count": 1,
+                     *         "link_count": 1,
+                     *         "links": [
+                     *           {
+                     *             "mainnet_netuid": 7,
+                     *             "matched_by": "github_repo",
+                     *             "testnet_netuid": 7
+                     *           }
+                     *         ],
+                     *         "matched_by_counts": {
+                     *           "example": 1
+                     *         },
+                     *         "notes": "Example description.",
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source_network": "example",
+                     *         "target_network": "example",
+                     *         "testnet_only_count": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["LineageArtifact"];
                     };
@@ -4815,6 +5990,40 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "components": {},
+                     *         "info": {},
+                     *         "openapi": "3.1.0",
+                     *         "paths": {},
+                     *         "servers": [
+                     *           {}
+                     *         ],
+                     *         "x-metagraphed": {}
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["OpenApiArtifact"];
                     };
@@ -4895,6 +6104,176 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "profiles": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "categories": [
+                     *               "example"
+                     *             ],
+                     *             "completeness": {
+                     *               "confidence": "low",
+                     *               "gap_reasons": [
+                     *                 "example"
+                     *               ],
+                     *               "identity_level": "none",
+                     *               "identity_surface_count": 1,
+                     *               "missing_critical_count": 1,
+                     *               "missing_identity": [
+                     *                 "archive"
+                     *               ],
+                     *               "missing_operational": [
+                     *                 "archive"
+                     *               ],
+                     *               "missing_required": [
+                     *                 "archive"
+                     *               ],
+                     *               "profile_level": "directory-only",
+                     *               "score": 100
+                     *             },
+                     *             "completeness_score": 100,
+                     *             "confidence": "low",
+                     *             "curation_level": "native",
+                     *             "derived_categories": [
+                     *               "example"
+                     *             ],
+                     *             "endpoint_count": 1,
+                     *             "gap_reasons": [
+                     *               "example"
+                     *             ],
+                     *             "identity_evidence": {
+                     *               "candidate_identity_count": 1,
+                     *               "curated_identity_count": 1,
+                     *               "curated_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "native_contact_present": false,
+                     *               "native_description_present": false,
+                     *               "native_identity_count": 1,
+                     *               "native_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "needs_promotion_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "unverified_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "missing_critical_count": 1,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_operational": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_required": [
+                     *               "archive"
+                     *             ],
+                     *             "monitored_endpoint_count": 1,
+                     *             "name": "Example Subnet",
+                     *             "native_identity": {
+                     *               "additional": "example",
+                     *               "contact_present": false,
+                     *               "description": "Example description.",
+                     *               "discord": "example",
+                     *               "discord_url": "https://api.metagraph.sh/example",
+                     *               "github_url": "https://api.metagraph.sh/example",
+                     *               "logo_url": "https://api.metagraph.sh/example",
+                     *               "source": "live-cron-prober",
+                     *               "subnet_name": "Example Subnet",
+                     *               "website_url": "https://api.metagraph.sh/example"
+                     *             },
+                     *             "netuid": 7,
+                     *             "operational_interface_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "primary_app_surface": {
+                     *               "id": "example",
+                     *               "kind": "archive",
+                     *               "name": "Example Subnet",
+                     *               "provider": "example-provider",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             },
+                     *             "primary_links": {
+                     *               "dashboard_url": "https://api.metagraph.sh/example",
+                     *               "docs_url": "https://api.metagraph.sh/example",
+                     *               "source_repo": "https://api.metagraph.sh/example",
+                     *               "website_url": "https://api.metagraph.sh/example"
+                     *             },
+                     *             "profile_level": "directory-only",
+                     *             "project_name": "example",
+                     *             "provenance": {
+                     *               "curation_level": "native",
+                     *               "identity_source": "live-cron-prober",
+                     *               "interface_source_count": 1,
+                     *               "review_state": "unreviewed",
+                     *               "reviewed_at": "2026-06-01T00:00:00.000Z",
+                     *               "source_urls": [
+                     *                 "https://api.metagraph.sh/example"
+                     *               ]
+                     *             },
+                     *             "review_state": "unreviewed",
+                     *             "slug": "example-subnet",
+                     *             "status": "active",
+                     *             "subnet_type": "root",
+                     *             "suggested_submission_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "supported_interface_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "surface_count": 1,
+                     *             "team": "example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "average_completeness_score": 100,
+                     *           "by_confidence": {},
+                     *           "by_identity_level": {},
+                     *           "by_profile_level": {},
+                     *           "identity_promotion_candidate_count": 1,
+                     *           "native_identity_count": 1,
+                     *           "native_identity_unpromoted_count": 1,
+                     *           "profile_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetProfilesArtifact"];
                     };
@@ -4971,6 +6350,46 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "providers": [
+                     *           {
+                     *             "authority": "official",
+                     *             "id": "example-subnet",
+                     *             "kind": "subnet-team",
+                     *             "name": "Example Subnet",
+                     *             "schema_version": 1,
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
@@ -5041,6 +6460,57 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "provider": {
+                     *           "authority": "official",
+                     *           "cluster_id": "example",
+                     *           "contact_url": "https://api.metagraph.sh/example",
+                     *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "endpoint_count": 1,
+                     *           "github_url": "https://api.metagraph.sh/example",
+                     *           "id": "example-subnet",
+                     *           "kind": "subnet-team",
+                     *           "name": "Example Subnet",
+                     *           "netuids": [
+                     *             7
+                     *           ],
+                     *           "notes": "Example description.",
+                     *           "public_notes": "example",
+                     *           "schema_version": 1,
+                     *           "subnet_count": 1,
+                     *           "surface_count": 1,
+                     *           "team_url": "https://api.metagraph.sh/example",
+                     *           "website_url": "https://api.metagraph.sh/example"
+                     *         },
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProviderArtifact"];
                     };
@@ -5122,6 +6592,81 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "provider": {
+                     *           "authority": "example",
+                     *           "id": "example",
+                     *           "kind": "example",
+                     *           "name": "Example Subnet"
+                     *         },
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "by_kind": {},
+                     *           "by_layer": {},
+                     *           "by_provider": {},
+                     *           "by_publication_state": {},
+                     *           "by_status": {},
+                     *           "endpoint_count": 1,
+                     *           "monitored_count": 1,
+                     *           "pool_eligible_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProviderEndpointsArtifact"];
                     };
@@ -5193,6 +6738,41 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "board": "example",
+                     *         "boards": {
+                     *           "example": [
+                     *             {}
+                     *           ]
+                     *         },
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RegistryLeaderboardsArtifact"];
                     };
@@ -5261,6 +6841,57 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "counts": {
+                     *           "candidates": 1,
+                     *           "endpoints": 1,
+                     *           "providers": 1,
+                     *           "surfaces": 1
+                     *         },
+                     *         "coverage": {},
+                     *         "curation_level_counts": {
+                     *           "example": 1
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "profile_level_counts": {
+                     *           "example": 1
+                     *         },
+                     *         "recent_changes": {},
+                     *         "schema_version": 1,
+                     *         "subnet_count": 1,
+                     *         "top_subnets": [
+                     *           {
+                     *             "completeness_score": 100,
+                     *             "netuid": 7
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RegistrySummaryArtifact"];
                     };
@@ -5340,6 +6971,75 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidates": [
+                     *           {
+                     *             "candidate_api_count": 1,
+                     *             "candidate_api_ids": [
+                     *               "example"
+                     *             ],
+                     *             "candidate_api_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "curation_level": "native",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "operational_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "operational_surface_count": 1,
+                     *             "operational_surface_ids": [
+                     *               "example"
+                     *             ],
+                     *             "priority_score": 100,
+                     *             "reason_codes": [
+                     *               "example"
+                     *             ],
+                     *             "recommended_adapter_kind": "custom-adapter",
+                     *             "slug": "example-subnet",
+                     *             "suggested_next_action": "example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "adapter_backed_count": 1,
+                     *           "by_curation_level": {},
+                     *           "by_recommended_adapter_kind": {},
+                     *           "candidate_api_kind_counts": {},
+                     *           "candidate_count": 1,
+                     *           "data_artifact_backed_count": 1,
+                     *           "openapi_backed_count": 1,
+                     *           "operational_kind_counts": {},
+                     *           "sse_backed_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewAdapterCandidatesArtifact"];
                     };
@@ -5419,6 +7119,79 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "entries": [
+                     *           {
+                     *             "candidate_evidence_by_kind": {},
+                     *             "candidate_evidence_summary": {
+                     *               "candidate_count": 1,
+                     *               "kinds_with_candidates": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_or_redirected_count": 1,
+                     *               "reviewable_count": 1,
+                     *               "stale_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_or_failed_count": 1,
+                     *               "unverified_count": 1,
+                     *               "unverified_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "direct_submission_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "evidence_action": "submit-new-evidence",
+                     *             "lane": "direct-submission",
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "slug": "example-subnet"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "entry_count": 1,
+                     *           "evidence_action_counts": {},
+                     *           "stale_candidate_count": 1,
+                     *           "subnet_count": 1,
+                     *           "unverified_candidate_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewEnrichmentEvidenceArtifact"];
                     };
@@ -5504,6 +7277,122 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "queue": [
+                     *           {
+                     *             "adapter_score": 100,
+                     *             "candidate_count": 1,
+                     *             "candidate_evidence_summary": {
+                     *               "candidate_count": 1,
+                     *               "kinds_with_candidates": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_or_redirected_count": 1,
+                     *               "reviewable_count": 1,
+                     *               "stale_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_or_failed_count": 1,
+                     *               "unverified_count": 1,
+                     *               "unverified_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "completeness_score": 100,
+                     *             "contribution_hint": "example",
+                     *             "curation_level": "native",
+                     *             "direct_submission_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "endpoint_count": 1,
+                     *             "evidence_action": "submit-new-evidence",
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "lane": "direct-submission",
+                     *             "manual_review_required": true,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "operational_interface_count": 1,
+                     *             "priority_score": 100,
+                     *             "profile_level": "directory-only",
+                     *             "reason_codes": [
+                     *               "example"
+                     *             ],
+                     *             "recommended_action": "2026-06-01T00:00:00.000Z",
+                     *             "review_state": "unreviewed",
+                     *             "sample_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_live_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_stale_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_target_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "slug": "example-subnet",
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ],
+                     *             "stale_candidate_count": 1,
+                     *             "surface_count": 1,
+                     *             "verified_candidate_count": 1
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "adapter_candidate_count": 1,
+                     *           "baseline_monitoring_count": 1,
+                     *           "direct_submission_count": 1,
+                     *           "evidence_action_counts": {},
+                     *           "identity_level_counts": {},
+                     *           "lane_counts": {},
+                     *           "maintainer_review_count": 1,
+                     *           "manual_review_required_count": 1,
+                     *           "monitoring_followup_count": 1,
+                     *           "queue_count": 1,
+                     *           "subnet_count": 1,
+                     *           "top_direct_submission_kinds": {}
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewEnrichmentQueueArtifact"];
                     };
@@ -5591,6 +7480,133 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "groups": [
+                     *           {
+                     *             "auto_review_candidate_count": 1,
+                     *             "kind": "archive",
+                     *             "manual_review_required_count": 1,
+                     *             "target_count": 1,
+                     *             "target_ids": [
+                     *               "example"
+                     *             ],
+                     *             "target_type": "surface-candidate",
+                     *             "top_netuids": [
+                     *               7
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "auto_review_candidate_count": 1,
+                     *           "by_evidence_action": {},
+                     *           "by_kind": {},
+                     *           "by_lane": {},
+                     *           "by_target_type": {},
+                     *           "manual_review_required_count": 1,
+                     *           "new_evidence_count": 1,
+                     *           "stale_replacement_count": 1,
+                     *           "subnet_count": 1,
+                     *           "target_count": 1
+                     *         },
+                     *         "targets": [
+                     *           {
+                     *             "auto_review_candidate": false,
+                     *             "candidate_command": "example",
+                     *             "candidate_evidence": {
+                     *               "candidate_count": 1,
+                     *               "classifications": {},
+                     *               "live_or_redirected_count": 1,
+                     *               "reviewable_count": 1,
+                     *               "sample_candidate_ids": [
+                     *                 "example"
+                     *               ],
+                     *               "stale_or_failed_count": 1,
+                     *               "unverified_count": 1
+                     *             },
+                     *             "contribution_prompt": "example",
+                     *             "evidence_action": "submit-new-evidence",
+                     *             "identity_level": "none",
+                     *             "kind": "archive",
+                     *             "lane": "direct-submission",
+                     *             "manual_review_required": true,
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "profile_level": "directory-only",
+                     *             "queue_context": {
+                     *               "adapter_score": 100,
+                     *               "candidate_count": 1,
+                     *               "completeness_score": 100,
+                     *               "curation_level": "native",
+                     *               "direct_submission_kind_count": 1,
+                     *               "endpoint_count": 1,
+                     *               "identity_surface_count": 1,
+                     *               "operational_interface_count": 1,
+                     *               "profile_level": "directory-only",
+                     *               "review_state": "unreviewed",
+                     *               "source_url_count": 1,
+                     *               "stale_candidate_count": 1,
+                     *               "surface_count": 1,
+                     *               "verified_candidate_count": 1
+                     *             },
+                     *             "reason_codes": [
+                     *               "example"
+                     *             ],
+                     *             "recommended_action": "2026-06-01T00:00:00.000Z",
+                     *             "sample_live_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_stale_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_target_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "slug": "example-subnet",
+                     *             "source_requirements": [
+                     *               "example"
+                     *             ],
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ],
+                     *             "submission_route": "direct-candidate-pr",
+                     *             "target_action": "submit-new-candidate",
+                     *             "target_id": "example",
+                     *             "target_type": "surface-candidate"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewEnrichmentTargetsArtifact"];
                     };
@@ -5667,6 +7683,53 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "priorities": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "curation_level": "native",
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "review_state": "unreviewed",
+                     *             "slug": "example-subnet",
+                     *             "suggested_next_action": "example",
+                     *             "surface_count": 1,
+                     *             "verified_candidate_count": 1
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewGapPrioritiesArtifact"];
                     };
@@ -5746,6 +7809,117 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "profiles": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "completeness_score": 100,
+                     *             "confidence": "low",
+                     *             "curation_level": "native",
+                     *             "gap_reasons": [
+                     *               "example"
+                     *             ],
+                     *             "identity_evidence": {
+                     *               "candidate_identity_count": 1,
+                     *               "curated_identity_count": 1,
+                     *               "curated_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "native_contact_present": false,
+                     *               "native_description_present": false,
+                     *               "native_identity_count": 1,
+                     *               "native_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "needs_promotion_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "unverified_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "identity_level": "none",
+                     *             "identity_promotion_kind_count": 1,
+                     *             "identity_promotion_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "identity_surface_count": 1,
+                     *             "live_identity_candidate_kind_count": 1,
+                     *             "missing_critical_count": 1,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_operational": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_required": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "native_identity_signal_count": 1,
+                     *             "native_name_quality": "chain",
+                     *             "netuid": 7,
+                     *             "operational_interface_count": 1,
+                     *             "priority_score": 100,
+                     *             "profile_level": "directory-only",
+                     *             "review_state": "unreviewed",
+                     *             "slug": "example-subnet",
+                     *             "source_count": 1,
+                     *             "stale_identity_candidate_kind_count": 1,
+                     *             "suggested_next_action": "example",
+                     *             "supported_interface_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "average_completeness_score": 100,
+                     *           "by_confidence": {},
+                     *           "by_identity_level": {},
+                     *           "by_profile_level": {},
+                     *           "critical_gap_counts": {},
+                     *           "identity_promotion_candidate_count": 1,
+                     *           "native_identity_count": 1,
+                     *           "native_identity_unpromoted_count": 1,
+                     *           "needs_identity_count": 1,
+                     *           "needs_operational_count": 1,
+                     *           "profile_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewProfileCompletenessArtifact"];
                     };
@@ -5826,6 +8000,59 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "chain": "bittensor",
+                     *             "classification": "live",
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "subtensor-rpc",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "network": "finney",
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "provider": "example-provider",
+                     *             "status": "ok",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "archive_supported_count": 1,
+                     *           "by_kind": {},
+                     *           "by_provider": {},
+                     *           "by_status": {},
+                     *           "endpoint_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RpcEndpointsArtifact"];
                     };
@@ -5894,6 +8121,94 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "disabled_proxy_contract": {
+                     *           "allowed_methods": [
+                     *             "GET"
+                     *           ],
+                     *           "denied_method_patterns": [
+                     *             "GET"
+                     *           ],
+                     *           "enabled": true,
+                     *           "feature_flag": "example",
+                     *           "rate_limit_required": true,
+                     *           "waf_required": true
+                     *         },
+                     *         "eligibility_policy": {
+                     *           "eligible_layers": [
+                     *             "example"
+                     *           ],
+                     *           "notes": "Example description.",
+                     *           "required_status": "ok",
+                     *           "requires_no_auth": false,
+                     *           "requires_public_safe": true,
+                     *           "source": "live-cron-prober",
+                     *           "user_reports_can_change_health": false
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "pools": [
+                     *           {
+                     *             "eligible_count": 1,
+                     *             "endpoint_count": 1,
+                     *             "endpoints": [
+                     *               {
+                     *                 "health_source": "probe-derived",
+                     *                 "health_stale": false,
+                     *                 "id": "example",
+                     *                 "last_ok": "2026-06-01T00:00:00.000Z",
+                     *                 "observed_at": "2026-06-01T00:00:00.000Z",
+                     *                 "pool_eligible": false,
+                     *                 "provider": "example-provider",
+                     *                 "score": 100,
+                     *                 "status": "ok",
+                     *                 "url": "https://api.metagraph.sh/example"
+                     *               }
+                     *             ],
+                     *             "id": "example",
+                     *             "kind": "example"
+                     *           }
+                     *         ],
+                     *         "provider_scores": [
+                     *           {
+                     *             "average_score": 100,
+                     *             "degraded_count": 1,
+                     *             "endpoint_count": 1,
+                     *             "failed_count": 1,
+                     *             "monitored_count": 1,
+                     *             "ok_count": 1,
+                     *             "operational_score": 100,
+                     *             "pool_eligible_count": 1,
+                     *             "provider": "example-provider"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RpcPoolsArtifact"];
                     };
@@ -5962,6 +8277,45 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "schemas": [
+                     *           {
+                     *             "drift_status": "changed",
+                     *             "schema_url": "https://api.metagraph.sh/example",
+                     *             "status": "captured",
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SchemaIndexArtifact"];
                     };
@@ -6036,6 +8390,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "document_count": 1,
+                     *         "documents": [
+                     *           {
+                     *             "artifact_path": "example",
+                     *             "id": "example",
+                     *             "title": "Example Subnet",
+                     *             "tokens": [
+                     *               "example"
+                     *             ],
+                     *             "type": "subnet"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SearchArtifact"];
                     };
@@ -6104,6 +8500,59 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "providers": [
+                     *           {
+                     *             "authority": "official",
+                     *             "candidate_count": 1,
+                     *             "classifications": {},
+                     *             "endpoint_count": 1,
+                     *             "id": "example",
+                     *             "kind": "subnet-team",
+                     *             "name": "Example Subnet",
+                     *             "rpc_endpoint_count": 1,
+                     *             "status": "ok",
+                     *             "verification_result_count": 1
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "source": "generated-provider-and-verification-summary",
+                     *         "summary": {
+                     *           "candidate_count": 1,
+                     *           "endpoint_count": 1,
+                     *           "provider_count": 1,
+                     *           "rpc_endpoint_count": 1,
+                     *           "status_counts": {},
+                     *           "verification_result_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SourceHealthArtifact"];
                     };
@@ -6178,6 +8627,54 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "sources": [
+                     *           {
+                     *             "captured_at": "2026-06-01T00:00:00.000Z",
+                     *             "hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *             "id": "example",
+                     *             "kind": "adapter-snapshot",
+                     *             "path": "example",
+                     *             "record_count": 1
+                     *           }
+                     *         ],
+                     *         "summary": {
+                     *           "adapter_snapshot_count": 1,
+                     *           "candidate_count": 1,
+                     *           "overlay_count": 1,
+                     *           "provider_count": 1,
+                     *           "source_count": 1,
+                     *           "verification_result_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SourceSnapshotsArtifact"];
                     };
@@ -6258,6 +8755,57 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "network": "finney",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "source": {
+                     *           "identity_storage": "example",
+                     *           "kind": "example",
+                     *           "method": "GET",
+                     *           "package": "example",
+                     *           "rpc_family": "example",
+                     *           "version": "2026-06-06.1"
+                     *         },
+                     *         "subnets": [
+                     *           {
+                     *             "coverage_level": "native-only",
+                     *             "curation_level": "native",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "slug": "example-subnet",
+                     *             "status": "active",
+                     *             "subnet_type": "root",
+                     *             "surface_count": 1
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetsArtifact"];
                     };
@@ -6328,6 +8876,185 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidate_surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "candidates": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "gaps": {
+                     *           "gap_notes": [
+                     *             "example"
+                     *           ],
+                     *           "missing_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_kinds": [
+                     *             "archive"
+                     *           ]
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "subnet": {
+                     *           "block": 5000000,
+                     *           "candidate_count": 1,
+                     *           "categories": [
+                     *             "example"
+                     *           ],
+                     *           "coverage_level": "native-only",
+                     *           "curation": {
+                     *             "level": "native",
+                     *             "review_state": "unreviewed"
+                     *           },
+                     *           "curation_level": "native",
+                     *           "dashboard_url": "https://api.metagraph.sh/example",
+                     *           "derived_categories": [
+                     *             "example"
+                     *           ],
+                     *           "description": "Example description.",
+                     *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "gap_count": 1,
+                     *           "gaps": {
+                     *             "gap_notes": [
+                     *               "example"
+                     *             ],
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "supported_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           },
+                     *           "lifecycle": "active",
+                     *           "links": [
+                     *             {}
+                     *           ],
+                     *           "logo_url": "https://api.metagraph.sh/example",
+                     *           "mechanism_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "native_name": "example",
+                     *           "native_name_quality": "chain",
+                     *           "native_slug": "example-subnet",
+                     *           "netuid": 7,
+                     *           "notes": "Example description.",
+                     *           "participant_count": 1,
+                     *           "probed_surface_count": 1,
+                     *           "provenance": {},
+                     *           "registered_at_block": 5000000,
+                     *           "slug": "example-subnet",
+                     *           "source_repo": "https://api.metagraph.sh/example",
+                     *           "status": "active",
+                     *           "subnet_type": "root",
+                     *           "surface_count": 1,
+                     *           "symbol": "example",
+                     *           "tempo": 1,
+                     *           "website_url": "https://api.metagraph.sh/example"
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "verified_surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetDetailArtifact"];
                     };
@@ -6406,6 +9133,51 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidates": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetCandidatesArtifact"];
                     };
@@ -6487,6 +9259,78 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet",
+                     *         "summary": {
+                     *           "by_kind": {},
+                     *           "by_layer": {},
+                     *           "by_provider": {},
+                     *           "by_publication_state": {},
+                     *           "by_status": {},
+                     *           "endpoint_count": 1,
+                     *           "monitored_count": 1,
+                     *           "pool_eligible_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEndpointsArtifact"];
                     };
@@ -6563,6 +9407,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "claims": [
+                     *           {
+                     *             "claim": "example",
+                     *             "confidence": "low",
+                     *             "limits": "example",
+                     *             "source_tier": "native-chain",
+                     *             "source_type": "example",
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "subject": "example",
+                     *             "support_summary": "Example description."
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEvidenceArtifact"];
                     };
@@ -6640,6 +9526,128 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "enrichment_queue": [
+                     *           {
+                     *             "adapter_score": 100,
+                     *             "candidate_count": 1,
+                     *             "candidate_evidence_summary": {
+                     *               "candidate_count": 1,
+                     *               "kinds_with_candidates": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_or_redirected_count": 1,
+                     *               "reviewable_count": 1,
+                     *               "stale_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_or_failed_count": 1,
+                     *               "unverified_count": 1,
+                     *               "unverified_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "completeness_score": 100,
+                     *             "contribution_hint": "example",
+                     *             "curation_level": "native",
+                     *             "direct_submission_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "endpoint_count": 1,
+                     *             "evidence_action": "submit-new-evidence",
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "lane": "direct-submission",
+                     *             "manual_review_required": true,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "operational_interface_count": 1,
+                     *             "priority_score": 100,
+                     *             "profile_level": "directory-only",
+                     *             "reason_codes": [
+                     *               "example"
+                     *             ],
+                     *             "recommended_action": "2026-06-01T00:00:00.000Z",
+                     *             "review_state": "unreviewed",
+                     *             "sample_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_live_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_stale_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_target_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "slug": "example-subnet",
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ],
+                     *             "stale_candidate_count": 1,
+                     *             "surface_count": 1,
+                     *             "verified_candidate_count": 1
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "priorities": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "curation_level": "native",
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "review_state": "unreviewed",
+                     *             "slug": "example-subnet",
+                     *             "suggested_next_action": "example",
+                     *             "surface_count": 1,
+                     *             "verified_candidate_count": 1
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetGapsArtifact"];
                     };
@@ -6719,6 +9727,63 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "health_source": "probe-derived",
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet",
+                     *         "summary": {
+                     *           "avg_latency_ms": 120,
+                     *           "degraded_count": 1,
+                     *           "failed_count": 1,
+                     *           "last_checked": "2026-06-01T00:00:00.000Z",
+                     *           "last_ok": "2026-06-01T00:00:00.000Z",
+                     *           "name": "Example Subnet",
+                     *           "netuid": 7,
+                     *           "ok_count": 1,
+                     *           "slug": "example-subnet",
+                     *           "status": "ok",
+                     *           "surface_count": 1,
+                     *           "unknown_count": 1
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "classification": "live",
+                     *             "netuid": 7,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthSubnetArtifact"];
                     };
@@ -6791,6 +9856,54 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "surfaces": [
+                     *           {
+                     *             "downtime_ms": 1,
+                     *             "incident_count": 1,
+                     *             "incidents": [
+                     *               {
+                     *                 "duration_ms": 1,
+                     *                 "ended_at": 1,
+                     *                 "failed_samples": 1,
+                     *                 "started_at": 1
+                     *               }
+                     *             ],
+                     *             "samples": 1,
+                     *             "surface_id": "example",
+                     *             "uptime_ratio": 0.9966
+                     *           }
+                     *         ],
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthIncidentsArtifact"];
                     };
@@ -6863,6 +9976,44 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "surfaces": [
+                     *           {
+                     *             "latency_ms": {},
+                     *             "samples": 1,
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthPercentilesArtifact"];
                     };
@@ -6933,6 +10084,50 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "windows": {
+                     *           "example": {
+                     *             "samples": 1,
+                     *             "surfaces": [
+                     *               {
+                     *                 "avg_latency_ms": 120,
+                     *                 "samples": 1,
+                     *                 "surface_id": "example",
+                     *                 "uptime_ratio": 0.9966
+                     *               }
+                     *             ],
+                     *             "uptime_ratio": 0.9966
+                     *           }
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthTrendsArtifact"];
                     };
@@ -7003,6 +10198,224 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "counts": {
+                     *           "candidates": 1,
+                     *           "endpoints": 1,
+                     *           "surfaces": 1
+                     *         },
+                     *         "curation": {
+                     *           "gap_notes": [
+                     *             "example"
+                     *           ],
+                     *           "level": "native",
+                     *           "review_state": "unreviewed",
+                     *           "reviewed_at": "2026-06-01T00:00:00.000Z",
+                     *           "source_count": 1,
+                     *           "verified_at": "2026-06-01T00:00:00.000Z"
+                     *         },
+                     *         "gap_priorities": [
+                     *           null
+                     *         ],
+                     *         "gaps": {
+                     *           "gap_notes": [
+                     *             "example"
+                     *           ],
+                     *           "missing_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_kinds": [
+                     *             "archive"
+                     *           ]
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "health": {
+                     *           "avg_latency_ms": 120,
+                     *           "degraded_count": 1,
+                     *           "failed_count": 1,
+                     *           "last_checked": "2026-06-01T00:00:00.000Z",
+                     *           "last_ok": "2026-06-01T00:00:00.000Z",
+                     *           "netuid": 7,
+                     *           "observed_by": "2026-06-01T00:00:00.000Z",
+                     *           "ok_count": 1,
+                     *           "status": "ok",
+                     *           "surface_count": 1,
+                     *           "unknown_count": 1
+                     *         },
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "profile": {
+                     *           "candidate_count": 1,
+                     *           "categories": [
+                     *             "example"
+                     *           ],
+                     *           "completeness": {
+                     *             "confidence": "low",
+                     *             "gap_reasons": [
+                     *               "example"
+                     *             ],
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "missing_critical_count": 1,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_operational": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_required": [
+                     *               "archive"
+                     *             ],
+                     *             "profile_level": "directory-only",
+                     *             "score": 100
+                     *           },
+                     *           "completeness_score": 100,
+                     *           "confidence": "low",
+                     *           "curation_level": "native",
+                     *           "derived_categories": [
+                     *             "example"
+                     *           ],
+                     *           "derived_description": "Example description.",
+                     *           "endpoint_count": 1,
+                     *           "gap_reasons": [
+                     *             "example"
+                     *           ],
+                     *           "identity_evidence": {
+                     *             "candidate_identity_count": 1,
+                     *             "curated_identity_count": 1,
+                     *             "curated_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "live_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "native_contact_present": false,
+                     *             "native_description_present": false,
+                     *             "native_identity_count": 1,
+                     *             "native_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "needs_promotion_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "stale_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "unverified_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           },
+                     *           "identity_level": "none",
+                     *           "identity_surface_count": 1,
+                     *           "injection_scrubbed": false,
+                     *           "integration_readiness": 1,
+                     *           "interface_count": 1,
+                     *           "lineage": {},
+                     *           "missing_critical_count": 1,
+                     *           "missing_identity": [
+                     *             "archive"
+                     *           ],
+                     *           "missing_operational": [
+                     *             "archive"
+                     *           ],
+                     *           "missing_required": [
+                     *             "archive"
+                     *           ],
+                     *           "monitored_endpoint_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "native_identity": {
+                     *             "additional": "example",
+                     *             "contact_present": false,
+                     *             "description": "Example description.",
+                     *             "discord": "example",
+                     *             "discord_url": "https://api.metagraph.sh/example",
+                     *             "github_url": "https://api.metagraph.sh/example",
+                     *             "logo_url": "https://api.metagraph.sh/example",
+                     *             "source": "live-cron-prober",
+                     *             "subnet_name": "Example Subnet",
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "native_name": "example",
+                     *           "native_name_quality": "chain",
+                     *           "netuid": 7,
+                     *           "operational_interface_count": 1,
+                     *           "operational_interface_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "primary_app_surface": {
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "provider": "example-provider",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "primary_links": {
+                     *             "dashboard_url": "https://api.metagraph.sh/example",
+                     *             "docs_url": "https://api.metagraph.sh/example",
+                     *             "source_repo": "https://api.metagraph.sh/example",
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "profile_level": "directory-only",
+                     *           "project_name": "example",
+                     *           "provenance": {
+                     *             "curation_level": "native",
+                     *             "identity_source": "live-cron-prober",
+                     *             "interface_source_count": 1,
+                     *             "review_state": "unreviewed",
+                     *             "reviewed_at": "2026-06-01T00:00:00.000Z",
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ]
+                     *           },
+                     *           "readiness": {
+                     *             "components": {},
+                     *             "readiness_version": 1,
+                     *             "score": 100
+                     *           },
+                     *           "review_state": "unreviewed",
+                     *           "slug": "example-subnet",
+                     *           "status": "active",
+                     *           "subnet_type": "root",
+                     *           "suggested_submission_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_interface_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "surface_count": 1,
+                     *           "symbol": "example",
+                     *           "team": "example"
+                     *         },
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet",
+                     *         "status": "ok"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetOverviewArtifact"];
                     };
@@ -7073,6 +10486,300 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidate_surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "gaps": {
+                     *           "gap_notes": [
+                     *             "example"
+                     *           ],
+                     *           "missing_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_kinds": [
+                     *             "archive"
+                     *           ]
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "profile": {
+                     *           "candidate_count": 1,
+                     *           "categories": [
+                     *             "example"
+                     *           ],
+                     *           "completeness": {
+                     *             "confidence": "low",
+                     *             "gap_reasons": [
+                     *               "example"
+                     *             ],
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "missing_critical_count": 1,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_operational": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_required": [
+                     *               "archive"
+                     *             ],
+                     *             "profile_level": "directory-only",
+                     *             "score": 100
+                     *           },
+                     *           "completeness_score": 100,
+                     *           "confidence": "low",
+                     *           "curation_level": "native",
+                     *           "derived_categories": [
+                     *             "example"
+                     *           ],
+                     *           "derived_description": "Example description.",
+                     *           "endpoint_count": 1,
+                     *           "gap_reasons": [
+                     *             "example"
+                     *           ],
+                     *           "identity_evidence": {
+                     *             "candidate_identity_count": 1,
+                     *             "curated_identity_count": 1,
+                     *             "curated_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "live_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "native_contact_present": false,
+                     *             "native_description_present": false,
+                     *             "native_identity_count": 1,
+                     *             "native_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "needs_promotion_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "stale_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "unverified_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           },
+                     *           "identity_level": "none",
+                     *           "identity_surface_count": 1,
+                     *           "injection_scrubbed": false,
+                     *           "integration_readiness": 1,
+                     *           "interface_count": 1,
+                     *           "lineage": {},
+                     *           "missing_critical_count": 1,
+                     *           "missing_identity": [
+                     *             "archive"
+                     *           ],
+                     *           "missing_operational": [
+                     *             "archive"
+                     *           ],
+                     *           "missing_required": [
+                     *             "archive"
+                     *           ],
+                     *           "monitored_endpoint_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "native_identity": {
+                     *             "additional": "example",
+                     *             "contact_present": false,
+                     *             "description": "Example description.",
+                     *             "discord": "example",
+                     *             "discord_url": "https://api.metagraph.sh/example",
+                     *             "github_url": "https://api.metagraph.sh/example",
+                     *             "logo_url": "https://api.metagraph.sh/example",
+                     *             "source": "live-cron-prober",
+                     *             "subnet_name": "Example Subnet",
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "native_name": "example",
+                     *           "native_name_quality": "chain",
+                     *           "netuid": 7,
+                     *           "operational_interface_count": 1,
+                     *           "operational_interface_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "primary_app_surface": {
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "provider": "example-provider",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "primary_links": {
+                     *             "dashboard_url": "https://api.metagraph.sh/example",
+                     *             "docs_url": "https://api.metagraph.sh/example",
+                     *             "source_repo": "https://api.metagraph.sh/example",
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "profile_level": "directory-only",
+                     *           "project_name": "example",
+                     *           "provenance": {
+                     *             "curation_level": "native",
+                     *             "identity_source": "live-cron-prober",
+                     *             "interface_source_count": 1,
+                     *             "review_state": "unreviewed",
+                     *             "reviewed_at": "2026-06-01T00:00:00.000Z",
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ]
+                     *           },
+                     *           "readiness": {
+                     *             "components": {},
+                     *             "readiness_version": 1,
+                     *             "score": 100
+                     *           },
+                     *           "review_state": "unreviewed",
+                     *           "slug": "example-subnet",
+                     *           "status": "active",
+                     *           "subnet_type": "root",
+                     *           "suggested_submission_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_interface_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "surface_count": 1,
+                     *           "symbol": "example",
+                     *           "team": "example"
+                     *         },
+                     *         "schema_version": 1,
+                     *         "subnet": {
+                     *           "block": 5000000,
+                     *           "candidate_count": 1,
+                     *           "categories": [
+                     *             "example"
+                     *           ],
+                     *           "coverage_level": "native-only",
+                     *           "curation": {
+                     *             "level": "native",
+                     *             "review_state": "unreviewed"
+                     *           },
+                     *           "curation_level": "native",
+                     *           "dashboard_url": "https://api.metagraph.sh/example",
+                     *           "derived_categories": [
+                     *             "example"
+                     *           ],
+                     *           "description": "Example description.",
+                     *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "gap_count": 1,
+                     *           "gaps": {
+                     *             "gap_notes": [
+                     *               "example"
+                     *             ],
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "supported_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           },
+                     *           "lifecycle": "active",
+                     *           "links": [
+                     *             {}
+                     *           ],
+                     *           "logo_url": "https://api.metagraph.sh/example",
+                     *           "mechanism_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "native_name": "example",
+                     *           "native_name_quality": "chain",
+                     *           "native_slug": "example-subnet",
+                     *           "netuid": 7,
+                     *           "notes": "Example description.",
+                     *           "participant_count": 1,
+                     *           "probed_surface_count": 1,
+                     *           "provenance": {},
+                     *           "registered_at_block": 5000000,
+                     *           "slug": "example-subnet",
+                     *           "source_repo": "https://api.metagraph.sh/example",
+                     *           "status": "active",
+                     *           "subnet_type": "root",
+                     *           "surface_count": 1,
+                     *           "symbol": "example",
+                     *           "tempo": 1,
+                     *           "website_url": "https://api.metagraph.sh/example"
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetProfileArtifact"];
                     };
@@ -7150,6 +10857,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetSurfacesArtifact"];
                     };
@@ -7220,6 +10969,43 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "deltas": {
+                     *           "example": {}
+                     *         },
+                     *         "netuid": 7,
+                     *         "point_count": 1,
+                     *         "points": [
+                     *           {
+                     *             "date": "2026-06-01"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetTrajectoryArtifact"];
                     };
@@ -7292,6 +11078,63 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "netuid": 7,
+                     *         "reliability": {
+                     *           "avg_latency_ms": 120,
+                     *           "computed_at": "2026-06-01T00:00:00.000Z",
+                     *           "day_count": 1,
+                     *           "grade": "A",
+                     *           "sample_count": 1,
+                     *           "score": 100,
+                     *           "surface_count": 1,
+                     *           "uptime_ratio": 0.9966,
+                     *           "window": "30d"
+                     *         },
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "surfaces": [
+                     *           {
+                     *             "day_count": 1,
+                     *             "days": [
+                     *               {
+                     *                 "day": "2026-06-01",
+                     *                 "samples": 1,
+                     *                 "status": "ok",
+                     *                 "uptime_ratio": 0.9966
+                     *               }
+                     *             ],
+                     *             "samples": 1,
+                     *             "surface_id": "example",
+                     *             "uptime_ratio": 0.9966
+                     *           }
+                     *         ],
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["UptimeArtifact"];
                     };
@@ -7368,6 +11211,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SurfacesArtifact"];
                     };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -9117,6 +9117,73 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "artifact_contracts": [
+                      {
+                        "contract_version": "2026-06-06.1",
+                        "id": "example",
+                        "path": "/metagraph/example.json",
+                        "schema_ref": "#/components/schemas/Example",
+                        "storage_tier": "dual"
+                      }
+                    ],
+                    "base_path": "/api/v1",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "openapi_url": "/api/v1/openapi.json",
+                    "primary_domain": "api.metagraph.sh",
+                    "response_envelope": {
+                      "error_schema_ref": "#/components/schemas/ErrorEnvelope",
+                      "fields": [
+                        "ok"
+                      ],
+                      "notes": "Example description.",
+                      "schema_version": 1,
+                      "success_schema_ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    "routes": [
+                      {
+                        "artifact_path": "/metagraph/example.json",
+                        "cache": "short",
+                        "description": "Example description.",
+                        "id": "example",
+                        "method": "GET",
+                        "path": "/api/v1/example",
+                        "public": true,
+                        "query_parameters": [
+                          {
+                            "name": "Example Subnet",
+                            "schema": {}
+                          }
+                        ]
+                      }
+                    ],
+                    "schema_version": 1,
+                    "type_definitions_url": "/metagraph/types.d.ts"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -9215,6 +9282,41 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "extensions": {
+                      "example": {}
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "netuid": 7,
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "slug": "example-subnet",
+                    "snapshot": {},
+                    "subnet": "example"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -9303,6 +9405,43 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "callable_service_count": 1,
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "subnet_count": 1,
+                    "subnets": [
+                      {
+                        "netuid": 7,
+                        "service_count": 1
+                      }
+                    ],
+                    "total_subnet_count": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -9402,6 +9541,56 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "categories": [
+                      "example"
+                    ],
+                    "completeness_score": 100,
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "integration_readiness": 1,
+                    "name": "Example Subnet",
+                    "netuid": 7,
+                    "notes": "Example description.",
+                    "readiness": {
+                      "components": {},
+                      "readiness_version": 1,
+                      "score": 100
+                    },
+                    "schema_version": 1,
+                    "service_count": 1,
+                    "services": [
+                      {
+                        "base_url": "https://api.metagraph.sh/example",
+                        "kind": "example",
+                        "surface_id": "example"
+                      }
+                    ],
+                    "slug": "example-subnet",
+                    "subnet_type": "example"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -9491,6 +9680,63 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                    "contract_version": "2026-06-06.1",
+                    "copyable_agent": {
+                      "description": "Example description.",
+                      "title": "Example Subnet",
+                      "url": "https://api.metagraph.sh/example"
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "mcp": {
+                      "endpoint": "https://api.metagraph.sh/example",
+                      "install": "example",
+                      "server_card": "https://api.metagraph.sh/example",
+                      "tools": [
+                        {
+                          "name": "Example Subnet"
+                        }
+                      ],
+                      "transport": "example"
+                    },
+                    "notes": "Example description.",
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "resources": [
+                      {
+                        "id": "example",
+                        "title": "Example Subnet",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "schema_version": 1,
+                    "summary": {
+                      "callable_service_count": 1,
+                      "subnet_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -9579,6 +9825,50 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "artifact_budgets": [
+                      {
+                        "fail_bytes": 1,
+                        "path": "example",
+                        "size_bytes": 1,
+                        "status": "ok",
+                        "warn_bytes": 1
+                      }
+                    ],
+                    "artifact_count": 1,
+                    "artifact_size_bytes": 1,
+                    "candidate_count": 1,
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "provider_count": 1,
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "subnet_count": 1,
+                    "surface_count": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -9772,6 +10062,49 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "candidates": [
+                      {
+                        "auth_required": true,
+                        "id": "example",
+                        "kind": "archive",
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "schema_version": 1,
+                        "source_url": "https://api.metagraph.sh/example",
+                        "state": "schema-invalid",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -9860,6 +10193,66 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "artifacts": {
+                      "added": [
+                        "example"
+                      ],
+                      "modified": [
+                        "example"
+                      ],
+                      "removed": [
+                        "example"
+                      ]
+                    },
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "source": "generated-artifact-diff",
+                    "subnets": {
+                      "added": [
+                        1
+                      ],
+                      "removed": [
+                        1
+                      ],
+                      "renamed": [
+                        {}
+                      ]
+                    },
+                    "summary": {
+                      "artifact_added_count": 1,
+                      "artifact_modified_count": 1,
+                      "artifact_removed_count": 1,
+                      "coverage_delta": {},
+                      "netuid_added_count": 7,
+                      "netuid_removed_count": 7,
+                      "netuid_renamed_count": 7
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -9948,6 +10341,49 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "artifacts": [
+                      {
+                        "contract_version": "2026-06-06.1",
+                        "id": "example",
+                        "path": "/metagraph/example.json",
+                        "schema_ref": "#/components/schemas/Example",
+                        "storage_tier": "dual"
+                      }
+                    ],
+                    "base_path": "/metagraph",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "name": "Example Subnet",
+                    "notes": "Example description.",
+                    "openapi_url": "/metagraph/openapi.json",
+                    "primary_domain": "api.metagraph.sh",
+                    "schema_version": 1,
+                    "status_domain": null,
+                    "type_definitions_url": "/metagraph/types.d.ts"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -10036,6 +10472,67 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "application_subnet_count": 1,
+                    "candidate_count": 1,
+                    "candidate_subnet_count": 1,
+                    "chain_subnet_count": 1,
+                    "completeness": {
+                      "average_score": 100,
+                      "dimension_coverage": {},
+                      "fully_complete_count": 1,
+                      "fully_complete_pct": 1,
+                      "median_score": 100,
+                      "methodology": "GET",
+                      "score_distribution": {},
+                      "scored_subnet_count": 1
+                    },
+                    "contract_version": "2026-06-06.1",
+                    "curated_overlay_count": 1,
+                    "curation_level_counts": {
+                      "example": 1
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "manifested_count": 1,
+                    "native_only_count": 1,
+                    "native_only_with_candidates": 1,
+                    "native_only_without_candidates": 1,
+                    "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+                    "network": "finney",
+                    "notes": "Example description.",
+                    "probed_count": 1,
+                    "probed_surface_count": 1,
+                    "root_subnet_count": 1,
+                    "schema_version": 1,
+                    "source": {
+                      "candidates": "example",
+                      "native": "example",
+                      "overlays": "example"
+                    },
+                    "surface_count": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -10191,6 +10688,59 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "curation": [
+                      {
+                        "candidate_count": 1,
+                        "coverage_level": "native-only",
+                        "curation": {
+                          "level": "native",
+                          "review_state": "unreviewed"
+                        },
+                        "gaps": {
+                          "gap_notes": [
+                            "example"
+                          ],
+                          "missing_kinds": [
+                            "archive"
+                          ],
+                          "supported_kinds": [
+                            "archive"
+                          ]
+                        },
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "slug": "example-subnet",
+                        "surface_count": 1
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -10409,6 +10959,69 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "incidents": [
+                      {
+                        "classification": "live",
+                        "detected_at": "2026-06-01T00:00:00.000Z",
+                        "endpoint_id": "https://api.metagraph.sh/example",
+                        "health_source": "probe-derived",
+                        "health_stale": false,
+                        "id": "example",
+                        "kind": "archive",
+                        "last_checked": "2026-06-01T00:00:00.000Z",
+                        "last_ok": "2026-06-01T00:00:00.000Z",
+                        "layer": "bittensor-base",
+                        "netuid": 7,
+                        "observed_at": "2026-06-01T00:00:00.000Z",
+                        "operator": "example-provider",
+                        "pool_eligible": false,
+                        "provider": "example-provider",
+                        "reason": "example",
+                        "severity": "critical",
+                        "source": "probe-derived",
+                        "state": "active",
+                        "status": "ok",
+                        "surface_id": "example",
+                        "user_reported": false
+                      }
+                    ],
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "summary": {
+                      "active_count": 1,
+                      "by_kind": {},
+                      "by_layer": {},
+                      "by_provider": {},
+                      "by_severity": {},
+                      "by_status": {},
+                      "incident_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -10564,6 +11177,92 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "disabled_proxy_contract": {
+                      "allowed_methods": [
+                        "GET"
+                      ],
+                      "denied_method_patterns": [
+                        "GET"
+                      ],
+                      "enabled": true,
+                      "feature_flag": "example",
+                      "rate_limit_required": true,
+                      "waf_required": true
+                    },
+                    "eligibility_policy": {
+                      "eligible_layers": [
+                        "example"
+                      ],
+                      "notes": "Example description.",
+                      "required_status": "ok",
+                      "requires_no_auth": false,
+                      "requires_public_safe": true,
+                      "source": "live-cron-prober",
+                      "user_reports_can_change_health": false
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "pools": [
+                      {
+                        "eligible_count": 1,
+                        "endpoint_count": 1,
+                        "endpoints": [
+                          {
+                            "health_source": "probe-derived",
+                            "health_stale": false,
+                            "id": "example",
+                            "last_ok": "2026-06-01T00:00:00.000Z",
+                            "observed_at": "2026-06-01T00:00:00.000Z",
+                            "pool_eligible": false,
+                            "provider": "example-provider",
+                            "score": 100,
+                            "status": "ok",
+                            "url": "https://api.metagraph.sh/example"
+                          }
+                        ],
+                        "id": "example",
+                        "kind": "example"
+                      }
+                    ],
+                    "provider_scores": [
+                      {
+                        "average_score": 100,
+                        "degraded_count": 1,
+                        "endpoint_count": 1,
+                        "failed_count": 1,
+                        "monitored_count": 1,
+                        "ok_count": 1,
+                        "operational_score": 100,
+                        "pool_eligible_count": 1,
+                        "provider": "example-provider"
+                      }
+                    ],
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -10800,6 +11499,73 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "endpoints": [
+                      {
+                        "auth_required": true,
+                        "health_source": "probe-derived",
+                        "health_stale": false,
+                        "id": "example",
+                        "kind": "archive",
+                        "last_ok": "2026-06-01T00:00:00.000Z",
+                        "layer": "bittensor-base",
+                        "monitoring_policy": {
+                          "enabled": true,
+                          "expect": "example",
+                          "method": "GET",
+                          "source": "live-cron-prober"
+                        },
+                        "monitoring_status": "monitored",
+                        "netuid": 7,
+                        "observed_at": "2026-06-01T00:00:00.000Z",
+                        "operator": "example-provider",
+                        "pool_eligible": false,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "publication_state": "candidate",
+                        "score": 100,
+                        "status": "ok",
+                        "surface_id": "example",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "summary": {
+                      "by_kind": {},
+                      "by_layer": {},
+                      "by_provider": {},
+                      "by_publication_state": {},
+                      "by_status": {},
+                      "endpoint_count": 1,
+                      "monitored_count": 1,
+                      "pool_eligible_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -10941,6 +11707,46 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "claims": [
+                      {
+                        "claim": "example",
+                        "confidence": "low",
+                        "limits": "example",
+                        "source_tier": "native-chain",
+                        "source_type": "example",
+                        "source_url": "https://api.metagraph.sh/example",
+                        "subject": "example",
+                        "support_summary": "Example description."
+                      }
+                    ],
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -11029,6 +11835,42 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "fixture_count": 1,
+                    "fixtures": [
+                      {
+                        "netuid": 7,
+                        "surface_id": "example"
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -11118,6 +11960,68 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "sources": [
+                      {
+                        "as_of": "example",
+                        "id": "example",
+                        "lane": "adapter-snapshot",
+                        "path": "example",
+                        "required_for_publish": true,
+                        "stale_after_hours": 1,
+                        "stale_behavior": "block",
+                        "status": "captured",
+                        "timestamp": "example",
+                        "timestamp_field": "example"
+                      }
+                    ],
+                    "summary": {
+                      "adapter_count": 1,
+                      "adapter_snapshot_as_of": "example",
+                      "blocking_source_count": 5000000,
+                      "candidate_discovery_as_of": "example",
+                      "health_probe_as_of": "example",
+                      "health_surface_count": 1,
+                      "missing_blocking_source_count": 5000000,
+                      "native_data_as_of": "example",
+                      "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+                      "openapi_surface_count": 1,
+                      "publish_ready_without_age_check": false,
+                      "schema_snapshot_as_of": "example",
+                      "stale_window_warnings": [
+                        "30d"
+                      ],
+                      "verification_as_of": "example",
+                      "verification_generated_at": "2026-06-01T00:00:00.000Z",
+                      "warning_source_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -11289,6 +12193,54 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "gaps": [
+                      {
+                        "coverage_level": "native-only",
+                        "curation_level": "native",
+                        "gaps": {
+                          "gap_notes": [
+                            "example"
+                          ],
+                          "missing_kinds": [
+                            "archive"
+                          ],
+                          "supported_kinds": [
+                            "archive"
+                          ]
+                        },
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "slug": "example-subnet"
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -11452,6 +12404,48 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "global": {},
+                    "health_source": "probe-derived",
+                    "operational_observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "scope": "example",
+                    "source": "live-cron-prober",
+                    "subnets": [
+                      {
+                        "degraded_count": 1,
+                        "failed_count": 1,
+                        "ok_count": 1,
+                        "status": "ok",
+                        "surface_count": 1,
+                        "unknown_count": 1
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -11676,6 +12670,53 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "date": "2026-06-01",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "probe_finished_at": "2026-06-01T00:00:00.000Z",
+                    "probe_started_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source": "live-cron-prober",
+                    "summary": {
+                      "classification_counts": {},
+                      "status_counts": {},
+                      "surface_count": 1
+                    },
+                    "surfaces": [
+                      {
+                        "classification": "live",
+                        "kind": "archive",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "status": "ok",
+                        "surface_id": "example"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -11777,6 +12818,52 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source": "live-cron-prober",
+                    "summary": {
+                      "affected_surface_count": 1,
+                      "incident_count": 1
+                    },
+                    "surfaces": [
+                      {
+                        "incident_count": 1,
+                        "incidents": [
+                          {
+                            "duration_ms": 1,
+                            "ended_at": 1,
+                            "started_at": 1
+                          }
+                        ],
+                        "netuid": 7,
+                        "surface_id": "example"
+                      }
+                    ],
+                    "window": "30d"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -11866,6 +12953,50 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "graduated_subnet_count": 1,
+                    "link_count": 1,
+                    "links": [
+                      {
+                        "mainnet_netuid": 7,
+                        "matched_by": "github_repo",
+                        "testnet_netuid": 7
+                      }
+                    ],
+                    "matched_by_counts": {
+                      "example": 1
+                    },
+                    "notes": "Example description.",
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source_network": "example",
+                    "target_network": "example",
+                    "testnet_only_count": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -11955,6 +13086,38 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "components": {},
+                    "info": {},
+                    "openapi": "3.1.0",
+                    "paths": {},
+                    "servers": [
+                      {}
+                    ],
+                    "x-metagraphed": {}
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -12174,6 +13337,174 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "profiles": [
+                      {
+                        "candidate_count": 1,
+                        "categories": [
+                          "example"
+                        ],
+                        "completeness": {
+                          "confidence": "low",
+                          "gap_reasons": [
+                            "example"
+                          ],
+                          "identity_level": "none",
+                          "identity_surface_count": 1,
+                          "missing_critical_count": 1,
+                          "missing_identity": [
+                            "archive"
+                          ],
+                          "missing_operational": [
+                            "archive"
+                          ],
+                          "missing_required": [
+                            "archive"
+                          ],
+                          "profile_level": "directory-only",
+                          "score": 100
+                        },
+                        "completeness_score": 100,
+                        "confidence": "low",
+                        "curation_level": "native",
+                        "derived_categories": [
+                          "example"
+                        ],
+                        "endpoint_count": 1,
+                        "gap_reasons": [
+                          "example"
+                        ],
+                        "identity_evidence": {
+                          "candidate_identity_count": 1,
+                          "curated_identity_count": 1,
+                          "curated_identity_kinds": [
+                            "archive"
+                          ],
+                          "live_candidate_identity_kinds": [
+                            "archive"
+                          ],
+                          "native_contact_present": false,
+                          "native_description_present": false,
+                          "native_identity_count": 1,
+                          "native_identity_kinds": [
+                            "archive"
+                          ],
+                          "needs_promotion_kinds": [
+                            "archive"
+                          ],
+                          "stale_candidate_identity_kinds": [
+                            "archive"
+                          ],
+                          "unverified_candidate_identity_kinds": [
+                            "archive"
+                          ]
+                        },
+                        "identity_level": "none",
+                        "identity_surface_count": 1,
+                        "missing_critical_count": 1,
+                        "missing_identity": [
+                          "archive"
+                        ],
+                        "missing_operational": [
+                          "archive"
+                        ],
+                        "missing_required": [
+                          "archive"
+                        ],
+                        "monitored_endpoint_count": 1,
+                        "name": "Example Subnet",
+                        "native_identity": {
+                          "additional": "example",
+                          "contact_present": false,
+                          "description": "Example description.",
+                          "discord": "example",
+                          "discord_url": "https://api.metagraph.sh/example",
+                          "github_url": "https://api.metagraph.sh/example",
+                          "logo_url": "https://api.metagraph.sh/example",
+                          "source": "live-cron-prober",
+                          "subnet_name": "Example Subnet",
+                          "website_url": "https://api.metagraph.sh/example"
+                        },
+                        "netuid": 7,
+                        "operational_interface_kinds": [
+                          "archive"
+                        ],
+                        "primary_app_surface": {
+                          "id": "example",
+                          "kind": "archive",
+                          "name": "Example Subnet",
+                          "provider": "example-provider",
+                          "url": "https://api.metagraph.sh/example"
+                        },
+                        "primary_links": {
+                          "dashboard_url": "https://api.metagraph.sh/example",
+                          "docs_url": "https://api.metagraph.sh/example",
+                          "source_repo": "https://api.metagraph.sh/example",
+                          "website_url": "https://api.metagraph.sh/example"
+                        },
+                        "profile_level": "directory-only",
+                        "project_name": "example",
+                        "provenance": {
+                          "curation_level": "native",
+                          "identity_source": "live-cron-prober",
+                          "interface_source_count": 1,
+                          "review_state": "unreviewed",
+                          "reviewed_at": "2026-06-01T00:00:00.000Z",
+                          "source_urls": [
+                            "https://api.metagraph.sh/example"
+                          ]
+                        },
+                        "review_state": "unreviewed",
+                        "slug": "example-subnet",
+                        "status": "active",
+                        "subnet_type": "root",
+                        "suggested_submission_kinds": [
+                          "archive"
+                        ],
+                        "supported_interface_kinds": [
+                          "archive"
+                        ],
+                        "surface_count": 1,
+                        "team": "example"
+                      }
+                    ],
+                    "schema_version": 1,
+                    "summary": {
+                      "average_completeness_score": 100,
+                      "by_confidence": {},
+                      "by_identity_level": {},
+                      "by_profile_level": {},
+                      "identity_promotion_candidate_count": 1,
+                      "native_identity_count": 1,
+                      "native_identity_unpromoted_count": 1,
+                      "profile_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -12345,6 +13676,44 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "providers": [
+                      {
+                        "authority": "official",
+                        "id": "example-subnet",
+                        "kind": "subnet-team",
+                        "name": "Example Subnet",
+                        "schema_version": 1,
+                        "website_url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -12443,6 +13812,55 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "provider": {
+                      "authority": "official",
+                      "cluster_id": "example",
+                      "contact_url": "https://api.metagraph.sh/example",
+                      "docs_url": "https://api.metagraph.sh/example",
+                      "endpoint_count": 1,
+                      "github_url": "https://api.metagraph.sh/example",
+                      "id": "example-subnet",
+                      "kind": "subnet-team",
+                      "name": "Example Subnet",
+                      "netuids": [
+                        7
+                      ],
+                      "notes": "Example description.",
+                      "public_notes": "example",
+                      "schema_version": 1,
+                      "subnet_count": 1,
+                      "surface_count": 1,
+                      "team_url": "https://api.metagraph.sh/example",
+                      "website_url": "https://api.metagraph.sh/example"
+                    },
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -12680,6 +14098,79 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "endpoints": [
+                      {
+                        "auth_required": true,
+                        "health_source": "probe-derived",
+                        "health_stale": false,
+                        "id": "example",
+                        "kind": "archive",
+                        "last_ok": "2026-06-01T00:00:00.000Z",
+                        "layer": "bittensor-base",
+                        "monitoring_policy": {
+                          "enabled": true,
+                          "expect": "example",
+                          "method": "GET",
+                          "source": "live-cron-prober"
+                        },
+                        "monitoring_status": "monitored",
+                        "netuid": 7,
+                        "observed_at": "2026-06-01T00:00:00.000Z",
+                        "operator": "example-provider",
+                        "pool_eligible": false,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "publication_state": "candidate",
+                        "score": 100,
+                        "status": "ok",
+                        "surface_id": "example",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "provider": {
+                      "authority": "example",
+                      "id": "example",
+                      "kind": "example",
+                      "name": "Example Subnet"
+                    },
+                    "schema_version": 1,
+                    "summary": {
+                      "by_kind": {},
+                      "by_layer": {},
+                      "by_provider": {},
+                      "by_publication_state": {},
+                      "by_status": {},
+                      "endpoint_count": 1,
+                      "monitored_count": 1,
+                      "pool_eligible_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -12794,6 +14285,39 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "board": "example",
+                    "boards": {
+                      "example": [
+                        {}
+                      ]
+                    },
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source": "live-cron-prober"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -12883,6 +14407,55 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "counts": {
+                      "candidates": 1,
+                      "endpoints": 1,
+                      "providers": 1,
+                      "surfaces": 1
+                    },
+                    "coverage": {},
+                    "curation_level_counts": {
+                      "example": 1
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "profile_level_counts": {
+                      "example": 1
+                    },
+                    "recent_changes": {},
+                    "schema_version": 1,
+                    "subnet_count": 1,
+                    "top_subnets": [
+                      {
+                        "completeness_score": 100,
+                        "netuid": 7
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -13115,6 +14688,73 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "candidates": [
+                      {
+                        "candidate_api_count": 1,
+                        "candidate_api_ids": [
+                          "example"
+                        ],
+                        "candidate_api_kinds": [
+                          "archive"
+                        ],
+                        "curation_level": "native",
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "operational_kinds": [
+                          "archive"
+                        ],
+                        "operational_surface_count": 1,
+                        "operational_surface_ids": [
+                          "example"
+                        ],
+                        "priority_score": 100,
+                        "reason_codes": [
+                          "example"
+                        ],
+                        "recommended_adapter_kind": "custom-adapter",
+                        "slug": "example-subnet",
+                        "suggested_next_action": "example"
+                      }
+                    ],
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "summary": {
+                      "adapter_backed_count": 1,
+                      "by_curation_level": {},
+                      "by_recommended_adapter_kind": {},
+                      "candidate_api_kind_counts": {},
+                      "candidate_count": 1,
+                      "data_artifact_backed_count": 1,
+                      "openapi_backed_count": 1,
+                      "operational_kind_counts": {},
+                      "sse_backed_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -13346,6 +14986,77 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "entries": [
+                      {
+                        "candidate_evidence_by_kind": {},
+                        "candidate_evidence_summary": {
+                          "candidate_count": 1,
+                          "kinds_with_candidates": [
+                            "archive"
+                          ],
+                          "live_kinds": [
+                            "archive"
+                          ],
+                          "live_or_redirected_count": 1,
+                          "reviewable_count": 1,
+                          "stale_kinds": [
+                            "archive"
+                          ],
+                          "stale_or_failed_count": 1,
+                          "unverified_count": 1,
+                          "unverified_kinds": [
+                            "archive"
+                          ]
+                        },
+                        "direct_submission_kinds": [
+                          "archive"
+                        ],
+                        "evidence_action": "submit-new-evidence",
+                        "lane": "direct-submission",
+                        "missing_kinds": [
+                          "archive"
+                        ],
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "priority_score": 100,
+                        "slug": "example-subnet"
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "summary": {
+                      "entry_count": 1,
+                      "evidence_action_counts": {},
+                      "stale_candidate_count": 1,
+                      "subnet_count": 1,
+                      "unverified_candidate_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -13663,6 +15374,120 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "queue": [
+                      {
+                        "adapter_score": 100,
+                        "candidate_count": 1,
+                        "candidate_evidence_summary": {
+                          "candidate_count": 1,
+                          "kinds_with_candidates": [
+                            "archive"
+                          ],
+                          "live_kinds": [
+                            "archive"
+                          ],
+                          "live_or_redirected_count": 1,
+                          "reviewable_count": 1,
+                          "stale_kinds": [
+                            "archive"
+                          ],
+                          "stale_or_failed_count": 1,
+                          "unverified_count": 1,
+                          "unverified_kinds": [
+                            "archive"
+                          ]
+                        },
+                        "completeness_score": 100,
+                        "contribution_hint": "example",
+                        "curation_level": "native",
+                        "direct_submission_kinds": [
+                          "archive"
+                        ],
+                        "endpoint_count": 1,
+                        "evidence_action": "submit-new-evidence",
+                        "identity_level": "none",
+                        "identity_surface_count": 1,
+                        "lane": "direct-submission",
+                        "manual_review_required": true,
+                        "missing_identity": [
+                          "archive"
+                        ],
+                        "missing_kinds": [
+                          "archive"
+                        ],
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "operational_interface_count": 1,
+                        "priority_score": 100,
+                        "profile_level": "directory-only",
+                        "reason_codes": [
+                          "example"
+                        ],
+                        "recommended_action": "2026-06-01T00:00:00.000Z",
+                        "review_state": "unreviewed",
+                        "sample_candidate_ids": [
+                          "example"
+                        ],
+                        "sample_live_candidate_ids": [
+                          "example"
+                        ],
+                        "sample_stale_candidate_ids": [
+                          "example"
+                        ],
+                        "sample_target_candidate_ids": [
+                          "example"
+                        ],
+                        "slug": "example-subnet",
+                        "source_urls": [
+                          "https://api.metagraph.sh/example"
+                        ],
+                        "stale_candidate_count": 1,
+                        "surface_count": 1,
+                        "verified_candidate_count": 1
+                      }
+                    ],
+                    "schema_version": 1,
+                    "summary": {
+                      "adapter_candidate_count": 1,
+                      "baseline_monitoring_count": 1,
+                      "direct_submission_count": 1,
+                      "evidence_action_counts": {},
+                      "identity_level_counts": {},
+                      "lane_counts": {},
+                      "maintainer_review_count": 1,
+                      "manual_review_required_count": 1,
+                      "monitoring_followup_count": 1,
+                      "queue_count": 1,
+                      "subnet_count": 1,
+                      "top_direct_submission_kinds": {}
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -14009,6 +15834,131 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "groups": [
+                      {
+                        "auto_review_candidate_count": 1,
+                        "kind": "archive",
+                        "manual_review_required_count": 1,
+                        "target_count": 1,
+                        "target_ids": [
+                          "example"
+                        ],
+                        "target_type": "surface-candidate",
+                        "top_netuids": [
+                          7
+                        ]
+                      }
+                    ],
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "summary": {
+                      "auto_review_candidate_count": 1,
+                      "by_evidence_action": {},
+                      "by_kind": {},
+                      "by_lane": {},
+                      "by_target_type": {},
+                      "manual_review_required_count": 1,
+                      "new_evidence_count": 1,
+                      "stale_replacement_count": 1,
+                      "subnet_count": 1,
+                      "target_count": 1
+                    },
+                    "targets": [
+                      {
+                        "auto_review_candidate": false,
+                        "candidate_command": "example",
+                        "candidate_evidence": {
+                          "candidate_count": 1,
+                          "classifications": {},
+                          "live_or_redirected_count": 1,
+                          "reviewable_count": 1,
+                          "sample_candidate_ids": [
+                            "example"
+                          ],
+                          "stale_or_failed_count": 1,
+                          "unverified_count": 1
+                        },
+                        "contribution_prompt": "example",
+                        "evidence_action": "submit-new-evidence",
+                        "identity_level": "none",
+                        "kind": "archive",
+                        "lane": "direct-submission",
+                        "manual_review_required": true,
+                        "missing_kinds": [
+                          "archive"
+                        ],
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "priority_score": 100,
+                        "profile_level": "directory-only",
+                        "queue_context": {
+                          "adapter_score": 100,
+                          "candidate_count": 1,
+                          "completeness_score": 100,
+                          "curation_level": "native",
+                          "direct_submission_kind_count": 1,
+                          "endpoint_count": 1,
+                          "identity_surface_count": 1,
+                          "operational_interface_count": 1,
+                          "profile_level": "directory-only",
+                          "review_state": "unreviewed",
+                          "source_url_count": 1,
+                          "stale_candidate_count": 1,
+                          "surface_count": 1,
+                          "verified_candidate_count": 1
+                        },
+                        "reason_codes": [
+                          "example"
+                        ],
+                        "recommended_action": "2026-06-01T00:00:00.000Z",
+                        "sample_live_candidate_ids": [
+                          "example"
+                        ],
+                        "sample_stale_candidate_ids": [
+                          "example"
+                        ],
+                        "sample_target_candidate_ids": [
+                          "example"
+                        ],
+                        "slug": "example-subnet",
+                        "source_requirements": [
+                          "example"
+                        ],
+                        "source_urls": [
+                          "https://api.metagraph.sh/example"
+                        ],
+                        "submission_route": "direct-candidate-pr",
+                        "target_action": "submit-new-candidate",
+                        "target_id": "example",
+                        "target_type": "surface-candidate"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -14180,6 +16130,51 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "priorities": [
+                      {
+                        "candidate_count": 1,
+                        "curation_level": "native",
+                        "missing_kinds": [
+                          "archive"
+                        ],
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "priority_score": 100,
+                        "review_state": "unreviewed",
+                        "slug": "example-subnet",
+                        "suggested_next_action": "example",
+                        "surface_count": 1,
+                        "verified_candidate_count": 1
+                      }
+                    ],
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -14412,6 +16407,115 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "profiles": [
+                      {
+                        "candidate_count": 1,
+                        "completeness_score": 100,
+                        "confidence": "low",
+                        "curation_level": "native",
+                        "gap_reasons": [
+                          "example"
+                        ],
+                        "identity_evidence": {
+                          "candidate_identity_count": 1,
+                          "curated_identity_count": 1,
+                          "curated_identity_kinds": [
+                            "archive"
+                          ],
+                          "live_candidate_identity_kinds": [
+                            "archive"
+                          ],
+                          "native_contact_present": false,
+                          "native_description_present": false,
+                          "native_identity_count": 1,
+                          "native_identity_kinds": [
+                            "archive"
+                          ],
+                          "needs_promotion_kinds": [
+                            "archive"
+                          ],
+                          "stale_candidate_identity_kinds": [
+                            "archive"
+                          ],
+                          "unverified_candidate_identity_kinds": [
+                            "archive"
+                          ]
+                        },
+                        "identity_level": "none",
+                        "identity_promotion_kind_count": 1,
+                        "identity_promotion_kinds": [
+                          "archive"
+                        ],
+                        "identity_surface_count": 1,
+                        "live_identity_candidate_kind_count": 1,
+                        "missing_critical_count": 1,
+                        "missing_identity": [
+                          "archive"
+                        ],
+                        "missing_operational": [
+                          "archive"
+                        ],
+                        "missing_required": [
+                          "archive"
+                        ],
+                        "name": "Example Subnet",
+                        "native_identity_signal_count": 1,
+                        "native_name_quality": "chain",
+                        "netuid": 7,
+                        "operational_interface_count": 1,
+                        "priority_score": 100,
+                        "profile_level": "directory-only",
+                        "review_state": "unreviewed",
+                        "slug": "example-subnet",
+                        "source_count": 1,
+                        "stale_identity_candidate_kind_count": 1,
+                        "suggested_next_action": "example",
+                        "supported_interface_kinds": [
+                          "archive"
+                        ]
+                      }
+                    ],
+                    "schema_version": 1,
+                    "summary": {
+                      "average_completeness_score": 100,
+                      "by_confidence": {},
+                      "by_identity_level": {},
+                      "by_profile_level": {},
+                      "critical_gap_counts": {},
+                      "identity_promotion_candidate_count": 1,
+                      "native_identity_count": 1,
+                      "native_identity_unpromoted_count": 1,
+                      "needs_identity_count": 1,
+                      "needs_operational_count": 1,
+                      "profile_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -14650,6 +16754,57 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "endpoints": [
+                      {
+                        "chain": "bittensor",
+                        "classification": "live",
+                        "health_source": "probe-derived",
+                        "health_stale": false,
+                        "id": "example",
+                        "kind": "subtensor-rpc",
+                        "last_ok": "2026-06-01T00:00:00.000Z",
+                        "network": "finney",
+                        "observed_at": "2026-06-01T00:00:00.000Z",
+                        "provider": "example-provider",
+                        "status": "ok",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "summary": {
+                      "archive_supported_count": 1,
+                      "by_kind": {},
+                      "by_provider": {},
+                      "by_status": {},
+                      "endpoint_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -14738,6 +16893,92 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "disabled_proxy_contract": {
+                      "allowed_methods": [
+                        "GET"
+                      ],
+                      "denied_method_patterns": [
+                        "GET"
+                      ],
+                      "enabled": true,
+                      "feature_flag": "example",
+                      "rate_limit_required": true,
+                      "waf_required": true
+                    },
+                    "eligibility_policy": {
+                      "eligible_layers": [
+                        "example"
+                      ],
+                      "notes": "Example description.",
+                      "required_status": "ok",
+                      "requires_no_auth": false,
+                      "requires_public_safe": true,
+                      "source": "live-cron-prober",
+                      "user_reports_can_change_health": false
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "pools": [
+                      {
+                        "eligible_count": 1,
+                        "endpoint_count": 1,
+                        "endpoints": [
+                          {
+                            "health_source": "probe-derived",
+                            "health_stale": false,
+                            "id": "example",
+                            "last_ok": "2026-06-01T00:00:00.000Z",
+                            "observed_at": "2026-06-01T00:00:00.000Z",
+                            "pool_eligible": false,
+                            "provider": "example-provider",
+                            "score": 100,
+                            "status": "ok",
+                            "url": "https://api.metagraph.sh/example"
+                          }
+                        ],
+                        "id": "example",
+                        "kind": "example"
+                      }
+                    ],
+                    "provider_scores": [
+                      {
+                        "average_score": 100,
+                        "degraded_count": 1,
+                        "endpoint_count": 1,
+                        "failed_count": 1,
+                        "monitored_count": 1,
+                        "ok_count": 1,
+                        "operational_score": 100,
+                        "pool_eligible_count": 1,
+                        "provider": "example-provider"
+                      }
+                    ],
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -14826,6 +17067,43 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "schemas": [
+                      {
+                        "drift_status": "changed",
+                        "schema_url": "https://api.metagraph.sh/example",
+                        "status": "captured",
+                        "surface_id": "example"
+                      }
+                    ],
+                    "source": "live-cron-prober"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -14967,6 +17245,46 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "document_count": 1,
+                    "documents": [
+                      {
+                        "artifact_path": "example",
+                        "id": "example",
+                        "title": "Example Subnet",
+                        "tokens": [
+                          "example"
+                        ],
+                        "type": "subnet"
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -15055,6 +17373,57 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "providers": [
+                      {
+                        "authority": "official",
+                        "candidate_count": 1,
+                        "classifications": {},
+                        "endpoint_count": 1,
+                        "id": "example",
+                        "kind": "subnet-team",
+                        "name": "Example Subnet",
+                        "rpc_endpoint_count": 1,
+                        "status": "ok",
+                        "verification_result_count": 1
+                      }
+                    ],
+                    "schema_version": 1,
+                    "source": "generated-provider-and-verification-summary",
+                    "summary": {
+                      "candidate_count": 1,
+                      "endpoint_count": 1,
+                      "provider_count": 1,
+                      "rpc_endpoint_count": 1,
+                      "status_counts": {},
+                      "verification_result_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -15196,6 +17565,52 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "sources": [
+                      {
+                        "captured_at": "2026-06-01T00:00:00.000Z",
+                        "hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                        "id": "example",
+                        "kind": "adapter-snapshot",
+                        "path": "example",
+                        "record_count": 1
+                      }
+                    ],
+                    "summary": {
+                      "adapter_snapshot_count": 1,
+                      "candidate_count": 1,
+                      "overlay_count": 1,
+                      "provider_count": 1,
+                      "source_count": 1,
+                      "verification_result_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -15432,6 +17847,55 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "network": "finney",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "source": {
+                      "identity_storage": "example",
+                      "kind": "example",
+                      "method": "GET",
+                      "package": "example",
+                      "rpc_family": "example",
+                      "version": "2026-06-06.1"
+                    },
+                    "subnets": [
+                      {
+                        "coverage_level": "native-only",
+                        "curation_level": "native",
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "slug": "example-subnet",
+                        "status": "active",
+                        "subnet_type": "root",
+                        "surface_count": 1
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -15530,6 +17994,183 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "candidate_surfaces": [
+                      {
+                        "auth_required": true,
+                        "id": "example",
+                        "kind": "archive",
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "schema_version": 1,
+                        "source_url": "https://api.metagraph.sh/example",
+                        "state": "schema-invalid",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "candidates": [
+                      {
+                        "auth_required": true,
+                        "id": "example",
+                        "kind": "archive",
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "schema_version": 1,
+                        "source_url": "https://api.metagraph.sh/example",
+                        "state": "schema-invalid",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "contract_version": "2026-06-06.1",
+                    "endpoints": [
+                      {
+                        "auth_required": true,
+                        "health_source": "probe-derived",
+                        "health_stale": false,
+                        "id": "example",
+                        "kind": "archive",
+                        "last_ok": "2026-06-01T00:00:00.000Z",
+                        "layer": "bittensor-base",
+                        "monitoring_policy": {
+                          "enabled": true,
+                          "expect": "example",
+                          "method": "GET",
+                          "source": "live-cron-prober"
+                        },
+                        "monitoring_status": "monitored",
+                        "netuid": 7,
+                        "observed_at": "2026-06-01T00:00:00.000Z",
+                        "operator": "example-provider",
+                        "pool_eligible": false,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "publication_state": "candidate",
+                        "score": 100,
+                        "status": "ok",
+                        "surface_id": "example",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "gaps": {
+                      "gap_notes": [
+                        "example"
+                      ],
+                      "missing_kinds": [
+                        "archive"
+                      ],
+                      "supported_kinds": [
+                        "archive"
+                      ]
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "subnet": {
+                      "block": 5000000,
+                      "candidate_count": 1,
+                      "categories": [
+                        "example"
+                      ],
+                      "coverage_level": "native-only",
+                      "curation": {
+                        "level": "native",
+                        "review_state": "unreviewed"
+                      },
+                      "curation_level": "native",
+                      "dashboard_url": "https://api.metagraph.sh/example",
+                      "derived_categories": [
+                        "example"
+                      ],
+                      "description": "Example description.",
+                      "docs_url": "https://api.metagraph.sh/example",
+                      "gap_count": 1,
+                      "gaps": {
+                        "gap_notes": [
+                          "example"
+                        ],
+                        "missing_kinds": [
+                          "archive"
+                        ],
+                        "supported_kinds": [
+                          "archive"
+                        ]
+                      },
+                      "lifecycle": "active",
+                      "links": [
+                        {}
+                      ],
+                      "logo_url": "https://api.metagraph.sh/example",
+                      "mechanism_count": 1,
+                      "name": "Example Subnet",
+                      "native_name": "example",
+                      "native_name_quality": "chain",
+                      "native_slug": "example-subnet",
+                      "netuid": 7,
+                      "notes": "Example description.",
+                      "participant_count": 1,
+                      "probed_surface_count": 1,
+                      "provenance": {},
+                      "registered_at_block": 5000000,
+                      "slug": "example-subnet",
+                      "source_repo": "https://api.metagraph.sh/example",
+                      "status": "active",
+                      "subnet_type": "root",
+                      "surface_count": 1,
+                      "symbol": "example",
+                      "tempo": 1,
+                      "website_url": "https://api.metagraph.sh/example"
+                    },
+                    "surfaces": [
+                      {
+                        "auth_required": true,
+                        "authority": "official",
+                        "id": "example",
+                        "kind": "archive",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "verified_surfaces": [
+                      {
+                        "auth_required": true,
+                        "authority": "official",
+                        "id": "example",
+                        "kind": "archive",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -15723,6 +18364,49 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "candidates": [
+                      {
+                        "auth_required": true,
+                        "id": "example",
+                        "kind": "archive",
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "schema_version": 1,
+                        "source_url": "https://api.metagraph.sh/example",
+                        "state": "schema-invalid",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -15960,6 +18644,76 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "endpoints": [
+                      {
+                        "auth_required": true,
+                        "health_source": "probe-derived",
+                        "health_stale": false,
+                        "id": "example",
+                        "kind": "archive",
+                        "last_ok": "2026-06-01T00:00:00.000Z",
+                        "layer": "bittensor-base",
+                        "monitoring_policy": {
+                          "enabled": true,
+                          "expect": "example",
+                          "method": "GET",
+                          "source": "live-cron-prober"
+                        },
+                        "monitoring_status": "monitored",
+                        "netuid": 7,
+                        "observed_at": "2026-06-01T00:00:00.000Z",
+                        "operator": "example-provider",
+                        "pool_eligible": false,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "publication_state": "candidate",
+                        "score": 100,
+                        "status": "ok",
+                        "surface_id": "example",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "name": "Example Subnet",
+                    "netuid": 7,
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "slug": "example-subnet",
+                    "summary": {
+                      "by_kind": {},
+                      "by_layer": {},
+                      "by_provider": {},
+                      "by_publication_state": {},
+                      "by_status": {},
+                      "endpoint_count": 1,
+                      "monitored_count": 1,
+                      "pool_eligible_count": 1
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -16111,6 +18865,46 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "claims": [
+                      {
+                        "claim": "example",
+                        "confidence": "low",
+                        "limits": "example",
+                        "source_tier": "native-chain",
+                        "source_type": "example",
+                        "source_url": "https://api.metagraph.sh/example",
+                        "subject": "example",
+                        "support_summary": "Example description."
+                      }
+                    ],
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -16281,6 +19075,126 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "enrichment_queue": [
+                      {
+                        "adapter_score": 100,
+                        "candidate_count": 1,
+                        "candidate_evidence_summary": {
+                          "candidate_count": 1,
+                          "kinds_with_candidates": [
+                            "archive"
+                          ],
+                          "live_kinds": [
+                            "archive"
+                          ],
+                          "live_or_redirected_count": 1,
+                          "reviewable_count": 1,
+                          "stale_kinds": [
+                            "archive"
+                          ],
+                          "stale_or_failed_count": 1,
+                          "unverified_count": 1,
+                          "unverified_kinds": [
+                            "archive"
+                          ]
+                        },
+                        "completeness_score": 100,
+                        "contribution_hint": "example",
+                        "curation_level": "native",
+                        "direct_submission_kinds": [
+                          "archive"
+                        ],
+                        "endpoint_count": 1,
+                        "evidence_action": "submit-new-evidence",
+                        "identity_level": "none",
+                        "identity_surface_count": 1,
+                        "lane": "direct-submission",
+                        "manual_review_required": true,
+                        "missing_identity": [
+                          "archive"
+                        ],
+                        "missing_kinds": [
+                          "archive"
+                        ],
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "operational_interface_count": 1,
+                        "priority_score": 100,
+                        "profile_level": "directory-only",
+                        "reason_codes": [
+                          "example"
+                        ],
+                        "recommended_action": "2026-06-01T00:00:00.000Z",
+                        "review_state": "unreviewed",
+                        "sample_candidate_ids": [
+                          "example"
+                        ],
+                        "sample_live_candidate_ids": [
+                          "example"
+                        ],
+                        "sample_stale_candidate_ids": [
+                          "example"
+                        ],
+                        "sample_target_candidate_ids": [
+                          "example"
+                        ],
+                        "slug": "example-subnet",
+                        "source_urls": [
+                          "https://api.metagraph.sh/example"
+                        ],
+                        "stale_candidate_count": 1,
+                        "surface_count": 1,
+                        "verified_candidate_count": 1
+                      }
+                    ],
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "name": "Example Subnet",
+                    "netuid": 7,
+                    "notes": "Example description.",
+                    "priorities": [
+                      {
+                        "candidate_count": 1,
+                        "curation_level": "native",
+                        "missing_kinds": [
+                          "archive"
+                        ],
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "priority_score": 100,
+                        "review_state": "unreviewed",
+                        "slug": "example-subnet",
+                        "suggested_next_action": "example",
+                        "surface_count": 1,
+                        "verified_candidate_count": 1
+                      }
+                    ],
+                    "schema_version": 1,
+                    "slug": "example-subnet"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -16498,6 +19412,61 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "health_source": "probe-derived",
+                    "name": "Example Subnet",
+                    "netuid": 7,
+                    "operational_observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "slug": "example-subnet",
+                    "summary": {
+                      "avg_latency_ms": 120,
+                      "degraded_count": 1,
+                      "failed_count": 1,
+                      "last_checked": "2026-06-01T00:00:00.000Z",
+                      "last_ok": "2026-06-01T00:00:00.000Z",
+                      "name": "Example Subnet",
+                      "netuid": 7,
+                      "ok_count": 1,
+                      "slug": "example-subnet",
+                      "status": "ok",
+                      "surface_count": 1,
+                      "unknown_count": 1
+                    },
+                    "surfaces": [
+                      {
+                        "classification": "live",
+                        "netuid": 7,
+                        "status": "ok",
+                        "surface_id": "example",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -16609,6 +19578,52 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "netuid": 7,
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source": "live-cron-prober",
+                    "surfaces": [
+                      {
+                        "downtime_ms": 1,
+                        "incident_count": 1,
+                        "incidents": [
+                          {
+                            "duration_ms": 1,
+                            "ended_at": 1,
+                            "failed_samples": 1,
+                            "started_at": 1
+                          }
+                        ],
+                        "samples": 1,
+                        "surface_id": "example",
+                        "uptime_ratio": 0.9966
+                      }
+                    ],
+                    "window": "30d"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -16721,6 +19736,42 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "netuid": 7,
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source": "live-cron-prober",
+                    "surfaces": [
+                      {
+                        "latency_ms": {},
+                        "samples": 1,
+                        "surface_id": "example"
+                      }
+                    ],
+                    "window": "30d"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -16821,6 +19872,48 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "netuid": 7,
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source": "live-cron-prober",
+                    "windows": {
+                      "example": {
+                        "samples": 1,
+                        "surfaces": [
+                          {
+                            "avg_latency_ms": 120,
+                            "samples": 1,
+                            "surface_id": "example",
+                            "uptime_ratio": 0.9966
+                          }
+                        ],
+                        "uptime_ratio": 0.9966
+                      }
+                    }
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -16920,6 +20013,222 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "counts": {
+                      "candidates": 1,
+                      "endpoints": 1,
+                      "surfaces": 1
+                    },
+                    "curation": {
+                      "gap_notes": [
+                        "example"
+                      ],
+                      "level": "native",
+                      "review_state": "unreviewed",
+                      "reviewed_at": "2026-06-01T00:00:00.000Z",
+                      "source_count": 1,
+                      "verified_at": "2026-06-01T00:00:00.000Z"
+                    },
+                    "gap_priorities": [
+                      null
+                    ],
+                    "gaps": {
+                      "gap_notes": [
+                        "example"
+                      ],
+                      "missing_kinds": [
+                        "archive"
+                      ],
+                      "supported_kinds": [
+                        "archive"
+                      ]
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "health": {
+                      "avg_latency_ms": 120,
+                      "degraded_count": 1,
+                      "failed_count": 1,
+                      "last_checked": "2026-06-01T00:00:00.000Z",
+                      "last_ok": "2026-06-01T00:00:00.000Z",
+                      "netuid": 7,
+                      "observed_by": "2026-06-01T00:00:00.000Z",
+                      "ok_count": 1,
+                      "status": "ok",
+                      "surface_count": 1,
+                      "unknown_count": 1
+                    },
+                    "name": "Example Subnet",
+                    "netuid": 7,
+                    "notes": "Example description.",
+                    "profile": {
+                      "candidate_count": 1,
+                      "categories": [
+                        "example"
+                      ],
+                      "completeness": {
+                        "confidence": "low",
+                        "gap_reasons": [
+                          "example"
+                        ],
+                        "identity_level": "none",
+                        "identity_surface_count": 1,
+                        "missing_critical_count": 1,
+                        "missing_identity": [
+                          "archive"
+                        ],
+                        "missing_operational": [
+                          "archive"
+                        ],
+                        "missing_required": [
+                          "archive"
+                        ],
+                        "profile_level": "directory-only",
+                        "score": 100
+                      },
+                      "completeness_score": 100,
+                      "confidence": "low",
+                      "curation_level": "native",
+                      "derived_categories": [
+                        "example"
+                      ],
+                      "derived_description": "Example description.",
+                      "endpoint_count": 1,
+                      "gap_reasons": [
+                        "example"
+                      ],
+                      "identity_evidence": {
+                        "candidate_identity_count": 1,
+                        "curated_identity_count": 1,
+                        "curated_identity_kinds": [
+                          "archive"
+                        ],
+                        "live_candidate_identity_kinds": [
+                          "archive"
+                        ],
+                        "native_contact_present": false,
+                        "native_description_present": false,
+                        "native_identity_count": 1,
+                        "native_identity_kinds": [
+                          "archive"
+                        ],
+                        "needs_promotion_kinds": [
+                          "archive"
+                        ],
+                        "stale_candidate_identity_kinds": [
+                          "archive"
+                        ],
+                        "unverified_candidate_identity_kinds": [
+                          "archive"
+                        ]
+                      },
+                      "identity_level": "none",
+                      "identity_surface_count": 1,
+                      "injection_scrubbed": false,
+                      "integration_readiness": 1,
+                      "interface_count": 1,
+                      "lineage": {},
+                      "missing_critical_count": 1,
+                      "missing_identity": [
+                        "archive"
+                      ],
+                      "missing_operational": [
+                        "archive"
+                      ],
+                      "missing_required": [
+                        "archive"
+                      ],
+                      "monitored_endpoint_count": 1,
+                      "name": "Example Subnet",
+                      "native_identity": {
+                        "additional": "example",
+                        "contact_present": false,
+                        "description": "Example description.",
+                        "discord": "example",
+                        "discord_url": "https://api.metagraph.sh/example",
+                        "github_url": "https://api.metagraph.sh/example",
+                        "logo_url": "https://api.metagraph.sh/example",
+                        "source": "live-cron-prober",
+                        "subnet_name": "Example Subnet",
+                        "website_url": "https://api.metagraph.sh/example"
+                      },
+                      "native_name": "example",
+                      "native_name_quality": "chain",
+                      "netuid": 7,
+                      "operational_interface_count": 1,
+                      "operational_interface_kinds": [
+                        "archive"
+                      ],
+                      "primary_app_surface": {
+                        "id": "example",
+                        "kind": "archive",
+                        "name": "Example Subnet",
+                        "provider": "example-provider",
+                        "url": "https://api.metagraph.sh/example"
+                      },
+                      "primary_links": {
+                        "dashboard_url": "https://api.metagraph.sh/example",
+                        "docs_url": "https://api.metagraph.sh/example",
+                        "source_repo": "https://api.metagraph.sh/example",
+                        "website_url": "https://api.metagraph.sh/example"
+                      },
+                      "profile_level": "directory-only",
+                      "project_name": "example",
+                      "provenance": {
+                        "curation_level": "native",
+                        "identity_source": "live-cron-prober",
+                        "interface_source_count": 1,
+                        "review_state": "unreviewed",
+                        "reviewed_at": "2026-06-01T00:00:00.000Z",
+                        "source_urls": [
+                          "https://api.metagraph.sh/example"
+                        ]
+                      },
+                      "readiness": {
+                        "components": {},
+                        "readiness_version": 1,
+                        "score": 100
+                      },
+                      "review_state": "unreviewed",
+                      "slug": "example-subnet",
+                      "status": "active",
+                      "subnet_type": "root",
+                      "suggested_submission_kinds": [
+                        "archive"
+                      ],
+                      "supported_interface_kinds": [
+                        "archive"
+                      ],
+                      "surface_count": 1,
+                      "symbol": "example",
+                      "team": "example"
+                    },
+                    "schema_version": 1,
+                    "slug": "example-subnet",
+                    "status": "ok"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -17020,6 +20329,298 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "candidate_surfaces": [
+                      {
+                        "auth_required": true,
+                        "id": "example",
+                        "kind": "archive",
+                        "name": "Example Subnet",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "schema_version": 1,
+                        "source_url": "https://api.metagraph.sh/example",
+                        "state": "schema-invalid",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "contract_version": "2026-06-06.1",
+                    "endpoints": [
+                      {
+                        "auth_required": true,
+                        "health_source": "probe-derived",
+                        "health_stale": false,
+                        "id": "example",
+                        "kind": "archive",
+                        "last_ok": "2026-06-01T00:00:00.000Z",
+                        "layer": "bittensor-base",
+                        "monitoring_policy": {
+                          "enabled": true,
+                          "expect": "example",
+                          "method": "GET",
+                          "source": "live-cron-prober"
+                        },
+                        "monitoring_status": "monitored",
+                        "netuid": 7,
+                        "observed_at": "2026-06-01T00:00:00.000Z",
+                        "operator": "example-provider",
+                        "pool_eligible": false,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "publication_state": "candidate",
+                        "score": 100,
+                        "status": "ok",
+                        "surface_id": "example",
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ],
+                    "gaps": {
+                      "gap_notes": [
+                        "example"
+                      ],
+                      "missing_kinds": [
+                        "archive"
+                      ],
+                      "supported_kinds": [
+                        "archive"
+                      ]
+                    },
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "profile": {
+                      "candidate_count": 1,
+                      "categories": [
+                        "example"
+                      ],
+                      "completeness": {
+                        "confidence": "low",
+                        "gap_reasons": [
+                          "example"
+                        ],
+                        "identity_level": "none",
+                        "identity_surface_count": 1,
+                        "missing_critical_count": 1,
+                        "missing_identity": [
+                          "archive"
+                        ],
+                        "missing_operational": [
+                          "archive"
+                        ],
+                        "missing_required": [
+                          "archive"
+                        ],
+                        "profile_level": "directory-only",
+                        "score": 100
+                      },
+                      "completeness_score": 100,
+                      "confidence": "low",
+                      "curation_level": "native",
+                      "derived_categories": [
+                        "example"
+                      ],
+                      "derived_description": "Example description.",
+                      "endpoint_count": 1,
+                      "gap_reasons": [
+                        "example"
+                      ],
+                      "identity_evidence": {
+                        "candidate_identity_count": 1,
+                        "curated_identity_count": 1,
+                        "curated_identity_kinds": [
+                          "archive"
+                        ],
+                        "live_candidate_identity_kinds": [
+                          "archive"
+                        ],
+                        "native_contact_present": false,
+                        "native_description_present": false,
+                        "native_identity_count": 1,
+                        "native_identity_kinds": [
+                          "archive"
+                        ],
+                        "needs_promotion_kinds": [
+                          "archive"
+                        ],
+                        "stale_candidate_identity_kinds": [
+                          "archive"
+                        ],
+                        "unverified_candidate_identity_kinds": [
+                          "archive"
+                        ]
+                      },
+                      "identity_level": "none",
+                      "identity_surface_count": 1,
+                      "injection_scrubbed": false,
+                      "integration_readiness": 1,
+                      "interface_count": 1,
+                      "lineage": {},
+                      "missing_critical_count": 1,
+                      "missing_identity": [
+                        "archive"
+                      ],
+                      "missing_operational": [
+                        "archive"
+                      ],
+                      "missing_required": [
+                        "archive"
+                      ],
+                      "monitored_endpoint_count": 1,
+                      "name": "Example Subnet",
+                      "native_identity": {
+                        "additional": "example",
+                        "contact_present": false,
+                        "description": "Example description.",
+                        "discord": "example",
+                        "discord_url": "https://api.metagraph.sh/example",
+                        "github_url": "https://api.metagraph.sh/example",
+                        "logo_url": "https://api.metagraph.sh/example",
+                        "source": "live-cron-prober",
+                        "subnet_name": "Example Subnet",
+                        "website_url": "https://api.metagraph.sh/example"
+                      },
+                      "native_name": "example",
+                      "native_name_quality": "chain",
+                      "netuid": 7,
+                      "operational_interface_count": 1,
+                      "operational_interface_kinds": [
+                        "archive"
+                      ],
+                      "primary_app_surface": {
+                        "id": "example",
+                        "kind": "archive",
+                        "name": "Example Subnet",
+                        "provider": "example-provider",
+                        "url": "https://api.metagraph.sh/example"
+                      },
+                      "primary_links": {
+                        "dashboard_url": "https://api.metagraph.sh/example",
+                        "docs_url": "https://api.metagraph.sh/example",
+                        "source_repo": "https://api.metagraph.sh/example",
+                        "website_url": "https://api.metagraph.sh/example"
+                      },
+                      "profile_level": "directory-only",
+                      "project_name": "example",
+                      "provenance": {
+                        "curation_level": "native",
+                        "identity_source": "live-cron-prober",
+                        "interface_source_count": 1,
+                        "review_state": "unreviewed",
+                        "reviewed_at": "2026-06-01T00:00:00.000Z",
+                        "source_urls": [
+                          "https://api.metagraph.sh/example"
+                        ]
+                      },
+                      "readiness": {
+                        "components": {},
+                        "readiness_version": 1,
+                        "score": 100
+                      },
+                      "review_state": "unreviewed",
+                      "slug": "example-subnet",
+                      "status": "active",
+                      "subnet_type": "root",
+                      "suggested_submission_kinds": [
+                        "archive"
+                      ],
+                      "supported_interface_kinds": [
+                        "archive"
+                      ],
+                      "surface_count": 1,
+                      "symbol": "example",
+                      "team": "example"
+                    },
+                    "schema_version": 1,
+                    "subnet": {
+                      "block": 5000000,
+                      "candidate_count": 1,
+                      "categories": [
+                        "example"
+                      ],
+                      "coverage_level": "native-only",
+                      "curation": {
+                        "level": "native",
+                        "review_state": "unreviewed"
+                      },
+                      "curation_level": "native",
+                      "dashboard_url": "https://api.metagraph.sh/example",
+                      "derived_categories": [
+                        "example"
+                      ],
+                      "description": "Example description.",
+                      "docs_url": "https://api.metagraph.sh/example",
+                      "gap_count": 1,
+                      "gaps": {
+                        "gap_notes": [
+                          "example"
+                        ],
+                        "missing_kinds": [
+                          "archive"
+                        ],
+                        "supported_kinds": [
+                          "archive"
+                        ]
+                      },
+                      "lifecycle": "active",
+                      "links": [
+                        {}
+                      ],
+                      "logo_url": "https://api.metagraph.sh/example",
+                      "mechanism_count": 1,
+                      "name": "Example Subnet",
+                      "native_name": "example",
+                      "native_name_quality": "chain",
+                      "native_slug": "example-subnet",
+                      "netuid": 7,
+                      "notes": "Example description.",
+                      "participant_count": 1,
+                      "probed_surface_count": 1,
+                      "provenance": {},
+                      "registered_at_block": 5000000,
+                      "slug": "example-subnet",
+                      "source_repo": "https://api.metagraph.sh/example",
+                      "status": "active",
+                      "subnet_type": "root",
+                      "surface_count": 1,
+                      "symbol": "example",
+                      "tempo": 1,
+                      "website_url": "https://api.metagraph.sh/example"
+                    },
+                    "surfaces": [
+                      {
+                        "auth_required": true,
+                        "authority": "official",
+                        "id": "example",
+                        "kind": "archive",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -17196,6 +20797,46 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "surfaces": [
+                      {
+                        "auth_required": true,
+                        "authority": "official",
+                        "id": "example",
+                        "kind": "archive",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -17295,6 +20936,41 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "deltas": {
+                      "example": {}
+                    },
+                    "netuid": 7,
+                    "point_count": 1,
+                    "points": [
+                      {
+                        "date": "2026-06-01"
+                      }
+                    ],
+                    "schema_version": 1
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -17406,6 +21082,61 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "netuid": 7,
+                    "reliability": {
+                      "avg_latency_ms": 120,
+                      "computed_at": "2026-06-01T00:00:00.000Z",
+                      "day_count": 1,
+                      "grade": "A",
+                      "sample_count": 1,
+                      "score": 100,
+                      "surface_count": 1,
+                      "uptime_ratio": 0.9966,
+                      "window": "30d"
+                    },
+                    "schema_version": 1,
+                    "source": "live-cron-prober",
+                    "surfaces": [
+                      {
+                        "day_count": 1,
+                        "days": [
+                          {
+                            "day": "2026-06-01",
+                            "samples": 1,
+                            "status": "ok",
+                            "uptime_ratio": 0.9966
+                          }
+                        ],
+                        "samples": 1,
+                        "surface_id": "example",
+                        "uptime_ratio": 0.9966
+                      }
+                    ],
+                    "window": "30d"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {
@@ -17583,6 +21314,46 @@
           "200": {
             "content": {
               "application/json": {
+                "example": {
+                  "data": {
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "notes": "Example description.",
+                    "schema_version": 1,
+                    "surfaces": [
+                      {
+                        "auth_required": true,
+                        "authority": "official",
+                        "id": "example",
+                        "kind": "archive",
+                        "netuid": 7,
+                        "provider": "example-provider",
+                        "public_safe": true,
+                        "url": "https://api.metagraph.sh/example"
+                      }
+                    ]
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
                 "schema": {
                   "allOf": [
                     {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -3234,6 +3234,75 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "artifact_contracts": [
+                     *           {
+                     *             "contract_version": "2026-06-06.1",
+                     *             "id": "example",
+                     *             "path": "/metagraph/example.json",
+                     *             "schema_ref": "#/components/schemas/Example",
+                     *             "storage_tier": "dual"
+                     *           }
+                     *         ],
+                     *         "base_path": "/api/v1",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "openapi_url": "/api/v1/openapi.json",
+                     *         "primary_domain": "api.metagraph.sh",
+                     *         "response_envelope": {
+                     *           "error_schema_ref": "#/components/schemas/ErrorEnvelope",
+                     *           "fields": [
+                     *             "ok"
+                     *           ],
+                     *           "notes": "Example description.",
+                     *           "schema_version": 1,
+                     *           "success_schema_ref": "#/components/schemas/SuccessEnvelope"
+                     *         },
+                     *         "routes": [
+                     *           {
+                     *             "artifact_path": "/metagraph/example.json",
+                     *             "cache": "short",
+                     *             "description": "Example description.",
+                     *             "id": "example",
+                     *             "method": "GET",
+                     *             "path": "/api/v1/example",
+                     *             "public": true,
+                     *             "query_parameters": [
+                     *               {
+                     *                 "name": "Example Subnet",
+                     *                 "schema": {}
+                     *               }
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "type_definitions_url": "/metagraph/types.d.ts"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ApiIndexArtifact"];
                     };
@@ -3304,6 +3373,43 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "extensions": {
+                     *           "example": {}
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet",
+                     *         "snapshot": {},
+                     *         "subnet": "example"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AdapterArtifact"];
                     };
@@ -3372,6 +3478,45 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "callable_service_count": 1,
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "subnet_count": 1,
+                     *         "subnets": [
+                     *           {
+                     *             "netuid": 7,
+                     *             "service_count": 1
+                     *           }
+                     *         ],
+                     *         "total_subnet_count": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AgentCatalogArtifact"];
                     };
@@ -3442,6 +3587,58 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "categories": [
+                     *           "example"
+                     *         ],
+                     *         "completeness_score": 100,
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "integration_readiness": 1,
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "readiness": {
+                     *           "components": {},
+                     *           "readiness_version": 1,
+                     *           "score": 100
+                     *         },
+                     *         "schema_version": 1,
+                     *         "service_count": 1,
+                     *         "services": [
+                     *           {
+                     *             "base_url": "https://api.metagraph.sh/example",
+                     *             "kind": "example",
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "slug": "example-subnet",
+                     *         "subnet_type": "example"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AgentCatalogSubnetArtifact"];
                     };
@@ -3510,6 +3707,65 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "content_hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "copyable_agent": {
+                     *           "description": "Example description.",
+                     *           "title": "Example Subnet",
+                     *           "url": "https://api.metagraph.sh/example"
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "mcp": {
+                     *           "endpoint": "https://api.metagraph.sh/example",
+                     *           "install": "example",
+                     *           "server_card": "https://api.metagraph.sh/example",
+                     *           "tools": [
+                     *             {
+                     *               "name": "Example Subnet"
+                     *             }
+                     *           ],
+                     *           "transport": "example"
+                     *         },
+                     *         "notes": "Example description.",
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "resources": [
+                     *           {
+                     *             "id": "example",
+                     *             "title": "Example Subnet",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "callable_service_count": 1,
+                     *           "subnet_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["AgentResourcesArtifact"];
                     };
@@ -3578,6 +3834,52 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "artifact_budgets": [
+                     *           {
+                     *             "fail_bytes": 1,
+                     *             "path": "example",
+                     *             "size_bytes": 1,
+                     *             "status": "ok",
+                     *             "warn_bytes": 1
+                     *           }
+                     *         ],
+                     *         "artifact_count": 1,
+                     *         "artifact_size_bytes": 1,
+                     *         "candidate_count": 1,
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "provider_count": 1,
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "subnet_count": 1,
+                     *         "surface_count": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["BuildSummaryArtifact"];
                     };
@@ -3655,6 +3957,51 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidates": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["CandidatesArtifact"];
                     };
@@ -3723,6 +4070,68 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "artifacts": {
+                     *           "added": [
+                     *             "example"
+                     *           ],
+                     *           "modified": [
+                     *             "example"
+                     *           ],
+                     *           "removed": [
+                     *             "example"
+                     *           ]
+                     *         },
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "source": "generated-artifact-diff",
+                     *         "subnets": {
+                     *           "added": [
+                     *             1
+                     *           ],
+                     *           "removed": [
+                     *             1
+                     *           ],
+                     *           "renamed": [
+                     *             {}
+                     *           ]
+                     *         },
+                     *         "summary": {
+                     *           "artifact_added_count": 1,
+                     *           "artifact_modified_count": 1,
+                     *           "artifact_removed_count": 1,
+                     *           "coverage_delta": {},
+                     *           "netuid_added_count": 7,
+                     *           "netuid_removed_count": 7,
+                     *           "netuid_renamed_count": 7
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ChangelogArtifact"];
                     };
@@ -3791,6 +4200,51 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "artifacts": [
+                     *           {
+                     *             "contract_version": "2026-06-06.1",
+                     *             "id": "example",
+                     *             "path": "/metagraph/example.json",
+                     *             "schema_ref": "#/components/schemas/Example",
+                     *             "storage_tier": "dual"
+                     *           }
+                     *         ],
+                     *         "base_path": "/metagraph",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "name": "Example Subnet",
+                     *         "notes": "Example description.",
+                     *         "openapi_url": "/metagraph/openapi.json",
+                     *         "primary_domain": "api.metagraph.sh",
+                     *         "schema_version": 1,
+                     *         "status_domain": null,
+                     *         "type_definitions_url": "/metagraph/types.d.ts"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ContractsArtifact"];
                     };
@@ -3859,6 +4313,69 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "application_subnet_count": 1,
+                     *         "candidate_count": 1,
+                     *         "candidate_subnet_count": 1,
+                     *         "chain_subnet_count": 1,
+                     *         "completeness": {
+                     *           "average_score": 100,
+                     *           "dimension_coverage": {},
+                     *           "fully_complete_count": 1,
+                     *           "fully_complete_pct": 1,
+                     *           "median_score": 100,
+                     *           "methodology": "GET",
+                     *           "score_distribution": {},
+                     *           "scored_subnet_count": 1
+                     *         },
+                     *         "contract_version": "2026-06-06.1",
+                     *         "curated_overlay_count": 1,
+                     *         "curation_level_counts": {
+                     *           "example": 1
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "manifested_count": 1,
+                     *         "native_only_count": 1,
+                     *         "native_only_with_candidates": 1,
+                     *         "native_only_without_candidates": 1,
+                     *         "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+                     *         "network": "finney",
+                     *         "notes": "Example description.",
+                     *         "probed_count": 1,
+                     *         "probed_surface_count": 1,
+                     *         "root_subnet_count": 1,
+                     *         "schema_version": 1,
+                     *         "source": {
+                     *           "candidates": "example",
+                     *           "native": "example",
+                     *           "overlays": "example"
+                     *         },
+                     *         "surface_count": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["CoverageArtifact"];
                     };
@@ -3934,6 +4451,61 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "curation": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "coverage_level": "native-only",
+                     *             "curation": {
+                     *               "level": "native",
+                     *               "review_state": "unreviewed"
+                     *             },
+                     *             "gaps": {
+                     *               "gap_notes": [
+                     *                 "example"
+                     *               ],
+                     *               "missing_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "supported_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "slug": "example-subnet",
+                     *             "surface_count": 1
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["CurationArtifact"];
                     };
@@ -4013,6 +4585,71 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "incidents": [
+                     *           {
+                     *             "classification": "live",
+                     *             "detected_at": "2026-06-01T00:00:00.000Z",
+                     *             "endpoint_id": "https://api.metagraph.sh/example",
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_checked": "2026-06-01T00:00:00.000Z",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "reason": "example",
+                     *             "severity": "critical",
+                     *             "source": "probe-derived",
+                     *             "state": "active",
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "user_reported": false
+                     *           }
+                     *         ],
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "active_count": 1,
+                     *           "by_kind": {},
+                     *           "by_layer": {},
+                     *           "by_provider": {},
+                     *           "by_severity": {},
+                     *           "by_status": {},
+                     *           "incident_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EndpointIncidentsArtifact"];
                     };
@@ -4088,6 +4725,94 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "disabled_proxy_contract": {
+                     *           "allowed_methods": [
+                     *             "GET"
+                     *           ],
+                     *           "denied_method_patterns": [
+                     *             "GET"
+                     *           ],
+                     *           "enabled": true,
+                     *           "feature_flag": "example",
+                     *           "rate_limit_required": true,
+                     *           "waf_required": true
+                     *         },
+                     *         "eligibility_policy": {
+                     *           "eligible_layers": [
+                     *             "example"
+                     *           ],
+                     *           "notes": "Example description.",
+                     *           "required_status": "ok",
+                     *           "requires_no_auth": false,
+                     *           "requires_public_safe": true,
+                     *           "source": "live-cron-prober",
+                     *           "user_reports_can_change_health": false
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "pools": [
+                     *           {
+                     *             "eligible_count": 1,
+                     *             "endpoint_count": 1,
+                     *             "endpoints": [
+                     *               {
+                     *                 "health_source": "probe-derived",
+                     *                 "health_stale": false,
+                     *                 "id": "example",
+                     *                 "last_ok": "2026-06-01T00:00:00.000Z",
+                     *                 "observed_at": "2026-06-01T00:00:00.000Z",
+                     *                 "pool_eligible": false,
+                     *                 "provider": "example-provider",
+                     *                 "score": 100,
+                     *                 "status": "ok",
+                     *                 "url": "https://api.metagraph.sh/example"
+                     *               }
+                     *             ],
+                     *             "id": "example",
+                     *             "kind": "example"
+                     *           }
+                     *         ],
+                     *         "provider_scores": [
+                     *           {
+                     *             "average_score": 100,
+                     *             "degraded_count": 1,
+                     *             "endpoint_count": 1,
+                     *             "failed_count": 1,
+                     *             "monitored_count": 1,
+                     *             "ok_count": 1,
+                     *             "operational_score": 100,
+                     *             "pool_eligible_count": 1,
+                     *             "provider": "example-provider"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EndpointPoolsArtifact"];
                     };
@@ -4168,6 +4893,75 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "by_kind": {},
+                     *           "by_layer": {},
+                     *           "by_provider": {},
+                     *           "by_publication_state": {},
+                     *           "by_status": {},
+                     *           "endpoint_count": 1,
+                     *           "monitored_count": 1,
+                     *           "pool_eligible_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EndpointsArtifact"];
                     };
@@ -4242,6 +5036,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "claims": [
+                     *           {
+                     *             "claim": "example",
+                     *             "confidence": "low",
+                     *             "limits": "example",
+                     *             "source_tier": "native-chain",
+                     *             "source_type": "example",
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "subject": "example",
+                     *             "support_summary": "Example description."
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["EvidenceLedgerArtifact"];
                     };
@@ -4310,6 +5146,44 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "fixture_count": 1,
+                     *         "fixtures": [
+                     *           {
+                     *             "netuid": 7,
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["FixturesIndexArtifact"];
                     };
@@ -4378,6 +5252,70 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "sources": [
+                     *           {
+                     *             "as_of": "example",
+                     *             "id": "example",
+                     *             "lane": "adapter-snapshot",
+                     *             "path": "example",
+                     *             "required_for_publish": true,
+                     *             "stale_after_hours": 1,
+                     *             "stale_behavior": "block",
+                     *             "status": "captured",
+                     *             "timestamp": "example",
+                     *             "timestamp_field": "example"
+                     *           }
+                     *         ],
+                     *         "summary": {
+                     *           "adapter_count": 1,
+                     *           "adapter_snapshot_as_of": "example",
+                     *           "blocking_source_count": 5000000,
+                     *           "candidate_discovery_as_of": "example",
+                     *           "health_probe_as_of": "example",
+                     *           "health_surface_count": 1,
+                     *           "missing_blocking_source_count": 5000000,
+                     *           "native_data_as_of": "example",
+                     *           "native_snapshot_captured_at": "2026-06-01T00:00:00.000Z",
+                     *           "openapi_surface_count": 1,
+                     *           "publish_ready_without_age_check": false,
+                     *           "schema_snapshot_as_of": "example",
+                     *           "stale_window_warnings": [
+                     *             "30d"
+                     *           ],
+                     *           "verification_as_of": "example",
+                     *           "verification_generated_at": "2026-06-01T00:00:00.000Z",
+                     *           "warning_source_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["FreshnessArtifact"];
                     };
@@ -4454,6 +5392,56 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "gaps": [
+                     *           {
+                     *             "coverage_level": "native-only",
+                     *             "curation_level": "native",
+                     *             "gaps": {
+                     *               "gap_notes": [
+                     *                 "example"
+                     *               ],
+                     *               "missing_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "supported_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "slug": "example-subnet"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["GapsArtifact"];
                     };
@@ -4529,6 +5517,50 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "global": {},
+                     *         "health_source": "probe-derived",
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "scope": "example",
+                     *         "source": "live-cron-prober",
+                     *         "subnets": [
+                     *           {
+                     *             "degraded_count": 1,
+                     *             "failed_count": 1,
+                     *             "ok_count": 1,
+                     *             "status": "ok",
+                     *             "surface_count": 1,
+                     *             "unknown_count": 1
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthSummaryArtifact"];
                     };
@@ -4609,6 +5641,55 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "date": "2026-06-01",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "probe_finished_at": "2026-06-01T00:00:00.000Z",
+                     *         "probe_started_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "summary": {
+                     *           "classification_counts": {},
+                     *           "status_counts": {},
+                     *           "surface_count": 1
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "classification": "live",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "status": "ok",
+                     *             "surface_id": "example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthHistoryArtifact"];
                     };
@@ -4679,6 +5760,54 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "summary": {
+                     *           "affected_surface_count": 1,
+                     *           "incident_count": 1
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "incident_count": 1,
+                     *             "incidents": [
+                     *               {
+                     *                 "duration_ms": 1,
+                     *                 "ended_at": 1,
+                     *                 "started_at": 1
+                     *               }
+                     *             ],
+                     *             "netuid": 7,
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["GlobalIncidentsArtifact"];
                     };
@@ -4747,6 +5876,52 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "graduated_subnet_count": 1,
+                     *         "link_count": 1,
+                     *         "links": [
+                     *           {
+                     *             "mainnet_netuid": 7,
+                     *             "matched_by": "github_repo",
+                     *             "testnet_netuid": 7
+                     *           }
+                     *         ],
+                     *         "matched_by_counts": {
+                     *           "example": 1
+                     *         },
+                     *         "notes": "Example description.",
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source_network": "example",
+                     *         "target_network": "example",
+                     *         "testnet_only_count": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["LineageArtifact"];
                     };
@@ -4815,6 +5990,40 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "components": {},
+                     *         "info": {},
+                     *         "openapi": "3.1.0",
+                     *         "paths": {},
+                     *         "servers": [
+                     *           {}
+                     *         ],
+                     *         "x-metagraphed": {}
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["OpenApiArtifact"];
                     };
@@ -4895,6 +6104,176 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "profiles": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "categories": [
+                     *               "example"
+                     *             ],
+                     *             "completeness": {
+                     *               "confidence": "low",
+                     *               "gap_reasons": [
+                     *                 "example"
+                     *               ],
+                     *               "identity_level": "none",
+                     *               "identity_surface_count": 1,
+                     *               "missing_critical_count": 1,
+                     *               "missing_identity": [
+                     *                 "archive"
+                     *               ],
+                     *               "missing_operational": [
+                     *                 "archive"
+                     *               ],
+                     *               "missing_required": [
+                     *                 "archive"
+                     *               ],
+                     *               "profile_level": "directory-only",
+                     *               "score": 100
+                     *             },
+                     *             "completeness_score": 100,
+                     *             "confidence": "low",
+                     *             "curation_level": "native",
+                     *             "derived_categories": [
+                     *               "example"
+                     *             ],
+                     *             "endpoint_count": 1,
+                     *             "gap_reasons": [
+                     *               "example"
+                     *             ],
+                     *             "identity_evidence": {
+                     *               "candidate_identity_count": 1,
+                     *               "curated_identity_count": 1,
+                     *               "curated_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "native_contact_present": false,
+                     *               "native_description_present": false,
+                     *               "native_identity_count": 1,
+                     *               "native_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "needs_promotion_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "unverified_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "missing_critical_count": 1,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_operational": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_required": [
+                     *               "archive"
+                     *             ],
+                     *             "monitored_endpoint_count": 1,
+                     *             "name": "Example Subnet",
+                     *             "native_identity": {
+                     *               "additional": "example",
+                     *               "contact_present": false,
+                     *               "description": "Example description.",
+                     *               "discord": "example",
+                     *               "discord_url": "https://api.metagraph.sh/example",
+                     *               "github_url": "https://api.metagraph.sh/example",
+                     *               "logo_url": "https://api.metagraph.sh/example",
+                     *               "source": "live-cron-prober",
+                     *               "subnet_name": "Example Subnet",
+                     *               "website_url": "https://api.metagraph.sh/example"
+                     *             },
+                     *             "netuid": 7,
+                     *             "operational_interface_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "primary_app_surface": {
+                     *               "id": "example",
+                     *               "kind": "archive",
+                     *               "name": "Example Subnet",
+                     *               "provider": "example-provider",
+                     *               "url": "https://api.metagraph.sh/example"
+                     *             },
+                     *             "primary_links": {
+                     *               "dashboard_url": "https://api.metagraph.sh/example",
+                     *               "docs_url": "https://api.metagraph.sh/example",
+                     *               "source_repo": "https://api.metagraph.sh/example",
+                     *               "website_url": "https://api.metagraph.sh/example"
+                     *             },
+                     *             "profile_level": "directory-only",
+                     *             "project_name": "example",
+                     *             "provenance": {
+                     *               "curation_level": "native",
+                     *               "identity_source": "live-cron-prober",
+                     *               "interface_source_count": 1,
+                     *               "review_state": "unreviewed",
+                     *               "reviewed_at": "2026-06-01T00:00:00.000Z",
+                     *               "source_urls": [
+                     *                 "https://api.metagraph.sh/example"
+                     *               ]
+                     *             },
+                     *             "review_state": "unreviewed",
+                     *             "slug": "example-subnet",
+                     *             "status": "active",
+                     *             "subnet_type": "root",
+                     *             "suggested_submission_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "supported_interface_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "surface_count": 1,
+                     *             "team": "example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "average_completeness_score": 100,
+                     *           "by_confidence": {},
+                     *           "by_identity_level": {},
+                     *           "by_profile_level": {},
+                     *           "identity_promotion_candidate_count": 1,
+                     *           "native_identity_count": 1,
+                     *           "native_identity_unpromoted_count": 1,
+                     *           "profile_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetProfilesArtifact"];
                     };
@@ -4971,6 +6350,46 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "providers": [
+                     *           {
+                     *             "authority": "official",
+                     *             "id": "example-subnet",
+                     *             "kind": "subnet-team",
+                     *             "name": "Example Subnet",
+                     *             "schema_version": 1,
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProvidersArtifact"];
                     };
@@ -5041,6 +6460,57 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "provider": {
+                     *           "authority": "official",
+                     *           "cluster_id": "example",
+                     *           "contact_url": "https://api.metagraph.sh/example",
+                     *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "endpoint_count": 1,
+                     *           "github_url": "https://api.metagraph.sh/example",
+                     *           "id": "example-subnet",
+                     *           "kind": "subnet-team",
+                     *           "name": "Example Subnet",
+                     *           "netuids": [
+                     *             7
+                     *           ],
+                     *           "notes": "Example description.",
+                     *           "public_notes": "example",
+                     *           "schema_version": 1,
+                     *           "subnet_count": 1,
+                     *           "surface_count": 1,
+                     *           "team_url": "https://api.metagraph.sh/example",
+                     *           "website_url": "https://api.metagraph.sh/example"
+                     *         },
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProviderArtifact"];
                     };
@@ -5122,6 +6592,81 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "provider": {
+                     *           "authority": "example",
+                     *           "id": "example",
+                     *           "kind": "example",
+                     *           "name": "Example Subnet"
+                     *         },
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "by_kind": {},
+                     *           "by_layer": {},
+                     *           "by_provider": {},
+                     *           "by_publication_state": {},
+                     *           "by_status": {},
+                     *           "endpoint_count": 1,
+                     *           "monitored_count": 1,
+                     *           "pool_eligible_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ProviderEndpointsArtifact"];
                     };
@@ -5193,6 +6738,41 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "board": "example",
+                     *         "boards": {
+                     *           "example": [
+                     *             {}
+                     *           ]
+                     *         },
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RegistryLeaderboardsArtifact"];
                     };
@@ -5261,6 +6841,57 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "counts": {
+                     *           "candidates": 1,
+                     *           "endpoints": 1,
+                     *           "providers": 1,
+                     *           "surfaces": 1
+                     *         },
+                     *         "coverage": {},
+                     *         "curation_level_counts": {
+                     *           "example": 1
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "profile_level_counts": {
+                     *           "example": 1
+                     *         },
+                     *         "recent_changes": {},
+                     *         "schema_version": 1,
+                     *         "subnet_count": 1,
+                     *         "top_subnets": [
+                     *           {
+                     *             "completeness_score": 100,
+                     *             "netuid": 7
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RegistrySummaryArtifact"];
                     };
@@ -5340,6 +6971,75 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidates": [
+                     *           {
+                     *             "candidate_api_count": 1,
+                     *             "candidate_api_ids": [
+                     *               "example"
+                     *             ],
+                     *             "candidate_api_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "curation_level": "native",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "operational_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "operational_surface_count": 1,
+                     *             "operational_surface_ids": [
+                     *               "example"
+                     *             ],
+                     *             "priority_score": 100,
+                     *             "reason_codes": [
+                     *               "example"
+                     *             ],
+                     *             "recommended_adapter_kind": "custom-adapter",
+                     *             "slug": "example-subnet",
+                     *             "suggested_next_action": "example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "adapter_backed_count": 1,
+                     *           "by_curation_level": {},
+                     *           "by_recommended_adapter_kind": {},
+                     *           "candidate_api_kind_counts": {},
+                     *           "candidate_count": 1,
+                     *           "data_artifact_backed_count": 1,
+                     *           "openapi_backed_count": 1,
+                     *           "operational_kind_counts": {},
+                     *           "sse_backed_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewAdapterCandidatesArtifact"];
                     };
@@ -5419,6 +7119,79 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "entries": [
+                     *           {
+                     *             "candidate_evidence_by_kind": {},
+                     *             "candidate_evidence_summary": {
+                     *               "candidate_count": 1,
+                     *               "kinds_with_candidates": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_or_redirected_count": 1,
+                     *               "reviewable_count": 1,
+                     *               "stale_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_or_failed_count": 1,
+                     *               "unverified_count": 1,
+                     *               "unverified_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "direct_submission_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "evidence_action": "submit-new-evidence",
+                     *             "lane": "direct-submission",
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "slug": "example-subnet"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "entry_count": 1,
+                     *           "evidence_action_counts": {},
+                     *           "stale_candidate_count": 1,
+                     *           "subnet_count": 1,
+                     *           "unverified_candidate_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewEnrichmentEvidenceArtifact"];
                     };
@@ -5504,6 +7277,122 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "queue": [
+                     *           {
+                     *             "adapter_score": 100,
+                     *             "candidate_count": 1,
+                     *             "candidate_evidence_summary": {
+                     *               "candidate_count": 1,
+                     *               "kinds_with_candidates": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_or_redirected_count": 1,
+                     *               "reviewable_count": 1,
+                     *               "stale_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_or_failed_count": 1,
+                     *               "unverified_count": 1,
+                     *               "unverified_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "completeness_score": 100,
+                     *             "contribution_hint": "example",
+                     *             "curation_level": "native",
+                     *             "direct_submission_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "endpoint_count": 1,
+                     *             "evidence_action": "submit-new-evidence",
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "lane": "direct-submission",
+                     *             "manual_review_required": true,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "operational_interface_count": 1,
+                     *             "priority_score": 100,
+                     *             "profile_level": "directory-only",
+                     *             "reason_codes": [
+                     *               "example"
+                     *             ],
+                     *             "recommended_action": "2026-06-01T00:00:00.000Z",
+                     *             "review_state": "unreviewed",
+                     *             "sample_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_live_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_stale_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_target_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "slug": "example-subnet",
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ],
+                     *             "stale_candidate_count": 1,
+                     *             "surface_count": 1,
+                     *             "verified_candidate_count": 1
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "adapter_candidate_count": 1,
+                     *           "baseline_monitoring_count": 1,
+                     *           "direct_submission_count": 1,
+                     *           "evidence_action_counts": {},
+                     *           "identity_level_counts": {},
+                     *           "lane_counts": {},
+                     *           "maintainer_review_count": 1,
+                     *           "manual_review_required_count": 1,
+                     *           "monitoring_followup_count": 1,
+                     *           "queue_count": 1,
+                     *           "subnet_count": 1,
+                     *           "top_direct_submission_kinds": {}
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewEnrichmentQueueArtifact"];
                     };
@@ -5591,6 +7480,133 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "groups": [
+                     *           {
+                     *             "auto_review_candidate_count": 1,
+                     *             "kind": "archive",
+                     *             "manual_review_required_count": 1,
+                     *             "target_count": 1,
+                     *             "target_ids": [
+                     *               "example"
+                     *             ],
+                     *             "target_type": "surface-candidate",
+                     *             "top_netuids": [
+                     *               7
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "auto_review_candidate_count": 1,
+                     *           "by_evidence_action": {},
+                     *           "by_kind": {},
+                     *           "by_lane": {},
+                     *           "by_target_type": {},
+                     *           "manual_review_required_count": 1,
+                     *           "new_evidence_count": 1,
+                     *           "stale_replacement_count": 1,
+                     *           "subnet_count": 1,
+                     *           "target_count": 1
+                     *         },
+                     *         "targets": [
+                     *           {
+                     *             "auto_review_candidate": false,
+                     *             "candidate_command": "example",
+                     *             "candidate_evidence": {
+                     *               "candidate_count": 1,
+                     *               "classifications": {},
+                     *               "live_or_redirected_count": 1,
+                     *               "reviewable_count": 1,
+                     *               "sample_candidate_ids": [
+                     *                 "example"
+                     *               ],
+                     *               "stale_or_failed_count": 1,
+                     *               "unverified_count": 1
+                     *             },
+                     *             "contribution_prompt": "example",
+                     *             "evidence_action": "submit-new-evidence",
+                     *             "identity_level": "none",
+                     *             "kind": "archive",
+                     *             "lane": "direct-submission",
+                     *             "manual_review_required": true,
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "profile_level": "directory-only",
+                     *             "queue_context": {
+                     *               "adapter_score": 100,
+                     *               "candidate_count": 1,
+                     *               "completeness_score": 100,
+                     *               "curation_level": "native",
+                     *               "direct_submission_kind_count": 1,
+                     *               "endpoint_count": 1,
+                     *               "identity_surface_count": 1,
+                     *               "operational_interface_count": 1,
+                     *               "profile_level": "directory-only",
+                     *               "review_state": "unreviewed",
+                     *               "source_url_count": 1,
+                     *               "stale_candidate_count": 1,
+                     *               "surface_count": 1,
+                     *               "verified_candidate_count": 1
+                     *             },
+                     *             "reason_codes": [
+                     *               "example"
+                     *             ],
+                     *             "recommended_action": "2026-06-01T00:00:00.000Z",
+                     *             "sample_live_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_stale_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_target_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "slug": "example-subnet",
+                     *             "source_requirements": [
+                     *               "example"
+                     *             ],
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ],
+                     *             "submission_route": "direct-candidate-pr",
+                     *             "target_action": "submit-new-candidate",
+                     *             "target_id": "example",
+                     *             "target_type": "surface-candidate"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewEnrichmentTargetsArtifact"];
                     };
@@ -5667,6 +7683,53 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "priorities": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "curation_level": "native",
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "review_state": "unreviewed",
+                     *             "slug": "example-subnet",
+                     *             "suggested_next_action": "example",
+                     *             "surface_count": 1,
+                     *             "verified_candidate_count": 1
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewGapPrioritiesArtifact"];
                     };
@@ -5746,6 +7809,117 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "profiles": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "completeness_score": 100,
+                     *             "confidence": "low",
+                     *             "curation_level": "native",
+                     *             "gap_reasons": [
+                     *               "example"
+                     *             ],
+                     *             "identity_evidence": {
+                     *               "candidate_identity_count": 1,
+                     *               "curated_identity_count": 1,
+                     *               "curated_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "native_contact_present": false,
+                     *               "native_description_present": false,
+                     *               "native_identity_count": 1,
+                     *               "native_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "needs_promotion_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "unverified_candidate_identity_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "identity_level": "none",
+                     *             "identity_promotion_kind_count": 1,
+                     *             "identity_promotion_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "identity_surface_count": 1,
+                     *             "live_identity_candidate_kind_count": 1,
+                     *             "missing_critical_count": 1,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_operational": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_required": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "native_identity_signal_count": 1,
+                     *             "native_name_quality": "chain",
+                     *             "netuid": 7,
+                     *             "operational_interface_count": 1,
+                     *             "priority_score": 100,
+                     *             "profile_level": "directory-only",
+                     *             "review_state": "unreviewed",
+                     *             "slug": "example-subnet",
+                     *             "source_count": 1,
+                     *             "stale_identity_candidate_kind_count": 1,
+                     *             "suggested_next_action": "example",
+                     *             "supported_interface_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "average_completeness_score": 100,
+                     *           "by_confidence": {},
+                     *           "by_identity_level": {},
+                     *           "by_profile_level": {},
+                     *           "critical_gap_counts": {},
+                     *           "identity_promotion_candidate_count": 1,
+                     *           "native_identity_count": 1,
+                     *           "native_identity_unpromoted_count": 1,
+                     *           "needs_identity_count": 1,
+                     *           "needs_operational_count": 1,
+                     *           "profile_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["ReviewProfileCompletenessArtifact"];
                     };
@@ -5826,6 +8000,59 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "chain": "bittensor",
+                     *             "classification": "live",
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "subtensor-rpc",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "network": "finney",
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "provider": "example-provider",
+                     *             "status": "ok",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "summary": {
+                     *           "archive_supported_count": 1,
+                     *           "by_kind": {},
+                     *           "by_provider": {},
+                     *           "by_status": {},
+                     *           "endpoint_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RpcEndpointsArtifact"];
                     };
@@ -5894,6 +8121,94 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "disabled_proxy_contract": {
+                     *           "allowed_methods": [
+                     *             "GET"
+                     *           ],
+                     *           "denied_method_patterns": [
+                     *             "GET"
+                     *           ],
+                     *           "enabled": true,
+                     *           "feature_flag": "example",
+                     *           "rate_limit_required": true,
+                     *           "waf_required": true
+                     *         },
+                     *         "eligibility_policy": {
+                     *           "eligible_layers": [
+                     *             "example"
+                     *           ],
+                     *           "notes": "Example description.",
+                     *           "required_status": "ok",
+                     *           "requires_no_auth": false,
+                     *           "requires_public_safe": true,
+                     *           "source": "live-cron-prober",
+                     *           "user_reports_can_change_health": false
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "pools": [
+                     *           {
+                     *             "eligible_count": 1,
+                     *             "endpoint_count": 1,
+                     *             "endpoints": [
+                     *               {
+                     *                 "health_source": "probe-derived",
+                     *                 "health_stale": false,
+                     *                 "id": "example",
+                     *                 "last_ok": "2026-06-01T00:00:00.000Z",
+                     *                 "observed_at": "2026-06-01T00:00:00.000Z",
+                     *                 "pool_eligible": false,
+                     *                 "provider": "example-provider",
+                     *                 "score": 100,
+                     *                 "status": "ok",
+                     *                 "url": "https://api.metagraph.sh/example"
+                     *               }
+                     *             ],
+                     *             "id": "example",
+                     *             "kind": "example"
+                     *           }
+                     *         ],
+                     *         "provider_scores": [
+                     *           {
+                     *             "average_score": 100,
+                     *             "degraded_count": 1,
+                     *             "endpoint_count": 1,
+                     *             "failed_count": 1,
+                     *             "monitored_count": 1,
+                     *             "ok_count": 1,
+                     *             "operational_score": 100,
+                     *             "pool_eligible_count": 1,
+                     *             "provider": "example-provider"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RpcPoolsArtifact"];
                     };
@@ -5962,6 +8277,45 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "schemas": [
+                     *           {
+                     *             "drift_status": "changed",
+                     *             "schema_url": "https://api.metagraph.sh/example",
+                     *             "status": "captured",
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SchemaIndexArtifact"];
                     };
@@ -6036,6 +8390,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "document_count": 1,
+                     *         "documents": [
+                     *           {
+                     *             "artifact_path": "example",
+                     *             "id": "example",
+                     *             "title": "Example Subnet",
+                     *             "tokens": [
+                     *               "example"
+                     *             ],
+                     *             "type": "subnet"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SearchArtifact"];
                     };
@@ -6104,6 +8500,59 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "providers": [
+                     *           {
+                     *             "authority": "official",
+                     *             "candidate_count": 1,
+                     *             "classifications": {},
+                     *             "endpoint_count": 1,
+                     *             "id": "example",
+                     *             "kind": "subnet-team",
+                     *             "name": "Example Subnet",
+                     *             "rpc_endpoint_count": 1,
+                     *             "status": "ok",
+                     *             "verification_result_count": 1
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "source": "generated-provider-and-verification-summary",
+                     *         "summary": {
+                     *           "candidate_count": 1,
+                     *           "endpoint_count": 1,
+                     *           "provider_count": 1,
+                     *           "rpc_endpoint_count": 1,
+                     *           "status_counts": {},
+                     *           "verification_result_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SourceHealthArtifact"];
                     };
@@ -6178,6 +8627,54 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "sources": [
+                     *           {
+                     *             "captured_at": "2026-06-01T00:00:00.000Z",
+                     *             "hash": "a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1a3f1",
+                     *             "id": "example",
+                     *             "kind": "adapter-snapshot",
+                     *             "path": "example",
+                     *             "record_count": 1
+                     *           }
+                     *         ],
+                     *         "summary": {
+                     *           "adapter_snapshot_count": 1,
+                     *           "candidate_count": 1,
+                     *           "overlay_count": 1,
+                     *           "provider_count": 1,
+                     *           "source_count": 1,
+                     *           "verification_result_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SourceSnapshotsArtifact"];
                     };
@@ -6258,6 +8755,57 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "network": "finney",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "source": {
+                     *           "identity_storage": "example",
+                     *           "kind": "example",
+                     *           "method": "GET",
+                     *           "package": "example",
+                     *           "rpc_family": "example",
+                     *           "version": "2026-06-06.1"
+                     *         },
+                     *         "subnets": [
+                     *           {
+                     *             "coverage_level": "native-only",
+                     *             "curation_level": "native",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "slug": "example-subnet",
+                     *             "status": "active",
+                     *             "subnet_type": "root",
+                     *             "surface_count": 1
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetsArtifact"];
                     };
@@ -6328,6 +8876,185 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidate_surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "candidates": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "gaps": {
+                     *           "gap_notes": [
+                     *             "example"
+                     *           ],
+                     *           "missing_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_kinds": [
+                     *             "archive"
+                     *           ]
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "subnet": {
+                     *           "block": 5000000,
+                     *           "candidate_count": 1,
+                     *           "categories": [
+                     *             "example"
+                     *           ],
+                     *           "coverage_level": "native-only",
+                     *           "curation": {
+                     *             "level": "native",
+                     *             "review_state": "unreviewed"
+                     *           },
+                     *           "curation_level": "native",
+                     *           "dashboard_url": "https://api.metagraph.sh/example",
+                     *           "derived_categories": [
+                     *             "example"
+                     *           ],
+                     *           "description": "Example description.",
+                     *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "gap_count": 1,
+                     *           "gaps": {
+                     *             "gap_notes": [
+                     *               "example"
+                     *             ],
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "supported_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           },
+                     *           "lifecycle": "active",
+                     *           "links": [
+                     *             {}
+                     *           ],
+                     *           "logo_url": "https://api.metagraph.sh/example",
+                     *           "mechanism_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "native_name": "example",
+                     *           "native_name_quality": "chain",
+                     *           "native_slug": "example-subnet",
+                     *           "netuid": 7,
+                     *           "notes": "Example description.",
+                     *           "participant_count": 1,
+                     *           "probed_surface_count": 1,
+                     *           "provenance": {},
+                     *           "registered_at_block": 5000000,
+                     *           "slug": "example-subnet",
+                     *           "source_repo": "https://api.metagraph.sh/example",
+                     *           "status": "active",
+                     *           "subnet_type": "root",
+                     *           "surface_count": 1,
+                     *           "symbol": "example",
+                     *           "tempo": 1,
+                     *           "website_url": "https://api.metagraph.sh/example"
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "verified_surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetDetailArtifact"];
                     };
@@ -6406,6 +9133,51 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidates": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetCandidatesArtifact"];
                     };
@@ -6487,6 +9259,78 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet",
+                     *         "summary": {
+                     *           "by_kind": {},
+                     *           "by_layer": {},
+                     *           "by_provider": {},
+                     *           "by_publication_state": {},
+                     *           "by_status": {},
+                     *           "endpoint_count": 1,
+                     *           "monitored_count": 1,
+                     *           "pool_eligible_count": 1
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEndpointsArtifact"];
                     };
@@ -6563,6 +9407,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "claims": [
+                     *           {
+                     *             "claim": "example",
+                     *             "confidence": "low",
+                     *             "limits": "example",
+                     *             "source_tier": "native-chain",
+                     *             "source_type": "example",
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "subject": "example",
+                     *             "support_summary": "Example description."
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetEvidenceArtifact"];
                     };
@@ -6640,6 +9526,128 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "enrichment_queue": [
+                     *           {
+                     *             "adapter_score": 100,
+                     *             "candidate_count": 1,
+                     *             "candidate_evidence_summary": {
+                     *               "candidate_count": 1,
+                     *               "kinds_with_candidates": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "live_or_redirected_count": 1,
+                     *               "reviewable_count": 1,
+                     *               "stale_kinds": [
+                     *                 "archive"
+                     *               ],
+                     *               "stale_or_failed_count": 1,
+                     *               "unverified_count": 1,
+                     *               "unverified_kinds": [
+                     *                 "archive"
+                     *               ]
+                     *             },
+                     *             "completeness_score": 100,
+                     *             "contribution_hint": "example",
+                     *             "curation_level": "native",
+                     *             "direct_submission_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "endpoint_count": 1,
+                     *             "evidence_action": "submit-new-evidence",
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "lane": "direct-submission",
+                     *             "manual_review_required": true,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "operational_interface_count": 1,
+                     *             "priority_score": 100,
+                     *             "profile_level": "directory-only",
+                     *             "reason_codes": [
+                     *               "example"
+                     *             ],
+                     *             "recommended_action": "2026-06-01T00:00:00.000Z",
+                     *             "review_state": "unreviewed",
+                     *             "sample_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_live_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_stale_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "sample_target_candidate_ids": [
+                     *               "example"
+                     *             ],
+                     *             "slug": "example-subnet",
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ],
+                     *             "stale_candidate_count": 1,
+                     *             "surface_count": 1,
+                     *             "verified_candidate_count": 1
+                     *           }
+                     *         ],
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "priorities": [
+                     *           {
+                     *             "candidate_count": 1,
+                     *             "curation_level": "native",
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "priority_score": 100,
+                     *             "review_state": "unreviewed",
+                     *             "slug": "example-subnet",
+                     *             "suggested_next_action": "example",
+                     *             "surface_count": 1,
+                     *             "verified_candidate_count": 1
+                     *           }
+                     *         ],
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetGapsArtifact"];
                     };
@@ -6719,6 +9727,63 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "health_source": "probe-derived",
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "operational_observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet",
+                     *         "summary": {
+                     *           "avg_latency_ms": 120,
+                     *           "degraded_count": 1,
+                     *           "failed_count": 1,
+                     *           "last_checked": "2026-06-01T00:00:00.000Z",
+                     *           "last_ok": "2026-06-01T00:00:00.000Z",
+                     *           "name": "Example Subnet",
+                     *           "netuid": 7,
+                     *           "ok_count": 1,
+                     *           "slug": "example-subnet",
+                     *           "status": "ok",
+                     *           "surface_count": 1,
+                     *           "unknown_count": 1
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "classification": "live",
+                     *             "netuid": 7,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthSubnetArtifact"];
                     };
@@ -6791,6 +9856,54 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "surfaces": [
+                     *           {
+                     *             "downtime_ms": 1,
+                     *             "incident_count": 1,
+                     *             "incidents": [
+                     *               {
+                     *                 "duration_ms": 1,
+                     *                 "ended_at": 1,
+                     *                 "failed_samples": 1,
+                     *                 "started_at": 1
+                     *               }
+                     *             ],
+                     *             "samples": 1,
+                     *             "surface_id": "example",
+                     *             "uptime_ratio": 0.9966
+                     *           }
+                     *         ],
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthIncidentsArtifact"];
                     };
@@ -6863,6 +9976,44 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "surfaces": [
+                     *           {
+                     *             "latency_ms": {},
+                     *             "samples": 1,
+                     *             "surface_id": "example"
+                     *           }
+                     *         ],
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthPercentilesArtifact"];
                     };
@@ -6933,6 +10084,50 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "netuid": 7,
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "windows": {
+                     *           "example": {
+                     *             "samples": 1,
+                     *             "surfaces": [
+                     *               {
+                     *                 "avg_latency_ms": 120,
+                     *                 "samples": 1,
+                     *                 "surface_id": "example",
+                     *                 "uptime_ratio": 0.9966
+                     *               }
+                     *             ],
+                     *             "uptime_ratio": 0.9966
+                     *           }
+                     *         }
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["HealthTrendsArtifact"];
                     };
@@ -7003,6 +10198,224 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "counts": {
+                     *           "candidates": 1,
+                     *           "endpoints": 1,
+                     *           "surfaces": 1
+                     *         },
+                     *         "curation": {
+                     *           "gap_notes": [
+                     *             "example"
+                     *           ],
+                     *           "level": "native",
+                     *           "review_state": "unreviewed",
+                     *           "reviewed_at": "2026-06-01T00:00:00.000Z",
+                     *           "source_count": 1,
+                     *           "verified_at": "2026-06-01T00:00:00.000Z"
+                     *         },
+                     *         "gap_priorities": [
+                     *           null
+                     *         ],
+                     *         "gaps": {
+                     *           "gap_notes": [
+                     *             "example"
+                     *           ],
+                     *           "missing_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_kinds": [
+                     *             "archive"
+                     *           ]
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "health": {
+                     *           "avg_latency_ms": 120,
+                     *           "degraded_count": 1,
+                     *           "failed_count": 1,
+                     *           "last_checked": "2026-06-01T00:00:00.000Z",
+                     *           "last_ok": "2026-06-01T00:00:00.000Z",
+                     *           "netuid": 7,
+                     *           "observed_by": "2026-06-01T00:00:00.000Z",
+                     *           "ok_count": 1,
+                     *           "status": "ok",
+                     *           "surface_count": 1,
+                     *           "unknown_count": 1
+                     *         },
+                     *         "name": "Example Subnet",
+                     *         "netuid": 7,
+                     *         "notes": "Example description.",
+                     *         "profile": {
+                     *           "candidate_count": 1,
+                     *           "categories": [
+                     *             "example"
+                     *           ],
+                     *           "completeness": {
+                     *             "confidence": "low",
+                     *             "gap_reasons": [
+                     *               "example"
+                     *             ],
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "missing_critical_count": 1,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_operational": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_required": [
+                     *               "archive"
+                     *             ],
+                     *             "profile_level": "directory-only",
+                     *             "score": 100
+                     *           },
+                     *           "completeness_score": 100,
+                     *           "confidence": "low",
+                     *           "curation_level": "native",
+                     *           "derived_categories": [
+                     *             "example"
+                     *           ],
+                     *           "derived_description": "Example description.",
+                     *           "endpoint_count": 1,
+                     *           "gap_reasons": [
+                     *             "example"
+                     *           ],
+                     *           "identity_evidence": {
+                     *             "candidate_identity_count": 1,
+                     *             "curated_identity_count": 1,
+                     *             "curated_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "live_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "native_contact_present": false,
+                     *             "native_description_present": false,
+                     *             "native_identity_count": 1,
+                     *             "native_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "needs_promotion_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "stale_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "unverified_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           },
+                     *           "identity_level": "none",
+                     *           "identity_surface_count": 1,
+                     *           "injection_scrubbed": false,
+                     *           "integration_readiness": 1,
+                     *           "interface_count": 1,
+                     *           "lineage": {},
+                     *           "missing_critical_count": 1,
+                     *           "missing_identity": [
+                     *             "archive"
+                     *           ],
+                     *           "missing_operational": [
+                     *             "archive"
+                     *           ],
+                     *           "missing_required": [
+                     *             "archive"
+                     *           ],
+                     *           "monitored_endpoint_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "native_identity": {
+                     *             "additional": "example",
+                     *             "contact_present": false,
+                     *             "description": "Example description.",
+                     *             "discord": "example",
+                     *             "discord_url": "https://api.metagraph.sh/example",
+                     *             "github_url": "https://api.metagraph.sh/example",
+                     *             "logo_url": "https://api.metagraph.sh/example",
+                     *             "source": "live-cron-prober",
+                     *             "subnet_name": "Example Subnet",
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "native_name": "example",
+                     *           "native_name_quality": "chain",
+                     *           "netuid": 7,
+                     *           "operational_interface_count": 1,
+                     *           "operational_interface_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "primary_app_surface": {
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "provider": "example-provider",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "primary_links": {
+                     *             "dashboard_url": "https://api.metagraph.sh/example",
+                     *             "docs_url": "https://api.metagraph.sh/example",
+                     *             "source_repo": "https://api.metagraph.sh/example",
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "profile_level": "directory-only",
+                     *           "project_name": "example",
+                     *           "provenance": {
+                     *             "curation_level": "native",
+                     *             "identity_source": "live-cron-prober",
+                     *             "interface_source_count": 1,
+                     *             "review_state": "unreviewed",
+                     *             "reviewed_at": "2026-06-01T00:00:00.000Z",
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ]
+                     *           },
+                     *           "readiness": {
+                     *             "components": {},
+                     *             "readiness_version": 1,
+                     *             "score": 100
+                     *           },
+                     *           "review_state": "unreviewed",
+                     *           "slug": "example-subnet",
+                     *           "status": "active",
+                     *           "subnet_type": "root",
+                     *           "suggested_submission_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_interface_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "surface_count": 1,
+                     *           "symbol": "example",
+                     *           "team": "example"
+                     *         },
+                     *         "schema_version": 1,
+                     *         "slug": "example-subnet",
+                     *         "status": "ok"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetOverviewArtifact"];
                     };
@@ -7073,6 +10486,300 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "candidate_surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "schema_version": 1,
+                     *             "source_url": "https://api.metagraph.sh/example",
+                     *             "state": "schema-invalid",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "contract_version": "2026-06-06.1",
+                     *         "endpoints": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "health_source": "probe-derived",
+                     *             "health_stale": false,
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "last_ok": "2026-06-01T00:00:00.000Z",
+                     *             "layer": "bittensor-base",
+                     *             "monitoring_policy": {
+                     *               "enabled": true,
+                     *               "expect": "example",
+                     *               "method": "GET",
+                     *               "source": "live-cron-prober"
+                     *             },
+                     *             "monitoring_status": "monitored",
+                     *             "netuid": 7,
+                     *             "observed_at": "2026-06-01T00:00:00.000Z",
+                     *             "operator": "example-provider",
+                     *             "pool_eligible": false,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "publication_state": "candidate",
+                     *             "score": 100,
+                     *             "status": "ok",
+                     *             "surface_id": "example",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ],
+                     *         "gaps": {
+                     *           "gap_notes": [
+                     *             "example"
+                     *           ],
+                     *           "missing_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_kinds": [
+                     *             "archive"
+                     *           ]
+                     *         },
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "profile": {
+                     *           "candidate_count": 1,
+                     *           "categories": [
+                     *             "example"
+                     *           ],
+                     *           "completeness": {
+                     *             "confidence": "low",
+                     *             "gap_reasons": [
+                     *               "example"
+                     *             ],
+                     *             "identity_level": "none",
+                     *             "identity_surface_count": 1,
+                     *             "missing_critical_count": 1,
+                     *             "missing_identity": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_operational": [
+                     *               "archive"
+                     *             ],
+                     *             "missing_required": [
+                     *               "archive"
+                     *             ],
+                     *             "profile_level": "directory-only",
+                     *             "score": 100
+                     *           },
+                     *           "completeness_score": 100,
+                     *           "confidence": "low",
+                     *           "curation_level": "native",
+                     *           "derived_categories": [
+                     *             "example"
+                     *           ],
+                     *           "derived_description": "Example description.",
+                     *           "endpoint_count": 1,
+                     *           "gap_reasons": [
+                     *             "example"
+                     *           ],
+                     *           "identity_evidence": {
+                     *             "candidate_identity_count": 1,
+                     *             "curated_identity_count": 1,
+                     *             "curated_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "live_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "native_contact_present": false,
+                     *             "native_description_present": false,
+                     *             "native_identity_count": 1,
+                     *             "native_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "needs_promotion_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "stale_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "unverified_candidate_identity_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           },
+                     *           "identity_level": "none",
+                     *           "identity_surface_count": 1,
+                     *           "injection_scrubbed": false,
+                     *           "integration_readiness": 1,
+                     *           "interface_count": 1,
+                     *           "lineage": {},
+                     *           "missing_critical_count": 1,
+                     *           "missing_identity": [
+                     *             "archive"
+                     *           ],
+                     *           "missing_operational": [
+                     *             "archive"
+                     *           ],
+                     *           "missing_required": [
+                     *             "archive"
+                     *           ],
+                     *           "monitored_endpoint_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "native_identity": {
+                     *             "additional": "example",
+                     *             "contact_present": false,
+                     *             "description": "Example description.",
+                     *             "discord": "example",
+                     *             "discord_url": "https://api.metagraph.sh/example",
+                     *             "github_url": "https://api.metagraph.sh/example",
+                     *             "logo_url": "https://api.metagraph.sh/example",
+                     *             "source": "live-cron-prober",
+                     *             "subnet_name": "Example Subnet",
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "native_name": "example",
+                     *           "native_name_quality": "chain",
+                     *           "netuid": 7,
+                     *           "operational_interface_count": 1,
+                     *           "operational_interface_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "primary_app_surface": {
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "name": "Example Subnet",
+                     *             "provider": "example-provider",
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "primary_links": {
+                     *             "dashboard_url": "https://api.metagraph.sh/example",
+                     *             "docs_url": "https://api.metagraph.sh/example",
+                     *             "source_repo": "https://api.metagraph.sh/example",
+                     *             "website_url": "https://api.metagraph.sh/example"
+                     *           },
+                     *           "profile_level": "directory-only",
+                     *           "project_name": "example",
+                     *           "provenance": {
+                     *             "curation_level": "native",
+                     *             "identity_source": "live-cron-prober",
+                     *             "interface_source_count": 1,
+                     *             "review_state": "unreviewed",
+                     *             "reviewed_at": "2026-06-01T00:00:00.000Z",
+                     *             "source_urls": [
+                     *               "https://api.metagraph.sh/example"
+                     *             ]
+                     *           },
+                     *           "readiness": {
+                     *             "components": {},
+                     *             "readiness_version": 1,
+                     *             "score": 100
+                     *           },
+                     *           "review_state": "unreviewed",
+                     *           "slug": "example-subnet",
+                     *           "status": "active",
+                     *           "subnet_type": "root",
+                     *           "suggested_submission_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "supported_interface_kinds": [
+                     *             "archive"
+                     *           ],
+                     *           "surface_count": 1,
+                     *           "symbol": "example",
+                     *           "team": "example"
+                     *         },
+                     *         "schema_version": 1,
+                     *         "subnet": {
+                     *           "block": 5000000,
+                     *           "candidate_count": 1,
+                     *           "categories": [
+                     *             "example"
+                     *           ],
+                     *           "coverage_level": "native-only",
+                     *           "curation": {
+                     *             "level": "native",
+                     *             "review_state": "unreviewed"
+                     *           },
+                     *           "curation_level": "native",
+                     *           "dashboard_url": "https://api.metagraph.sh/example",
+                     *           "derived_categories": [
+                     *             "example"
+                     *           ],
+                     *           "description": "Example description.",
+                     *           "docs_url": "https://api.metagraph.sh/example",
+                     *           "gap_count": 1,
+                     *           "gaps": {
+                     *             "gap_notes": [
+                     *               "example"
+                     *             ],
+                     *             "missing_kinds": [
+                     *               "archive"
+                     *             ],
+                     *             "supported_kinds": [
+                     *               "archive"
+                     *             ]
+                     *           },
+                     *           "lifecycle": "active",
+                     *           "links": [
+                     *             {}
+                     *           ],
+                     *           "logo_url": "https://api.metagraph.sh/example",
+                     *           "mechanism_count": 1,
+                     *           "name": "Example Subnet",
+                     *           "native_name": "example",
+                     *           "native_name_quality": "chain",
+                     *           "native_slug": "example-subnet",
+                     *           "netuid": 7,
+                     *           "notes": "Example description.",
+                     *           "participant_count": 1,
+                     *           "probed_surface_count": 1,
+                     *           "provenance": {},
+                     *           "registered_at_block": 5000000,
+                     *           "slug": "example-subnet",
+                     *           "source_repo": "https://api.metagraph.sh/example",
+                     *           "status": "active",
+                     *           "subnet_type": "root",
+                     *           "surface_count": 1,
+                     *           "symbol": "example",
+                     *           "tempo": 1,
+                     *           "website_url": "https://api.metagraph.sh/example"
+                     *         },
+                     *         "surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetProfileArtifact"];
                     };
@@ -7150,6 +10857,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetSurfacesArtifact"];
                     };
@@ -7220,6 +10969,43 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "deltas": {
+                     *           "example": {}
+                     *         },
+                     *         "netuid": 7,
+                     *         "point_count": 1,
+                     *         "points": [
+                     *           {
+                     *             "date": "2026-06-01"
+                     *           }
+                     *         ],
+                     *         "schema_version": 1
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SubnetTrajectoryArtifact"];
                     };
@@ -7292,6 +11078,63 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "netuid": 7,
+                     *         "reliability": {
+                     *           "avg_latency_ms": 120,
+                     *           "computed_at": "2026-06-01T00:00:00.000Z",
+                     *           "day_count": 1,
+                     *           "grade": "A",
+                     *           "sample_count": 1,
+                     *           "score": 100,
+                     *           "surface_count": 1,
+                     *           "uptime_ratio": 0.9966,
+                     *           "window": "30d"
+                     *         },
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "surfaces": [
+                     *           {
+                     *             "day_count": 1,
+                     *             "days": [
+                     *               {
+                     *                 "day": "2026-06-01",
+                     *                 "samples": 1,
+                     *                 "status": "ok",
+                     *                 "uptime_ratio": 0.9966
+                     *               }
+                     *             ],
+                     *             "samples": 1,
+                     *             "surface_id": "example",
+                     *             "uptime_ratio": 0.9966
+                     *           }
+                     *         ],
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["UptimeArtifact"];
                     };
@@ -7368,6 +11211,48 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "notes": "Example description.",
+                     *         "schema_version": 1,
+                     *         "surfaces": [
+                     *           {
+                     *             "auth_required": true,
+                     *             "authority": "official",
+                     *             "id": "example",
+                     *             "kind": "archive",
+                     *             "netuid": 7,
+                     *             "provider": "example-provider",
+                     *             "public_safe": true,
+                     *             "url": "https://api.metagraph.sh/example"
+                     *           }
+                     *         ]
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["SurfacesArtifact"];
                     };

--- a/scripts/validate-openapi-examples.mjs
+++ b/scripts/validate-openapi-examples.mjs
@@ -1,18 +1,15 @@
+// Enforces that EVERY /api/v1 operation ships a worked response `example` in the
+// OpenAPI contract, and that each example is valid against its own response
+// schema. The examples are generated deterministically from the schemas at
+// build time (src/openapi-sample.mjs via buildOpenApiArtifact) so they stay
+// reproducible (no live data) and self-maintaining; this gate guarantees they
+// stay present + schema-correct, and surfaces any schema construct the sampler
+// mishandles.
 import Ajv2020 from "ajv/dist/2020.js";
 import addFormats from "ajv-formats";
-import { promises as fs } from "node:fs";
 import path from "node:path";
-import {
-  API_ROUTES,
-  artifactPathFromTemplate,
-  CONTRACT_VERSION,
-} from "../src/contracts.mjs";
-import {
-  artifactDirectoryPath,
-  artifactFilePath,
-  readJson,
-  repoRoot,
-} from "./lib.mjs";
+import { API_ROUTES } from "../src/contracts.mjs";
+import { readJson, repoRoot } from "./lib.mjs";
 
 const openapi = await readJson(
   path.join(repoRoot, "public/metagraph/openapi.json"),
@@ -26,64 +23,43 @@ const ajv = new Ajv2020({
 addFormats(ajv);
 
 const errors = [];
+let validated = 0;
 
 for (const route of API_ROUTES) {
-  const artifactPath = await exampleArtifactPath(route.artifact_path);
-  if (artifactPath === null) {
-    console.warn(
-      `validate-openapi-examples: no example artifact on disk for ${route.path}; skipping.`,
-    );
-    continue;
-  }
-  let artifact;
-  try {
-    artifact = await readJson(
-      artifactFilePath(artifactPath.replace(/^\/metagraph\//, "")),
-    );
-  } catch (error) {
-    // The example artifact isn't on disk in this build context (e.g. an
-    // R2-only or per-subnet artifact that depends on D1/health data). Presence
-    // is enforced by other gates (build, r2-manifest, contract-drift, live
-    // smoke) — this gate only validates example↔schema conformance for the
-    // artifacts that ARE present, so skip-with-warning instead of crashing.
-    if (error.code === "ENOENT") {
-      console.warn(
-        `validate-openapi-examples: example artifact not generated for ${route.path}; skipping.`,
-      );
-      continue;
-    }
-    throw error;
-  }
-  const body = {
-    ok: true,
-    schema_version: 1,
-    data: artifact,
-    meta: {
-      artifact_path: artifactPath,
-      cache: route.cache,
-      contract_version: CONTRACT_VERSION,
-      generated_at: artifact.generated_at || null,
-      source: "example-artifact",
-    },
-  };
   const operation = openapi.paths?.[route.path]?.[route.method.toLowerCase()];
-  const responseSchema =
-    operation?.responses?.["200"]?.content?.["application/json"]?.schema;
+  const media = operation?.responses?.["200"]?.content?.["application/json"];
+  const responseSchema = media?.schema;
   if (!responseSchema) {
     errors.push(`${route.path}: missing 200 response schema`);
+    continue;
+  }
+  const example = media?.example;
+  if (example === undefined) {
+    errors.push(
+      `${route.path}: missing a worked response example (every operation must ship one)`,
+    );
     continue;
   }
   const validator = ajv.compile({
     components: openapi.components,
     ...responseSchema,
   });
-  if (!validator(body)) {
+  if (!validator(example)) {
     errors.push(
-      `${route.path}: example response failed OpenAPI validation: ${ajv.errorsText(
+      `${route.path}: response example failed schema validation: ${ajv.errorsText(
         validator.errors,
       )}`,
     );
+    continue;
   }
+  validated += 1;
+}
+
+// Full-coverage invariant: every configured route ships a valid example.
+if (errors.length === 0 && validated !== API_ROUTES.length) {
+  errors.push(
+    `example coverage is ${validated}/${API_ROUTES.length} — every route must ship a worked example`,
+  );
 }
 
 if (errors.length > 0) {
@@ -97,96 +73,5 @@ if (errors.length > 0) {
 }
 
 console.log(
-  `OpenAPI example validation passed for ${API_ROUTES.length} route(s).`,
+  `OpenAPI example validation passed: ${validated}/${API_ROUTES.length} route(s) ship a schema-valid worked example.`,
 );
-
-async function exampleArtifactPath(template) {
-  if (template.includes("{date}")) {
-    const files = await fs.readdir(artifactDirectoryPath("health/history"));
-    const latest = files
-      .filter((file) => /^\d{4}-\d{2}-\d{2}\.json$/.test(file))
-      .sort()
-      .at(-1);
-    return artifactPathFromTemplate(template, {
-      date: latest.replace(/\.json$/, ""),
-    });
-  }
-  if (template.includes("{slug}")) {
-    const slug = template.includes("/providers/")
-      ? await firstProviderSlug(template)
-      : "allways";
-    return artifactPathFromTemplate(template, { slug });
-  }
-  if (template.includes("{netuid}")) {
-    const netuid = await firstExistingNetuid(template);
-    return netuid === null
-      ? null
-      : artifactPathFromTemplate(template, { netuid });
-  }
-  return template;
-}
-
-// Pick a netuid whose artifact actually exists on disk for this template,
-// preferring 7 for stable/consistent examples. Per-subnet artifacts (e.g.
-// health/trends/{netuid}.json) are only emitted when that subnet has data, so
-// hard-coding netuid 7 made validate:openapi-examples (and the scheduled
-// Sync Subnets job that runs it) fail with ENOENT whenever 7 had no instance.
-// Returns null when no instance exists at all (nothing to validate → skip).
-async function firstExistingNetuid(template) {
-  const nested = /\{netuid\}\/.+/.test(template);
-  const relativeDir = template
-    .replace(/^\/metagraph\//, "")
-    .split("{netuid}")[0]
-    .replace(/\/+$/, "");
-  let entries;
-  try {
-    entries = await fs.readdir(artifactDirectoryPath(relativeDir), {
-      withFileTypes: true,
-    });
-  } catch {
-    return null;
-  }
-  const candidates = entries
-    .filter((entry) => (nested ? entry.isDirectory() : entry.isFile()))
-    .map((entry) => entry.name.replace(/\.json$/, ""))
-    .filter((name) => /^\d+$/.test(name))
-    .map(Number)
-    .sort((a, b) => a - b);
-  if (candidates.length === 0) {
-    return null;
-  }
-  const order = candidates.includes(7)
-    ? [7, ...candidates.filter((netuid) => netuid !== 7)]
-    : candidates;
-  if (!nested) {
-    return order[0];
-  }
-  for (const netuid of order) {
-    const filePath = artifactFilePath(
-      artifactPathFromTemplate(template, { netuid }).replace(
-        /^\/metagraph\//,
-        "",
-      ),
-    );
-    try {
-      await fs.access(filePath);
-      return netuid;
-    } catch {
-      // try the next candidate
-    }
-  }
-  return null;
-}
-
-async function firstProviderSlug(template) {
-  if (template.endsWith("/endpoints.json")) {
-    const providers = await fs.readdir(artifactDirectoryPath("providers"), {
-      withFileTypes: true,
-    });
-    return providers
-      .filter((entry) => entry.isDirectory())
-      .map((entry) => entry.name)
-      .sort()[0];
-  }
-  return "allways";
-}

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -1,5 +1,6 @@
 import { artifactStorageTierForPath } from "./artifact-storage.mjs";
 import { DOMAIN_TAGS } from "./domain-tags.mjs";
+import { sampleFromSchema } from "./openapi-sample.mjs";
 
 export const CONTRACT_VERSION = "2026-06-06.1";
 export const SCHEMA_VERSION = 1;
@@ -1632,6 +1633,19 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
   const paths = {};
   for (const entry of API_ROUTES) {
     const openApiPath = entry.path;
+    const responseSchema = {
+      allOf: [
+        { $ref: "#/components/schemas/SuccessEnvelope" },
+        {
+          type: "object",
+          properties: {
+            data: {
+              $ref: `#/components/schemas/${schemaRefForArtifactPath(entry.artifact_path)}`,
+            },
+          },
+        },
+      ],
+    };
     paths[openApiPath] = {
       ...(paths[openApiPath] || {}),
       [entry.method.toLowerCase()]: {
@@ -1660,19 +1674,11 @@ export function buildOpenApiArtifact(generatedAt, componentSchemas) {
             headers: apiResponseHeaders(),
             content: {
               "application/json": {
-                schema: {
-                  allOf: [
-                    { $ref: "#/components/schemas/SuccessEnvelope" },
-                    {
-                      type: "object",
-                      properties: {
-                        data: {
-                          $ref: `#/components/schemas/${schemaRefForArtifactPath(entry.artifact_path)}`,
-                        },
-                      },
-                    },
-                  ],
-                },
+                schema: responseSchema,
+                // Deterministic worked example (schema-valid, no live data) so
+                // Swagger UI + agents see a concrete response shape. Generated
+                // from the schema; enforced by validate-openapi-examples.
+                example: sampleFromSchema(responseSchema, componentSchemas),
               },
             },
           },

--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -1,0 +1,191 @@
+// Deterministic, schema-valid example generator for the OpenAPI contract.
+//
+// Produces a minimal-but-realistic instance for any component/response schema so
+// every operation can ship a worked `example` WITHOUT depending on live data —
+// keeping public/metagraph/openapi.json reproducible from contracts + schemas
+// alone (validate:contract-drift regenerates it offline). Values are seeded by
+// field name + format + pattern so the examples read like real metagraphed
+// responses rather than bare placeholders. Validity is enforced downstream by
+// scripts/validate-openapi-examples.mjs (ajv against each operation's schema).
+
+// Top levels show optional fields (informative); deeper levels stay required-only
+// so examples don't explode. MAX_DEPTH bounds recursion on self-referential schemas.
+const OPTIONAL_DEPTH = 3;
+const MAX_DEPTH = 8;
+const ISO = "2026-06-01T00:00:00.000Z";
+const HEX64 = "a3f1".repeat(16); // 64 hex chars, matches ^[a-f0-9]{64}$
+
+function valueForPattern(pattern) {
+  switch (pattern) {
+    case "^[a-f0-9]{64}$":
+      return HEX64;
+    case "^\\d{4}-\\d{2}-\\d{2}$":
+      return "2026-06-01";
+    case "^[a-z0-9][a-z0-9-]*$":
+      return "example-subnet";
+    case "^/metagraph/":
+      return "/metagraph/example.json";
+    case "^/api/v1":
+      return "/api/v1/example";
+    case "^#/components/schemas/[A-Za-z0-9]+$":
+      return "#/components/schemas/Example";
+    default:
+      return "example";
+  }
+}
+
+function seededString(name) {
+  const n = String(name || "").toLowerCase();
+  if (/(^url$|_url$|href|endpoint|uri|repository|documentation|logo)/.test(n)) {
+    return "https://api.metagraph.sh/example";
+  }
+  if (
+    /(_at$|_time$|^last_|observed|checked|reviewed|verified|captured|published_|generated_|updated_|started_|ended_)/.test(
+      n,
+    )
+  ) {
+    return ISO;
+  }
+  if (/(^day$|^date$)/.test(n)) return "2026-06-01";
+  if (/window/.test(n)) return "30d";
+  if (/slug/.test(n)) return "example-subnet";
+  if (/(^name$|title|subnet_name|display_name)/.test(n))
+    return "Example Subnet";
+  if (/(description|^notes$|instructions|summary$)/.test(n)) {
+    return "Example description.";
+  }
+  if (/version/.test(n)) return "2026-06-06.1";
+  if (/(provider|operator)/.test(n)) return "example-provider";
+  if (/(content_hash|_hash$|^hash$)/.test(n)) return HEX64;
+  if (/health_source/.test(n)) return "probe-derived";
+  if (/source$/.test(n)) return "live-cron-prober";
+  if (/status$/.test(n)) return "ok";
+  if (/grade/.test(n)) return "A";
+  if (/method/.test(n)) return "GET";
+  if (/(surface_id|^id$|_id$)/.test(n)) return "example";
+  return "example";
+}
+
+function seededNumber(name, schema) {
+  const n = String(name || "").toLowerCase();
+  const isInt =
+    schema.type === "integer" ||
+    (Array.isArray(schema.type) && schema.type.includes("integer"));
+  let value;
+  if (/netuid/.test(n)) value = 7;
+  else if (/(uptime_ratio|_ratio$)/.test(n)) value = 0.9966;
+  else if (/score$/.test(n)) value = 100;
+  else if (/latency/.test(n)) value = 120;
+  else if (/block/.test(n)) value = 5000000;
+  else if (/(_count$|count$|samples|^total$|returned|limit|cursor)/.test(n)) {
+    value = 1;
+  } else value = isInt ? 1 : 0.5;
+  if (typeof schema.minimum === "number" && value < schema.minimum) {
+    value = schema.minimum;
+  }
+  if (typeof schema.maximum === "number" && value > schema.maximum) {
+    value = schema.maximum;
+  }
+  return isInt ? Math.round(value) : value;
+}
+
+function seededBoolean(name) {
+  return /(required|^enabled$|public_safe|^ok$|supported)/.test(
+    String(name || "").toLowerCase(),
+  );
+}
+
+function pickType(type) {
+  if (Array.isArray(type)) {
+    return type.find((entry) => entry !== "null") || type[0];
+  }
+  return type;
+}
+
+function resolveRef(ref, components) {
+  return components[ref.split("/").pop()];
+}
+
+// Sample a JSON-Schema (2020-12 subset used by the metagraphed contract) into a
+// concrete, valid instance. `components` is the bundle's components.schemas map.
+export function sampleFromSchema(schema, components, name = "", depth = 0) {
+  if (!schema || typeof schema !== "object") return null;
+  if (schema.$ref) {
+    return sampleFromSchema(
+      resolveRef(schema.$ref, components),
+      components,
+      name,
+      depth,
+    );
+  }
+  if ("const" in schema) return schema.const;
+  if (Array.isArray(schema.enum) && schema.enum.length > 0) {
+    return schema.enum.find((value) => value !== null) ?? schema.enum[0];
+  }
+  if (Array.isArray(schema.allOf)) {
+    let merged = {};
+    let scalar;
+    for (const sub of schema.allOf) {
+      const part = sampleFromSchema(sub, components, name, depth);
+      if (part && typeof part === "object" && !Array.isArray(part)) {
+        merged = { ...merged, ...part };
+      } else if (part !== null && part !== undefined) {
+        scalar = part;
+      }
+    }
+    return Object.keys(merged).length > 0 ? merged : (scalar ?? merged);
+  }
+  const variants = schema.oneOf || schema.anyOf;
+  if (Array.isArray(variants) && variants.length > 0) {
+    const pick =
+      variants.find((variant) => pickType(variant.type) !== "null") ||
+      variants[0];
+    return sampleFromSchema(pick, components, name, depth);
+  }
+
+  const type = pickType(schema.type);
+  if (type === "null") return null;
+
+  if (type === "object" || (!type && schema.properties)) {
+    const out = {};
+    const props = schema.properties || {};
+    const required = new Set(schema.required || []);
+    const includeOptional = depth < OPTIONAL_DEPTH;
+    for (const [key, propSchema] of Object.entries(props)) {
+      if (!required.has(key) && !includeOptional) continue;
+      out[key] = sampleFromSchema(propSchema, components, key, depth + 1);
+    }
+    // Pure map object (additionalProperties is a schema, no named props): show
+    // one representative entry so the shape is visible.
+    if (
+      Object.keys(props).length === 0 &&
+      schema.additionalProperties &&
+      typeof schema.additionalProperties === "object" &&
+      depth < OPTIONAL_DEPTH
+    ) {
+      out.example = sampleFromSchema(
+        schema.additionalProperties,
+        components,
+        "example",
+        depth + 1,
+      );
+    }
+    return out;
+  }
+
+  if (type === "array") {
+    if (depth >= MAX_DEPTH) return [];
+    return [sampleFromSchema(schema.items || {}, components, name, depth + 1)];
+  }
+
+  if (type === "string") {
+    if (schema.pattern) return valueForPattern(schema.pattern);
+    if (schema.format === "uri") return "https://api.metagraph.sh/example";
+    if (schema.format === "date-time") return ISO;
+    return seededString(name);
+  }
+  if (type === "integer" || type === "number")
+    return seededNumber(name, schema);
+  if (type === "boolean") return seededBoolean(name);
+  return null;
+}

--- a/tests/openapi-sample.test.mjs
+++ b/tests/openapi-sample.test.mjs
@@ -1,0 +1,240 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { sampleFromSchema } from "../src/openapi-sample.mjs";
+
+const components = {
+  Level: { enum: ["native", "verified"] },
+  Inner: {
+    type: "object",
+    required: ["x"],
+    properties: { x: { type: "integer" } },
+  },
+};
+const s = (schema, name) => sampleFromSchema(schema, components, name);
+
+describe("sampleFromSchema", () => {
+  test("const + enum (prefers a non-null enum value)", () => {
+    assert.equal(s({ const: true }), true);
+    assert.equal(s({ const: 1 }), 1);
+    assert.equal(s({ enum: ["a", "b"] }), "a");
+    assert.equal(s({ enum: [null, "z"] }), "z");
+  });
+
+  test("$ref resolves against components", () => {
+    assert.equal(s({ $ref: "#/components/schemas/Level" }), "native");
+    assert.deepEqual(s({ $ref: "#/components/schemas/Inner" }), { x: 1 });
+  });
+
+  test("allOf merges object members (later wins)", () => {
+    const out = s({
+      allOf: [
+        {
+          type: "object",
+          required: ["a"],
+          properties: { a: { type: "string" } },
+        },
+        {
+          type: "object",
+          required: ["n"],
+          properties: { n: { type: "integer" } },
+        },
+      ],
+    });
+    assert.equal(out.a, "example");
+    assert.equal(out.n, 1);
+  });
+
+  test("oneOf/anyOf pick the first non-null variant", () => {
+    assert.equal(
+      s({ oneOf: [{ type: "null" }, { type: "string" }] }),
+      "example",
+    );
+    assert.equal(s({ anyOf: [{ type: "null" }, { const: 5 }] }), 5);
+    // all-null variants -> falls back to the first variant -> null
+    assert.equal(s({ oneOf: [{ type: "null" }, { type: "null" }] }), null);
+  });
+
+  test("allOf with only a null member yields an empty object", () => {
+    assert.deepEqual(s({ allOf: [{ type: "null" }] }), {});
+  });
+
+  test("objects include required + optional scalars at shallow depth", () => {
+    const out = s({
+      type: "object",
+      required: ["id"],
+      properties: {
+        id: { type: "string" },
+        extra: { type: "boolean" },
+      },
+    });
+    assert.equal(out.id, "example");
+    assert.equal("extra" in out, true);
+  });
+
+  test("arrays emit a single sampled item", () => {
+    assert.deepEqual(s({ type: "array", items: { type: "string" } }), [
+      "example",
+    ]);
+    // array without items -> samples the empty schema (null) as the lone item
+    assert.deepEqual(s({ type: "array" }), [null]);
+  });
+
+  test("string seeds cover the field-name dictionary", () => {
+    const cases = {
+      day: "2026-06-01",
+      window: "30d",
+      slug: "example-subnet",
+      provider: "example-provider",
+      content_hash: "a3f1".repeat(16),
+      health_source: "probe-derived",
+      source: "live-cron-prober",
+      status: "ok",
+      grade: "A",
+      method: "GET",
+      surface_id: "example",
+      unmatched_field: "example",
+    };
+    for (const [name, expected] of Object.entries(cases)) {
+      assert.equal(s({ type: "string" }, name), expected);
+    }
+  });
+
+  test("string format awareness (uri, date-time)", () => {
+    assert.match(s({ type: "string", format: "uri" }), /^https:\/\//);
+    assert.equal(
+      s({ type: "string", format: "date-time" }),
+      "2026-06-01T00:00:00.000Z",
+    );
+  });
+
+  test("string pattern awareness", () => {
+    assert.match(
+      s({ type: "string", pattern: "^[a-f0-9]{64}$" }),
+      /^[a-f0-9]{64}$/,
+    );
+    assert.equal(
+      s({ type: "string", pattern: "^\\d{4}-\\d{2}-\\d{2}$" }),
+      "2026-06-01",
+    );
+    assert.match(
+      s({ type: "string", pattern: "^[a-z0-9][a-z0-9-]*$" }),
+      /^[a-z0-9][a-z0-9-]*$/,
+    );
+    assert.match(
+      s({ type: "string", pattern: "^/metagraph/" }),
+      /^\/metagraph\//,
+    );
+    assert.match(s({ type: "string", pattern: "^/api/v1" }), /^\/api\/v1/);
+    assert.match(
+      s({ type: "string", pattern: "^#/components/schemas/[A-Za-z0-9]+$" }),
+      /^#\/components\/schemas\//,
+    );
+    assert.equal(s({ type: "string", pattern: "^something-else$" }), "example");
+  });
+
+  test("number seeds by field name + clamps to min/max", () => {
+    assert.equal(s({ type: "integer" }, "netuid"), 7);
+    assert.equal(s({ type: "integer" }, "surface_count"), 1);
+    assert.equal(s({ type: "integer" }, "score"), 100);
+    assert.equal(s({ type: "integer" }, "latency_ms"), 120);
+    assert.equal(
+      s({ type: "number", minimum: 0, maximum: 1 }, "uptime_ratio"),
+      0.9966,
+    );
+    // integer type expressed as a nullable union still rounds to an int
+    assert.equal(s({ type: ["integer", "null"] }, "samples"), 1);
+    // generic number defaults to 0.5; integer defaults to 1; unnamed -> 0.5
+    assert.equal(s({ type: "number" }, "whatever"), 0.5);
+    assert.equal(s({ type: "integer" }, "whatever"), 1);
+    assert.equal(s({ type: "number" }), 0.5);
+    // clamp upward to minimum
+    assert.equal(s({ type: "integer", minimum: 50 }, "whatever"), 50);
+  });
+
+  test("boolean seeds true for affirmative field names, else false", () => {
+    assert.equal(s({ type: "boolean" }, "enabled"), true);
+    assert.equal(s({ type: "boolean" }, "public_safe"), true);
+    assert.equal(s({ type: "boolean" }, "archive_support"), false);
+    // unnamed boolean (name defaults to "") -> false
+    assert.equal(s({ type: "boolean" }), false);
+  });
+
+  test("nullable type arrays pick the non-null type; explicit null -> null", () => {
+    assert.equal(typeof s({ type: ["string", "null"] }, "name"), "string");
+    assert.equal(s({ type: "null" }), null);
+    assert.equal(s(null), null);
+    assert.equal(s({}), null);
+    // all-null type array + all-null enum exercise the fallback arms
+    assert.equal(s({ type: ["null"] }), null);
+    assert.equal(s({ enum: [null] }), null);
+  });
+
+  test("pure map objects (additionalProperties schema) show one entry", () => {
+    const out = s({
+      type: "object",
+      additionalProperties: { type: "integer" },
+    });
+    assert.equal(out.example, 1);
+  });
+
+  test("covers remaining seed/clamp/allOf-scalar branches", () => {
+    // name-based string seeds (no format): url-ish -> https, timestamp -> ISO
+    assert.match(s({ type: "string" }, "url"), /^https:\/\//);
+    assert.equal(
+      s({ type: "string" }, "last_checked"),
+      "2026-06-01T00:00:00.000Z",
+    );
+    // description/summary-style string fields
+    assert.equal(s({ type: "string" }, "description"), "Example description.");
+    assert.equal(s({ type: "string" }, "summary"), "Example description.");
+    assert.equal(s({ type: "string" }, "version"), "2026-06-06.1");
+    // clamp DOWN to maximum (block seeds high, capped here)
+    assert.equal(s({ type: "integer", maximum: 3 }, "block"), 3);
+    // allOf whose only member is a scalar -> returns that scalar
+    assert.equal(s({ allOf: [{ const: "x" }] }), "x");
+    assert.equal(s({ allOf: [{ type: "string" }] }), "example");
+  });
+
+  test("bounds recursion: deep objects drop optionals, deep arrays bottom out", () => {
+    // Nest optional objects past OPTIONAL_DEPTH -> deep optionals are dropped.
+    let obj = { type: "string" };
+    for (let i = 0; i < 6; i += 1) {
+      obj = { type: "object", properties: { child: obj } };
+    }
+    const objOut = sampleFromSchema(obj, {}, "root");
+    assert.equal(typeof objOut, "object");
+    // child is included while depth < OPTIONAL_DEPTH (3), then dropped.
+    assert.equal("child" in objOut.child.child, true);
+    assert.deepEqual(objOut.child.child.child, {});
+
+    // Nest arrays past MAX_DEPTH -> inner array bottoms out to [].
+    let arr = { type: "string" };
+    for (let i = 0; i < 10; i += 1) {
+      arr = { type: "array", items: arr };
+    }
+    assert.equal(Array.isArray(sampleFromSchema(arr, {}, "root")), true);
+  });
+
+  test("a sampled instance validates against its own schema (round-trip)", () => {
+    const ajv = new Ajv2020({ strict: false, validateFormats: true });
+    addFormats(ajv);
+    const schema = {
+      type: "object",
+      required: ["netuid", "status", "uptime_ratio", "observed_at", "tags"],
+      additionalProperties: false,
+      properties: {
+        netuid: { type: "integer", minimum: 0 },
+        status: { enum: ["ok", "degraded"] },
+        uptime_ratio: { type: "number", minimum: 0, maximum: 1 },
+        observed_at: { type: "string", format: "date-time" },
+        url: { type: "string", format: "uri" },
+        slug: { type: "string", pattern: "^[a-z0-9][a-z0-9-]*$" },
+        tags: { type: "array", items: { type: "string" } },
+      },
+    };
+    const sample = sampleFromSchema(schema, components, "root");
+    assert.equal(ajv.validate(schema, sample), true, ajv.errorsText());
+  });
+});


### PR DESCRIPTION
Closes #531 (the deferred Part 2; Part 1 schema-depth shipped in #536).

## What
Every `/api/v1` operation now ships a **schema-valid worked `example`** response in the OpenAPI contract, and a gate enforces it (57/57).

- **`src/openapi-sample.mjs`** — a deterministic *sample-from-schema* generator. Produces a minimal-but-realistic valid instance for any schema: handles `$ref`/`allOf`/`oneOf`/`anyOf`/`enum`/`const`, `uri`+`date-time` formats, all 6 contract patterns, nullable type-unions, map objects, and bounds recursion. Values are **seeded by field name** (`netuid: 7`, `status: "ok"`, real-ish URLs, ISO timestamps) so examples read like real responses, not bare placeholders.
- **Deterministic + self-maintaining**: examples are generated from the committed schemas at build time — no live data, so `openapi.json` stays reproducible (`validate:contract-drift` regenerates it offline), and new schemas automatically get examples.
- **`buildOpenApiArtifact`** embeds `example` on each 200 response.
- **`validate-openapi-examples.mjs`** rewritten to *require* an example on every operation and ajv-validate each against its response schema — enforcing coverage AND surfacing any construct the sampler mishandles.

## Why sample-from-schema (not fetched real data)
`openapi.json` must be reproducible from contracts+schemas alone (contract-drift regenerates it without network). A deterministic generator satisfies that; the deepened schemas (Part 1) + name-seeded values make the examples realistic.

## Verification
- `validate:openapi-examples`: **57/57 ship a schema-valid worked example**.
- `validate:contract-drift` green (sampler is deterministic → regeneration matches).
- Sampler unit-tested to **100% statements** (every construct, an ajv round-trip, recursion bounds).
- Full contract suite green (`schemas`, `openapi`, `types`, `generated-client`, `api`, `docs`). openapi.json grew ~155KB (embedded examples) — acceptable for a self-describing contract.