### PR TITLE
fix(python-sdk): handle non-string error codes

### DIFF
--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -113,7 +113,7 @@ def _error_detail(error: "urllib.error.HTTPError") -> str:
     envelope = parsed.get("error") if isinstance(parsed, dict) else None
     if isinstance(envelope, dict) and envelope.get("message"):
         code = envelope.get("code")
-        return f": {code + ' — ' if code else ''}{envelope['message']}"
+        return f": {str(code) + ' — ' if code else ''}{envelope['message']}"
     return f": {raw[:200]}"
 
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -133,6 +133,26 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(ctx.exception.status, 404)
         self.assertIn("no such subnet", str(ctx.exception))
 
+    def test_http_error_with_non_string_error_code_is_exception_safe(self):
+        import io
+
+        def fake_urlopen(request, timeout=None):
+            body = io.BytesIO(
+                json.dumps(
+                    {
+                        "ok": False,
+                        "error": {"code": 123, "message": "nonconforming upstream"},
+                    }
+                ).encode("utf-8")
+            )
+            raise urllib.error.HTTPError(request.full_url, 502, "Bad Gateway", {}, body)
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            with self.assertRaises(MetagraphedError) as ctx:
+                metagraphed_fetch("/api/v1/health")
+        self.assertEqual(ctx.exception.status, 502)
+        self.assertIn("123 — nonconforming upstream", str(ctx.exception))
+
     def test_non_json_response_raises_metagraphed_error(self):
         class _BadResponse(_FakeResponse):
             def __init__(self):


### PR DESCRIPTION
### Motivation
- The HTTP error envelope helper `_error_detail` concatenated `code + ' — '` without coercing `code` to a string, which can raise `TypeError` if the API returns a non-string truthy `code` value and break callers expecting `MetagraphedError`.
- Make the helper exception-safe so it matches its docstring "Never raises" and remains robust against nonconforming upstream error envelopes.

### Description
- Coerce the API envelope `code` with `str(code)` when formatting the HTTP error detail in `python/src/metagraphed/client.py` to avoid `TypeError` on non-string codes.
- Add a regression unit test `test_http_error_with_non_string_error_code_is_exception_safe` in `python/tests/test_client.py` that simulates a numeric error code and asserts a `MetagraphedError` is raised and includes the formatted detail.

### Testing
- Ran the hermetic test suite with `PYTHONPATH=python/src python -m unittest python.tests.test_client -q` and all tests passed (`10 tests OK`).
- The new regression test verifies the numeric `code` case and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e725ec514832ab0a80137054c4aa8)