### PR TITLE
fix(python-sdk): real User-Agent (was WAF-403'd) + docs/error fixes (v0.1.1)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -21,12 +21,13 @@ from metagraphed import MetagraphedClient, metagraphed_fetch
 
 client = MetagraphedClient()  # base_url defaults to https://api.metagraph.sh
 
-# List subnets (query params; None values are dropped)
+# List subnets (query params; None values are dropped). The /subnets collection
+# nests its rows under data.subnets:
 subnets = client.fetch(
     "/api/v1/subnets",
     query={"limit": 10, "sort": "completeness_score", "order": "desc"},
 )
-print(subnets["data"][0]["name"])
+print(subnets["data"]["subnets"][0]["name"])
 
 # One subnet by netuid (path params)
 detail = client.fetch("/api/v1/subnets/{netuid}", path_params={"netuid": 7})
@@ -34,8 +35,8 @@ detail = client.fetch("/api/v1/subnets/{netuid}", path_params={"netuid": 7})
 # Which subnets are buildable? (integration readiness lives in the agent catalog)
 catalog = client.fetch("/api/v1/agent-catalog")
 
-# Point at the frontend origin instead, ad hoc:
-metagraphed_fetch("/api/v1/health", base_url="https://metagraph.sh")
+# Health of the registry itself:
+health = metagraphed_fetch("/api/v1/health")
 ```
 
 Every response is the standard envelope:

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "metagraphed"
-version = "0.1.0"
+version = "0.1.1"
 description = "Thin Python client for metagraphed — the operational + integration registry for Bittensor subnets (api.metagraph.sh)."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/python/src/metagraphed/__init__.py
+++ b/python/src/metagraphed/__init__.py
@@ -2,14 +2,16 @@
 
 from .client import (
     DEFAULT_BASE_URL,
+    DEFAULT_USER_AGENT,
     MetagraphedClient,
     MetagraphedError,
+    __version__,
     metagraphed_fetch,
 )
 
-__version__ = "0.1.0"
 __all__ = [
     "DEFAULT_BASE_URL",
+    "DEFAULT_USER_AGENT",
     "MetagraphedClient",
     "MetagraphedError",
     "metagraphed_fetch",

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -14,7 +14,14 @@ import urllib.parse
 import urllib.request
 from typing import Any, Mapping, Optional
 
+__version__ = "0.1.1"
 DEFAULT_BASE_URL = "https://api.metagraph.sh"
+# A descriptive User-Agent is required: api.metagraph.sh sits behind a Cloudflare
+# managed bot rule that returns HTTP 403 for stdlib urllib's default
+# "Python-urllib/<ver>" UA. Callers may override it via the ``headers`` argument.
+DEFAULT_USER_AGENT = (
+    f"metagraphed-python/{__version__} (+https://github.com/JSONbored/metagraphed)"
+)
 _PATH_PARAM = re.compile(r"\{([^{}]+)\}")
 
 
@@ -59,9 +66,12 @@ def metagraphed_fetch(
         if pairs:
             url += "?" + urllib.parse.urlencode(pairs, doseq=True)
 
+    # Defaults first so a caller-supplied header (e.g. a custom User-Agent) wins.
+    merged_headers = {"Accept": "application/json", "User-Agent": DEFAULT_USER_AGENT}
+    merged_headers.update(headers or {})
+
     request = urllib.request.Request(url, method="GET")
-    request.add_header("Accept", "application/json")
-    for key, value in (headers or {}).items():
+    for key, value in merged_headers.items():
         request.add_header(key, value)
 
     try:
@@ -69,12 +79,42 @@ def metagraphed_fetch(
             body = response.read().decode("utf-8")
     except urllib.error.HTTPError as error:
         raise MetagraphedError(
-            f"GET {url} failed: HTTP {error.code}", status=error.code
+            f"GET {url} failed: HTTP {error.code}{_error_detail(error)}",
+            status=error.code,
         ) from error
     except urllib.error.URLError as error:
         raise MetagraphedError(f"GET {url} failed: {error.reason}") from error
 
-    return json.loads(body)
+    try:
+        return json.loads(body)
+    except ValueError as error:
+        raise MetagraphedError(
+            f"GET {url} returned a non-JSON response"
+        ) from error
+
+
+def _error_detail(error: "urllib.error.HTTPError") -> str:
+    """Best-effort extraction of the API's error envelope from a failed response.
+
+    api.metagraph.sh returns ``{ error: { code, message } }`` on errors; surface
+    that (or a truncated raw body) so callers can see *why* a request failed
+    instead of a bare status code. Never raises.
+    """
+    try:
+        raw = error.read().decode("utf-8", "replace").strip()
+    except Exception:
+        return ""
+    if not raw:
+        return ""
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        return f": {raw[:200]}"
+    envelope = parsed.get("error") if isinstance(parsed, dict) else None
+    if isinstance(envelope, dict) and envelope.get("message"):
+        code = envelope.get("code")
+        return f": {code + ' — ' if code else ''}{envelope['message']}"
+    return f": {raw[:200]}"
 
 
 class MetagraphedClient:

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -84,6 +84,66 @@ class ClientTest(unittest.TestCase):
                 metagraphed_fetch("/api/v1/subnets/{netuid}", path_params={"netuid": 9999})
         self.assertEqual(ctx.exception.status, 404)
 
+    def test_sets_descriptive_user_agent(self):
+        # Regression: the Cloudflare WAF on api.metagraph.sh 403s the default
+        # "Python-urllib/<ver>" UA, so a descriptive UA must be sent by default.
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["ua"] = request.get_header("User-agent")
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            metagraphed_fetch("/api/v1/health")
+
+        self.assertIsNotNone(captured["ua"])
+        self.assertTrue(captured["ua"].startswith("metagraphed-python/"))
+
+    def test_caller_can_override_user_agent(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["ua"] = request.get_header("User-agent")
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            metagraphed_fetch("/api/v1/health", headers={"User-Agent": "my-app/1.0"})
+
+        self.assertEqual(captured["ua"], "my-app/1.0")
+
+    def test_http_error_surfaces_api_error_envelope(self):
+        import io
+
+        def fake_urlopen(request, timeout=None):
+            body = io.BytesIO(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": {"code": "not_found", "message": "no such subnet"},
+                    }
+                ).encode("utf-8")
+            )
+            raise urllib.error.HTTPError(request.full_url, 404, "Not Found", {}, body)
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            with self.assertRaises(MetagraphedError) as ctx:
+                metagraphed_fetch(
+                    "/api/v1/subnets/{netuid}", path_params={"netuid": 9999}
+                )
+        self.assertEqual(ctx.exception.status, 404)
+        self.assertIn("no such subnet", str(ctx.exception))
+
+    def test_non_json_response_raises_metagraphed_error(self):
+        class _BadResponse(_FakeResponse):
+            def __init__(self):
+                self._body = b"<html>not json</html>"
+
+        with mock.patch(
+            "urllib.request.urlopen", lambda request, timeout=None: _BadResponse()
+        ):
+            with self.assertRaises(MetagraphedError):
+                metagraphed_fetch("/api/v1/health")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 🔴 The published v0.1.0 SDK is non-functional out of the box
urllib's default `Python-urllib/<ver>` User-Agent is blocked by the Cloudflare managed bot rule on `api.metagraph.sh` (HTTP **403**, code 1010) — so **every** SDK method fails against its own default `base_url`. (Surfaced by the quality audit; reproduced live.)

## Fixes
- **client.py — default User-Agent** `metagraphed-python/<version> (+repo)`, overridable via `headers={}`. Clears the WAF 403 — **verified live**: `/api/v1/subnets`, `/subnets/7`, `/health` now all return 200.
- **client.py — error visibility**: surface the API error envelope (`{error:{code,message}}`) or a truncated body on `HTTPError` (was a bare `HTTP 404`); raise `MetagraphedError` on a non-JSON body instead of letting `json.loads` bubble.
- **README**: fix the wrong list example (rows are nested under `data.subnets`); drop the apex-origin example (`metagraph.sh` doesn't serve `/api/v1`).
- **version** 0.1.0 → 0.1.1 (single-sourced in client.py). The republish also **reconciles the license**: the published 0.1.0 wheel declared **MIT** (stale); current source is consistently **Apache-2.0** (pyproject + classifier + README + full LICENSE text), so 0.1.1 ships correct metadata.
- **tests**: UA-present, UA-override, error-envelope, and non-JSON regression cases.

## Verification
- `9/9` unit tests pass (hermetic, urllib mocked)
- Live end-to-end against `api.metagraph.sh` with the new UA: 200s across list/detail/health

After merge: bump is on `main`, then **Actions → Publish Python SDK → Run workflow** publishes 0.1.1 via OIDC (gated by the `pypi-production` environment).