### PR TITLE
fix(release): make release-please actually trigger the OIDC publishes

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -7,12 +7,18 @@ name: Publish client SDK
 # publish, and a Trusted Publisher pointing at this repo + workflow + the
 # `npm-production` environment.
 on:
-  # Auto: release-please tags `client-v<semver>` when its Release PR merges
-  # (#394) → publish to npm. Manual: workflow_dispatch is kept as an override.
-  push:
-    tags:
-      - "client-v*"
+  # release-please dispatches this workflow after it merges a Release PR and
+  # creates the client-v<semver> tag + GitHub Release (#394), passing
+  # released_by_release_please=true so this run skips re-tagging. A bare manual
+  # dispatch is the override and self-tags. A push:tags trigger can't be used:
+  # GITHUB_TOKEN-created tags don't fire workflows, and the validate gate requires
+  # GITHUB_REF=refs/heads/main (a tag ref would fail it).
   workflow_dispatch:
+    inputs:
+      released_by_release_please:
+        description: "Internal: set by release-please's dispatch so this run skips the tag/release it already created."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -39,6 +45,8 @@ jobs:
           registry-url: https://registry.npmjs.org
 
       - name: Validate release version
+        env:
+          RELEASE_PLEASE_TRIGGERED: ${{ inputs.released_by_release_please }}
         run: bash scripts/validate-client-release.sh
 
       # Build + pack happen in THIS unprivileged job (no id-token). The privileged
@@ -89,6 +97,8 @@ jobs:
 
       - name: Validate release version
         id: release
+        env:
+          RELEASE_PLEASE_TRIGGERED: ${{ inputs.released_by_release_please }}
         run: bash scripts/validate-client-release.sh
 
       # Pull the tarball built by the unprivileged validate job — this job never
@@ -114,11 +124,11 @@ jobs:
           tarball=$(find "$RUNNER_TEMP/client-package" -maxdepth 1 -type f -name "*.tgz" -print -quit)
           npm publish "$tarball" --access public --provenance --ignore-scripts
 
-      # Only on the manual override — when release-please triggers via the
-      # client-v* tag, it has already created the tag + GitHub Release with the
-      # generated notes, so re-creating them here would conflict (#394).
+      # Only on the bare manual override. When release-please dispatched this run
+      # (released_by_release_please=true) it already created the tag + GitHub
+      # Release with the generated notes, so re-creating them here would conflict.
       - name: Tag + GitHub release
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.released_by_release_please != true
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -6,12 +6,18 @@ name: Publish Python SDK
 # trusted publisher pointing at this repo + workflow + the `pypi-production`
 # environment.
 on:
-  # Auto: release-please tags `python-v<semver>` when its Release PR merges
-  # (#394) → publish to PyPI. Manual: workflow_dispatch is kept as an override.
-  push:
-    tags:
-      - "python-v*"
+  # release-please dispatches this workflow after it merges a Release PR and
+  # creates the python-v<semver> tag + GitHub Release (#394), passing
+  # released_by_release_please=true so this run skips re-tagging. A bare manual
+  # dispatch is the override and self-tags. A push:tags trigger can't be used:
+  # GITHUB_TOKEN-created tags don't fire workflows, and the validate gate requires
+  # GITHUB_REF=refs/heads/main (a tag ref would fail it).
   workflow_dispatch:
+    inputs:
+      released_by_release_please:
+        description: "Internal: set by release-please's dispatch so this run skips the tag/release it already created."
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -35,6 +41,8 @@ jobs:
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
 
       - name: Validate release version
+        env:
+          RELEASE_PLEASE_TRIGGERED: ${{ inputs.released_by_release_please }}
         run: bash scripts/validate-python-release.sh
 
       # Build happens in THIS unprivileged job (no id-token). The privileged
@@ -77,6 +85,8 @@ jobs:
 
       - name: Validate release version
         id: release
+        env:
+          RELEASE_PLEASE_TRIGGERED: ${{ inputs.released_by_release_please }}
         run: bash scripts/validate-python-release.sh
 
       # Pull the dist built by the unprivileged build job — this job never builds,
@@ -92,10 +102,11 @@ jobs:
         with:
           packages-dir: ${{ runner.temp }}/dist
 
-      # Only on the manual override — release-please already created the tag +
-      # GitHub Release when triggered via the python-v* tag (#394).
+      # Only on the bare manual override. When release-please dispatched this run
+      # (released_by_release_please=true) it already created the tag + GitHub
+      # Release with the generated notes, so re-creating them here would conflict.
       - name: Tag + GitHub release
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && inputs.released_by_release_please != true
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ steps.release.outputs.tag }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write # dispatch publish-client / publish-python after a release
 
 concurrency:
   group: release-please
@@ -31,8 +32,27 @@ jobs:
           persist-credentials: false
 
       - name: Run release-please
+        id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      # release-please creates the component tag + GitHub Release with GITHUB_TOKEN,
+      # which (by GitHub's recursion-prevention rule) does NOT fire push/tag-based
+      # workflows. workflow_dispatch IS exempt from that rule, so we explicitly
+      # dispatch the OIDC publish workflows here, telling them release-please
+      # already created the tag/release. Without this, merging a Release PR would
+      # silently never publish.
+      - name: Dispatch npm publish
+        if: ${{ steps.release.outputs['packages/client--release_created'] == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish-client.yml --ref main -f released_by_release_please=true
+
+      - name: Dispatch PyPI publish
+        if: ${{ steps.release.outputs['python--release_created'] == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run publish-python.yml --ref main -f released_by_release_please=true

--- a/scripts/validate-client-release.sh
+++ b/scripts/validate-client-release.sh
@@ -21,8 +21,15 @@ fi
 
 release_tag="client-v$release_version"
 if git rev-parse "$release_tag" >/dev/null 2>&1; then
-  echo "::error::Release tag already exists: $release_tag"
-  exit 1
+  # release-please creates the tag BEFORE dispatching this publish, so a
+  # pre-existing tag is expected on that path. The npm-version check below is the
+  # real double-publish guard; only refuse on a stray tag in the manual flow.
+  if [ "${RELEASE_PLEASE_TRIGGERED:-}" = "true" ]; then
+    echo "Tag $release_tag already exists (created by release-please); continuing."
+  else
+    echo "::error::Release tag already exists: $release_tag"
+    exit 1
+  fi
 fi
 if npm view "@jsonbored/metagraphed@$release_version" version >/dev/null 2>&1; then
   echo "::error::npm version already exists: @jsonbored/metagraphed@$release_version"

--- a/scripts/validate-python-release.sh
+++ b/scripts/validate-python-release.sh
@@ -21,8 +21,15 @@ fi
 
 release_tag="python-v$release_version"
 if git rev-parse "$release_tag" >/dev/null 2>&1; then
-  echo "::error::Release tag already exists: $release_tag"
-  exit 1
+  # release-please creates the tag BEFORE dispatching this publish, so a
+  # pre-existing tag is expected on that path. The PyPI-version check below is the
+  # real double-publish guard; only refuse on a stray tag in the manual flow.
+  if [ "${RELEASE_PLEASE_TRIGGERED:-}" = "true" ]; then
+    echo "Tag $release_tag already exists (created by release-please); continuing."
+  else
+    echo "::error::Release tag already exists: $release_tag"
+    exit 1
+  fi
 fi
 if curl -fsS "https://pypi.org/pypi/metagraphed/$release_version/json" >/dev/null 2>&1; then
   echo "::error::PyPI version already exists: metagraphed==$release_version"


### PR DESCRIPTION
## Problem (verified HIGH ops)
release-please tags created with `GITHUB_TOKEN` don't fire the tag-gated `publish-client`/`publish-python` workflows (GitHub recursion-prevention). Every successful publish to date was a manual `workflow_dispatch`; merging a Release PR would *silently* never publish — and #612 had just added docs asserting the automation works.

## Fix
`workflow_dispatch`/`repository_dispatch` are **exempt** from the recursion rule, so `release-please.yml` now dispatches the publish workflows via `gh workflow run` (needs `actions: write`) when a component's `--release_created` output is true, passing `released_by_release_please=true`. On that path:
- the publish workflow **skips its own tag/release step** (release-please already created them);
- the validate gate **accepts the pre-existing tag** but still refuses on an existing npm/PyPI version (the real double-publish guard).

The dead `push: tags` triggers (which also fail the `GITHUB_REF=refs/heads/main` validate check) are replaced with the honest `workflow_dispatch` + internal input. A bare manual dispatch still self-tags as the override.

⚠️ First real release should be eyeballed — release-please can't be verified locally. `validate:workflows` + `bash -n` pass.