### PR TITLE
refactor(worker): extract workers/responses.mjs envelope builders (#510 — de-monolith, PR 5)

### DIFF
--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -2,7 +2,6 @@ import {
   API_ROUTES,
   PUBLIC_ARTIFACTS,
   CACHE_SECONDS,
-  CONTRACT_VERSION,
   PRIMARY_DOMAIN,
   artifactPathFromTemplate,
   compileRoutePattern,
@@ -17,6 +16,12 @@ import {
   readHealthKv,
   withTimeout,
 } from "./storage.mjs";
+import {
+  contractVersion,
+  dataResponse,
+  envelopeResponse,
+  publishedAt,
+} from "./responses.mjs";
 import {
   buildChangeEvent,
   generateSecret,
@@ -2529,22 +2534,6 @@ async function handleAskRequest(request, env) {
   }
 }
 
-// Success envelope for non-cacheable (mutation / dynamic) JSON responses.
-function dataResponse(env, data, status = 200, extraMeta = {}) {
-  const headers = apiHeaders("short");
-  headers.set("cache-control", "no-store");
-  return new Response(
-    JSON.stringify({
-      ok: true,
-      schema_version: 1,
-      data,
-      error: null,
-      meta: { contract_version: contractVersion(env), ...extraMeta },
-    }),
-    { status, headers },
-  );
-}
-
 // Explicit `unknown` health payloads for the live-only routes when the live
 // store (KV + D1) is cold — served instead of a stale baked value or a 404.
 function unknownGlobalHealth(contractVersionValue) {
@@ -2671,41 +2660,6 @@ async function liveHealthOverlay(env, matched, staticData) {
   }
 
   return data ? { data } : null;
-}
-
-// Real publish timestamp for envelope meta, read from the KV latest pointer.
-// API routes are edge-cached (cache-control max-age + stale-while-revalidate),
-// so this KV read only happens on origin misses. Returns null when KV is
-// unbound or the pointer predates published_at support.
-async function publishedAt(env) {
-  const pointer = await latestPointer(env);
-  return pointer?.published_at || null;
-}
-
-async function envelopeResponse(request, payload, cacheProfile) {
-  const body = JSON.stringify({
-    ok: true,
-    schema_version: 1,
-    data: payload.data,
-    meta: payload.meta,
-  });
-  const headers = apiHeaders(cacheProfile);
-  const etag = await weakEtag(body);
-  headers.set("etag", etag);
-  headers.set(
-    "x-metagraph-contract-version",
-    payload.meta.contract_version || CONTRACT_VERSION,
-  );
-  if (request.headers.get("if-none-match") === etag) {
-    return new Response(null, {
-      status: 304,
-      headers,
-    });
-  }
-  return new Response(request.method === "HEAD" ? null : body, {
-    status: 200,
-    headers,
-  });
 }
 
 function corsPreflight(request) {
@@ -2907,10 +2861,6 @@ async function agentToolsResponse(request, env, kind) {
     status: 200,
     headers,
   });
-}
-
-function contractVersion(env) {
-  return env.METAGRAPH_CONTRACT_VERSION || CONTRACT_VERSION;
 }
 
 // Build the FULL ordered candidate list of eligible, upstream-safe, HTTP(S)

--- a/workers/responses.mjs
+++ b/workers/responses.mjs
@@ -1,0 +1,64 @@
+// Response envelope builders for the API Worker — the canonical success/data
+// envelopes, the contract-version resolver, and the published-at lookup.
+// Extracted from workers/api.mjs (issue #510, de-monolith). Depends only on the
+// http + storage leaf modules and the contract version; it calls nothing back
+// into api.mjs, so there is no import cycle.
+import { CONTRACT_VERSION } from "../src/contracts.mjs";
+import { apiHeaders, weakEtag } from "./http.mjs";
+import { latestPointer } from "./storage.mjs";
+
+export function contractVersion(env) {
+  return env.METAGRAPH_CONTRACT_VERSION || CONTRACT_VERSION;
+}
+
+// Published-at is read from the latest-pointer KV (warmed on publish), so this
+// only touches KV on origin misses. Returns null when KV is unbound or the
+// pointer predates published_at support.
+export async function publishedAt(env) {
+  const pointer = await latestPointer(env);
+  return pointer?.published_at || null;
+}
+
+// Success envelope for non-cacheable (mutation / dynamic) JSON responses.
+export function dataResponse(env, data, status = 200, extraMeta = {}) {
+  const headers = apiHeaders("short");
+  headers.set("cache-control", "no-store");
+  return new Response(
+    JSON.stringify({
+      ok: true,
+      schema_version: 1,
+      data,
+      error: null,
+      meta: { contract_version: contractVersion(env), ...extraMeta },
+    }),
+    { status, headers },
+  );
+}
+
+// Cacheable success envelope with a weak ETag + 304 short-circuit; HEAD returns
+// headers only. cacheProfile selects the cache-control max-age via apiHeaders.
+export async function envelopeResponse(request, payload, cacheProfile) {
+  const body = JSON.stringify({
+    ok: true,
+    schema_version: 1,
+    data: payload.data,
+    meta: payload.meta,
+  });
+  const headers = apiHeaders(cacheProfile);
+  const etag = await weakEtag(body);
+  headers.set("etag", etag);
+  headers.set(
+    "x-metagraph-contract-version",
+    payload.meta.contract_version || CONTRACT_VERSION,
+  );
+  if (request.headers.get("if-none-match") === etag) {
+    return new Response(null, {
+      status: 304,
+      headers,
+    });
+  }
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers,
+  });
+}


### PR DESCRIPTION
Part of #510 (Wave B — Maintainability: de-monolith). **Pure restructuring, NO behaviour change.**

## What — the response-envelope layer
Move `contractVersion`, `publishedAt`, `dataResponse`, and `envelopeResponse` into a new **leaf module** `workers/responses.mjs`.

## Why this shape
- `responses.mjs` imports only `CONTRACT_VERSION` (`../src/contracts.mjs`), `apiHeaders`/`weakEtag` (`./http.mjs`), and `latestPointer` (`./storage.mjs`) — all leaves; calls nothing back into `api.mjs` → no cycle.
- Dropped the now-unused `CONTRACT_VERSION` import from `api.mjs` (its only remaining users moved here). `latestPointer` stays imported in `api.mjs` (still used directly by handlers).

With config/http/storage/responses/list-query all extracted, **the whole request-serving infrastructure layer is now out of `api.mjs`** — the handler groups (rpc, badge, analytics, webhooks, mcp, discovery) can be split next, since they consume these leaves.

`api.mjs`: 3064 → 3014 LOC (**3570 → 3014 across PRs 1–5 of #510**).

## Verification (no logic diff)
- 229 worker tests pass across 6 suites · `worker:test` (esbuild) green · `validate:contract-drift` clean · `lint` clean
- None of the 4 are test-imported (exercised via `handleRequest`) → no re-exports