### PR TITLE
feat(health): RPC pool-eligibility hysteresis

### DIFF
--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -11,6 +11,17 @@ import { computeReliability } from "./reliability.mjs";
 
 const D1_HEALTH_FALLBACK_MAX_AGE_MS = 10 * 60 * 1000;
 
+// Pool-eligibility hysteresis (cosmos.directory-style "don't flap"): an RPC
+// endpoint is only dropped from the proxy pool after this many CONSECUTIVE
+// failed 2-min probes, so a single transient blip (~2-4 min) doesn't evict an
+// otherwise-healthy node. cosmos.directory tolerates ~10 errors before removal;
+// at a 2-min cadence, 4 (~8 min) is a conservative middle that still removes
+// genuinely-down nodes promptly. Env-overridable.
+const POOL_SUSTAINED_DOWN_FAILURES = Math.max(
+  1,
+  Number(globalThis.process?.env?.METAGRAPH_POOL_SUSTAINED_DOWN_FAILURES) || 4,
+);
+
 const OPERATIONAL_KINDS = new Set([
   "subtensor-rpc",
   "subtensor-wss",
@@ -212,7 +223,8 @@ export function overlayRpcPoolEligibility(pool, liveRpcPool) {
       const live = liveById.get(endpoint.id);
       if (!live) return endpoint;
       const sustainedDown =
-        live.status !== "ok" && (live.consecutive_failures || 0) >= 2;
+        live.status !== "ok" &&
+        (live.consecutive_failures || 0) >= POOL_SUSTAINED_DOWN_FAILURES;
       return {
         ...endpoint,
         status: live.status,

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -143,11 +143,11 @@ describe("overlayRpcPoolEligibility", () => {
       { id: "b", url: "https://b", pool_eligible: true },
     ],
   };
-  test("drops endpoints only after 2+ consecutive failures", () => {
+  test("drops endpoints only after sustained (>=4) consecutive failures", () => {
     const live = {
       endpoints: [
-        { id: "a", status: "failed", consecutive_failures: 1 }, // transient → stays
-        { id: "b", status: "failed", consecutive_failures: 3 }, // sustained → drop
+        { id: "a", status: "failed", consecutive_failures: 3 }, // transient blip → stays (hysteresis)
+        { id: "b", status: "failed", consecutive_failures: 4 }, // sustained → drop
       ],
     };
     const out = overlayRpcPoolEligibility(pool, live);
@@ -591,7 +591,7 @@ describe("overlayRpcPoolEligibility (additional paths)", () => {
     };
     const live = {
       endpoints: [
-        { id: "a", status: "failed", consecutive_failures: 2, latency_ms: 70 },
+        { id: "a", status: "failed", consecutive_failures: 4, latency_ms: 70 },
       ],
     };
     const out = overlayRpcPoolEligibility(pool, live);


### PR DESCRIPTION
## Why

From the cosmos.directory analysis: their health monitor keeps an endpoint in the routing pool until it accumulates ~10 errors (`ALLOWED_ERRORS`), so a transient blip never evicts an otherwise-healthy node. metagraphed dropped an endpoint from the RPC proxy pool after just **2** consecutive failed probes (~4 min) — too trigger-happy, churning the pool on brief flaps.

## What

`overlayRpcPoolEligibility` now requires `POOL_SUSTAINED_DOWN_FAILURES` (default **4**, ~8 min at the 2-min cadence; env `METAGRAPH_POOL_SUSTAINED_DOWN_FAILURES`) consecutive failures before marking an endpoint pool-ineligible. Still removes genuinely-down nodes promptly; debounces the transient blips. Pure-function change; the RPC proxy's own per-request failover still handles a node that flaps mid-window.

## Verification

`overlayRpcPoolEligibility` tests updated to the new contract (3 consecutive = blip → stays eligible; 4 = sustained → dropped) and pass. The 2 unrelated `composed …` failures in this file are pre-existing committed-artifact drift (fail identically on clean `main`; CI rebuilds fresh).

Follow-up (separate PR): chain/genesis verification for RPC endpoints (the other cosmos.directory lesson — reject wrong-network nodes; finney genesis `0x2f0555…c03` already verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)