### PR TITLE
refactor(worker): extract workers/http.mjs response primitives (#510 — de-monolith, PR 3)

### DIFF
--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -8,6 +8,7 @@ import {
   compileRoutePattern,
 } from "../src/contracts.mjs";
 import { applyQueryFilters } from "./list-query.mjs";
+import { apiHeaders, errorResponse, weakEtag } from "./http.mjs";
 import {
   artifactStorageTierForPath,
   ARTIFACT_STORAGE_TIERS,
@@ -2891,37 +2892,6 @@ async function envelopeResponse(request, payload, cacheProfile) {
   });
 }
 
-function errorResponse(
-  code,
-  message,
-  status = 500,
-  meta = {},
-  extraHeaders = {},
-) {
-  const headers = apiHeaders("short");
-  headers.set("x-metagraph-error-code", code);
-  for (const [key, value] of Object.entries(extraHeaders)) {
-    headers.set(key, value);
-  }
-
-  return new Response(
-    JSON.stringify({
-      ok: false,
-      schema_version: 1,
-      data: null,
-      error: { code, message },
-      meta: {
-        contract_version: CONTRACT_VERSION,
-        ...meta,
-      },
-    }),
-    {
-      status,
-      headers,
-    },
-  );
-}
-
 function corsPreflight(request) {
   const url = new URL(request.url);
   const headers = apiHeaders("short");
@@ -3121,29 +3091,6 @@ async function agentToolsResponse(request, env, kind) {
     status: 200,
     headers,
   });
-}
-
-function apiHeaders(cacheProfile) {
-  const headers = new Headers();
-  headers.set("access-control-allow-origin", "*");
-  headers.set(
-    "cache-control",
-    `public, max-age=${CACHE_SECONDS[cacheProfile] || CACHE_SECONDS.standard}, stale-while-revalidate=300`,
-  );
-  headers.set("content-type", JSON_CONTENT_TYPE);
-  headers.set("x-content-type-options", "nosniff");
-  headers.set("x-metagraph-cache-profile", cacheProfile);
-  headers.set("vary", "Accept-Encoding");
-  return headers;
-}
-
-async function weakEtag(body) {
-  const encoded = new TextEncoder().encode(body);
-  const digest = await crypto.subtle.digest("SHA-256", encoded);
-  const hash = [...new Uint8Array(digest)]
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
-  return `W/"${hash.slice(0, 32)}"`;
 }
 
 function contractVersion(env) {

--- a/workers/http.mjs
+++ b/workers/http.mjs
@@ -1,0 +1,61 @@
+// Shared HTTP response primitives for the API Worker — header construction,
+// weak ETags, and the canonical error envelope. Extracted from workers/api.mjs
+// (issue #510, de-monolith) as a leaf module: it imports only contract/config
+// constants and nothing from api.mjs, so every request-handler module can share
+// these without an import cycle.
+import { CACHE_SECONDS, CONTRACT_VERSION } from "../src/contracts.mjs";
+import { JSON_CONTENT_TYPE } from "./config.mjs";
+
+export function apiHeaders(cacheProfile) {
+  const headers = new Headers();
+  headers.set("access-control-allow-origin", "*");
+  headers.set(
+    "cache-control",
+    `public, max-age=${CACHE_SECONDS[cacheProfile] || CACHE_SECONDS.standard}, stale-while-revalidate=300`,
+  );
+  headers.set("content-type", JSON_CONTENT_TYPE);
+  headers.set("x-content-type-options", "nosniff");
+  headers.set("x-metagraph-cache-profile", cacheProfile);
+  headers.set("vary", "Accept-Encoding");
+  return headers;
+}
+
+export function errorResponse(
+  code,
+  message,
+  status = 500,
+  meta = {},
+  extraHeaders = {},
+) {
+  const headers = apiHeaders("short");
+  headers.set("x-metagraph-error-code", code);
+  for (const [key, value] of Object.entries(extraHeaders)) {
+    headers.set(key, value);
+  }
+
+  return new Response(
+    JSON.stringify({
+      ok: false,
+      schema_version: 1,
+      data: null,
+      error: { code, message },
+      meta: {
+        contract_version: CONTRACT_VERSION,
+        ...meta,
+      },
+    }),
+    {
+      status,
+      headers,
+    },
+  );
+}
+
+export async function weakEtag(body) {
+  const encoded = new TextEncoder().encode(body);
+  const digest = await crypto.subtle.digest("SHA-256", encoded);
+  const hash = [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `W/"${hash.slice(0, 32)}"`;
+}


### PR DESCRIPTION
Part of #510 (Wave B — Maintainability: de-monolith). **Pure restructuring, NO behaviour change.**

## What — the shared-util keystone
Move the three pure HTTP response primitives — `apiHeaders`, `errorResponse`, `weakEtag` (74 combined call sites) — into a new **leaf module** `workers/http.mjs`.

## Why this shape
- `http.mjs` imports only `CACHE_SECONDS` + `CONTRACT_VERSION` (`../src/contracts.mjs`) and `JSON_CONTENT_TYPE` (`./config.mjs`) — **nothing from `api.mjs`**, so no cycle.
- The more entangled response builders (`envelopeResponse`, `dataResponse`, `corsPreflight`) **stay** in `api.mjs` — they read env/pointer data or need `WEBHOOK_SECRET_HEADER`; they now consume the imported primitives.
- All three constants remain used elsewhere in `api.mjs`, so their imports stay.

This is the **keystone** that unblocks the upcoming handler-group splits (rpc, badge, analytics, …) — those couldn't move while these primitives lived in `api.mjs`.

`api.mjs`: 3301 → 3248 LOC (3570 at the start of #510).

## Verification (no logic diff)
- 122 worker tests pass (`worker-runtime`, `api-coverage`, `webhooks-worker`, `subnet-overview`)
- `worker:test` (esbuild bundle) green · `validate:contract-drift` clean · `lint` clean
- None of the three are exported/imported by tests (exercised via `handleRequest`) → no re-exports