### PR TITLE
fix(publish): capture live fixtures in the production build

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -87,6 +87,15 @@ function productionSteps() {
     // the caller (publish-cloudflare.yml); without a token this carries
     // forward committed adapter data rather than failing.
     nodeStep("adapters-snapshot", "scripts/snapshot-adapters.mjs", "--write"),
+    // Capture one sanitized live request/response sample per no-auth GET
+    // surface (issue #352) before build-artifacts, mirroring schemas-snapshot:
+    // build-artifacts grabs the fixtures/{surface_id}.json files before its
+    // staging wipe, re-attaches them, and builds the fixtures.json index that
+    // powers the get_fixture MCP tool. Degrades gracefully — every unreachable
+    // surface is skipped (the step always exits 0), so a flaky surface never
+    // blocks the publish. Without this step the index is empty and get_fixture
+    // returns nothing.
+    nodeStep("capture-fixtures", "scripts/capture-fixtures.mjs", "--write"),
     nodeStep("build-artifacts", "scripts/build-artifacts.mjs"),
     nodeStep("probes-smoke", "scripts/probes-smoke.mjs", {
       METAGRAPH_WRITE_PROBE_RESULTS: "1",


### PR DESCRIPTION
## Problem

`capture:fixtures` (issue #352 — one sanitized live request/response sample per no-auth GET surface) was defined in `package.json` but **wired into no build path**. So the published `fixtures.json` index was always empty (`fixture_count: 0`), and the `get_fixture` MCP tool returned nothing for every surface — a documented agent-facing feature producing zero data.

## Fix

Add `capture-fixtures` to `build.mjs productionSteps()` immediately before `build-artifacts`, mirroring the existing `schemas-snapshot` pattern:
- The network step writes one sanitized sample per eligible surface to the R2 staging tree.
- `build-artifacts` grabs them before its staging wipe, re-attaches the per-surface `fixtures/{id}.json` (R2-only), and builds the committed `fixtures.json` index that powers `get_fixture`.

**Safety:**
- **Degrades gracefully** — every unreachable surface is skipped and the step always exits 0, so a flaky surface never blocks the publish (same posture as `snapshot-openapi`).
- **Survives the double `build-artifacts`** the same way probe-health does (shared `R2_STAGING_RELATIVE_ROOT` means each build's preserve-read finds the prior build's re-attached output).
- **No contract drift** — only `productionSteps()` runs capture; local/PR builds (`localSteps`) keep the committed empty index unchanged.

## Verification

Locally ran `capture:fixtures` → `build-artifacts`:
- captured **27 of 35** candidate no-auth GET surfaces
- 27 per-surface `fixtures/{id}.json` written to `dist/metagraph-r2/metagraph/fixtures/` (the tree the publish stages via `cp -R dist/metagraph-r2`)
- `public/metagraph/fixtures.json` index rebuilt with `fixture_count: 27`

After the next publish, `get_fixture` will return real samples and `/metagraph/fixtures.json` will list them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)