### PR TITLE
fix(publish): restore refreshed native snapshot

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -83,6 +83,8 @@ jobs:
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/publish-artifacts"
           cp -R public "$RUNNER_TEMP/publish-artifacts/public"
+          mkdir -p "$RUNNER_TEMP/publish-artifacts/registry/native"
+          cp registry/native/finney-subnets.json "$RUNNER_TEMP/publish-artifacts/registry/native/finney-subnets.json"
           mkdir -p "$RUNNER_TEMP/publish-artifacts/dist"
           if [ -d dist/metagraph-r2 ]; then
             cp -R dist/metagraph-r2 "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2"
@@ -134,6 +136,7 @@ jobs:
           }
           rm -rf public/metagraph dist/metagraph-r2
           cp -R "$RUNNER_TEMP/publish-artifacts/public/metagraph" public/metagraph
+          cp "$RUNNER_TEMP/publish-artifacts/registry/native/finney-subnets.json" registry/native/finney-subnets.json
           if [ -d "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" ]; then
             mkdir -p dist
             cp -R "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" dist/metagraph-r2
@@ -183,6 +186,7 @@ jobs:
           set -euo pipefail
           rm -rf public/metagraph dist/metagraph-r2
           cp -R "$RUNNER_TEMP/publish-artifacts/public/metagraph" public/metagraph
+          cp "$RUNNER_TEMP/publish-artifacts/registry/native/finney-subnets.json" registry/native/finney-subnets.json
           if [ -d "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" ]; then
             mkdir -p dist
             cp -R "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" dist/metagraph-r2


### PR DESCRIPTION
### Motivation
- Prevent the publish job's `npm run validate` from failing when artifacts were built from a refreshed `registry/native/finney-subnets.json` that was not restored into the publish checkout, causing timestamp/subnet mismatches between artifacts and checked-out inputs.

### Description
- Stage `registry/native/finney-subnets.json` alongside generated artifacts in `.github/workflows/publish-cloudflare.yml` and restore it into `registry/native/finney-subnets.json` in the `publish` job during both the initial restore and the final re-restore so validation runs against the same refreshed native snapshot used to build the artifacts.

### Testing
- Ran `npm run validate:workflows` which passed. 
- Attempted `npm run validate` locally but it could not complete in this checkout because generated artifact `public/metagraph/providers.json` is absent prior to a full build; full end-to-end validation is expected to run in CI where the refresh job produces the staged artifacts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eb2ead850832a9039831cf585b072)