### PR TITLE
fix(registry): mark Gittensory MCP auth-required + probe-disabled

### DIFF
--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -169,12 +169,17 @@
       "url": "https://gittensory-api.aethereal.dev/v1/public/subnet-interface"
     },
     {
-      "auth_required": false,
+      "auth_required": true,
       "authority": "provider-claimed",
       "id": "gittensory-mcp",
       "kind": "subnet-api",
       "name": "Gittensory MCP (contribution interface)",
       "notes": "Streamable-HTTP MCP server exposing deterministic, gittensor-native contribution signals (decision pack, check-before-start, preflight, notifications) to a contributor's own agent harness. POST-only JSON-RPC, so recurring read probes are intentionally disabled. Contributor tools are scoped to the authenticated GitHub login.",
+      "probe": {
+        "enabled": false,
+        "expect": "json",
+        "method": "JSON-RPC"
+      },
       "provider": "gittensory",
       "public_safe": true,
       "source_urls": [


### PR DESCRIPTION
Clean replacement for #602 (which bundled ~1640 lines of degraded local-build artifact regeneration — epoch-0 timestamps, collapsed counts).

**The fix:** the `gittensory-mcp` surface is POST-only JSON-RPC, but on main it was `auth_required:false` with no probe block, so it satisfied the fixture-capture candidate filter (`capture-fixtures.mjs`, live in the publish since #570) and the build would fire a GET at the POST-only `/mcp` endpoint. This sets `auth_required:true` and adds an explicit `probe:{enabled:false, expect:json, method:JSON-RPC}` block so it's never treated as a GET probe/fixture candidate.

Registry-only edit off current main. `gittensory-mcp` is not in the committed `operational-surfaces.json`, and this edit keeps it out (consistent), so no artifact regeneration is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)