### PR TITLE
fix(publish): refresh candidate discovery+verification in the build (tolerant)

### DIFF
--- a/.github/workflows/publish-cloudflare.yml
+++ b/.github/workflows/publish-cloudflare.yml
@@ -87,12 +87,15 @@ jobs:
           if [ -d dist/metagraph-r2 ]; then
             cp -R dist/metagraph-r2 "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2"
           fi
-          # Stage the refreshed native chain snapshot (ADR 0006 step 2): the
-          # build fetched it fresh, so the publish job must validate against the
-          # SAME snapshot, not the stale committed one — otherwise validate.mjs's
-          # native_data_as_of / native_snapshot_captured_at cross-check fails.
-          mkdir -p "$RUNNER_TEMP/publish-artifacts/registry"
-          cp -R registry/native "$RUNNER_TEMP/publish-artifacts/registry/native"
+          # Stage the whole registry (ADR 0006 step 2 + #599): the build refreshes
+          # several machine inputs in place — native snapshot (refresh-native-snapshot),
+          # candidate discovery + verification (refresh-candidates), adapter snapshots
+          # — so the publish job must validate against the SAME refreshed inputs, not
+          # the stale committed ones, or validate.mjs's committed-vs-staged cross-checks
+          # fail (native native_data_as_of; candidate/coverage counts). Human-authored
+          # registry files are identical to the checkout, so restoring the whole dir is
+          # a no-op for them.
+          cp -R registry "$RUNNER_TEMP/publish-artifacts/registry"
 
       - name: Upload reviewed publish artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
@@ -144,11 +147,12 @@ jobs:
             mkdir -p dist
             cp -R "$RUNNER_TEMP/publish-artifacts/dist/metagraph-r2" dist/metagraph-r2
           fi
-          # Restore the refreshed native snapshot so `npm run validate` reads the
-          # same snapshot the staged artifacts were built from (ADR 0006 step 2).
-          if [ -d "$RUNNER_TEMP/publish-artifacts/registry/native" ]; then
-            rm -rf registry/native
-            cp -R "$RUNNER_TEMP/publish-artifacts/registry/native" registry/native
+          # Restore the refreshed registry so `npm run validate` reads the same
+          # machine inputs the staged artifacts were built from (ADR 0006 step 2 +
+          # #599 — native snapshot, candidate discovery/verification, adapters).
+          if [ -d "$RUNNER_TEMP/publish-artifacts/registry" ]; then
+            rm -rf registry
+            cp -R "$RUNNER_TEMP/publish-artifacts/registry" registry
           fi
 
       - name: Validate registry

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -78,6 +78,12 @@ function productionSteps() {
     // sync-subnets PR. Tolerant: a chain RPC failure keeps the last snapshot and
     // the publish proceeds — it never blocks on the chain being reachable.
     nodeStep("native-snapshot", "scripts/refresh-native-snapshot.mjs"),
+    // Refresh candidate discovery + verification fresh each publish (issue #599)
+    // so their >24h block-freshness gate doesn't hard-fail the scheduled publish
+    // now that the sync PR is retired (#571). Runs AFTER native-snapshot
+    // (discover-candidates reads it); tolerant like native-snapshot — a live
+    // network failure keeps the last committed data and the publish proceeds.
+    nodeStep("refresh-candidates", "scripts/refresh-candidates.mjs"),
     // Capture live OpenAPI/Swagger specs (full document + auth) before
     // build-artifacts, so the per-surface schema files carry the real spec for
     // get_api_schema. build-artifacts grabs the document before its staging wipe

--- a/scripts/refresh-candidates.mjs
+++ b/scripts/refresh-candidates.mjs
@@ -1,0 +1,58 @@
+// Tolerant candidate-discovery + verification refresh for the PRODUCTION publish
+// (issue #599 / ADR 0006). candidate-discovery and candidate-verification are
+// block-behavior freshness sources (validate.mjs validateFreshnessForPublish):
+// once either is >24h old the scheduled publish HARD-FAILS. #571 retired the
+// scheduled sync-subnets PR that used to refresh them, so without this the 6h
+// publish starts failing ~24h after the last manual sync.
+//
+// Refreshes both fresh each publish, stamping their observed_at with the build
+// timestamp — but NEVER fails the publish: both scripts make heavy live network
+// calls (taomarketcap, GitHub, candidate URL probes) and write their artifacts
+// only after a successful run, so on failure the last committed
+// candidates/verification stay intact and the build proceeds (the >24h freshness
+// gate is the backstop, exactly as for the native snapshot in #598). The native
+// snapshot must already be refreshed first (discover-candidates reads it), so
+// this runs AFTER the native-snapshot step in build.mjs productionSteps.
+// Production-only; local/PR builds use the committed candidates/verification.
+import { spawnSync } from "node:child_process";
+import { stableStringify } from "./lib.mjs";
+
+const buildTimestamp = process.env.METAGRAPH_BUILD_TIMESTAMP || "";
+const env = {
+  ...process.env,
+  // Pin the discovery/verification observed_at to the publish timestamp so the
+  // regenerated artifacts are fresh-by-construction (build-artifacts reads these
+  // envs first when stamping native_snapshot_captured_at / observed_at).
+  METAGRAPH_DISCOVERY_OBSERVED_AT: buildTimestamp,
+  METAGRAPH_PERSIST_DISCOVERY_OBSERVED_AT: "1",
+  METAGRAPH_VERIFICATION_OBSERVED_AT: buildTimestamp,
+};
+
+const steps = [
+  ["discover-candidates", ["scripts/discover-candidates.mjs", "--write"]],
+  ["verify-candidates", ["scripts/verify-candidates.mjs", "--write"]],
+];
+
+for (const [label, args] of steps) {
+  const result = spawnSync(process.execPath, args, {
+    cwd: process.cwd(),
+    stdio: "inherit",
+    env,
+  });
+  if (result.status === 0) {
+    console.log(stableStringify({ step: label, status: "refreshed" }));
+  } else {
+    console.warn(
+      `::warning::${label} failed (live network); keeping the last committed data. Publish continues (issue #599).`,
+    );
+    console.log(
+      stableStringify({
+        step: label,
+        status: "fallback-to-last",
+        exit_code: result.status,
+      }),
+    );
+  }
+}
+
+process.exit(0);


### PR DESCRIPTION
Clean replacement for #599 (which was based on pre-#598 main, collided with #598's native-snapshot step, and added a redundant non-tolerant `sync-subnets` line).

## The gap

`candidate-discovery` and `candidate-verification` are block-behavior freshness sources (`validate.mjs` `validateFreshnessForPublish`): once either is >24h old the scheduled publish **hard-fails**. #571 retired the scheduled sync-subnets PR that refreshed them, so the 6h publish starts failing ~24h after the last manual sync. (Native + adapters are already refreshed in the build by #598 / `adapters-snapshot`; these two were the remaining gap.)

## Fix

- **`scripts/refresh-candidates.mjs`** — tolerant wrapper running `discover-candidates` + `verify-candidates` with the publish timestamp as `observed_at`; on a live-network failure it keeps the last committed data and exits 0 (mirrors #598's `refresh-native-snapshot` — never blocks the publish on external reachability).
- **`build.mjs productionSteps`** — runs it after `native-snapshot` (discover reads the native snapshot), before `build-artifacts`.
- **`publish-cloudflare.yml`** — generalizes #606's `registry/native` staging to the **whole `registry/`**, so the publish job validates against the same refreshed candidate/verification inputs. This is required: `validate.mjs` cross-checks `coverageArtifact.candidate_count` / `candidatesArtifact.candidates.length === candidates.length` (committed `loadCandidates()`), the same staged-vs-committed mismatch class #598 hit with native. Human-authored registry files are identical to the checkout, so it's a no-op for them.

## Verification

`validate:workflows` passes, scripts syntax + prettier clean. The wrapper is structurally identical to the verified #598 `refresh-native-snapshot.mjs` (tolerant, `process.exit(0)`). Will be exercised end-to-end by the next publish; I'm verifying that live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)