### PR TITLE
fix(publish): exempt mirrored fixture bodies from soft-terminology scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -59,9 +59,12 @@ const patterns = [
 // ("hotkey"/"wallet"/"coldkey" are core Bittensor vocabulary that nearly every
 // subnet API documents). Keep this exemption scoped to the generated public/R2
 // artifact directories so source schemas are still covered by the terminology
-// guard. The hard secret patterns above still apply to these files, and captured
-// fixture response bodies get a separate soft-wording scan below so live response
-// data cannot hide wallet/key/hotkey wording under generic JSON keys.
+// guard. The hard secret patterns above still apply to these files. Captured
+// fixture response bodies additionally get a structural HARD-secret scan below
+// (parsed JSON string values, so a real key/token can't hide under a generic
+// JSON key); soft terminology stays exempt there too, since it is the same
+// public API vocabulary the subnet documents — soft-scanning mirrored bodies
+// guarantees false positives ("The miner hotkey to look up") and wedges publish.
 function isMirroredExternalSpec(relativePath) {
   return [
     /^public\/metagraph\/schemas\/(?!index\.json$)[^/]+\.json$/,
@@ -161,7 +164,10 @@ function scanCapturedFixtureBody(relativePath, content) {
 
   for (const { valuePath, value } of walkJsonStrings(body)) {
     for (const pattern of patterns) {
-      if (!pattern.soft) {
+      // Only HARD secret patterns apply to mirrored fixture bodies. Soft
+      // terminology (hotkey/wallet/coldkey wording) is legitimate upstream API
+      // documentation here, exactly as it is exempted for the line scan.
+      if (pattern.soft) {
         continue;
       }
       if (pattern.regex.test(value)) {

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -1,6 +1,37 @@
 import assert from "node:assert/strict";
-import { describe, test } from "vitest";
-import { isUnsafeResolvedUrl, isUnsafeUrl } from "../scripts/lib.mjs";
+import { execFileSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, test } from "vitest";
+import { isUnsafeResolvedUrl, isUnsafeUrl, repoRoot } from "../scripts/lib.mjs";
+
+const FIXTURE_DIR = path.join(repoRoot, "dist/metagraph-r2/metagraph/fixtures");
+const TEST_FIXTURE = "__public_safety_test__.json";
+const TEST_FIXTURE_PATH = path.join(FIXTURE_DIR, TEST_FIXTURE);
+
+async function writeTestFixture(body) {
+  await fs.mkdir(FIXTURE_DIR, { recursive: true });
+  await fs.writeFile(
+    TEST_FIXTURE_PATH,
+    JSON.stringify({ response: { body } }),
+    "utf8",
+  );
+}
+
+// Run the real scanner and return its combined output. The scanner walks the
+// whole repo, so its exit code depends on unrelated tree state — assertions key
+// off the test fixture's path in the output, which is independent of that.
+function runScanOutput() {
+  try {
+    execFileSync("node", ["scripts/scan-public-safety.mjs"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+    return "";
+  } catch (err) {
+    return `${err.stdout ?? ""}${err.stderr ?? ""}`;
+  }
+}
 
 describe("public URL safety checks", () => {
   test("blocks private, loopback, and link-local literal targets", () => {
@@ -41,6 +72,38 @@ describe("public URL safety checks", () => {
     assert.equal(
       await isUnsafeResolvedUrl("https://metagraphed.invalid/"),
       true,
+    );
+  });
+});
+
+describe("captured-fixture body scan", () => {
+  afterEach(async () => {
+    await fs.rm(TEST_FIXTURE_PATH, { force: true });
+  });
+
+  test("does not flag soft Bittensor terminology in a mirrored fixture body", async () => {
+    // Regression for the publish-wedging false positive: upstream API docs
+    // legitimately say "miner hotkey" / "validator hotkey path".
+    await writeTestFixture({
+      summary: "The miner hotkey to look up",
+      detail: "Provide the validator hotkey path and coldkey wording.",
+    });
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_FIXTURE),
+      false,
+      `soft terminology should be exempt in mirrored fixture bodies; got:\n${output}`,
+    );
+  });
+
+  test("still flags a hard secret hidden in a fixture body value", async () => {
+    await writeTestFixture({
+      note: "token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+    });
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_FIXTURE}:response.body`),
+      `hard secret patterns must still fire on fixture body values; got:\n${output}`,
     );
   });
 });


### PR DESCRIPTION
## Problem (live incident)

The scheduled 6h `publish-cloudflare.yml` has been **deterministically failing** at `scan:public-safety` since #567 merged (~14:32Z), so R2/KV data only stays fresh on manual dispatch — `/api/v1/health` `published_at` was stuck at the last manual publish while every scheduled run failed.

**Root cause:** `scanCapturedFixtureBody` (added in #567) applies **soft** terminology patterns to captured fixture *response bodies*, but it only ever runs on mirrored external fixtures (`isMirroredExternalFixture`) — exactly the files whose `hotkey`/`wallet`/`coldkey` wording is legitimate upstream API documentation (SN6/22/46/74/97 OpenAPI specs say things like "The miner hotkey to look up"). The line scan already exempts mirrored specs from soft patterns (#557); the body-walk re-introduced the exact false positive #557 fixed, so it fired by construction.

Invisible to PR CI because fixtures are only captured in the production build (`METAGRAPH_PRODUCTION_BUILD=1`), never committed.

## Fix

Flip the body-walk to apply **only HARD secret patterns** to parsed JSON string values — real defense-in-depth (a key/token can't hide under a generic JSON key) while soft terminology stays exempt, matching the line scan. **No HARD pattern is weakened.**

Adds a regression test: soft terminology in a mirrored fixture body passes; a hard secret (`ghp_…`) in a body value still fires.

## Verify
- `npx vitest run tests/public-safety.test.mjs` → 7 passed
- After merge: dispatch `publish-cloudflare.yml` to unstick the stale R2/KV data.