### PR TITLE
feat(registry): add Gittensory as the SN74 contribution interface

### DIFF
--- a/registry/providers/gittensory.json
+++ b/registry/providers/gittensory.json
@@ -1,0 +1,11 @@
+{
+  "schema_version": 1,
+  "id": "gittensory",
+  "name": "Gittensory",
+  "kind": "data-provider",
+  "website_url": "https://gittensory.aethereal.dev",
+  "docs_url": "https://gittensory.aethereal.dev",
+  "github_url": "https://github.com/JSONbored/gittensory",
+  "authority": "provider-claimed",
+  "notes": "Gittensor-native contribution quality & planning layer for SN74: deterministic MCP signals for contributors and a free anti-slop + AI second-opinion gate (GitHub App) for maintainers. Provider-claimed; surfaces pending registry verification."
+}

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -150,6 +150,52 @@
       "public_safe": true,
       "source_urls": ["https://docs.gittensor.io/repository-hyperparameters"],
       "url": "https://raw.githubusercontent.com/entrius/gittensor/main/gittensor/validator/weights/master_repositories.json"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "id": "gittensory-contribution-interface",
+      "kind": "data-artifact",
+      "name": "Gittensory contribution-interface descriptor",
+      "notes": "Machine-readable descriptor declaring Gittensory as the SN74 contribution interface: MCP endpoint, contribution-relevant tools, GitHub App, and onboarding steps.",
+      "probe": {
+        "enabled": true,
+        "expect": "json",
+        "method": "GET"
+      },
+      "provider": "gittensory",
+      "public_safe": true,
+      "source_urls": ["https://gittensory.aethereal.dev/"],
+      "url": "https://gittensory-api.aethereal.dev/v1/public/subnet-interface"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "id": "gittensory-mcp",
+      "kind": "subnet-api",
+      "name": "Gittensory MCP (contribution interface)",
+      "notes": "Streamable-HTTP MCP server exposing deterministic, gittensor-native contribution signals (decision pack, check-before-start, preflight, notifications) to a contributor's own agent harness. POST-only JSON-RPC, so recurring read probes are intentionally disabled. Contributor tools are scoped to the authenticated GitHub login.",
+      "provider": "gittensory",
+      "public_safe": true,
+      "source_urls": [
+        "https://gittensory-api.aethereal.dev/v1/public/subnet-interface"
+      ],
+      "url": "https://gittensory-api.aethereal.dev/mcp"
+    },
+    {
+      "auth_required": false,
+      "authority": "provider-claimed",
+      "id": "gittensory-website",
+      "kind": "website",
+      "name": "Gittensory",
+      "probe": {
+        "enabled": true,
+        "expect": "html",
+        "method": "HEAD"
+      },
+      "provider": "gittensory",
+      "public_safe": true,
+      "url": "https://gittensory.aethereal.dev/"
     }
   ],
   "website_url": "https://gittensor.io/"


### PR DESCRIPTION
## What

Surfaces **Gittensory** in the gittensor (Bittensor subnet 74) catalog so agents/devs who discover gittensor via metagraphed find its **contribution path**. This closes the discovery → contribution funnel (the metagraphed half of [gittensory#695](https://github.com/JSONbored/gittensory/issues/695); the gittensory-side descriptor endpoint shipped in JSONbored/gittensory#709).

- **New provider `gittensory`** (`data-provider`, `provider-claimed`) — the gittensor-native contribution quality & planning layer for SN74.
- **Three surfaces on the gittensor subnet** (`provider: gittensory`):
  - `gittensory-contribution-interface` (`data-artifact`) — the machine-readable descriptor at `https://gittensory-api.aethereal.dev/v1/public/subnet-interface` (MCP endpoint, contribution-relevant tools, GitHub App, onboarding steps). Probed as JSON.
  - `gittensory-mcp` (`subnet-api`) — the streamable-HTTP MCP server. POST-only JSON-RPC, so recurring read probes are intentionally disabled (mirrors the existing `green-compute` POST-only API pattern).
  - `gittensory-website` (`website`).

After this, `get_subnet` / `list_subnet_apis` / `how_do_i_call` for netuid 74 surface Gittensory's MCP + onboarding via these surfaces.

## Scope / artifacts
**Source-only change** (`registry/providers/gittensory.json` + `registry/subnets/gittensor.json`). Derived `public/` artifacts regenerate from source via `npm run build` in CI + on deploy — this is the repo's regenerate-on-build model, and the PR-only "verify submitted public artifacts are reproducible" check exits clean when no artifacts are submitted. Kept source-only deliberately to avoid local-vs-CI byte-reproducibility drift.

## Verification (local)
- `prettier --check` ✓ on both files
- `npm run scan:public-safety` ✓ (all provider-claimed + `public_safe`; no private/reward wording)
- `artifacts:prepare-local` generates the gittensory rows correctly into `datasets/providers.csv`, `surfaces.csv`, and the SN74 row in `subnets.csv` (surface counts 16 → 19)
- Full `validate:schemas` / `test:coverage` / `r2:manifest` require R2 + network — left to CI.

All surfaces are provider-claimed + `public_safe`; pending registry probe-verification.