### PR TITLE
Refresh publish-blocking data during production builds

### DIFF
--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -71,8 +71,31 @@ function localSteps() {
 }
 
 function productionSteps() {
+  const refreshEnv = {
+    METAGRAPH_DISCOVERY_OBSERVED_AT: effectiveBuildTimestamp,
+    METAGRAPH_PERSIST_DISCOVERY_OBSERVED_AT: "1",
+    METAGRAPH_VERIFICATION_OBSERVED_AT: effectiveBuildTimestamp,
+  };
   return [
     nodeStep("bundle-schemas", "scripts/bundle-schemas.mjs", "--write"),
+    // Refresh publish-blocking native subnet, generated candidate discovery,
+    // and candidate verification inputs during the scheduled publish build.
+    // sync-subnets.yml remains manual-only for reviewed Git backfills, but the
+    // production data publish must be self-sufficient so the freshness gate does
+    // not depend on a recently merged sync PR.
+    nodeStep("sync-subnets", "scripts/sync-subnets.mjs", "--write"),
+    nodeStep(
+      "discover-candidates",
+      "scripts/discover-candidates.mjs",
+      "--write",
+      refreshEnv,
+    ),
+    nodeStep(
+      "verify-candidates",
+      "scripts/verify-candidates.mjs",
+      "--write",
+      refreshEnv,
+    ),
     // Capture live OpenAPI/Swagger specs (full document + auth) before
     // build-artifacts, so the per-surface schema files carry the real spec for
     // get_api_schema. build-artifacts grabs the document before its staging wipe


### PR DESCRIPTION
### Motivation
- Scheduled `sync-subnets` was made `workflow_dispatch`-only which left the scheduled publish pipeline unable to refresh machine-produced inputs (`native-subnets`, `candidate-discovery`, `candidate-verification`) and caused the freshness gate to fail. 
- The production publish must be self-sufficient so scheduled runs do not hard-fail when committed inputs age out of the default 24h window.

### Description
- Updated `scripts/build.mjs` to run the refresh steps as part of production builds by adding `sync-subnets`, `discover-candidates`, and `verify-candidates` to `productionSteps()`.
- Added a `refreshEnv` object that sets `METAGRAPH_DISCOVERY_OBSERVED_AT`, `METAGRAPH_PERSIST_DISCOVERY_OBSERVED_AT`, and `METAGRAPH_VERIFICATION_OBSERVED_AT` for the discovery/verification steps so regenerated artifacts carry the publish timestamp.
- Preserved the manual-only `sync-subnets.yml` backfill workflow while making scheduled publishes self-sufficient for freshness validation.
- The change is contained to `scripts/build.mjs` and does not alter the publish workflow triggers or secrets handling.

### Testing
- Ran `npm run validate:workflows` which completed successfully and validated workflow requirements. 
- Ran linting for the changed file with `npm run lint -- scripts/build.mjs` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e96645c40832a8578b3ff5e8c24a6)