### PR TITLE
feat(contrib): enrichment-issue generator for the gittensor farmer queue

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "submission:pr": "node scripts/submission-pr.mjs",
     "submission:comment": "node scripts/submission-comment.mjs",
     "candidate:new": "node scripts/candidate-new.mjs",
+    "enrich:issues": "node scripts/enrichment-issues.mjs --write",
+    "enrich:issues:dry-run": "node scripts/enrichment-issues.mjs --dry-run",
     "validate:candidate": "node scripts/validate-candidate.mjs",
     "provider:new": "node scripts/provider-new.mjs",
     "providers:list": "node scripts/list-providers.mjs",

--- a/scripts/enrichment-issues.mjs
+++ b/scripts/enrichment-issues.mjs
@@ -1,0 +1,199 @@
+// enrichment-issues: generate "Enrich SN<n>" contributor tasks from the LIVE
+// enrichment queue (issue #427), deduped against the open issues already on the
+// tracker. This is the scalable home for the gittensor-farmer work surface —
+// pull the live gaps, never hardcode (mirrors the #427 epic + CONTRIBUTING).
+//
+//   node scripts/enrichment-issues.mjs --dry-run            # default: print plan
+//   node scripts/enrichment-issues.mjs --write --limit 20   # create up to 20
+//   node scripts/enrichment-issues.mjs --kinds openapi,subnet-api --limit 15
+//
+// --write shells out to `gh issue create` (needs gh auth). Each issue mirrors
+// the established format: title "Enrich SN<n> <name> — add <kinds>", body links
+// the candidate:new command + CONTRIBUTING, labels gittensor:priority +
+// good first issue + help wanted, and references the #427 tracker.
+import { execFileSync } from "node:child_process";
+
+const args = new Set(process.argv.slice(2));
+const write = args.has("--write");
+const dryRun = !write;
+const getOpt = (name, fallback) => {
+  const hit = [...args].find((a) => a.startsWith(`${name}=`));
+  if (hit) return hit.slice(name.length + 1);
+  const idx = process.argv.indexOf(name);
+  return idx >= 0 && process.argv[idx + 1] ? process.argv[idx + 1] : fallback;
+};
+
+const API_BASE =
+  process.env.METAGRAPH_LIVE_BASE_URL || "https://api.metagraph.sh";
+const TRACKER = 427;
+const LABELS = ["gittensor:priority", "good first issue", "help wanted"];
+const LIMIT = Number(getOpt("--limit", "20"));
+// Default to the operational gaps (the remaining volume); identity gaps
+// (source-repo/website) are nearly exhausted by the existing tracker issues.
+const KINDS = getOpt("--kinds", "openapi,subnet-api,data-artifact,sse")
+  .split(",")
+  .map((k) => k.trim())
+  .filter(Boolean);
+
+// Highest agent value first — a callable API + its spec beat artifacts/streams.
+const VALUE_PRIORITY = [
+  "subnet-api",
+  "openapi",
+  "data-artifact",
+  "sse",
+  "source-repo",
+  "website",
+  "docs",
+  "sdk",
+];
+
+// Human phrasing + the candidate:new --kind value for each gap kind.
+const KIND_LABEL = {
+  "source-repo": "source repository",
+  website: "official website",
+  docs: "documentation",
+  openapi: "OpenAPI/Swagger spec",
+  "subnet-api": "public API endpoint",
+  "data-artifact": "public data artifact",
+  sse: "SSE stream",
+  sdk: "SDK",
+};
+
+async function fetchJson(path) {
+  const res = await fetch(`${API_BASE}${path}`);
+  if (!res.ok) throw new Error(`${path}: HTTP ${res.status}`);
+  return res.json();
+}
+
+// netuids that already have an open "Enrich SN<n>" issue — skip them so we never
+// pile a second task on a subnet the tracker already covers.
+function coveredNetuids() {
+  try {
+    const out = execFileSync(
+      "gh",
+      [
+        "issue",
+        "list",
+        "--state",
+        "open",
+        "--limit",
+        "200",
+        "--json",
+        "title",
+        "-q",
+        ".[].title",
+      ],
+      { encoding: "utf8" },
+    );
+    const covered = new Set();
+    for (const title of out.split("\n")) {
+      const m = /Enrich SN(\d+)\b/.exec(title);
+      if (m) covered.add(Number(m[1]));
+    }
+    return covered;
+  } catch (error) {
+    console.warn(
+      `warning: could not read open issues for dedup (${error.message}); proceeding WITHOUT dedup.`,
+    );
+    return new Set();
+  }
+}
+
+function issueBody(netuid, name, kinds) {
+  const kindList = kinds.map((k) => KIND_LABEL[k] || k).join(", ");
+  const primary = kinds[0];
+  return `Part of #${TRACKER}.
+
+**Subnet ${netuid} — ${name}** is missing from the registry: **${kindList}**. Research whether the subnet exposes ${kinds.length > 1 ? "these" : "this"}, find the real public link(s), and submit them.
+
+### Find it
+Search for the subnet's official ${kindList} (project site / GitHub / docs / Bittensor). Confirm each link is real, public, no-auth, and genuinely SN${netuid}'s — cross-reference the subnet name + Bittensor. ⚠️ Many subnets simply don't expose a public API yet, and on-chain identity links are often **stale/dead** — verify each link actually resolves before submitting. If the subnet genuinely exposes no such public surface, comment here so a maintainer can close it.
+
+### Submit — one candidate per surface, one file
+\`\`\`bash
+npm run candidate:new -- --netuid ${netuid} --kind ${primary} \\
+  --url <real-public-url> --source-url <link-that-proves-it> \\
+  --provider <slug> --submitted-by <your-login> --write
+\`\`\`
+
+Open a PR touching **exactly one** \`registry/candidates/community/*.json\` file — the review gate validates + reviews it.
+
+**Rules:** a real \`url\` that resolves · a \`source_url\` that proves it's official · one file · no generated artifacts · \`public_safe: true\` · \`auth_required: false\`. Full guide: [CONTRIBUTING → Community submissions](https://github.com/JSONbored/metagraphed/blob/main/CONTRIBUTING.md#community-submissions).`;
+}
+
+const queue =
+  (await fetchJson(`/api/v1/review/enrichment-queue?limit=128`)).data?.queue ||
+  [];
+const covered = coveredNetuids();
+
+const planned = [];
+for (const entry of queue) {
+  if (planned.length >= LIMIT) break;
+  const netuid = entry.netuid;
+  if (covered.has(netuid)) continue;
+  const missing = (entry.missing_kinds || [])
+    .filter((k) => KINDS.includes(k))
+    // Lead with the highest-value surface so the candidate:new command targets
+    // it: a callable API + its spec matter more to agents than artifacts/streams.
+    .sort((a, b) => VALUE_PRIORITY.indexOf(a) - VALUE_PRIORITY.indexOf(b));
+  if (!missing.length) continue;
+  // One issue per subnet; ask for its top 2 in-scope missing kinds (the
+  // candidate:new command targets the first).
+  const kinds = missing.slice(0, 2);
+  planned.push({
+    netuid,
+    name: entry.name || `Subnet ${netuid}`,
+    kinds,
+    title:
+      `Enrich SN${netuid} ${entry.name || ""}`.trim() +
+      ` — add ${kinds.map((k) => KIND_LABEL[k] || k).join(" + ")}`,
+  });
+}
+
+console.log(
+  JSON.stringify(
+    {
+      mode: dryRun ? "dry-run" : "write",
+      api_base: API_BASE,
+      queue_size: queue.length,
+      already_covered: covered.size,
+      kinds_in_scope: KINDS,
+      limit: LIMIT,
+      planned_count: planned.length,
+      planned: planned.map((p) => ({ netuid: p.netuid, title: p.title })),
+    },
+    null,
+    2,
+  ),
+);
+
+if (dryRun) {
+  console.log(
+    "\n(dry-run — no issues created. Re-run with --write to create them.)",
+  );
+} else {
+  let created = 0;
+  for (const p of planned) {
+    const labelArgs = LABELS.flatMap((l) => ["--label", l]);
+    try {
+      const url = execFileSync(
+        "gh",
+        [
+          "issue",
+          "create",
+          "--title",
+          p.title,
+          "--body",
+          issueBody(p.netuid, p.name, p.kinds),
+          ...labelArgs,
+        ],
+        { encoding: "utf8" },
+      ).trim();
+      created += 1;
+      console.log(`created: ${url}`);
+    } catch (error) {
+      console.error(`failed SN${p.netuid}: ${error.message}`);
+    }
+  }
+  console.log(`\nCreated ${created}/${planned.length} enrichment issues.`);
+}


### PR DESCRIPTION
## Why

With metagraphed about to be gittensor emission-weighted, contributors ("farmers") need a steady supply of well-scoped, grabbable tasks. The data shows the opportunity: of 129 subnets, only ~15 expose a callable API and ~13 an OpenAPI spec — **~114 subnets need an API surface registered**. The #427 epic + `/api/v1/review/enrichment-queue` already track these gaps; what was missing was a way to turn them into issues at scale without duplicating the 32 already on the tracker.

## What

`scripts/enrichment-issues.mjs` (+ `enrich:issues` / `enrich:issues:dry-run`):
- Pulls the **live** enrichment queue (per #427's "pull the gaps, don't hardcode" rule).
- **Dedupes** against open `Enrich SN<n>` issues so it never piles a second task on a covered subnet.
- Emits one task per uncovered subnet, **leading with the highest-value missing surface** (`subnet-api`/`openapi` before `data-artifact`/`sse`) so the `candidate:new` command targets the best ask.
- Mirrors the established issue format exactly: `candidate:new` command, CONTRIBUTING link, `gittensor:priority` + `good first issue` + `help wanted` labels, and honest research framing (with a "comment to close if none exists" path).
- `--dry-run` (default) prints the plan; `--write` creates via `gh`; `--limit` / `--kinds` tune the batch.

## Done with it

Created the first curated batch — **[#573](https://github.com/JSONbored/metagraphed/issues/573)–[#592](https://github.com/JSONbored/metagraphed/issues/592)** (20 issues), deduped against the existing 32, so the tracker now has ~52 open farmer tasks for Monday. Re-run `npm run enrich:issues:dry-run` anytime to top up from the live gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)