### PR TITLE
chore: contributor-launch hygiene — lint/format clean, CHANGELOG, FUNDING

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Supported funding-model platforms (https://docs.github.com/sponsors/funding-models)
+github: [jsonbored]
+ko_fi: jsonbored
+buy_me_a_coffee: jsonbored

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,48 @@
+# Changelog
+
+All notable, contributor-visible changes to the **metagraphed backend** (the
+Cloudflare Worker + registry build) are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+A few things this project versions differently:
+
+- The **hosted API + artifacts** are continuously deployed and identified by the
+  date-based `CONTRACT_VERSION` in `src/contracts.mjs` (e.g. `2026-06-06.1`) —
+  there are no semantic "platform" releases.
+- The **published client SDKs** are versioned independently: npm
+  [`@jsonbored/metagraphed`](https://www.npmjs.com/package/@jsonbored/metagraphed)
+  and PyPI [`metagraphed`](https://pypi.org/project/metagraphed/).
+- **Registry data enrichments** (new/updated subnets, providers, surfaces) are
+  not listed here — they show up in the live `/api/v1/changelog` feed.
+
+This file tracks notable changes to the API surface, contracts, MCP server, and
+contributor experience.
+
+## [Unreleased]
+
+### Added
+
+- Static agent tool specs for OpenAI + Anthropic at
+  `/.well-known/agent-tools/{index,openai,anthropic}.json`, projected from the
+  MCP tool list.
+- Per-subnet / per-endpoint reliability score (0–100 + grade) over the durable
+  uptime history, surfaced on `/api/v1/subnets/{netuid}/uptime` and MCP
+  `get_subnet_health`.
+- Global cross-subnet incident ledger at `GET /api/v1/incidents` (7d/30d window).
+- A worked, schema-valid `example` on every OpenAPI operation, enforced in CI.
+- Bidirectional MCP Registry backlink in the served server-card, `mcp.json`, and
+  the live `initialize` result.
+- The MCP server is listed in the canonical MCP Registry as
+  `io.github.JSONbored/metagraphed`.
+- `good first issue` / `help wanted` labels on the enrichment queue;
+  `CHANGELOG.md`, `FUNDING.yml`.
+
+### Changed
+
+- Deepened the previously-shallow OpenAPI response schemas to be fully typed
+  down to the leaf fields.
+
+### Fixed
+
+- Bounded the `/api/v1/incidents` source query so it can't be used as a database
+  load generator; adapter `extensions` values now type as open maps.

--- a/docs/adr/0001-r2-only-data-artifacts.md
+++ b/docs/adr/0001-r2-only-data-artifacts.md
@@ -23,7 +23,7 @@ This created three coupled problems, all observed in production:
 1. **Generated-artifact churn.** Every data change re-commits all ~22 dual
    artifacts — including `surfaces.json` (1.1 MB), `evidence-ledger.json`
    (858 KB), `search.json`, `profiles.json` — and the digests (`r2-manifest`,
-   `build-summary`, `changelog`) churn on *every* build. The UGC import bot
+   `build-summary`, `changelog`) churn on _every_ build. The UGC import bot
    (`intake-import-pr.yml`) re-commits the whole set for a single 2 KB
    community submission. Git size grows with data volume and contribution rate,
    not curation effort.
@@ -32,7 +32,7 @@ This created three coupled problems, all observed in production:
    them. Run mid-`pipeline:refresh` (before the workflow commits), it
    self-fails the sync job whenever a refresh changes a diff-checked artifact.
 3. **A freshness/merge race.** The publish gate requires fresh probe-derived
-   health *and* fresh adapter snapshots, but the production build only re-probed
+   health _and_ fresh adapter snapshots, but the production build only re-probed
    health — adapters came from committed data that ages past the block window,
    so the publish depended on a recently-merged sync PR racing a 12 h window.
 
@@ -42,7 +42,7 @@ build is deterministic from committed inputs, and R2 keeps versioned `runs/`
 history. Their only roles — fast ASSETS edge path, PR-diff review, and
 reproducibility — are respectively a marginal optimization (R2 + 300 s edge
 cache is comparable), low value (review belongs on inputs; contributors are
-*blocked* from editing generated files), and redundant (outputs are a pure
+_blocked_ from editing generated files), and redundant (outputs are a pure
 function of committed inputs).
 
 ## Decision
@@ -59,13 +59,13 @@ everything else from R2.**
    `freshness`, `changelog`, `review/*`, `build-summary`, `r2-manifest`,
    `schema-drift`, `profile-completeness`.
 3. **Self-sufficient publish:** the production build re-snapshots adapters (it
-   already re-probes health), so all freshness-gated data is fresh *by
-   construction*; the gate verifies rather than blocks, and any push publishes.
+   already re-probes health), so all freshness-gated data is fresh _by
+   construction_; the gate verifies rather than blocks, and any push publishes.
 4. **UGC = a one-file commit:** the import bot commits only the source candidate;
    artifacts are rebuilt and published to R2 by the publish workflow.
 
-Verifiability of "trustworthy, complete coverage" shifts from *diffing committed
-outputs* to **reviewable committed inputs + a deterministic reproducible build +
+Verifiability of "trustworthy, complete coverage" shifts from _diffing committed
+outputs_ to **reviewable committed inputs + a deterministic reproducible build +
 the published, versioned R2 evidence-ledger** — a cleaner provenance story.
 
 ## Consequences
@@ -77,7 +77,7 @@ the published, versioned R2 evidence-ledger** — a cleaner provenance story.
 - Worker serves the moved artifacts from R2 + edge cache (first-hit ~ms, then
   cached; the existing 5 s R2 timeout / 504 handling applies).
 - **Hard sequencing constraint:** R2 must be populated by a successful publish
-  *before* an artifact is made R2-only, or production 404s. Phase 2 therefore
+  _before_ an artifact is made R2-only, or production 404s. Phase 2 therefore
   depends on Phase 1 shipping a green publish first.
 - Local development must `npm run build` to serve the data locally (already the
   case).

--- a/docs/adr/0004-candidate-trust-model.md
+++ b/docs/adr/0004-candidate-trust-model.md
@@ -36,17 +36,20 @@ raw candidates. Candidates surface under explicitly-labelled
 Three guards defend the path from attacker-controlled text to a callable URL:
 
 ### 1. Prompt-injection sanitization (ADR 0003 / #339)
+
 All chain text is run through `sanitizeChainText` before it reaches an LLM, and
 the profile carries `injection_scrubbed`. The MCP tools + `llms.txt` additionally
 warn that field values are untrusted data (#340).
 
 ### 2. SSRF protection (DNS-resolving)
+
 `isUnsafeUrl` / `isUnsafeResolvedUrl` (`scripts/lib.mjs`) reject URLs that target
 internal infrastructure, checking against `unsafeIpBlocks`:
 loopback (`127.0.0.0/8`, `::1`), RFC-1918 private (`10/8`, `172.16/12`,
 `192.168/16`), CGNAT (`100.64/10`), **link-local + cloud metadata
 (`169.254.0.0/16`, e.g. `169.254.169.254`)**, the unspecified range, multicast,
 and the IPv6 equivalents (`fc00::/7`, `fe80::/10`, NAT64).
+
 - **Intake** (`normalizePublicUrl`) applies the synchronous literal-IP filter
   `isUnsafeUrl` so obviously-internal targets never enter the bundle.
 - **Probe + promotion** (`fetchWithSafeRedirects`, `generated-overlays.mjs`)
@@ -56,6 +59,7 @@ and the IPv6 equivalents (`fc00::/7`, `fe80::/10`, NAT64).
   check is what gates anything that gets probed or promoted.
 
 ### 3. Brand-impersonation guard (#341)
+
 `isBrandImpersonationUrl` rejects candidate URLs that impersonate metagraphed's
 own domain (`metagraph.sh.evil.com`, `metagraphsh.com`, `metagraph-sh.io`). These
 pass the SSRF guard — they resolve to public IPs — but a `base_url` reading as

--- a/docs/integration-readiness.md
+++ b/docs/integration-readiness.md
@@ -1,8 +1,8 @@
 # Integration readiness
 
 `integration_readiness` is a codified, **objective** score (0–100) for the
-question developers and their agents actually ask: *can I build on this subnet
-today?* It appears on each subnet in the agent catalog
+question developers and their agents actually ask: _can I build on this subnet
+today?_ It appears on each subnet in the agent catalog
 (`/api/v1/agent-catalog`, `/api/v1/agent-catalog/{netuid}`) and ranks
 `find_subnets_by_capability` results in the MCP server.
 
@@ -12,15 +12,15 @@ breakdown ships alongside the score so you can re-weight it for your own needs.
 
 ## What it is not
 
-- **Not live up/down.** Readiness is a *build-time eligibility* signal computed
+- **Not live up/down.** Readiness is a _build-time eligibility_ signal computed
   from the reproducible registry snapshot — never the 2-minute health prober.
   A subnet can be "ready" and momentarily down. For "is it up right now" use
   `get_subnet_health` / the per-service `health` block. Keeping live status out
   of the score is what lets it stay a deterministic, reproducible artifact value.
 - **Not a verdict on the ~99 non-API subnets.** Only ~30 subnets expose callable
   public APIs today; the rest score low because they have nothing to build on
-  *yet*, not because they're "bad". This is the buildable-today subset.
-- **Not chain economics.** Whether a subnet is worth *running a validator on*
+  _yet_, not because they're "bad". This is the buildable-today subset.
+- **Not chain economics.** Whether a subnet is worth _running a validator on_
   (emissions, TAO price, miner quality) is a different question — that's chain
   data, not metagraphed's lane.
 
@@ -29,14 +29,14 @@ breakdown ships alongside the score so you can re-weight it for your own needs.
 Score = sum of the component weights below, clamped to 100. Each component is an
 objective boolean published under `readiness.components`.
 
-| Component | Weight | True when |
-|---|---|---|
-| `has_callable_api` | 30 | the subnet exposes ≥1 catalogued service surface |
-| `documented` | 25 | ≥1 service has a captured OpenAPI/Swagger schema |
-| `auth_clarity` | 15 | every callable service has clear auth — either no auth, or auth required *with* known schemes (so an agent knows whether and how to authenticate) |
-| `callable_now` | 15 | ≥1 service is structurally callable (public-safe, not dead/unsafe) |
-| `active_lifecycle` | 10 | `lifecycle === "active"` (not deprecated/parked/pending) |
-| `profile_complete` | 5 | the subnet's `completeness_score` ≥ 70 |
+| Component          | Weight | True when                                                                                                                                         |
+| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `has_callable_api` | 30     | the subnet exposes ≥1 catalogued service surface                                                                                                  |
+| `documented`       | 25     | ≥1 service has a captured OpenAPI/Swagger schema                                                                                                  |
+| `auth_clarity`     | 15     | every callable service has clear auth — either no auth, or auth required _with_ known schemes (so an agent knows whether and how to authenticate) |
+| `callable_now`     | 15     | ≥1 service is structurally callable (public-safe, not dead/unsafe)                                                                                |
+| `active_lifecycle` | 10     | `lifecycle === "active"` (not deprecated/parked/pending)                                                                                          |
+| `profile_complete` | 5      | the subnet's `completeness_score` ≥ 70                                                                                                            |
 
 `auth_clarity` intentionally treats "auth required, schemes known" as **clear** —
 it does not penalize an honestly auth-gated API.

--- a/public/skills/bittensor/SKILL.md
+++ b/public/skills/bittensor/SKILL.md
@@ -63,7 +63,7 @@ Cursor / other clients: add an MCP server with url
   for "is it up right now". The committed registry data (names, APIs, schemas)
   refreshes every ~6h.
 - **Auth honestly.** If `auth_required` is true, the user needs a key from that
-  subnet's team — metagraphed tells you *that* auth is required and *which*
+  subnet's team — metagraphed tells you _that_ auth is required and _which_
   scheme, not the secret itself.
 - **Scope.** ~30 of ~129 subnets expose callable public APIs today; the rest are
   catalogued but not yet integrable. `agent-catalog` is the integrable subset.

--- a/schemas/components/09-schemas-adapters-r2.schema.json
+++ b/schemas/components/09-schemas-adapters-r2.schema.json
@@ -252,7 +252,10 @@
               "extensions": {
                 "type": "object",
                 "description": "Per-adapter extension metadata, keyed by provider id; each value's shape is adapter-specific.",
-                "additionalProperties": { "type": "object", "additionalProperties": true }
+                "additionalProperties": {
+                  "type": "object",
+                  "additionalProperties": true
+                }
               },
               "snapshot": {
                 "type": ["object", "null"],

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -649,8 +649,7 @@ const readinessByNetuid = new Map(
 // Index gets the compact score (list/ranking); the profile carries the full
 // component breakdown for the detail view.
 for (const entry of subnetIndex) {
-  entry.integration_readiness =
-    readinessByNetuid.get(entry.netuid)?.score ?? 0;
+  entry.integration_readiness = readinessByNetuid.get(entry.netuid)?.score ?? 0;
 }
 for (const profile of profileArtifacts.profiles) {
   const readiness = readinessByNetuid.get(profile.netuid) ?? null;
@@ -1165,7 +1164,11 @@ function buildSubnetServices(netuid) {
 // up right now" dimension is intentionally separate (get_subnet_health / the
 // health overlay). Components are published so agents can re-weight to their own
 // needs. Rubric: docs/integration-readiness.md.
-function subnetIntegrationReadiness({ services, lifecycle, completenessScore }) {
+function subnetIntegrationReadiness({
+  services,
+  lifecycle,
+  completenessScore,
+}) {
   const callable = services.filter((service) => service.eligibility.callable);
   const components = {
     has_callable_api: services.length > 0,
@@ -1364,14 +1367,17 @@ const serverCardContent = {
   _meta: MCP_REGISTRY_META,
   tools: listToolDefinitions(),
 };
-await writeJson(path.join(repoRoot, "public/.well-known/mcp/server-card.json"), {
-  ...serverCardContent,
-  // Real publish time + deterministic content fingerprint (issue #349) so
-  // agents don't read the deterministic 1970 generated_at as "stale".
-  generated_at: generatedAt,
-  published_at: publishedAt(),
-  content_hash: hashJson(serverCardContent),
-});
+await writeJson(
+  path.join(repoRoot, "public/.well-known/mcp/server-card.json"),
+  {
+    ...serverCardContent,
+    // Real publish time + deterministic content fingerprint (issue #349) so
+    // agents don't read the deterministic 1970 generated_at as "stale".
+    generated_at: generatedAt,
+    published_at: publishedAt(),
+    content_hash: hashJson(serverCardContent),
+  },
+);
 await writeJson(path.join(repoRoot, "public/.well-known/mcp.json"), {
   schema_version: 1,
   servers: [
@@ -1651,7 +1657,11 @@ const sitemapUrls = [
 const sitemapXml = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n${sitemapUrls
   .map((loc) => `  <url><loc>${loc}</loc></url>`)
   .join("\n")}\n</urlset>\n`;
-await fs.writeFile(path.join(repoRoot, "public/sitemap.xml"), sitemapXml, "utf8");
+await fs.writeFile(
+  path.join(repoRoot, "public/sitemap.xml"),
+  sitemapXml,
+  "utf8",
+);
 await fs.writeFile(
   path.join(repoRoot, "public/robots.txt"),
   `User-agent: *\nAllow: /\nSitemap: ${llmsApiBase}/sitemap.xml\n`,
@@ -1692,11 +1702,7 @@ Anonymous abuse-control limits apply per client IP (no key raises them):
 - OpenAPI 3.1: ${llmsApiBase}/metagraph/openapi.json
 - MCP server card: ${llmsApiBase}/.well-known/mcp/server-card.json
 `;
-await fs.writeFile(
-  path.join(repoRoot, "public/auth.md"),
-  authMarkdown,
-  "utf8",
-);
+await fs.writeFile(path.join(repoRoot, "public/auth.md"), authMarkdown, "utf8");
 
 await writeJson(artifactFile("contracts.json"), contracts);
 await writeJson(

--- a/scripts/build-network-registry.mjs
+++ b/scripts/build-network-registry.mjs
@@ -87,14 +87,18 @@ function buildNativeSubnet(nativeSubnet, snapshot) {
   return {
     block: nativeSubnet.block,
     candidate_count: 0,
-    categories: nativeSubnet.netuid === 0 ? ["root", "system"] : ["native-only"],
+    categories:
+      nativeSubnet.netuid === 0 ? ["root", "system"] : ["native-only"],
     coverage_level: "native-only",
     curation_level: "native",
     dashboard_url: null,
-    description: cleanDescription(nativeSubnet.chain_identity?.description) || null,
+    description:
+      cleanDescription(nativeSubnet.chain_identity?.description) || null,
     docs_url: null,
     gaps: {
-      missing_kinds: EXPECTED_GAP_KINDS.filter((kind) => !supportedKinds.has(kind)),
+      missing_kinds: EXPECTED_GAP_KINDS.filter(
+        (kind) => !supportedKinds.has(kind),
+      ),
       supported_kinds: [...supportedKinds].sort(),
       gap_notes: [],
     },
@@ -123,7 +127,10 @@ function buildNativeSubnet(nativeSubnet, snapshot) {
       interface_metadata: "none",
     },
     lifecycle: subnetLifecycle(nativeSubnet),
-    logo_url: backfilledIdentityUrl(null, nativeSubnet.chain_identity?.logo_url),
+    logo_url: backfilledIdentityUrl(
+      null,
+      nativeSubnet.chain_identity?.logo_url,
+    ),
     registered_at_block: nativeSubnet.registered_at_block,
     slug: `sn-${nativeSubnet.netuid}`,
     source_repo: sourceRepo,
@@ -246,21 +253,26 @@ export async function buildNetworkRegistry({ prefix, snapshotPath }) {
     ),
   });
 
-  const detailDir = path.dirname(artifactOutputPath(`${prefix}/subnets/0.json`));
+  const detailDir = path.dirname(
+    artifactOutputPath(`${prefix}/subnets/0.json`),
+  );
   await fs.rm(detailDir, { recursive: true, force: true });
   await fs.mkdir(detailDir, { recursive: true });
   for (const subnet of subnets) {
-    await writeJson(artifactOutputPath(`${prefix}/subnets/${subnet.netuid}.json`), {
-      schema_version: SCHEMA_VERSION,
-      generated_at: generatedAt,
-      subnet,
-      candidate_surfaces: [],
-      candidates: [],
-      endpoints: [],
-      gaps: subnet.gaps,
-      surfaces: [],
-      verified_surfaces: [],
-    });
+    await writeJson(
+      artifactOutputPath(`${prefix}/subnets/${subnet.netuid}.json`),
+      {
+        schema_version: SCHEMA_VERSION,
+        generated_at: generatedAt,
+        subnet,
+        candidate_surfaces: [],
+        candidates: [],
+        endpoints: [],
+        gaps: subnet.gaps,
+        surfaces: [],
+        verified_surfaces: [],
+      },
+    );
   }
 
   await writeJson(

--- a/tests/ai-search.test.mjs
+++ b/tests/ai-search.test.mjs
@@ -717,7 +717,14 @@ describe("ai-search defensive branches", () => {
     const block = formatAskContextBlock(
       [{ metadata: { type: "subnet", title: "Apex", netuid: 1 } }],
       new Map([
-        [1, { callable_count: 2, base_url: "https://api.apex.io", health: "operational" }],
+        [
+          1,
+          {
+            callable_count: 2,
+            base_url: "https://api.apex.io",
+            health: "operational",
+          },
+        ],
       ]),
     );
     const parsed = JSON.parse(block);

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -5,7 +5,6 @@ import {
   cpSync,
   existsSync,
   mkdtempSync,
-  mkdirSync,
   readFileSync,
   readdirSync,
   rmSync,

--- a/tests/webhooks-worker.test.mjs
+++ b/tests/webhooks-worker.test.mjs
@@ -336,10 +336,13 @@ describe("webhook route edge cases", () => {
 
   test("404 on DELETE of an unknown subscription id", async () => {
     const res = await handleRequest(
-      req("/api/v1/webhooks/subscriptions/00000000-0000-4000-8000-000000000000", {
-        method: "DELETE",
-        headers: { "x-metagraph-webhook-secret": "whatever" },
-      }),
+      req(
+        "/api/v1/webhooks/subscriptions/00000000-0000-4000-8000-000000000000",
+        {
+          method: "DELETE",
+          headers: { "x-metagraph-webhook-secret": "whatever" },
+        },
+      ),
       envWith(makeKv()),
       {},
     );
@@ -373,7 +376,9 @@ describe("webhook route edge cases", () => {
       throw new Error("kv get down");
     };
     const res = await handleRequest(
-      req("/api/v1/webhooks/subscriptions/00000000-0000-4000-8000-000000000000"),
+      req(
+        "/api/v1/webhooks/subscriptions/00000000-0000-4000-8000-000000000000",
+      ),
       envWith(kv),
       {},
     );


### PR DESCRIPTION
Prep for Monday's contributor influx (gittensor emissions go live).

- **Lint**: removes the lone ESLint error (unused `mkdirSync` import in `tests/artifacts.test.mjs`) so `npm run lint` and the documented pre-push `npm run check` pass on a clean checkout.
- **Format**: `prettier --write` the 9 pre-existing format-dirty files — the whole repo is now prettier-clean, so a new contributor's first `npm run check` doesn't fail on dirt they didn't cause.
- **CHANGELOG.md** (Keep a Changelog) with an Unreleased section.
- **.github/FUNDING.yml** — github / ko-fi / buy-me-a-coffee, all `jsonbored`.

No behavior change (formatting + docs only). The `good first issue` / `help wanted` labels were created + applied to the 30 open enrichment issues (#435–#466) out-of-band, so CONTRIBUTING.md's label links now resolve.