### PR TITLE
fix(contrib): candidate:new quickstart used an invalid provider

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,20 +43,25 @@ Community data becomes a reviewed **candidate**, not direct registry truth. PR-f
 
 > Add **exactly one** file — `registry/candidates/community/*.json` (a candidate) **or** `registry/providers/community/*.json` (a provider profile) — and **nothing else**. No generated artifacts.
 
-Generate a candidate locally:
+Generate a candidate locally — three steps:
 
 ```bash
+# 1. Find the provider slug for the team/operator behind this surface.
+#    (No match? Register one in the same PR with `npm run provider:new`.)
+npm run providers:list
+
+# 2. Generate the candidate with a REAL --provider slug (a placeholder like
+#    "community" is not a registered provider and will fail validation).
 npm run candidate:new -- \
   --netuid 7 --kind docs \
   --url https://docs.example.com \
   --source-url https://github.com/example/project \
-  --provider community --submitted-by <github-login> --write
+  --provider <provider-slug> --submitted-by <github-login> --write
+
+# 3. Check it before pushing — a fast local pre-check that catches schema +
+#    provider-slug mistakes without the full build (CI runs the full validate).
+npm run validate:candidate -- registry/candidates/community/<your-file>.json
 ```
-
-Two helpers make this faster:
-
-- **Find a real provider slug** for `--provider` (instead of `community`, which routes to manual review and won't auto-merge): `npm run providers:list`.
-- **Check your candidate before pushing** — a fast local pre-check that catches schema mistakes and bad provider slugs without running the full build: `npm run validate:candidate -- registry/candidates/community/<your-file>.json` (no argument validates every community candidate).
 
 A good candidate PR is small: one public URL, one source URL proving the claim, one active netuid, no generated files. Best kinds (these can be auto-reviewed): `docs`, `website`, `source-repo`, `dashboard`, `openapi`, `subnet-api`, `sse`, `data-artifact`, `sdk`, `example`.
 

--- a/scripts/candidate-new.mjs
+++ b/scripts/candidate-new.mjs
@@ -52,6 +52,18 @@ if (authRequired === null) {
   fail("--auth-required must be true or false");
 }
 
+// `provider` must be a registered slug for the candidate to validate (the
+// default placeholder "community" is NOT one). Warn — don't fail — so adding a
+// provider alongside the candidate still works; the contributor can fix it.
+const providerIds = new Set((await loadProviders()).map((entry) => entry.id));
+if (!providerIds.has(provider)) {
+  console.warn(
+    `Warning: provider "${provider}" is not a registered slug, so this candidate will ` +
+      "FAIL `npm run validate:candidate` and CI. Pick a real one with `npm run providers:list`, " +
+      "or register it with `npm run provider:new`.",
+  );
+}
+
 const host = new URL(url).hostname;
 const id = `community-sn-${netuid}-${kind}-${slugify(host)}`;
 const outPath =


### PR DESCRIPTION
The documented `candidate:new ... --provider community` quickstart produced a candidate that **fails CI** — `community` isn't a registered provider, so both `validate:candidate` and the full `npm run validate` reject it ("unknown provider community"). Found while testing the new contributor tooling.

- `candidate:new` now **warns** (doesn't fail) when `--provider` isn't registered, pointing at `providers:list` / `provider:new`.
- CONTRIBUTING quickstart is now a clear 3-step flow: `providers:list` → `candidate:new --provider <real-slug>` → `validate:candidate`.

Verified: `community` warns, `allways` is clean + passes `validate:candidate`.