### PR TITLE
fix(mcp): nullable url in get_best_rpc_endpoint schema + real surface_id examples

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -539,7 +539,7 @@ export const MCP_TOOLS = [
       properties: {
         surface_id: {
           type: "string",
-          description: "Surface id, e.g. '7:subnet-api:allways'.",
+          description: "Surface id (slug-style), e.g. 'allways-docs' or 'sn-64-chutes-openapi'.",
         },
       },
       required: ["surface_id"],
@@ -573,7 +573,7 @@ export const MCP_TOOLS = [
       properties: {
         surface_id: {
           type: "string",
-          description: "Surface id, e.g. '7:subnet-api:allways'.",
+          description: "Surface id (slug-style), e.g. 'allways-docs' or 'sn-64-chutes-openapi'.",
         },
       },
       required: ["surface_id"],
@@ -1088,7 +1088,7 @@ const TOOL_OUTPUT_SCHEMAS = {
       live_health: ANY,
       endpoints: objectItems({
         id: { type: "string" },
-        url: { type: "string" },
+        url: NULLABLE_STRING,
         provider: NULLABLE_STRING,
         kind: NULLABLE_STRING,
         score: ANY,


### PR DESCRIPTION
Two MCP polish items from the quality audit (LOW):

- **`get_best_rpc_endpoint` output schema** declared `endpoints[].url` as a required non-nullable `string`, but the handler emits `url: endpoint.url ?? null`. A pool-eligible endpoint without a url would fail `structuredContent` validation for strict MCP clients → changed to `NULLABLE_STRING` to match the handler.
- **`get_api_schema` + `get_fixture` descriptions** used the surface_id example `'7:subnet-api:allways'`, but no live surface_id uses that `<netuid>:<kind>:<slug>` format — real ids are slug-style (`allways-docs`, `sn-64-chutes-openapi`). Fixed both so agents pass valid ids.

## Verification
- `worker:test` (esbuild bundle) green.
- The local `mcp-server` test + `validate:mcp` failures are **pre-existing committed-artifact drift** (identical on clean main with this change stashed) — CI rebuilds fresh artifacts, so the gates pass there.

Note: `get_fixture` itself should now return data (fixtures are published to R2 as of today's pipeline recovery — `/metagraph/fixtures.json` is live).