### PR TITLE
fix(contract): adapter extension values are open maps (re-applies #541 on current main)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -980,7 +980,9 @@ export interface components {
         AdapterArtifact: components["schemas"]["ArtifactBase"] & ({
             /** @description Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific. */
             extensions: {
-                [key: string]: Record<string, never>;
+                [key: string]: {
+                    [key: string]: unknown;
+                };
             };
             netuid: number;
             slug: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -28,6 +28,7 @@
             "properties": {
               "extensions": {
                 "additionalProperties": {
+                  "additionalProperties": true,
                   "type": "object"
                 },
                 "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -980,7 +980,9 @@ export interface components {
         AdapterArtifact: components["schemas"]["ArtifactBase"] & ({
             /** @description Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific. */
             extensions: {
-                [key: string]: Record<string, never>;
+                [key: string]: {
+                    [key: string]: unknown;
+                };
             };
             netuid: number;
             slug: string;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -14,6 +14,7 @@
             "properties": {
               "extensions": {
                 "additionalProperties": {
+                  "additionalProperties": true,
                   "type": "object"
                 },
                 "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",

--- a/schemas/components/09-schemas-adapters-r2.schema.json
+++ b/schemas/components/09-schemas-adapters-r2.schema.json
@@ -252,7 +252,7 @@
               "extensions": {
                 "type": "object",
                 "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",
-                "additionalProperties": { "type": "object" }
+                "additionalProperties": { "type": "object", "additionalProperties": true }
               },
               "snapshot": {
                 "type": ["object", "null"],


### PR DESCRIPTION
Re-applies codex #541's valid fix on **current** main. Merging #541 directly would have reverted the #542 OpenAPI examples (its base predates #542) — so the one-line schema fix is re-applied here and regenerated on top of the examples.

`AdapterArtifact.extensions` per-provider values were typed `Record<string, never>` (always-empty), conflicting with real adapter data. Now `{ [key: string]: unknown }`. `validate:openapi-examples` stays **57/57**; all contract validators green. Closes #541's intent.