### PR TITLE
fix(health): reject wrong-chain WSS RPCs

### DIFF
--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -492,7 +492,9 @@ export async function probeSubtensorWss(url, timeoutMs, options = {}) {
     const rawResults = await connect(url, SUBTENSOR_PROBE_CALLS, timeoutMs);
     let genesisHash = null;
     for (const call of SUBTENSOR_PROBE_CALLS) {
-      const response = rawResults.get(call.key) || { error: "missing response" };
+      const response = rawResults.get(call.key) || {
+        error: "missing response",
+      };
       if (call.key === "genesis" && typeof response.result === "string") {
         genesisHash = response.result;
       }

--- a/src/health-probe-core.mjs
+++ b/src/health-probe-core.mjs
@@ -463,7 +463,11 @@ async function jsonRpcHttp(url, method, params, id, timeoutMs, options = {}) {
 // `fetch(url, { headers: { Upgrade: "websocket" } })` → `response.webSocket`.
 // `connect(url, calls, timeoutMs)` resolves a Map<callKey, {ok, result, rpc_error}>.
 export async function probeSubtensorWss(url, timeoutMs, options = {}) {
-  const { isUnsafeUrl = isUnsafePublicUrl, connect } = options;
+  const {
+    isUnsafeUrl = isUnsafePublicUrl,
+    connect,
+    expectedGenesis = FINNEY_GENESIS_HASH,
+  } = options;
   if (await isUnsafeUrl(url)) {
     return {
       unsafe_url: true,
@@ -486,14 +490,22 @@ export async function probeSubtensorWss(url, timeoutMs, options = {}) {
   const methodResults = {};
   try {
     const rawResults = await connect(url, SUBTENSOR_PROBE_CALLS, timeoutMs);
+    let genesisHash = null;
     for (const call of SUBTENSOR_PROBE_CALLS) {
-      methodResults[call.key] = normalizeJsonRpcResult(
-        rawResults.get(call.key) || { error: "missing response" },
-      );
+      const response = rawResults.get(call.key) || { error: "missing response" };
+      if (call.key === "genesis" && typeof response.result === "string") {
+        genesisHash = response.result;
+      }
+      methodResults[call.key] = normalizeJsonRpcResult(response);
     }
+    const expected = normalizeHash(expectedGenesis);
+    const chainVerified = genesisHash
+      ? normalizeHash(genesisHash) === expected
+      : null;
     return summarizeRpcProbe({
       latency_ms: Math.round(performance.now() - started),
       method_results: methodResults,
+      chain_verified: chainVerified,
       verified_at: new Date().toISOString(),
     });
   } catch (error) {

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -222,6 +222,7 @@ export function overlayRpcPoolEligibility(pool, liveRpcPool) {
     endpoints: (pool.endpoints || []).map((endpoint) => {
       const live = liveById.get(endpoint.id);
       if (!live) return endpoint;
+      const wrongChain = live.classification === "wrong-chain";
       const sustainedDown =
         live.status !== "ok" &&
         (live.consecutive_failures || 0) >= POOL_SUSTAINED_DOWN_FAILURES;
@@ -230,7 +231,8 @@ export function overlayRpcPoolEligibility(pool, liveRpcPool) {
         status: live.status,
         latency_ms: live.latency_ms ?? endpoint.latency_ms,
         health_source: "live-cron-prober",
-        pool_eligible: Boolean(endpoint.pool_eligible) && !sustainedDown,
+        pool_eligible:
+          Boolean(endpoint.pool_eligible) && !wrongChain && !sustainedDown,
       };
     }),
   };

--- a/tests/health-probe-core.test.mjs
+++ b/tests/health-probe-core.test.mjs
@@ -649,9 +649,26 @@ describe("probeSubtensorWss", () => {
         ]),
     });
     assert.equal(classifyRpcProbe(probe), "live");
+    assert.equal(probe.chain_verified, null);
     assert.equal(probe.latest_block, 0x20);
     assert.equal(probe.archive_support, true);
     assert.equal(probe.rpc_method_count, 2);
+  });
+
+  test("flags a mismatched WSS genesis as wrong-chain", async () => {
+    const probe = await probeSubtensorWss("wss://wrong.dev", 5000, {
+      isUnsafeUrl: async () => false,
+      connect: async () =>
+        new Map([
+          ["chain_getHeader", { ok: true, result: { number: "0x1" } }],
+          ["system_health", { ok: true, result: { peers: 1 } }],
+          ["rpc_methods", { ok: true, result: { methods: [] } }],
+          ["archive_probe", { ok: true, result: "0xabc" }],
+          ["genesis", { ok: true, result: "0xother_network_genesis" }],
+        ]),
+    });
+    assert.equal(probe.chain_verified, false);
+    assert.equal(classifyRpcProbe(probe), "wrong-chain");
   });
 
   test("connector resolving a partial Map fills missing keys", async () => {

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -154,6 +154,22 @@ describe("overlayRpcPoolEligibility", () => {
     assert.equal(out.endpoints.find((e) => e.id === "a").pool_eligible, true);
     assert.equal(out.endpoints.find((e) => e.id === "b").pool_eligible, false);
   });
+  test("immediately drops wrong-chain endpoints from the proxy pool", () => {
+    const live = {
+      endpoints: [
+        {
+          id: "a",
+          status: "failed",
+          classification: "wrong-chain",
+          consecutive_failures: 1,
+        },
+      ],
+    };
+    const out = overlayRpcPoolEligibility(pool, live);
+    assert.equal(out.endpoints.find((e) => e.id === "a").pool_eligible, false);
+    assert.equal(out.endpoints.find((e) => e.id === "b").pool_eligible, true);
+  });
+
   test("returns the static pool unchanged when live is cold", () => {
     assert.equal(overlayRpcPoolEligibility(pool, null), pool);
   });


### PR DESCRIPTION
### Motivation
- Ensure the newly-introduced genesis (block-0) verification is enforced for WebSocket (WSS) subtensor probes as it is for HTTP probes so wrong-chain WSS endpoints cannot be treated as `live`.
- Immediately evict endpoints classified `wrong-chain` from the RPC proxy pool instead of waiting for the generic sustained-failure hysteresis, matching the intended hard-failure semantics for wrong-chain detections.

### Description
- `probeSubtensorWss()` now derives `chain_verified` from the shared `genesis` RPC result (honoring `expectedGenesis`) and includes it in the probe summary to match `probeSubtensorHttp()` behavior (`src/health-probe-core.mjs`).
- `overlayRpcPoolEligibility()` now treats live entries with `classification === "wrong-chain"` as ineligible immediately while preserving the existing sustained-failure check for other failure types (`src/health-serving.mjs`).
- Added unit tests asserting that a WSS probe with no genesis remains `chain_verified: null` and that a mismatched WSS genesis yields `chain_verified: false` and classification `wrong-chain` (`tests/health-probe-core.test.mjs`).
- Added a unit test ensuring `overlayRpcPoolEligibility()` immediately drops `wrong-chain` endpoints from pool eligibility (`tests/health-serving.test.mjs`).

### Testing
- Ran targeted unit tests with `npx vitest run tests/health-probe-core.test.mjs -t "probeSubtensorWss|wrong-chain"` and the added WSS genesis tests passed.
- Ran targeted overlay tests with `npx vitest run tests/health-serving.test.mjs -t "overlayRpcPoolEligibility"` and the wrong-chain eviction test passed.
- Executed broader test runs (`npx vitest run tests/health-probe-core.test.mjs tests/health-serving.test.mjs` and `npm test`) where the new targeted tests succeed but the full suite fails in this environment due to unrelated missing generated artifacts and environment constraints (absent `public/metagraph` and `dist/metagraph-r2` artifacts and DNS/environment differences), not due to the changes in the health-probe logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ea1a2d194832aa33f0631250d76bf)