### PR TITLE
refactor(worker): extract workers/storage.mjs IO layer from api.mjs (#510 — de-monolith, PR 4)

### DIFF
--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -10,9 +10,13 @@ import {
 import { applyQueryFilters } from "./list-query.mjs";
 import { apiHeaders, errorResponse, weakEtag } from "./http.mjs";
 import {
-  artifactStorageTierForPath,
-  ARTIFACT_STORAGE_TIERS,
-} from "../src/artifact-storage.mjs";
+  d1TimeoutMs,
+  latestPointer,
+  logEvent,
+  readArtifact,
+  readHealthKv,
+  withTimeout,
+} from "./storage.mjs";
 import {
   buildChangeEvent,
   generateSecret,
@@ -85,7 +89,6 @@ import {
   MAX_RPC_BODY_BYTES,
   MAX_UPTIME_ROWS,
   MAX_WEBHOOK_BODY_BYTES,
-  METAGRAPH_LATEST_KEY,
   PERCENTILES_PATH_PATTERN,
   RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN,
   SAFE_RPC_METHODS,
@@ -2042,53 +2045,6 @@ function matchRoute(pathname) {
   return null;
 }
 
-const DEFAULT_R2_TIMEOUT_MS = 5000;
-
-// Structured log captured by Workers observability. Only called on notable
-// non-happy paths (R2 timeout, static fallback) so it does not spam logs.
-// Disabled with METAGRAPH_DISABLE_REQUEST_LOGS=true.
-function logEvent(env, level, event, fields = {}) {
-  if (env.METAGRAPH_DISABLE_REQUEST_LOGS === "true") {
-    return;
-  }
-  try {
-    console.log(JSON.stringify({ level, event, ...fields }));
-  } catch {
-    // Never let logging break a request.
-  }
-}
-
-function r2TimeoutMs(env) {
-  const raw = Number(env.METAGRAPH_R2_TIMEOUT_MS);
-  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_R2_TIMEOUT_MS;
-}
-
-const DEFAULT_D1_TIMEOUT_MS = 5000;
-
-// Health-analytics D1 reads (trends/percentiles/incidents/uptime) can scan large
-// time-series. Bound them so a slow/degraded query degrades to the route's normal
-// empty-result path instead of holding the isolate until the CPU limit kills it.
-// Tunable via METAGRAPH_D1_TIMEOUT_MS.
-function d1TimeoutMs(env) {
-  const raw = Number(env.METAGRAPH_D1_TIMEOUT_MS);
-  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_D1_TIMEOUT_MS;
-}
-
-// R2's get() takes no AbortSignal, so bound it with a race: a slow/degraded
-// bucket yields a controlled 504 (and static fallback where allowed) instead of
-// hanging the request until the platform wall-clock limit.
-async function withTimeout(promise, ms) {
-  let timer;
-  const timeout = new Promise((_, reject) => {
-    timer = setTimeout(() => reject(new Error("timeout")), ms);
-  });
-  try {
-    return await Promise.race([promise, timeout]);
-  } finally {
-    clearTimeout(timer);
-  }
-}
-
 // Lightweight readiness probe for uptime checks and load balancers. Reports
 // which bindings are wired without touching R2/KV (no I/O, no cold-start cost).
 async function handleHealthRequest(request, env) {
@@ -2166,118 +2122,6 @@ async function handleHealthRequest(request, env) {
     status: stale ? 503 : 200,
     headers,
   });
-}
-
-async function readArtifact(env, artifactPath) {
-  const storageTier = artifactStorageTierForPath(artifactPath);
-
-  if (storageTier === ARTIFACT_STORAGE_TIERS.r2) {
-    const r2 = await readR2(env, artifactPath, storageTier);
-    if (r2.ok || env.METAGRAPH_ALLOW_R2_STATIC_FALLBACK !== "true") {
-      return r2;
-    }
-    logEvent(env, "warn", "r2_static_fallback", {
-      artifact_path: artifactPath,
-      r2_code: r2.code,
-    });
-    return readAsset(env, artifactPath, storageTier);
-  }
-
-  const asset = await readAsset(env, artifactPath, storageTier);
-  if (asset.ok) {
-    return asset;
-  }
-
-  const r2 = await readR2(env, artifactPath, storageTier);
-  if (r2.ok) {
-    return r2;
-  }
-
-  return asset.status !== 404 ? asset : r2;
-}
-
-async function readAsset(env, artifactPath, storageTier) {
-  if (!env.ASSETS?.fetch) {
-    return {
-      ok: false,
-      status: 404,
-      code: "asset_binding_missing",
-      message: "No ASSETS binding is configured.",
-    };
-  }
-
-  const response = await env.ASSETS.fetch(
-    new Request(`https://assets.local${artifactPath}`),
-  );
-  if (!response.ok) {
-    await response.body?.cancel?.();
-    return {
-      ok: false,
-      status: response.status,
-      code: "artifact_not_found",
-      message: `Artifact not found in static assets: ${artifactPath}`,
-    };
-  }
-
-  return {
-    ok: true,
-    data: await response.json(),
-    source: "static-assets",
-    storage_tier: storageTier,
-  };
-}
-
-async function readR2(env, artifactPath, storageTier) {
-  if (!env.METAGRAPH_ARCHIVE?.get) {
-    return {
-      ok: false,
-      status: 404,
-      code: "r2_binding_missing",
-      message: "No R2 archive binding is configured.",
-    };
-  }
-
-  const key = await latestR2Key(artifactPath, env);
-  let object;
-  try {
-    object = await withTimeout(
-      env.METAGRAPH_ARCHIVE.get(key),
-      r2TimeoutMs(env),
-    );
-  } catch {
-    logEvent(env, "warn", "r2_read_timeout", {
-      key,
-      storage_tier: storageTier,
-    });
-    return {
-      ok: false,
-      status: 504,
-      code: "r2_timeout",
-      message: `R2 read timed out: ${key}`,
-    };
-  }
-  if (!object) {
-    return {
-      ok: false,
-      status: 404,
-      code: "artifact_not_found",
-      message: `Artifact not found in R2: ${key}`,
-    };
-  }
-
-  return {
-    ok: true,
-    data: await object.json(),
-    source: "r2",
-    storage_tier: storageTier,
-  };
-}
-
-async function latestR2Key(artifactPath, env) {
-  const pointer = await latestPointer(env);
-  const prefix =
-    pointer?.latest_prefix || env.METAGRAPH_R2_LATEST_PREFIX || "latest/";
-  return `${prefix}${artifactPath.replace(/^\/metagraph\//, "")}`;
 }
 
 // --- Change-feed webhooks -----------------------------------------------------
@@ -2699,34 +2543,6 @@ function dataResponse(env, data, status = 200, extraMeta = {}) {
     }),
     { status, headers },
   );
-}
-
-async function latestPointer(env) {
-  if (!env.METAGRAPH_CONTROL?.get) {
-    return null;
-  }
-
-  try {
-    return await env.METAGRAPH_CONTROL.get(METAGRAPH_LATEST_KEY, {
-      type: "json",
-    });
-  } catch {
-    return null;
-  }
-}
-
-// Read a live health snapshot written by the cron prober (KV health:* keys).
-// Returns null when KV is unbound or the key is cold so callers fall back to the
-// static artifact.
-async function readHealthKv(env, key) {
-  if (!env.METAGRAPH_CONTROL?.get) {
-    return null;
-  }
-  try {
-    return await env.METAGRAPH_CONTROL.get(key, { type: "json" });
-  } catch {
-    return null;
-  }
 }
 
 // Explicit `unknown` health payloads for the live-only routes when the live

--- a/workers/storage.mjs
+++ b/workers/storage.mjs
@@ -1,0 +1,196 @@
+// Storage + IO layer for the API Worker — artifact reads (R2 + static-asset
+// tiers with fallback), the latest-pointer / health-KV reads, request logging,
+// and the timeout guards that bound R2/D1 access. Extracted from workers/api.mjs
+// (issue #510, de-monolith) as a leaf module: it imports only the artifact-tier
+// contract and a config key, and calls nothing back into api.mjs, so handlers
+// and the response builders can share it without an import cycle.
+import {
+  artifactStorageTierForPath,
+  ARTIFACT_STORAGE_TIERS,
+} from "../src/artifact-storage.mjs";
+import { METAGRAPH_LATEST_KEY } from "./config.mjs";
+
+const DEFAULT_R2_TIMEOUT_MS = 5000;
+const DEFAULT_D1_TIMEOUT_MS = 5000;
+
+// Structured request logging on non-happy paths (R2 timeout, static fallback) so
+// it does not spam logs. Disabled with METAGRAPH_DISABLE_REQUEST_LOGS=true.
+export function logEvent(env, level, event, fields = {}) {
+  if (env.METAGRAPH_DISABLE_REQUEST_LOGS === "true") {
+    return;
+  }
+  try {
+    console.log(JSON.stringify({ level, event, ...fields }));
+  } catch {
+    // Never let logging break a request.
+  }
+}
+
+export function r2TimeoutMs(env) {
+  const raw = Number(env.METAGRAPH_R2_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_R2_TIMEOUT_MS;
+}
+
+// Health-analytics D1 reads (trends/percentiles/incidents/uptime) can scan large
+// time-series. Bound them so a slow/degraded query degrades to the route's normal
+// empty-result path instead of holding the isolate until the CPU limit kills it.
+// Tunable via METAGRAPH_D1_TIMEOUT_MS.
+export function d1TimeoutMs(env) {
+  const raw = Number(env.METAGRAPH_D1_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_D1_TIMEOUT_MS;
+}
+
+// R2's get() takes no AbortSignal, so bound it with a race: a slow/degraded
+// bucket yields a controlled 504 (and static fallback where allowed) instead of
+// hanging the request until the platform wall-clock limit.
+export async function withTimeout(promise, ms) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error("timeout")), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export async function readArtifact(env, artifactPath) {
+  const storageTier = artifactStorageTierForPath(artifactPath);
+
+  if (storageTier === ARTIFACT_STORAGE_TIERS.r2) {
+    const r2 = await readR2(env, artifactPath, storageTier);
+    if (r2.ok || env.METAGRAPH_ALLOW_R2_STATIC_FALLBACK !== "true") {
+      return r2;
+    }
+    logEvent(env, "warn", "r2_static_fallback", {
+      artifact_path: artifactPath,
+      r2_code: r2.code,
+    });
+    return readAsset(env, artifactPath, storageTier);
+  }
+
+  const asset = await readAsset(env, artifactPath, storageTier);
+  if (asset.ok) {
+    return asset;
+  }
+
+  const r2 = await readR2(env, artifactPath, storageTier);
+  if (r2.ok) {
+    return r2;
+  }
+
+  return asset.status !== 404 ? asset : r2;
+}
+
+export async function readAsset(env, artifactPath, storageTier) {
+  if (!env.ASSETS?.fetch) {
+    return {
+      ok: false,
+      status: 404,
+      code: "asset_binding_missing",
+      message: "No ASSETS binding is configured.",
+    };
+  }
+
+  const response = await env.ASSETS.fetch(
+    new Request(`https://assets.local${artifactPath}`),
+  );
+  if (!response.ok) {
+    await response.body?.cancel?.();
+    return {
+      ok: false,
+      status: response.status,
+      code: "artifact_not_found",
+      message: `Artifact not found in static assets: ${artifactPath}`,
+    };
+  }
+
+  return {
+    ok: true,
+    data: await response.json(),
+    source: "static-assets",
+    storage_tier: storageTier,
+  };
+}
+
+export async function readR2(env, artifactPath, storageTier) {
+  if (!env.METAGRAPH_ARCHIVE?.get) {
+    return {
+      ok: false,
+      status: 404,
+      code: "r2_binding_missing",
+      message: "No R2 archive binding is configured.",
+    };
+  }
+
+  const key = await latestR2Key(artifactPath, env);
+  let object;
+  try {
+    object = await withTimeout(
+      env.METAGRAPH_ARCHIVE.get(key),
+      r2TimeoutMs(env),
+    );
+  } catch {
+    logEvent(env, "warn", "r2_read_timeout", {
+      key,
+      storage_tier: storageTier,
+    });
+    return {
+      ok: false,
+      status: 504,
+      code: "r2_timeout",
+      message: `R2 read timed out: ${key}`,
+    };
+  }
+  if (!object) {
+    return {
+      ok: false,
+      status: 404,
+      code: "artifact_not_found",
+      message: `Artifact not found in R2: ${key}`,
+    };
+  }
+
+  return {
+    ok: true,
+    data: await object.json(),
+    source: "r2",
+    storage_tier: storageTier,
+  };
+}
+
+export async function latestR2Key(artifactPath, env) {
+  const pointer = await latestPointer(env);
+  const prefix =
+    pointer?.latest_prefix || env.METAGRAPH_R2_LATEST_PREFIX || "latest/";
+  return `${prefix}${artifactPath.replace(/^\/metagraph\//, "")}`;
+}
+
+export async function latestPointer(env) {
+  if (!env.METAGRAPH_CONTROL?.get) {
+    return null;
+  }
+
+  try {
+    return await env.METAGRAPH_CONTROL.get(METAGRAPH_LATEST_KEY, {
+      type: "json",
+    });
+  } catch {
+    return null;
+  }
+}
+
+// Read a live health snapshot written by the cron prober (KV health:* keys).
+// Returns null when KV is unbound or the key is cold so callers fall back to the
+// static artifact.
+export async function readHealthKv(env, key) {
+  if (!env.METAGRAPH_CONTROL?.get) {
+    return null;
+  }
+  try {
+    return await env.METAGRAPH_CONTROL.get(key, { type: "json" });
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Part of #510 (Wave B — Maintainability: de-monolith). **Pure restructuring, NO behaviour change.**

## What — the storage/IO foundation layer
Move the 10 artifact-read / KV / timeout / logging helpers into a new **leaf module** `workers/storage.mjs`: `logEvent`, `r2TimeoutMs`, `d1TimeoutMs`, `withTimeout`, `readArtifact`, `readAsset`, `readR2`, `latestR2Key`, `latestPointer`, `readHealthKv` (+ the `DEFAULT_R2/D1_TIMEOUT_MS` constants).

## Why this shape
- `storage.mjs` imports only the artifact-tier contract (`../src/artifact-storage.mjs`) and `METAGRAPH_LATEST_KEY` (`./config.mjs`) — **calls nothing back into `api.mjs`**, so it's a clean leaf.
- `api.mjs` imports the 6 it still uses; the other 4 are intra-module. Dropped the now-unused `artifactStorageTierForPath` / `ARTIFACT_STORAGE_TIERS` / `METAGRAPH_LATEST_KEY` imports from `api.mjs`.
- This **unblocks the handler-group splits** — they all read artifacts/health through these helpers.

`api.mjs`: 3248 → 3064 LOC (3570 at the start of #510).

## Verification (no logic diff)
- **231 worker tests** pass across 7 suites (`worker-runtime`, `api-coverage`, `subnet-overview`, `raw-artifact-freshness`, `health-prober`, `webhooks-worker`, `ai-search`)
- `worker:test` (esbuild bundle) green · `validate:contract-drift` clean · `lint` clean (no orphan imports)
- None of the 10 are exported/imported by tests (exercised via `handleRequest`) → no re-exports