### PR TITLE
perf(worker): edge-cache pure static-artifact GET responses

### DIFF
--- a/scripts/worker-test.mjs
+++ b/scripts/worker-test.mjs
@@ -356,4 +356,100 @@ try {
   globalThis.fetch = originalFetch;
 }
 
+// Edge-cache (Cloudflare Cache API): pure static-artifact GETs are cached and
+// served on repeat; live-overlay routes (e.g. /api/v1/health) are never cached
+// so live operational status can never go stale; conditional GETs still 304.
+{
+  const store = new Map();
+  let puts = 0;
+  let matchHits = 0;
+  const originalCaches = globalThis.caches;
+  globalThis.caches = {
+    default: {
+      async match(req) {
+        const r = store.get(req.url);
+        if (r) matchHits += 1;
+        return r ? r.clone() : undefined;
+      },
+      async put(req, res) {
+        puts += 1;
+        store.set(req.url, res.clone());
+      },
+    },
+  };
+  const cacheCtx = { waitUntil: (p) => p };
+  try {
+    // Pure static-artifact route: cached on first GET, served from cache after.
+    const first = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/schemas"),
+      env,
+      cacheCtx,
+    );
+    await Promise.resolve();
+    const firstBody = await first.text();
+    const etag = first.headers.get("etag");
+    assert.equal(first.status, 200, "schemas GET should be 200");
+    assert.equal(puts, 1, "a pure-artifact 200 GET should be cached");
+    assert.equal(matchHits, 0, "first GET is a cache miss");
+
+    const second = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/schemas"),
+      env,
+      cacheCtx,
+    );
+    assert.equal(
+      matchHits,
+      1,
+      "repeat GET should be served from the edge cache",
+    );
+    assert.equal(
+      await second.text(),
+      firstBody,
+      "cached response body must match the original",
+    );
+
+    // Conditional GET against the cached body's weak ETag → 304 (no body).
+    const conditional = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/schemas", {
+        headers: { "if-none-match": etag },
+      }),
+      env,
+      cacheCtx,
+    );
+    assert.equal(conditional.status, 304, "if-none-match hit should 304");
+    assert.equal(await conditional.text(), "", "304 must have no body");
+
+    // Live-overlay route MUST NOT be cached — live operational health stays fresh.
+    const putsBeforeHealth = puts;
+    const health = await handleRequest(
+      new Request("https://metagraph.sh/api/v1/health"),
+      env,
+      cacheCtx,
+    );
+    await Promise.resolve();
+    assert.equal(health.status, 200, "health GET should be 200");
+    assert.equal(
+      puts,
+      putsBeforeHealth,
+      "live-overlay routes (health) must never be edge-cached",
+    );
+
+    // Non-GET methods are never cached.
+    const putsBeforeHead = puts;
+    await handleRequest(
+      new Request("https://metagraph.sh/api/v1/schemas", { method: "HEAD" }),
+      env,
+      cacheCtx,
+    );
+    await Promise.resolve();
+    assert.equal(
+      puts,
+      putsBeforeHead,
+      "non-GET requests must not be edge-cached",
+    );
+  } finally {
+    globalThis.caches = originalCaches;
+  }
+}
+
 console.log("Worker runtime tests passed.");

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1322,6 +1322,87 @@ describe("Worker runtime", () => {
       assert.equal((await response.json()).error.code, "invalid_query");
     }
   });
+
+  test("edge-caches pure static-artifact GETs but never live-overlay routes", async () => {
+    const store = new Map();
+    let puts = 0;
+    let matchHits = 0;
+    const originalCaches = globalThis.caches;
+    globalThis.caches = {
+      default: {
+        async match(request) {
+          const cached = store.get(request.url);
+          if (cached) matchHits += 1;
+          return cached ? cached.clone() : undefined;
+        },
+        async put(request, response) {
+          puts += 1;
+          store.set(request.url, response.clone());
+        },
+      },
+    };
+    const ctx = { waitUntil: (promise) => promise };
+    try {
+      // Pure static-artifact route: cached on first GET, served on repeat.
+      const first = await handleRequest(
+        new Request("https://metagraph.sh/api/v1/schemas"),
+        env,
+        ctx,
+      );
+      await Promise.resolve();
+      const firstBody = await first.text();
+      const etag = first.headers.get("etag");
+      assert.equal(first.status, 200);
+      assert.equal(puts, 1, "a pure-artifact 200 GET should be cached");
+      assert.equal(matchHits, 0, "first GET is a cache miss");
+
+      const second = await handleRequest(
+        new Request("https://metagraph.sh/api/v1/schemas"),
+        env,
+        ctx,
+      );
+      assert.equal(matchHits, 1, "repeat GET is served from the edge cache");
+      assert.equal(await second.text(), firstBody);
+
+      // Conditional GET against the cached weak ETag → 304 (no body).
+      const conditional = await handleRequest(
+        new Request("https://metagraph.sh/api/v1/schemas", {
+          headers: { "if-none-match": etag },
+        }),
+        env,
+        ctx,
+      );
+      assert.equal(conditional.status, 304);
+      assert.equal(await conditional.text(), "");
+
+      // Live-overlay route MUST NOT be cached — live status stays fresh.
+      const putsBeforeHealth = puts;
+      const health = await handleRequest(
+        new Request("https://metagraph.sh/api/v1/health"),
+        env,
+        ctx,
+      );
+      await Promise.resolve();
+      assert.equal(health.status, 200);
+      assert.equal(
+        puts,
+        putsBeforeHealth,
+        "live-overlay routes (health) must never be edge-cached",
+      );
+
+      // Non-GET requests are never cached.
+      const putsBeforeHead = puts;
+      await handleRequest(
+        new Request("https://metagraph.sh/api/v1/schemas", { method: "HEAD" }),
+        env,
+        ctx,
+      );
+      await Promise.resolve();
+      assert.equal(puts, putsBeforeHead, "non-GET requests must not be cached");
+    } finally {
+      globalThis.caches = originalCaches;
+    }
+  });
 });
 
 describe("Agent discovery surfaces", () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -174,6 +174,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         env,
         networkRoute.url,
         networkRoute.network,
+        ctx,
       );
     }
   }
@@ -308,7 +309,7 @@ export async function handleRequest(request, env = {}, ctx = {}) {
     if (resolved.url.pathname === "/api/v1/incidents") {
       return handleGlobalIncidents(request, env, resolved.url);
     }
-    return handleApiRequest(request, env, resolved.url);
+    return handleApiRequest(request, env, resolved.url, DEFAULT_NETWORK, ctx);
   }
 
   if (BADGE_SVG_PATTERN.test(url.pathname)) {
@@ -355,7 +356,13 @@ function isMainnetOnlyApiPath(pathname) {
 // Only the registry artifact surfaces are network-partitioned; dynamic/AI/live
 // features stay mainnet-only. testnet/local data is R2-only and may not exist yet
 // — readArtifact then returns a clean 404 carrying the requested network.
-async function handleNetworkScopedRequest(request, env, url, network) {
+async function handleNetworkScopedRequest(
+  request,
+  env,
+  url,
+  network,
+  ctx = {},
+) {
   if (!["GET", "HEAD"].includes(request.method)) {
     return errorResponse(
       "method_not_allowed",
@@ -427,7 +434,7 @@ async function handleNetworkScopedRequest(request, env, url, network) {
         { network: network.id },
       );
     }
-    return handleApiRequest(request, env, resolved.url, network);
+    return handleApiRequest(request, env, resolved.url, network, ctx);
   }
 
   if (
@@ -886,10 +893,44 @@ async function lookupSubnetNetuid(
   return Number.isInteger(netuid) ? netuid : null;
 }
 
-async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
+async function handleApiRequest(
+  request,
+  env,
+  url,
+  network = DEFAULT_NETWORK,
+  ctx = {},
+) {
   const matched = matchRoute(url.pathname);
   if (!matched) {
     return errorResponse("not_found", "No API route matched this path.", 404);
+  }
+  // Edge-cache idempotent GETs for pure static-artifact routes (mirrors the
+  // RPC-proxy Cache API pattern). Live-overlay routes (health, subnet-health,
+  // and anything liveHealthOverlay touches) are NEVER cached here — they leave
+  // `live` non-null below and so skip the cache.put, keeping live status fresh.
+  // The key namespaces by network + contract version so a deploy or a network
+  // switch can never serve a cross-version body; the response's own
+  // cache-control max-age bounds staleness.
+  const edgeCache =
+    request.method === "GET" ? globalThis.caches?.default : null;
+  const edgeCacheKey = edgeCache
+    ? new Request(
+        `https://edge-cache.metagraph.sh/${network.id}/${encodeURIComponent(
+          contractVersion(env),
+        )}${url.pathname}${url.search}`,
+      )
+    : null;
+  if (edgeCache) {
+    const hit = await edgeCache.match(edgeCacheKey);
+    if (hit) {
+      // Honour conditional requests against the cached body's weak ETag so
+      // polling agents still get a 304 on a warm cache (mirrors envelopeResponse).
+      const etag = hit.headers.get("etag");
+      if (etag && request.headers.get("if-none-match") === etag) {
+        return new Response(null, { status: 304, headers: hit.headers });
+      }
+      return hit;
+    }
   }
   // Mainnet (default) reads the unprefixed artifact (no-op); non-default networks
   // read metagraph/{prefix}/… — see artifactPathForNetwork.
@@ -981,7 +1022,7 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
   ) {
     responseData = { ...responseData, published_at: pub };
   }
-  return envelopeResponse(
+  const response = await envelopeResponse(
     request,
     {
       data: responseData,
@@ -1000,6 +1041,13 @@ async function handleApiRequest(request, env, url, network = DEFAULT_NETWORK) {
     },
     matched.cache,
   );
+  // Cache only pure static-artifact 200s: `live` is non-null for every
+  // health-overlay route, so those always recompute. 304/HEAD/non-200 are
+  // skipped. The edge entry expires per the response's cache-control max-age.
+  if (edgeCache && live === null && response.status === 200) {
+    ctx?.waitUntil?.(edgeCache.put(edgeCacheKey, response.clone()));
+  }
+  return response;
 }
 
 // D1-backed 7d/30d uptime + latency trends for one subnet's operational


### PR DESCRIPTION
## What

Wraps idempotent GET responses for **pure static-artifact** API routes in the Cloudflare Cache API (\`caches.default\`), mirroring the existing RPC-proxy cache pattern in \`handleRpcProxyRequest\`.

- **Cache key**: \`network + contract-version + path + query\` — a deploy or network switch can never serve a cross-version body.
- **TTL**: governed by each response's own \`cache-control\` max-age (60–600s), so staleness is tightly bounded and well under the 6h data-refresh cadence.

## Safety: live status is never cached

The gate is \`live === null\`. \`liveHealthOverlay()\` returns non-null for **every** health-bearing route — \`/health\`, \`/subnets/{id}\` (overview), \`agent-catalog\`, \`freshness\`, \`rpc-endpoints\`, **and any artifact embedding a \`surface_id\` \`endpoints[]\` list** (the generic endpoint overlay). Those skip \`cache.put\` entirely and recompute live operational status on every request. Only genuinely status-free routes (schemas, contracts, gaps, datasets) are cached.

- Conditional GETs still **304** against the cached body's weak ETag (polling agents stay efficient on a warm cache).
- **HEAD** and non-200 responses are never cached.

## Implementation

- Threads \`ctx\` through \`handleNetworkScopedRequest\` → \`handleApiRequest\` for \`ctx.waitUntil(cache.put(...))\`.
- No schema/contract change — caching is transparent to the response envelope.

## Verification

- \`npm run worker:test\` green, with new assertions: cache miss→put→hit, conditional 304, **\`/api/v1/health\` never cached**, HEAD never cached.
- Probed locally with a stubbed cache: \`/schemas\`, \`/contracts\`, \`/subnets\` cached; \`/health\` excluded. ✓
- The 5 \`worker-runtime.test.mjs\` vitest failures are pre-existing committed-artifact drift (identical on clean \`main\`; vitest env has no \`globalThis.caches\` so this change is inert there). CI rebuilds artifacts fresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)