### PR TITLE
fix(worker): skip edge cache for live-overlay fallbacks

### DIFF
--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -1390,6 +1390,37 @@ describe("Worker runtime", () => {
         "live-overlay routes (health) must never be edge-cached",
       );
 
+      // Live-overlay fallback routes must also avoid the edge cache when KV/D1
+      // live data is cold and the handler serves the static artifact.
+      const putsBeforeColdFallback = puts;
+      const hitsBeforeColdFallback = matchHits;
+      const coldOverlayEnv = {
+        ...env,
+        METAGRAPH_ARCHIVE: r2ArchiveFixture({
+          "rpc-endpoints.json": {
+            endpoints: [{ id: "archive-rpc", status: "unknown" }],
+            generated_at: "1970-01-01T00:00:00.000Z",
+          },
+        }),
+      };
+      const rpcEndpoints = await handleRequest(
+        new Request("https://metagraph.sh/api/v1/rpc/endpoints"),
+        coldOverlayEnv,
+        ctx,
+      );
+      await Promise.resolve();
+      assert.equal(rpcEndpoints.status, 200);
+      assert.equal(
+        puts,
+        putsBeforeColdFallback,
+        "cold live-overlay fallbacks must not be edge-cached",
+      );
+      assert.equal(
+        matchHits,
+        hitsBeforeColdFallback,
+        "cold live-overlay fallbacks must bypass edge-cache lookup",
+      );
+
       // Non-GET requests are never cached.
       const putsBeforeHead = puts;
       await handleRequest(

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -121,6 +121,27 @@ const ROUTES = API_ROUTES.map((entry) => ({
   },
 }));
 
+// Routes that can include live operational-health overlays must never use the
+// edge Cache API. Cache eligibility is route-based instead of checking whether
+// live data was available for a particular request, so a cold KV/D1 overlay
+// cannot seed stale static fallbacks into the edge cache.
+const LIVE_OVERLAY_ROUTE_IDS = new Set([
+  "health",
+  "subnet-health",
+  "rpc-endpoints",
+  "freshness",
+  "subnet-overview",
+  "agent-catalog",
+  "agent-catalog-subnet",
+  "endpoints",
+  "subnet-endpoints",
+  "provider-endpoints",
+]);
+
+function isStaticEdgeCacheEligible(matched, network) {
+  return !network.isDefault || !LIVE_OVERLAY_ROUTE_IDS.has(matched.id);
+}
+
 export default {
   async fetch(request, env, ctx) {
     return handleRequest(request, env, ctx);
@@ -905,14 +926,16 @@ async function handleApiRequest(
     return errorResponse("not_found", "No API route matched this path.", 404);
   }
   // Edge-cache idempotent GETs for pure static-artifact routes (mirrors the
-  // RPC-proxy Cache API pattern). Live-overlay routes (health, subnet-health,
-  // and anything liveHealthOverlay touches) are NEVER cached here — they leave
-  // `live` non-null below and so skip the cache.put, keeping live status fresh.
+  // RPC-proxy Cache API pattern). Live-overlay routes are excluded by route id,
+  // not by whether live data happened to be available for this request, so cold
+  // KV/D1 fallback responses cannot seed stale operational metadata.
   // The key namespaces by network + contract version so a deploy or a network
   // switch can never serve a cross-version body; the response's own
   // cache-control max-age bounds staleness.
   const edgeCache =
-    request.method === "GET" ? globalThis.caches?.default : null;
+    request.method === "GET" && isStaticEdgeCacheEligible(matched, network)
+      ? globalThis.caches?.default
+      : null;
   const edgeCacheKey = edgeCache
     ? new Request(
         `https://edge-cache.metagraph.sh/${network.id}/${encodeURIComponent(
@@ -1041,9 +1064,10 @@ async function handleApiRequest(
     },
     matched.cache,
   );
-  // Cache only pure static-artifact 200s: `live` is non-null for every
-  // health-overlay route, so those always recompute. 304/HEAD/non-200 are
-  // skipped. The edge entry expires per the response's cache-control max-age.
+  // Cache only route-declared pure static-artifact 200s. Live-overlay routes
+  // are skipped even when their live store is cold and the response falls back
+  // to the static artifact. 304/HEAD/non-200 are skipped. The edge entry
+  // expires per the response's cache-control max-age.
   if (edgeCache && live === null && response.status === 200) {
     ctx?.waitUntil?.(edgeCache.put(edgeCacheKey, response.clone()));
   }


### PR DESCRIPTION
### Motivation
- Cold KV/D1 live-overlay fallbacks could be mistaken for pure static responses because cache eligibility was based on the runtime `live === null` value, allowing stale operational metadata to be seeded into the edge Cache API.
- The intent is to never edge-cache routes that can include live operational-health overlays regardless of transient live-store availability.

### Description
- Add a route-level exclusion set `LIVE_OVERLAY_ROUTE_IDS` and helper `isStaticEdgeCacheEligible(matched, network)` to declare which API routes may include live overlays and must be excluded from edge caching (`workers/api.mjs`).
- Gate the edge-cache lookup on route eligibility so live-overlay routes bypass `globalThis.caches?.default.match()` entirely and cannot return stale cached bodies before overlays are recomputed (`workers/api.mjs`).
- Keep the cache-write guard but update its semantics and comments to emphasize route-declared eligibility rather than per-request `live` availability (`workers/api.mjs`).
- Add a regression test asserting that a cold `/api/v1/rpc/endpoints` fallback both bypasses the edge-cache lookup and does not `put` into the cache (`tests/worker-runtime.test.mjs`).

### Testing
- Ran `npm test -- tests/worker-runtime.test.mjs -t "edge-caches"` and the focused edge-cache test passed.
- Ran `npm run worker:test` (scripted worker runtime checks) and it passed.
- Ran `npx prettier --check workers/api.mjs tests/worker-runtime.test.mjs` and formatting checks passed.
- Ran the full `npm test -- tests/worker-runtime.test.mjs` and it reported failures due to unrelated missing local public artifact files (404s) in this checkout, not regressions in the introduced edge-cache logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e8dca9e20832aafe0419822183c1f)