### PR TITLE
test: reviewbot live check (transient — will close)

### DIFF
--- a/registry/candidates/community/community-reviewbot-live-check.json
+++ b/registry/candidates/community/community-reviewbot-live-check.json
@@ -1,0 +1,22 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "low",
+      "id": "community-reviewbot-live-check",
+      "kind": "website",
+      "name": "Reviewbot Live Check (transient test)",
+      "netuid": 99999,
+      "provider": "reviewbot-test",
+      "public_safe": false,
+      "review_notes": "Transient deploy smoke-test candidate — intentionally public_safe:false so the gate declines. Safe to close.",
+      "schema_version": 1,
+      "source_type": "community-pr-intake",
+      "source_url": "https://example.invalid/reviewbot-test",
+      "source_urls": ["https://example.invalid/reviewbot-test"],
+      "state": "schema-valid",
+      "url": "https://example.invalid/reviewbot-test"
+    }
+  ],
+  "schema_version": 1
+}


### PR DESCRIPTION
Verifying the **metagraphed gate** is live after deploy. This candidate is intentionally `public_safe:false` with a nonexistent netuid (99999) and `.invalid` URLs, so the gate must **decline** (manual-review or close) — it can NOT auto-merge. Transient; will close.