### PR TITLE
test: reversal-tracking check (transient — will close)

### DIFF
--- a/registry/candidates/community/community-reviewbot-reversal-check.json
+++ b/registry/candidates/community/community-reviewbot-reversal-check.json
@@ -1,0 +1,22 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "low",
+      "id": "community-reviewbot-reversal-check",
+      "kind": "website",
+      "name": "Reviewbot Live Check (transient test)",
+      "netuid": 99999,
+      "provider": "reviewbot-test",
+      "public_safe": false,
+      "review_notes": "Transient deploy smoke-test candidate — intentionally public_safe:false so the gate declines. Safe to close.",
+      "schema_version": 1,
+      "source_type": "community-pr-intake",
+      "source_url": "https://example.invalid/reviewbot-test",
+      "source_urls": ["https://example.invalid/reviewbot-test"],
+      "state": "schema-valid",
+      "url": "https://example.invalid/reviewbot-test"
+    }
+  ],
+  "schema_version": 1
+}


### PR DESCRIPTION
Transient test for reversal tracking: this declines (public_safe:false), gets gate-closed, then I reopen it to confirm a reversal_reopened audit. Will clean up.