### PR TITLE
Fix regional App Engine owner-token clustering

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1206,6 +1206,12 @@ const CLUSTER_COUNTRY_CODE_SECOND_LEVEL_SUFFIX_LABELS = new Set([
 function clusterSuffixDomain(host) {
   const labels = host.split(".").filter(Boolean);
   if (labels.length < 2) return host || null;
+  if (labels.at(-1) === "com" && labels.at(-2) === "appspot") {
+    if (labels.at(-3) === "r") {
+      return labels.length >= 5 ? labels.slice(-5).join(".") : null;
+    }
+    return labels.length >= 3 ? labels.slice(-3).join(".") : null;
+  }
   for (
     let suffixLabelCount = labels.length;
     suffixLabelCount >= 2;

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -731,21 +731,47 @@ describe("clusterDomainFromUrl", () => {
 
   test("treats the extended multi-tenant platform hosts as per-tenant clusters (#419)", () => {
     // Each subdomain is a distinct tenant → keep the tenant label.
-    assert.equal(clusterDomainFromUrl("https://team.gitlab.io"), "team.gitlab.io");
+    assert.equal(
+      clusterDomainFromUrl("https://team.gitlab.io"),
+      "team.gitlab.io",
+    );
     assert.equal(clusterDomainFromUrl("https://app.surge.sh"), "app.surge.sh");
-    assert.equal(clusterDomainFromUrl("https://svc.onrender.com"), "svc.onrender.com");
+    assert.equal(
+      clusterDomainFromUrl("https://svc.onrender.com"),
+      "svc.onrender.com",
+    );
     assert.equal(
       clusterDomainFromUrl("https://api.azurewebsites.net"),
       "api.azurewebsites.net",
     );
-    assert.equal(clusterDomainFromUrl("https://bucket.r2.dev"), "bucket.r2.dev");
-    assert.equal(clusterDomainFromUrl("https://wiki.notion.site"), "wiki.notion.site");
-    assert.equal(clusterDomainFromUrl("https://user.pythonanywhere.com"), "user.pythonanywhere.com");
-    assert.equal(clusterDomainFromUrl("https://proj.appspot.com"), "proj.appspot.com");
-    assert.equal(clusterDomainFromUrl("https://site.netlify.com"), "site.netlify.com");
+    assert.equal(
+      clusterDomainFromUrl("https://bucket.r2.dev"),
+      "bucket.r2.dev",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://wiki.notion.site"),
+      "wiki.notion.site",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://user.pythonanywhere.com"),
+      "user.pythonanywhere.com",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://proj.appspot.com"),
+      "proj.appspot.com",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://attacker.uc.r.appspot.com/api"),
+      "attacker.uc.r.appspot.com",
+    );
+    assert.equal(
+      clusterDomainFromUrl("https://site.netlify.com"),
+      "site.netlify.com",
+    );
     // The bare platform suffix is not a cluster of its own.
     assert.equal(clusterDomainFromUrl("https://gitlab.io"), null);
     assert.equal(clusterDomainFromUrl("https://surge.sh"), null);
+    assert.equal(clusterDomainFromUrl("https://uc.r.appspot.com"), null);
   });
   test("returns null for non-URL / non-string input", () => {
     assert.equal(clusterDomainFromUrl("not a url"), null);

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -1237,6 +1237,9 @@ describe("submission-policy owner-identity + placeholder helpers", () => {
     assert.deepEqual(urlOwnerTokens("https://status.all-ways.io/x"), [
       "allways",
     ]);
+    assert.deepEqual(urlOwnerTokens("https://attacker.uc.r.appspot.com/api"), [
+      "attacker",
+    ]);
     assert.deepEqual(urlOwnerTokens("not a url"), []);
     assert.deepEqual(urlOwnerTokens(42), []);
     // a sub-4-char org is filtered out


### PR DESCRIPTION
### Motivation
- Regional Google App Engine hostnames like `attacker.uc.r.appspot.com` were being collapsed to `r.appspot.com` by the generic multi-tenant suffix logic, which produced an undersized owner token and allowed owner-mismatch checks to be suppressed.

### Description
- Special-case `*.appspot.com` in `clusterSuffixDomain` so `*.r.appspot.com` regional hostnames preserve the app and region labels (e.g. `attacker.uc.r.appspot.com` → `attacker.uc.r.appspot.com`) while bare regional suffixes like `uc.r.appspot.com` return `null`.
- Add regression tests to `tests/lib-helpers.test.mjs` to assert regional `appspot` clustering behavior and to `tests/submission-gate.test.mjs` to assert `urlOwnerTokens` extracts the app label for regional App Engine URLs.
- Minor formatting adjustments applied and ensured Prettier compliance for the touched files.

### Testing
- Ran the unit tests with `npm test -- --run tests/lib-helpers.test.mjs tests/submission-gate.test.mjs` and all tests passed (`2 files, 108 tests passed`).
- Ran `npx prettier --check` and used `npx prettier --write` to fix style issues, and a final `prettier --check` confirmed style compliance for the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e44c4a878832abeb7f76a19766ad3)