### PR TITLE
fix(providers): extend multi-tenant cluster hosts + dedup the suffix list (#419)

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -27,6 +27,7 @@ import {
   loadProviders,
   loadSubnets,
   loadVerification,
+  MULTI_TENANT_HOST_SUFFIXES,
   nativeContactHandle,
   nativeContactUrl,
   nativeDisplayName,
@@ -712,25 +713,10 @@ const GENERIC_CLUSTER_HOSTS = new Set([
   "linktr.ee",
   "huggingface.co",
 ]);
-const GENERIC_CLUSTER_HOST_SUFFIXES = new Set([
-  "github.io",
-  "pages.dev",
-  "workers.dev",
-  "vercel.app",
-  "netlify.app",
-  "web.app",
-  "firebaseapp.com",
-  "herokuapp.com",
-  "fly.dev",
-  "glitch.me",
-  "repl.co",
-  "webflow.io",
-]);
-
 function isGenericClusterHost(host) {
   return (
     GENERIC_CLUSTER_HOSTS.has(host) ||
-    [...GENERIC_CLUSTER_HOST_SUFFIXES].some(
+    [...MULTI_TENANT_HOST_SUFFIXES].some(
       (suffix) => host === suffix || host.endsWith(`.${suffix}`),
     )
   );

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1109,7 +1109,9 @@ export function buildSubnetLineageLinks(
 // Public Suffix List rules and private multi-tenant hosts used for documentation
 // or app/site hosting; matched hosts cluster on the tenant label, not the shared
 // suffix (for example team-a.co.uk, not co.uk).
-const CLUSTER_MULTI_LABEL_SUFFIXES = new Set([
+// Country-code multi-label public suffixes (eTLD+1 needs the extra label so
+// `team-a.co.uk` clusters as `team-a.co.uk`, not `co.uk`).
+const CLUSTER_CCTLD_SUFFIXES = [
   "ac.uk",
   "co.uk",
   "gov.uk",
@@ -1152,11 +1154,28 @@ const CLUSTER_MULTI_LABEL_SUFFIXES = new Set([
   "co.in",
   "co.kr",
   "co.za",
+];
+
+// Multi-tenant platform hosts: each subdomain is a distinct tenant, so the
+// cluster unit is the full `<tenant>.<suffix>` and the bare suffix is not a
+// cluster of its own. Single source of truth — `clusterDomainFromUrl` (here)
+// and `isGenericClusterHost` (build-artifacts.mjs) both consume this set so the
+// two cannot drift (issue #419).
+export const MULTI_TENANT_HOST_SUFFIXES = new Set([
   "github.io",
+  "gitlab.io",
   "pages.dev",
   "workers.dev",
   "vercel.app",
   "netlify.app",
+  "netlify.com",
+  "surge.sh",
+  "onrender.com",
+  "azurewebsites.net",
+  "r2.dev",
+  "notion.site",
+  "pythonanywhere.com",
+  "appspot.com",
   "web.app",
   "firebaseapp.com",
   "herokuapp.com",
@@ -1164,6 +1183,11 @@ const CLUSTER_MULTI_LABEL_SUFFIXES = new Set([
   "glitch.me",
   "repl.co",
   "webflow.io",
+]);
+
+const CLUSTER_MULTI_LABEL_SUFFIXES = new Set([
+  ...CLUSTER_CCTLD_SUFFIXES,
+  ...MULTI_TENANT_HOST_SUFFIXES,
 ]);
 
 const CLUSTER_COUNTRY_CODE_SECOND_LEVEL_SUFFIX_LABELS = new Set([

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -17,6 +17,7 @@ import {
   artifactDirectoryPath,
   artifactFilePath,
   createLocalArtifactEnv,
+  MULTI_TENANT_HOST_SUFFIXES,
   nativeContactHandle,
   nativeContactUrl,
   deriveDomainTags,
@@ -588,13 +589,9 @@ test("public artifacts are internally consistent", () => {
     "x.com",
     "twitter.com",
   ]);
-  const GENERIC_CLUSTER_HOST_SUFFIXES = [
-    "github.io",
-    "pages.dev",
-    "workers.dev",
-    "vercel.app",
-    "netlify.app",
-  ];
+  // Authoritative multi-tenant host set — shared with lib.mjs / build-artifacts
+  // so the assertion can't drift from the cluster derivation (issue #419).
+  const GENERIC_CLUSTER_HOST_SUFFIXES = [...MULTI_TENANT_HOST_SUFFIXES];
   let providersWithNetuids = 0;
   for (const provider of providersArtifact.providers) {
     assert.ok(

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -728,6 +728,25 @@ describe("clusterDomainFromUrl", () => {
     assert.equal(clusterDomainFromUrl("https://co.uk"), null);
     assert.equal(clusterDomainFromUrl("https://github.io"), null);
   });
+
+  test("treats the extended multi-tenant platform hosts as per-tenant clusters (#419)", () => {
+    // Each subdomain is a distinct tenant → keep the tenant label.
+    assert.equal(clusterDomainFromUrl("https://team.gitlab.io"), "team.gitlab.io");
+    assert.equal(clusterDomainFromUrl("https://app.surge.sh"), "app.surge.sh");
+    assert.equal(clusterDomainFromUrl("https://svc.onrender.com"), "svc.onrender.com");
+    assert.equal(
+      clusterDomainFromUrl("https://api.azurewebsites.net"),
+      "api.azurewebsites.net",
+    );
+    assert.equal(clusterDomainFromUrl("https://bucket.r2.dev"), "bucket.r2.dev");
+    assert.equal(clusterDomainFromUrl("https://wiki.notion.site"), "wiki.notion.site");
+    assert.equal(clusterDomainFromUrl("https://user.pythonanywhere.com"), "user.pythonanywhere.com");
+    assert.equal(clusterDomainFromUrl("https://proj.appspot.com"), "proj.appspot.com");
+    assert.equal(clusterDomainFromUrl("https://site.netlify.com"), "site.netlify.com");
+    // The bare platform suffix is not a cluster of its own.
+    assert.equal(clusterDomainFromUrl("https://gitlab.io"), null);
+    assert.equal(clusterDomainFromUrl("https://surge.sh"), null);
+  });
   test("returns null for non-URL / non-string input", () => {
     assert.equal(clusterDomainFromUrl("not a url"), null);
     assert.equal(clusterDomainFromUrl(null), null);


### PR DESCRIPTION
Closes #419. Follow-up to #415.

## Problem
The cluster-domain hardening covered `github.io` but left equivalent multi-tenant public-suffix hosts uncovered, and the host list was **duplicated across three files** that could silently drift:
- `scripts/lib.mjs` → `CLUSTER_MULTI_LABEL_SUFFIXES` (ccTLDs + 12 SaaS hosts)
- `scripts/build-artifacts.mjs` → `GENERIC_CLUSTER_HOST_SUFFIXES` (the same 12)
- `tests/artifacts.test.mjs` → a 5-host subset

## Fix
- **Single source of truth:** new exported `MULTI_TENANT_HOST_SUFFIXES` in `lib.mjs`. `clusterDomainFromUrl` (lib), `isGenericClusterHost` (build-artifacts), and the artifacts test now all consume it — the copies can't diverge.
- **Extended coverage** to the same class as `github.io`: `gitlab.io`, `surge.sh`, `onrender.com`, `azurewebsites.net`, `r2.dev`, `notion.site`, `pythonanywhere.com`, `appspot.com`, and legacy `netlify.com`.
- **Tests:** new `clusterDomainFromUrl` cases for the added hosts (tenant-scoped cluster; bare suffix → `null`).

## Notes
- `cluster_id` is a derived, reporting-only field (no security impact) — correctness/robustness hygiene.
- **0 cluster diffs** across the current 90 providers: verified none uses a newly-added host, so this is pure forward-coverage + dedup with no behaviour change for existing data.

## Verification
- `tests/lib-helpers.test.mjs` (incl. new cluster cases) + `tests/artifacts.test.mjs` pass in isolation
- `clusterDomainFromUrl` spot-checks confirm tenant-scoping for all 9 new hosts