### PR TITLE
test(worker): make build/server-card generated_at assertions refresh-safe (unblock data pipeline)

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -98,8 +98,11 @@ describe("Worker runtime", () => {
     // the real publish pointer so a body-reading agent sees genuine freshness.
     assert.equal(body.data.published_at, publishedAt);
     assert.equal(body.meta.published_at, publishedAt);
-    // generated_at stays the deterministic content marker (issue #349).
-    assert.equal(body.data.generated_at, "1970-01-01T00:00:00.000Z");
+    // generated_at is the build marker and must NOT be clobbered by the
+    // published_at overlay. It is epoch-0 in deterministic/CI builds but the real
+    // build time in a production refresh, so assert the invariant (distinct from
+    // the overlaid published_at), not a fixed fixture value (#349).
+    assert.notEqual(body.data.generated_at, publishedAt);
   });
 
   test("/.well-known/mcp/server-card.json overlays published_at from the KV pointer", async () => {
@@ -124,10 +127,11 @@ describe("Worker runtime", () => {
     assert.ok(response.headers.get("etag"));
     const card = await response.json();
     // The committed card carries published_at:null; serve overlays the real
-    // publish pointer. generated_at stays the deterministic marker; the
-    // content_hash + serverInfo are preserved.
+    // publish pointer. generated_at (the build marker, epoch-0 in CI / real in a
+    // production refresh) must not be clobbered by the overlay; content_hash +
+    // serverInfo are preserved.
     assert.equal(card.published_at, publishedAt);
-    assert.equal(card.generated_at, "1970-01-01T00:00:00.000Z");
+    assert.notEqual(card.generated_at, publishedAt);
     assert.ok(card.content_hash, "card must keep its content_hash");
     assert.ok(card.serverInfo?.name, "card must keep serverInfo");
 


### PR DESCRIPTION
## Second data-pipeline blocker (after #557)
With `scan:public-safety` unblocked by #557, the refresh pipeline reached its `test` step and failed on **one** assertion: `worker-runtime.test.mjs > /api/v1/build … generated_at`.

## Why
`pipeline.mjs --refresh` builds artifacts with a **real** `METAGRAPH_BUILD_TIMESTAMP` (so `generated_at` = real build time), then runs the full suite. Two assertions hardcoded the **deterministic epoch-0 marker** (`1970-01-01T00:00:00.000Z`) for the *served* build-summary / MCP server-card — valid for committed/CI artifacts, but not after a real refresh build. Latent until #557 let the pipeline get past the earlier step (last sync success was 06-12, before this surfaced).

## Fix
`generated_at` is epoch-0 in CI but the real build time in production — both valid. The real #349 invariant is that the **published_at KV overlay doesn't clobber generated_at**, so assert `notEqual(generated_at, publishedAt)` (matching the sibling test ~line 75) instead of a fixed fixture value. (All other `1970-` occurrences are test-provided mock fixtures — unaffected.)

## Verification
- Committed/epoch-0 build: **33/33 pass**
- Forced `METAGRAPH_BUILD_TIMESTAMP=…` `build:artifacts` (reproduces the refresh): both assertions **pass** (the old equality assertion failed there — reproducing the CI error)
- The refresh got past `validate:contract-drift` + all validate:* steps; this test was the sole failure, so this unblocks the pipeline.