### PR TITLE
fix(publish): stage+restore the refreshed native snapshot for the publish job

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -87,6 +87,12 @@ jobs:
           if [ -d dist/metagraph-r2 ]; then
             cp -R dist/metagraph-r2 "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2"
           fi
+          # Stage the refreshed native chain snapshot (ADR 0006 step 2): the
+          # build fetched it fresh, so the publish job must validate against the
+          # SAME snapshot, not the stale committed one — otherwise validate.mjs's
+          # native_data_as_of / native_snapshot_captured_at cross-check fails.
+          mkdir -p "$RUNNER_TEMP/publish-artifacts/registry"
+          cp -R registry/native "$RUNNER_TEMP/publish-artifacts/registry/native"
 
       - name: Upload reviewed publish artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -137,6 +143,12 @@ jobs:
           if [ -d "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" ]; then
             mkdir -p dist
             cp -R "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" dist/metagraph-r2
+          fi
+          # Restore the refreshed native snapshot so `npm run validate` reads the
+          # same snapshot the staged artifacts were built from (ADR 0006 step 2).
+          if [ -d "$RUNNER_TEMP/publish-artifacts/registry/native" ]; then
+            rm -rf registry/native
+            cp -R "$RUNNER_TEMP/publish-artifacts/registry/native" registry/native
           fi
 
       - name: Validate registry


### PR DESCRIPTION
## The bug (caught by verifying #598 live)

#598 made the production build fetch the finney native snapshot **fresh** each publish. The refresh job builds artifacts from that fresh snapshot, so the staged `freshness.json` records the fresh `captured_at`. But the publish job re-runs `npm run validate` against its **own git checkout's committed** `registry/native/finney-subnets.json` (still stale — the stage step only copied `public/` + `dist/`, not `registry/`). `validate.mjs:1148` cross-checks:

```js
freshnessArtifact.summary?.native_snapshot_captured_at === nativeSnapshot.captured_at  // staged-fresh !== committed-stale
```

→ 131 validation issues → the publish steps (R2 upload, KV pointer, smoke) all **skip**. So **every publish has been failing since #598 merged** (data stopped refreshing; pointer stuck).

Found via a manual `workflow_dispatch` verification (run `27500920198`): the **refresh job succeeded** (the new `native-snapshot` + `capture-fixtures` steps work), only the publish-job freshness cross-check failed.

## Fix

Stage the refreshed `registry/native` alongside the artifacts and restore it in the publish job, so `npm run validate` reads the **same** snapshot the staged artifacts were built from. Two-line additions to the Stage + Restore steps; the Re-restore step doesn't touch `registry/` so the fresh native persists. `validate:workflows` passes.

## Verify after merge

Re-trigger a publish and confirm it goes green end-to-end (R2 upload + KV pointer + smoke), `published_at` advances, fixtures populate, and native freshness reflects the publish-time fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)