### PR TITLE
feat(health): chain/genesis verification for RPC endpoints

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -14,7 +14,22 @@ export const SUBTENSOR_PROBE_CALLS = [
   { key: "system_health", method: "system_health", params: [] },
   { key: "rpc_methods", method: "rpc_methods", params: [] },
   { key: "archive_probe", method: "chain_getBlockHash", params: [1] },
+  // Genesis (block 0) hash — uniquely identifies the network. Lets us reject an
+  // RPC endpoint that answers but is on the WRONG chain (cosmos.directory checks
+  // chain_id the same way). A wrong/misconfigured submitted endpoint returns a
+  // different genesis and is excluded before it can pollute the proxy pool.
+  { key: "genesis", method: "chain_getBlockHash", params: [0] },
 ];
+
+// Finney (Bittensor mainnet) genesis hash — verified live against
+// bittensor-finney.api.onfinality.io. Endpoints whose block-0 hash differs are
+// classified `wrong-chain`. Override per-network via probeSubtensorHttp options.
+export const FINNEY_GENESIS_HASH =
+  "0x2f0555cc76fc2840a25a6ea3b9637146806f1f44b090c175ffde2a7e5ab36c03";
+
+function normalizeHash(value) {
+  return typeof value === "string" ? value.trim().toLowerCase() : null;
+}
 
 // Surface kinds whose health changes minute-to-minute and is worth probing live
 // (the 2-minute cron prober). Everything else — docs, website, source-repo,
@@ -242,6 +257,12 @@ export function classifyRpcProbe(probe) {
   if (probe.status_code >= 500) {
     return "transient";
   }
+  // Wrong network: the node answered but its genesis hash didn't match. Only
+  // triggers on an EXPLICIT mismatch (chain_verified === false); a node that
+  // didn't return a genesis (null) is judged on its other methods.
+  if (probe.chain_verified === false) {
+    return "wrong-chain";
+  }
   if (probe.error) {
     return "unsupported";
   }
@@ -287,6 +308,10 @@ export function statusForClassification(classification, surface = null) {
   if (["live", "redirected"].includes(classification)) {
     return "ok";
   }
+  // Wrong network is always a hard failure — never softened by authority.
+  if (classification === "wrong-chain") {
+    return "failed";
+  }
   if (
     ["rate-limited", "auth-required", "transient", "timeout"].includes(
       classification,
@@ -305,7 +330,11 @@ export function statusForClassification(classification, surface = null) {
 
 // --- Subtensor JSON-RPC probes (HTTP + WSS) -----------------------------------
 export async function probeSubtensorHttp(url, timeoutMs, options = {}) {
-  const { isUnsafeUrl = isUnsafePublicUrl, fetchImpl = fetch } = options;
+  const {
+    isUnsafeUrl = isUnsafePublicUrl,
+    fetchImpl = fetch,
+    expectedGenesis = FINNEY_GENESIS_HASH,
+  } = options;
   if (await isUnsafeUrl(url)) {
     return {
       unsafe_url: true,
@@ -319,6 +348,7 @@ export async function probeSubtensorHttp(url, timeoutMs, options = {}) {
   const methodResults = {};
   let statusCode = null;
   let contentType = null;
+  let genesisHash = null;
   for (const [index, call] of SUBTENSOR_PROBE_CALLS.entries()) {
     const response = await jsonRpcHttp(
       url,
@@ -330,6 +360,9 @@ export async function probeSubtensorHttp(url, timeoutMs, options = {}) {
     );
     statusCode = response.status_code || statusCode;
     contentType = response.content_type || contentType;
+    if (call.key === "genesis" && typeof response.result === "string") {
+      genesisHash = response.result;
+    }
     methodResults[call.key] = normalizeJsonRpcResult(response);
     if (response.transport_error) {
       return {
@@ -343,11 +376,20 @@ export async function probeSubtensorHttp(url, timeoutMs, options = {}) {
     }
   }
 
+  // chain_verified: true on a matching genesis, false on an explicit mismatch
+  // (wrong network), null when the node didn't return a genesis hash (don't
+  // penalize a node that simply restricts chain_getBlockHash).
+  const expected = normalizeHash(expectedGenesis);
+  const chainVerified = genesisHash
+    ? normalizeHash(genesisHash) === expected
+    : null;
+
   return summarizeRpcProbe({
     content_type: contentType,
     latency_ms: Math.round(performance.now() - started),
     method_results: methodResults,
     status_code: statusCode,
+    chain_verified: chainVerified,
     verified_at: new Date().toISOString(),
   });
 }

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -5,6 +5,7 @@ import {
   classifyProbe,
   classifyRpcProbe,
   contentMismatch,
+  FINNEY_GENESIS_HASH,
   isUnsafePublicUrl,
   mapLimit,
   nodeWebSocketConnector,
@@ -475,9 +476,14 @@ describe("probeSubtensorHttp / jsonRpcHttp (HTTP RPC)", () => {
               body: rpcBody(req.id, { methods: ["a", "b", "c"] }),
             });
           case "chain_getBlockHash":
+            // params[0] === 0 is the genesis probe; anything else is the
+            // archive probe (block 1).
             return fakeResponse({
               status: 200,
-              body: rpcBody(req.id, "0xdeadbeef"),
+              body: rpcBody(
+                req.id,
+                req.params[0] === 0 ? FINNEY_GENESIS_HASH : "0xdeadbeef",
+              ),
             });
           default:
             return fakeResponse({ status: 200, body: rpcBody(req.id, null) });
@@ -485,6 +491,7 @@ describe("probeSubtensorHttp / jsonRpcHttp (HTTP RPC)", () => {
       },
     });
     assert.equal(classifyRpcProbe(probe), "live");
+    assert.equal(probe.chain_verified, true);
     assert.equal(probe.archive_support, true);
     assert.equal(probe.latest_block, 0x1a2b);
     assert.equal(probe.rpc_method_count, 3);
@@ -983,6 +990,53 @@ describe("classifyProbe / classifyRpcProbe (remaining branches)", () => {
     assert.equal(classifyRpcProbe({ status_code: 500 }), "transient");
     assert.equal(classifyRpcProbe({ error: "boom" }), "unsupported");
     assert.equal(classifyRpcProbe({ method_results: {} }), "transient");
+  });
+
+  test("classifyRpcProbe: wrong-chain only on explicit genesis mismatch", () => {
+    const liveMethods = {
+      chain_getHeader: { ok: true },
+      system_health: { ok: true },
+    };
+    // Explicit mismatch → wrong-chain, even though the node otherwise looks live.
+    assert.equal(
+      classifyRpcProbe({ chain_verified: false, method_results: liveMethods }),
+      "wrong-chain",
+    );
+    // Matching or unverifiable genesis → judged on its other methods.
+    assert.equal(
+      classifyRpcProbe({ chain_verified: true, method_results: liveMethods }),
+      "live",
+    );
+    assert.equal(
+      classifyRpcProbe({ chain_verified: null, method_results: liveMethods }),
+      "live",
+    );
+    // wrong-chain is a hard failure regardless of authority.
+    assert.equal(statusForClassification("wrong-chain"), "failed");
+    assert.equal(
+      statusForClassification("wrong-chain", { authority: "community" }),
+      "failed",
+    );
+  });
+
+  test("probeSubtensorHttp flags a mismatched genesis as wrong-chain", async () => {
+    const probe = await probeSubtensorHttp("https://wrong.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      fetchImpl: async (_url, init) => {
+        const req = JSON.parse(init.body);
+        const result =
+          req.method === "chain_getBlockHash"
+            ? "0xother_network_genesis"
+            : req.method === "chain_getHeader"
+              ? { number: "0x1" }
+              : req.method === "system_health"
+                ? { peers: 1, isSyncing: false }
+                : null;
+        return fakeResponse({ status: 200, body: rpcBody(req.id, result) });
+      },
+    });
+    assert.equal(probe.chain_verified, false);
+    assert.equal(classifyRpcProbe(probe), "wrong-chain");
   });
 });
 


### PR DESCRIPTION
## Why

The other cosmos.directory lesson: their health monitor **verifies `chain_id`** and rejects nodes serving the wrong chain. metagraphed probed `chain_getHeader`/`system_health` but never checked *which* network answered — so a wrong/misconfigured submitted RPC endpoint that responds (but is on a different substrate chain) counted as a healthy pool member. This is exactly the "we could ping the wrong endpoints" risk.

## What

Every subtensor RPC health check now probes the **genesis hash** (`chain_getBlockHash[0]`) and compares it to finney's — `0x2f0555…c03`, **verified live** against `bittensor-finney.api.onfinality.io`:

- **Match** → `chain_verified: true` (judged normally).
- **Explicit mismatch** → `chain_verified: false` → classified `wrong-chain` → status `failed` → excluded from the proxy pool (a hard failure, never softened by authority).
- **No genesis returned** → `chain_verified: null` → judged on its other methods (method-restricted nodes aren't penalized).

`expectedGenesis` is a `probeSubtensorHttp` option for per-network overrides (testnet has a different genesis).

## Verification

All 90 `health-probe-core` tests pass (new wrong-chain/genesis-match/mismatch tests + updated full-run mock), plus 102 RPC/selection/failover/cache tests and `worker:test` green. The new `genesis` probe call adds one bounded RPC round-trip per endpoint per 2-min cycle (negligible).

Pairs with #594 (pool hysteresis) — together they bring metagraphed's RPC health monitoring in line with cosmos.directory's robustness model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)