### PR TITLE
fix(fixtures): redact common secret fixture fields

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -17,24 +17,45 @@ export const r2StagingRoot = path.join(repoRoot, R2_STAGING_RELATIVE_ROOT);
 export const generatedSourceRoot = path.join(repoRoot, "dist/metagraph-source");
 
 const credentialedUrlParams = new Set([
+  "access_key",
+  "access-token",
+  "access_token",
   "app_domain",
+  "api-key",
+  "api_key",
+  "apikey",
+  "auth",
+  "authorization",
   "authuser",
+  "bearer",
   "client_id",
   "code_challenge",
   "code_challenge_method",
   "continue",
+  "cookie",
+  "credential",
   "dsh",
   "flowname",
+  "jwt",
+  "key",
   "nonce",
   "opparams",
   "part",
+  "password",
   "prompt",
   "rart",
   "redirect_uri",
+  "refresh-token",
+  "refresh_token",
   "response_type",
   "scope",
+  "secret",
   "service",
+  "session",
+  "sig",
+  "signature",
   "state",
+  "token",
   "x-amz-credential",
   "x-amz-signature",
   "x-amz-security-token",
@@ -778,9 +799,10 @@ export function redactCredentialedUrls(value) {
 
 // Keys whose VALUES are redacted from a captured live response before it is
 // committed as a fixture (issue #352) — credentials/secrets that a subnet API
-// might echo back. Matched whole-word/segment, case-insensitive.
+// might echo back. Match common separator-delimited, camelCase, and compact
+// spellings so live fixtures do not publish token/session-like fields.
 const FIXTURE_SENSITIVE_KEY =
-  /(^|[_-])(token|secret|api[_-]?key|apikey|password|passwd|pwd|authorization|auth|cookie|session|credential|private[_-]?key|mnemonic|seed[_-]?phrase|bearer|access[_-]?key|refresh[_-]?token)([_-]|$)/i;
+  /(?:^|[_-])(?:token|secret|api[_-]?key|apikey|password|passwd|pwd|authorization|auth|cookie|session|credential|private[_-]?key|mnemonic|seed[_-]?phrase|bearer|access[_-]?key|refresh[_-]?token|csrf[_-]?token|jwt)(?:[_-]|$)|(?:access|refresh|csrf|session|cookie|password|private|seed)(?:Token|Key|Id|Value|Hash|Phrase)\b|(?:apiKey|passwordHash|cookieValue|sessionId|csrfToken|accessToken|refreshToken|privateKey|seedPhrase|jwt)\b/i;
 
 // Sanitize an arbitrary parsed JSON response from a third-party subnet API so a
 // single live sample can be committed as a fixture (issue #352). Redacts

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -660,12 +660,42 @@ describe("sanitizeFixtureBody (#352)", () => {
     assert.equal(out.list[0].keep, "ok");
     assert.equal(out.ok, true);
   });
+  test("redacts common compact and camelCase sensitive keys", () => {
+    const out = sanitizeFixtureBody({
+      accessToken: "access-token",
+      sessionId: "session-id",
+      cookieValue: "cookie-value",
+      passwordHash: "password-hash",
+      jwt: "jwt-value",
+      csrfToken: "csrf-token",
+      nested: { privateKey: "private-key", seedPhrase: "seed-phrase" },
+      keep: "ok",
+    });
+
+    assert.equal(out.accessToken, "[redacted]");
+    assert.equal(out.sessionId, "[redacted]");
+    assert.equal(out.cookieValue, "[redacted]");
+    assert.equal(out.passwordHash, "[redacted]");
+    assert.equal(out.jwt, "[redacted]");
+    assert.equal(out.csrfToken, "[redacted]");
+    assert.equal(out.nested.privateKey, "[redacted]");
+    assert.equal(out.nested.seedPhrase, "[redacted]");
+    assert.equal(out.keep, "ok");
+  });
   test("strips credentials from URL strings", () => {
     const out = sanitizeFixtureBody({
       url: "https://user:secret@api.example.io/x?token=abc",
+      apiKeyUrl: "https://api.example.io/x?api_key=abc",
+      accessTokenUrl: "https://api.example.io/x?access_token=abc",
+      jwtUrl: "https://api.example.io/x?jwt=abc",
+      sigUrl: "https://api.example.io/x?sig=abc",
     });
     assert.ok(!out.url.includes("secret"));
     assert.ok(!out.url.includes("token=abc"));
+    assert.equal(out.apiKeyUrl, "https://api.example.io/x");
+    assert.equal(out.accessTokenUrl, "https://api.example.io/x");
+    assert.equal(out.jwtUrl, "https://api.example.io/x");
+    assert.equal(out.sigUrl, "https://api.example.io/x");
   });
   test("bounds array length, string length, depth, and key count", () => {
     const out = sanitizeFixtureBody(

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -989,6 +989,11 @@ describe("script utility contracts", () => {
       isCredentialedUrl("https://example.com/download?file=1"),
       false,
     );
+    assert.equal(isCredentialedUrl("https://example.com/x?api_key=1"), true);
+    assert.equal(
+      redactCredentialedUrl("https://example.com/x?access_token=1"),
+      "https://example.com/x",
+    );
   });
 
   test("scopes evidence claims with authoritative source netuids before subject slugs", () => {


### PR DESCRIPTION
### Motivation
- Production publish builds now run the live fixture capture step which can publish captured third-party JSON responses, so the sanitizer gaps could expose sensitive tokens or session values in public fixture artifacts.
- The existing sanitizer only matched separator-delimited names and a small URL parameter list, missing many common compact/camelCase secret fields and query parameter names.

### Description
- Expanded the URL credential detection `credentialedUrlParams` (in `scripts/lib.mjs`) to include common parameter names such as `token`, `api_key`, `access_token`, `jwt`, `sig` and related variants so credentialed URLs are recognized and stripped before publication.
- Broadened the fixture key redaction regex `FIXTURE_SENSITIVE_KEY` (in `scripts/lib.mjs`) to match separator-delimited, compact, and camelCase secret-like keys (e.g. `accessToken`, `sessionId`, `cookieValue`, `passwordHash`, `jwt`, `csrfToken`, `privateKey`, `seedPhrase`).
- Added regression tests to cover the new URL detection and fixture-body redaction cases in `tests/lib-helpers.test.mjs` and `tests/script-utils.test.mjs`.
- Changes are limited to the sanitizer and tests so fixture capture behaviour remains intact while reducing risk of publishing sensitive values.

### Testing
- Ran the targeted unit tests with `npm test -- --run tests/lib-helpers.test.mjs tests/script-utils.test.mjs`, and all tests passed (96 tests total).
- Ran linting with `npm run lint -- --quiet`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e982fdd34832a806212d377641a2a)