### PR TITLE
fix(pipeline): exempt mirrored fixtures from soft public-safety heuristics (unblock stale data)

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -53,15 +53,19 @@ const patterns = [
   },
 ];
 
-// Per-surface schema artifacts embed the full upstream OpenAPI/Swagger spec
-// (TS2). Those are public docs the subnet published; the soft wording
-// heuristics false-positive on their API terminology. Keep this exemption scoped
-// to generated public/R2 artifact directories so source schemas are still
-// covered by the terminology guard.
+// Per-surface schema artifacts AND captured fixtures embed the full upstream
+// OpenAPI/Swagger spec or GitHub README (TS2). Those are public docs the subnet
+// published; the soft wording heuristics false-positive on their API terminology
+// ("hotkey"/"wallet"/"coldkey" are core Bittensor vocabulary that nearly every
+// subnet API documents). Keep this exemption scoped to the generated public/R2
+// artifact directories so source schemas are still covered by the terminology
+// guard. The hard secret patterns above still apply to these files.
 function isMirroredExternalSpec(relativePath) {
   return [
     /^public\/metagraph\/schemas\/(?!index\.json$)[^/]+\.json$/,
     /^dist\/metagraph-r2\/metagraph\/schemas\/(?!index\.json$)[^/]+\.json$/,
+    /^public\/metagraph\/fixtures\/[^/]+\.json$/,
+    /^dist\/metagraph-r2\/metagraph\/fixtures\/[^/]+\.json$/,
   ].some((pattern) => pattern.test(relativePath));
 }
 


### PR DESCRIPTION
## 🔴 Production impact
The data-refresh pipeline (`sync-subnets`) has **failed on every run since 2026-06-12T21:06**. Result: production has been serving **~35h-stale registry data** and `GET /api/v1/health` returns **503 (degraded)**. (Surfaced by the quality audit; this is the committed-artifact drift seen earlier, root-caused.)

## Root cause
`scan:public-safety`'s **soft** terminology heuristics ("sensitive hotkey wording", "wallet/key wording") fire on the freshly-captured **third-party fixtures** under `dist/metagraph-r2/metagraph/fixtures/*.json` — subnets' OWN published OpenAPI specs + GitHub READMEs (gittensor, numinous, babelbit, …). In Bittensor, "hotkey"/"coldkey"/"wallet"/"seed phrase" are **core API vocabulary**, not leaks. The existing `isMirroredExternalSpec` exemption covered `.../schemas/` but **not** `.../fixtures/`, so 12 false positives failed the scan → `sync` aborted → sources aged past the 24h blocking window → `publish-cloudflare`'s freshness gate blocked every publish.

## Fix
Extend the mirrored-spec exemption to the fixtures directories (public + R2). **Hard secret patterns still apply** to fixtures (private-key markers, GitHub/OpenAI/Slack tokens, signed storage URLs, token assignments, local paths) — only the soft terminology heuristics are skipped.

## Verification
Synthetic fixture under `dist/metagraph-r2/metagraph/fixtures/` with soft wording (`validator hotkey`, `coldkey`, `seed phrase`, `wallet path`) **+ an embedded `ghp_` token`**:
- soft wording → **exempt** (no findings) ✅
- `ghp_` token → **still flagged** as "github token" ✅

After merge I'll trigger `sync-subnets` + `publish-cloudflare` to refresh the live data immediately. Regression test to follow.