### PR TITLE
fix(publish): stop smoke + manifest referencing retired static health

### DIFF
--- a/scripts/r2-manifest.mjs
+++ b/scripts/r2-manifest.mjs
@@ -142,7 +142,6 @@ function buildCompactManifest(fullManifest) {
     ),
     required_artifact_paths: [
       "/metagraph/candidates.json",
-      "/metagraph/health/latest.json",
       "/metagraph/review-queue.json",
       "/metagraph/review/enrichment-evidence.json",
       "/metagraph/review/enrichment-targets.json",

--- a/scripts/smoke-live-api.mjs
+++ b/scripts/smoke-live-api.mjs
@@ -16,7 +16,9 @@ const rawArtifactChecks = [
   "/metagraph/openapi.json",
   "/metagraph/r2-manifest.json",
   "/metagraph/subnets/7.json",
-  "/metagraph/health/latest.json",
+  // Current-state health artifacts are retired (410); the durable daily
+  // history snapshot is the live raw health artifact still served from R2.
+  `/metagraph/health/history/${healthDate}.json`,
   "/metagraph/candidates.json",
   "/metagraph/review-queue.json",
 ];
@@ -307,22 +309,37 @@ console.log(
 );
 
 async function discoverHealthHistoryDate() {
-  const result = await fetchJson(`${baseUrl}/metagraph/health/latest.json`);
-  assert.equal(
-    result.status,
-    200,
-    "/metagraph/health/latest.json: expected HTTP 200",
-  );
-  const generatedAt =
-    result.body?.probe_finished_at ||
-    result.body?.probe_started_at ||
-    result.body?.generated_at;
+  // Current-state health is live-only — the static /metagraph/health/latest.json
+  // artifact is retired (410). Bootstrap the probe date from the live
+  // /api/v1/health endpoint, then walk backward to the most recent date that
+  // actually has a daily health-history snapshot. History is sparse (some days
+  // have no snapshot), so this keeps the downstream history check stable and
+  // robust across the midnight boundary.
+  const health = await fetchJson(`${baseUrl}/api/v1/health`);
+  assert.equal(health.status, 200, "/api/v1/health: expected HTTP 200");
+  const observedAt =
+    health.body?.data?.operational_observed_at ||
+    health.body?.data?.generated_at ||
+    health.body?.meta?.published_at;
   assert.match(
-    String(generatedAt || ""),
+    String(observedAt || ""),
     /^\d{4}-\d{2}-\d{2}T/,
-    "/metagraph/health/latest.json: probe timestamp must be an ISO timestamp",
+    "/api/v1/health: expected an ISO operational timestamp",
   );
-  return generatedAt.slice(0, 10);
+  const startMs = new Date(observedAt).getTime();
+  for (let back = 0; back < 14; back += 1) {
+    const date = new Date(startMs - back * 86400000).toISOString().slice(0, 10);
+    const snapshot = await fetchJson(
+      `${baseUrl}/api/v1/health/history/${date}`,
+    );
+    if (snapshot.status === 200 && snapshot.body?.ok) {
+      return date;
+    }
+  }
+  throw new assert.AssertionError({
+    message:
+      "no daily health-history snapshot found in the last 14 days via /api/v1/health/history/{date}",
+  });
 }
 
 function apiRouteUrl(routePath, date) {


### PR DESCRIPTION
## Problem

Every scheduled `publish-cloudflare` run was reporting **failure** even though the data published fine (the KV pointer advanced to today). Root cause: the post-publish **Smoke live API** step still referenced the **retired** static health artifact.

Current-state health is live-only — `/metagraph/health/latest.json` (and `summary`/`subnets`) are intentionally retired and return **410 Gone** (`RETIRED_CURRENT_HEALTH_ARTIFACT_PATTERN`). But `scripts/smoke-live-api.mjs` still:
1. bootstrapped its health-history date from `latest.json` (asserting 200), and
2. listed `latest.json` in `rawArtifactChecks` (asserting 200).

So the smoke test failed on `410 !== 200` after a fully successful publish.

## Fix

- **`smoke-live-api.mjs`** — `discoverHealthHistoryDate()` now bootstraps from the live `/api/v1/health` endpoint and **walks backward** to the most recent date that actually has a daily history snapshot. History is sparse (e.g. 06-13 has none), so the walk makes the downstream `/api/v1/health/history/{date}` check stable and robust across the midnight boundary. `rawArtifactChecks` swaps the retired `latest.json` for the durable **dated history artifact** (still served from R2 with all expected headers).
- **`r2-manifest.mjs`** — drop the retired `latest.json` from `required_artifact_paths` so the published manifest no longer advertises a 410 artifact as "required". (`validate.mjs` only reads this list to confirm `source-snapshots.json`/`types.d.ts`, so the removal is safe.)

## Verification

`npm run smoke:live` against production:
- `status: passed`, `api_route_count: 57`, `raw_artifact_count: 6`
- `health_history_date: 2026-06-14` discovered via the live endpoint + backward walk
- `ai_status: enabled`, `ai_crawler_access: unblocked`

🤖 Generated with [Claude Code](https://claude.com/claude-code)