### PR TITLE
fix(contrib): escape enrichment issue names

### DIFF
--- a/scripts/enrichment-issues.mjs
+++ b/scripts/enrichment-issues.mjs
@@ -59,6 +59,39 @@ const KIND_LABEL = {
   sdk: "SDK",
 };
 
+function formatMarkdownValue(value) {
+  const markdownCharacters = new Set("\\&<>{}[]()#*_`|.!+-");
+  let safeValue = "";
+
+  for (const char of String(value ?? "")) {
+    const codePoint = char.codePointAt(0);
+    if (char === "\r") {
+      safeValue += "\\r";
+    } else if (char === "\n") {
+      safeValue += "\\n";
+    } else if (char === "\t") {
+      safeValue += "\\t";
+    } else if (char === "@") {
+      safeValue += "@\u200b";
+    } else if (codePoint < 0x20 || codePoint === 0x7f) {
+      safeValue += `\\u${codePoint.toString(16).padStart(4, "0")}`;
+    } else if (markdownCharacters.has(char)) {
+      safeValue += `\\${char}`;
+    } else {
+      safeValue += char;
+    }
+  }
+
+  return safeValue;
+}
+
+function formatTitleValue(value, { maxLength = 120 } = {}) {
+  return formatMarkdownValue(value)
+    .replace(/\s+/g, " ")
+    .trim()
+    .slice(0, maxLength);
+}
+
 async function fetchJson(path) {
   const res = await fetch(`${API_BASE}${path}`);
   if (!res.ok) throw new Error(`${path}: HTTP ${res.status}`);
@@ -104,7 +137,7 @@ function issueBody(netuid, name, kinds) {
   const primary = kinds[0];
   return `Part of #${TRACKER}.
 
-**Subnet ${netuid} — ${name}** is missing from the registry: **${kindList}**. Research whether the subnet exposes ${kinds.length > 1 ? "these" : "this"}, find the real public link(s), and submit them.
+**Subnet ${netuid} — ${formatMarkdownValue(name)}** is missing from the registry: **${kindList}**. Research whether the subnet exposes ${kinds.length > 1 ? "these" : "this"}, find the real public link(s), and submit them.
 
 ### Find it
 Search for the subnet's official ${kindList} (project site / GitHub / docs / Bittensor). Confirm each link is real, public, no-auth, and genuinely SN${netuid}'s — cross-reference the subnet name + Bittensor. ⚠️ Many subnets simply don't expose a public API yet, and on-chain identity links are often **stale/dead** — verify each link actually resolves before submitting. If the subnet genuinely exposes no such public surface, comment here so a maintainer can close it.
@@ -145,7 +178,7 @@ for (const entry of queue) {
     name: entry.name || `Subnet ${netuid}`,
     kinds,
     title:
-      `Enrich SN${netuid} ${entry.name || ""}`.trim() +
+      `Enrich SN${netuid} ${formatTitleValue(entry.name)}`.trim() +
       ` — add ${kinds.map((k) => KIND_LABEL[k] || k).join(" + ")}`,
   });
 }


### PR DESCRIPTION
### Motivation
- The enrichment issue generator embedded untrusted `entry.name` values directly into GitHub issue titles and Markdown bodies, allowing Markdown/newline/mention/link injection when the live queue contains attacker-controlled names.
- Sanitize subnet names before rendering so maintainer-authored issues cannot be spoofed or abused by malicious metadata.

### Description
- Add `formatMarkdownValue()` to escape Markdown control characters, control bytes, newlines/tabs, and neutralize `@` mentions when rendering untrusted values for Markdown bodies.
- Add `formatTitleValue()` that reuses the safe rendering, collapses whitespace, neutralizes mentions, and truncates long values for issue titles.
- Use `formatMarkdownValue()` in `issueBody()` and `formatTitleValue()` when building planned `title` values to ensure both body and title are safe.
- Preserve existing issue format and labels while only changing how `entry.name` is rendered so behavior and labels remain unchanged.

### Testing
- Ran `node --check scripts/enrichment-issues.mjs` to validate syntax and it succeeded.
- Executed a mocked enrichment API and a fake `gh` wrapper to simulate a hostile `entry.name` payload and verified the captured `--title` and `--body` arguments contain escaped/neutralized content as expected.
- Ran `npx prettier --check scripts/enrichment-issues.mjs` and `git diff --check` which both reported clean results.
- Ran `npm test` which failed due to missing generated `public/metagraph/*` and `dist/metagraph-r2` artifacts and other environment/DNS-dependent checks unrelated to this change, so those failures do not indicate the fix is incorrect.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e98311068832aa84ff59045603e44)