### PR TITLE
feat(publish): tolerant native chain-snapshot refresh in the production build (ADR 0006 step 2)

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -73,6 +73,11 @@ function localSteps() {
 function productionSteps() {
   return [
     nodeStep("bundle-schemas", "scripts/bundle-schemas.mjs", "--write"),
+    // Refresh the finney native chain snapshot fresh each publish (ADR 0006
+    // step 2) so the registry stays current without the retired scheduled
+    // sync-subnets PR. Tolerant: a chain RPC failure keeps the last snapshot and
+    // the publish proceeds — it never blocks on the chain being reachable.
+    nodeStep("native-snapshot", "scripts/refresh-native-snapshot.mjs"),
     // Capture live OpenAPI/Swagger specs (full document + auth) before
     // build-artifacts, so the per-surface schema files carry the real spec for
     // get_api_schema. build-artifacts grabs the document before its staging wipe

--- a/scripts/refresh-native-snapshot.mjs
+++ b/scripts/refresh-native-snapshot.mjs
@@ -1,0 +1,50 @@
+// Tolerant native chain-snapshot refresh for the PRODUCTION publish (ADR 0006
+// step 2). Runs the finney chain fetch fresh each publish so the published
+// subnet registry stays current WITHOUT the retired scheduled sync-subnets PR
+// (issue #597) — but it must NEVER fail the data publish.
+//
+// Chain RPC rate-limits made ~half of standalone sync runs fail, so this wraps
+// scripts/sync-subnets.mjs and SWALLOWS failure: sync-subnets writes the
+// snapshot only after a successful fetch, so on failure the previous committed
+// snapshot is left intact and build-artifacts proceeds with the last-good data
+// (the only consequence is the existing 7-day completeness soft-demotion if the
+// snapshot is very stale — never a broken publish).
+//
+// Runs in build.mjs productionSteps before build-artifacts; local/PR builds keep
+// using the committed snapshot (this step is production-only).
+import { spawnSync } from "node:child_process";
+import { stableStringify } from "./lib.mjs";
+
+const startedAt = process.env.METAGRAPH_BUILD_TIMESTAMP || null;
+
+const result = spawnSync(
+  process.execPath,
+  ["scripts/sync-subnets.mjs", "--write"],
+  { cwd: process.cwd(), stdio: "inherit", env: process.env },
+);
+
+if (result.status === 0) {
+  console.log(
+    stableStringify({
+      step: "native-snapshot",
+      status: "refreshed",
+      started_at: startedAt,
+    }),
+  );
+} else {
+  // Tolerant by design — a transient chain RPC failure must not block the
+  // publish. The last committed snapshot remains the build input.
+  console.warn(
+    "::warning::native snapshot refresh failed (chain RPC); keeping the last snapshot. Publish continues (ADR 0006 step 2).",
+  );
+  console.log(
+    stableStringify({
+      step: "native-snapshot",
+      status: "fallback-to-last",
+      exit_code: result.status,
+      started_at: startedAt,
+    }),
+  );
+}
+
+process.exit(0);


### PR DESCRIPTION
## What

The core of ADR 0006 step 2: the **production publish now fetches the finney native chain snapshot fresh each run**, so the registry stays current without the retired scheduled `sync-subnets` PR (#571) or a manual sync. `scripts/refresh-native-snapshot.mjs` is wired into `build.mjs` `productionSteps` immediately before `build-artifacts` (alongside the existing `schemas-snapshot` / `adapters-snapshot` network refreshes; the publish runner already has `uv`).

## The key property: it can never break the publish

Chain RPC rate-limits failed **~half** of standalone `sync-subnets` runs. So the wrapper is **tolerant**: on a fetch failure it logs a `::warning::`, **exits 0**, and leaves the last committed snapshot intact (`sync-subnets` writes only *after* a successful fetch). The publish proceeds with last-good data — it never blocks on the chain being reachable. Production-only; local/PR builds keep using the committed snapshot.

## Verification (local, real `uv`)

- **Success path:** real chain fetch → fresh finney snapshot (129 subnets, `captured_at` advanced 09:03→12:07Z, `status: refreshed`) + testnet (506).
- **Fallback path:** forced chain-RPC failure → wrapper **exit 0**, committed snapshot **byte-identical** (verified via diff).

## Scope

This is the behavior-changing core (publish self-sufficiency → fresh data, no churn, no manual sync, no 7-day demotion). The remaining "purity" work — fully removing the committed snapshot from git (needs a public/R2 native artifact + a credential-less build fallback) and re-pointing the changelog baseline off committed-HEAD — stays the careful follow-up tracked in #597.

🤖 Generated with [Claude Code](https://claude.com/claude-code)