### PR TITLE
fix(health): bound global incident query

### DIFF
--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -337,9 +337,10 @@ function rowsForSql(sql) {
   if (sql.includes("SUM(ok) AS ok_count")) {
     return [{ surface_id: "s1", total: 100, ok_count: 98 }];
   }
-  if (sql.includes("WITH failures")) {
+  if (sql.includes("WITH failures") || sql.includes("failures AS")) {
     return [
       {
+        netuid: 7,
         surface_id: "s1",
         started_at: 1_000_000_000_000,
         ended_at: 1_000_000_120_000,
@@ -510,6 +511,38 @@ describe("analytics routes (fake D1 with data)", () => {
     assert.ok(incidentQuery.sql.includes("LIMIT ?"));
     assert.equal(incidentQuery.params.at(-1), 1000);
   });
+
+  test("global incidents SQL bounds source rows before window grouping", async () => {
+    const queries = [];
+    const envWithCapture = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare(sql) {
+          return {
+            bind(...params) {
+              queries.push({ sql, params });
+              return {
+                all: () => Promise.resolve({ results: rowsForSql(sql) }),
+              };
+            },
+          };
+        },
+      },
+    };
+    const { status } = await getJson(
+      "https://api.metagraph.sh/api/v1/incidents?window=30d",
+      envWithCapture,
+    );
+    assert.equal(status, 200);
+    const incidentQuery = queries.find((query) =>
+      query.sql.includes("WITH recent_failures"),
+    );
+    assert.ok(incidentQuery.sql.includes("ORDER BY checked_at DESC"));
+    assert.ok(incidentQuery.sql.includes("LIMIT ?"));
+    assert.equal(incidentQuery.params[1], 5000);
+    assert.equal(incidentQuery.params.at(-1), 1000);
+  });
+
   test("trajectory computes deltas from snapshots", async () => {
     const { body } = await getJson(
       "https://api.metagraph.sh/api/v1/subnets/7/trajectory",

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -91,6 +91,7 @@ const MAX_UPTIME_ROWS = 10000;
 const ANALYTICS_WINDOWS = { "7d": 7, "30d": 30 };
 const ANALYTICS_WINDOW_PARAM = "window";
 const MAX_INCIDENT_ROWS = 1000;
+const MAX_GLOBAL_INCIDENT_SOURCE_ROWS = 5000;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 const JSON_CONTENT_TYPE = "application/json; charset=utf-8";
@@ -1275,12 +1276,18 @@ async function handleGlobalIncidents(request, env, url) {
   const since = Date.now() - days * DAY_MS;
   const incidentRows = await d1All(
     env,
-    `WITH failures AS (
+    `WITH recent_failures AS (
+       SELECT netuid, surface_id, checked_at
+       FROM surface_checks
+       WHERE checked_at >= ? AND ok = 0
+       ORDER BY checked_at DESC
+       LIMIT ?
+     ),
+     failures AS (
        SELECT netuid, surface_id, checked_at,
               checked_at - LAG(checked_at)
                 OVER (PARTITION BY netuid, surface_id ORDER BY checked_at) AS gap
-       FROM surface_checks
-       WHERE checked_at >= ? AND ok = 0
+       FROM recent_failures
      ),
      grouped AS (
        SELECT netuid, surface_id, checked_at,
@@ -1296,7 +1303,12 @@ async function handleGlobalIncidents(request, env, url) {
      GROUP BY netuid, surface_id, grp
      ORDER BY started_at DESC
      LIMIT ?`,
-    [since, INCIDENT_GAP_MS, MAX_INCIDENT_ROWS],
+    [
+      since,
+      MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
+      INCIDENT_GAP_MS,
+      MAX_INCIDENT_ROWS,
+    ],
   );
   const meta = await readHealthKv(env, KV_HEALTH_META);
   const data = formatGlobalIncidents({


### PR DESCRIPTION
### Motivation

- The public `GET /api/v1/incidents` route executed a cross-subnet D1 query that scanned and sorted the entire recent `surface_checks` hot table with window functions, making the endpoint abusable as a database load generator. 
- The existing `MAX_INCIDENT_ROWS` cap was applied only after grouping, so it did not reduce D1 work and could still lead to large scans; the goal is to limit DB work while preserving the public response semantics.

### Description

- Added a new `MAX_GLOBAL_INCIDENT_SOURCE_ROWS` constant and used it to bound the number of source rows read for the global incidents query in `workers/api.mjs` by selecting the latest N failing `surface_checks` (`ORDER BY checked_at DESC LIMIT ?`) before applying the window-function gap-island grouping. 
- Adjusted the prepared-statement parameter ordering for `handleGlobalIncidents` to pass the new source-row bound into the SQL. 
- Preserved the existing `MAX_INCIDENT_ROWS` final cap on the formatted response so response size behavior is unchanged. 
- Updated `tests/analytics.test.mjs` to include `netuid` in the fake D1 fixture for global incident rows and added a regression test asserting the global incidents SQL uses `ORDER BY checked_at DESC` and a `LIMIT ?` on the source rows.

### Testing

- Ran the targeted analytics tests with `npx vitest run tests/analytics.test.mjs -t "global incidents SQL bounds source rows before window grouping|incidents SQL uses a hard incident row cap"`, and they passed. 
- Ran `npx prettier --check workers/api.mjs tests/analytics.test.mjs` (and applied formatting) and the check passed. 
- Ran the broader test command `npm test -- --run tests/analytics.test.mjs tests/health-serving.test.mjs`; the targeted analytics changes passed but there were three failing tests unrelated to this change (`leaderboards returns most-complete from profiles even with cold D1`, `composed routes fall back to the static artifact when KV+D1 are cold`, and `composed overview no longer embeds a baked health status`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2de377fa34832abae5746a5ce494b7)