### PR TITLE
fix(publish): drop redundant contract re-derivation from the publish job

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -148,12 +148,16 @@ jobs:
       # unit tests (e.g. build-summary published_at:null / generated_at epoch-0).
       # Code is already gated by `npm test` on every PR's CI; this job's purpose
       # is to validate + publish the DATA, which the guards below cover.
-      - name: Validate backend contracts
+      # Contract re-derivation (validate:schemas/api/openapi/types) is intentionally
+      # NOT run here. It regenerates the schema bundle + TS types and diffs them
+      # against the committed contract — which can drift in this rebuild-in-place
+      # publish env (e.g. openapi-typescript output) even when the contract is
+      # valid. The contract is already gated by `npm run validate` on every PR's
+      # CI, and the worker code being published (merged main) is unchanged. This
+      # job validates + publishes DATA; the artifact/data guards below + the
+      # publish guards on the re-restored tree cover that.
+      - name: Validate built artifacts (budgets, docs, intake, workflows)
         run: |
-          npm run validate:schemas
-          npm run validate:api
-          npm run validate:openapi
-          npm run validate:types
           npm run validate:artifact-budgets
           npm run validate:docs
           npm run validate:intake


### PR DESCRIPTION
Follow-up to [#562](https://github.com/JSONbored/metagraphed/pull/562). The publish job's `Validate backend contracts` step re-derived the schema bundle + TS types (`validate:schemas/api/openapi/types`) and diffed them against the committed contract. In this **rebuild-in-place** publish env that diff drifts (`validate:types` regenerated TS types differing from committed) even though the contract is valid on main and green on every PR — the **5th** rebuild-in-place-vs-committed gate to block the publish after the data was already fresh on main.

Per your call: trim the redundant contract re-derivation. It's already gated by `npm run validate` on every PR's CI, and the worker code being published (merged main) is unchanged.

**Kept:** the artifact/data guards (`validate:artifact-budgets/docs/intake/workflows`) and **all** publish-safety guards on the re-restored reviewed tree (`assert:probe-health`, `scan:public-safety`, `validate:private-boundary`). The job still validates + publishes DATA — it just no longer re-derives the CODE contract.

`validate:workflows` passes. After merge I'll re-run publish and confirm fresh data lands.