### PR TITLE
fix(serving): serve coverage/subnets R2-first so headline data isn't stale

### DIFF
--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -119,6 +119,27 @@ const DUAL_PATTERNS = [
   /^types\.d\.ts$/,
 ];
 
+// Dual-tier artifacts (committed + mirrored to R2) whose SERVING should prefer
+// the fresh R2 copy over the committed baseline. They carry per-publish data
+// (native_snapshot_captured_at, coverage counts) that the 6h refresh advances,
+// but the committed copy only changes on a code push — so the default
+// ASSETS-first dual resolution pins them to a stale snapshot, contradicting
+// /freshness on the same field. We keep them committed (the changelog diff +
+// ci-verify read the committed baseline) but serve R2-first, falling back to the
+// committed copy when R2 is cold (local/dev/CI).
+const R2_PREFERRED_DUAL_PATTERNS = [/^coverage\.json$/, /^subnets\.json$/];
+
+export function isR2PreferredDualArtifactPath(artifactPath = "") {
+  const normalized = artifactRelativePath(artifactPath);
+  if (
+    artifactStorageTierForRelativePath(normalized) !==
+    ARTIFACT_STORAGE_TIERS.dual
+  ) {
+    return false;
+  }
+  return R2_PREFERRED_DUAL_PATTERNS.some((pattern) => pattern.test(normalized));
+}
+
 export function artifactRelativePath(artifactPath = "") {
   const value = String(artifactPath);
   const normalized = value.replace(/^\/+/, "");

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -58,6 +58,7 @@ import {
   artifactStorageTierForPath,
   artifactStorageTierForRelativePath,
   isR2OnlyArtifactPath,
+  isR2PreferredDualArtifactPath,
   schemaDetailArtifactRelativePath,
 } from "../src/artifact-storage.mjs";
 import { buildCanonicalOpenApiArtifact } from "../scripts/openapi-components.mjs";
@@ -629,6 +630,25 @@ describe("script utility contracts", () => {
       true,
     );
     assert.equal(isR2OnlyArtifactPath("/metagraph/contracts.json"), false);
+    // R2-preferred dual artifacts: committed (for changelog/ci-verify) but served
+    // R2-first so per-publish fields aren't pinned to the committed snapshot.
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/coverage.json"),
+      true,
+    );
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/subnets.json"),
+      true,
+    );
+    // Other dual artifacts stay committed-first; R2-only artifacts are not "dual".
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/contracts.json"),
+      false,
+    );
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/freshness.json"),
+      false,
+    );
     assert.equal(
       schemaDetailArtifactRelativePath(
         "/metagraph/schemas/sn-6-numinous-openapi-schema.json",

--- a/tests/worker-runtime.test.mjs
+++ b/tests/worker-runtime.test.mjs
@@ -324,6 +324,71 @@ describe("Worker runtime", () => {
     assert.equal((await response.json()).endpoints[0].id, "local-fallback");
   });
 
+  test("serves coverage/subnets R2-first with a committed-asset fallback", async () => {
+    const committed = {
+      schema_version: 1,
+      generated_at: "1970-01-01T00:00:00.000Z",
+      native_snapshot_captured_at: "2026-06-14T09:03:28.000Z",
+    };
+    const fresh = {
+      schema_version: 1,
+      generated_at: "1970-01-01T00:00:00.000Z",
+      native_snapshot_captured_at: "2026-06-14T14:06:28.000Z",
+    };
+
+    // R2 warm → the fresh published copy wins over the stale committed asset.
+    const warm = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/coverage.json"),
+      {
+        ASSETS: {
+          async fetch() {
+            return Response.json(committed);
+          },
+        },
+        METAGRAPH_ARCHIVE: {
+          async get(key) {
+            assert.equal(key, "latest/coverage.json");
+            return {
+              async json() {
+                return fresh;
+              },
+            };
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(warm.status, 200);
+    assert.equal(warm.headers.get("x-metagraph-artifact-source"), "r2");
+    assert.equal(
+      (await warm.json()).native_snapshot_captured_at,
+      "2026-06-14T14:06:28.000Z",
+    );
+
+    // R2 cold → fall back to the committed baseline (local/dev/CI).
+    const cold = await handleRequest(
+      new Request("https://metagraph.sh/metagraph/subnets.json"),
+      {
+        ASSETS: {
+          async fetch() {
+            return Response.json(committed);
+          },
+        },
+        METAGRAPH_ARCHIVE: {
+          async get() {
+            return null;
+          },
+        },
+      },
+      {},
+    );
+    assert.equal(cold.status, 200);
+    assert.equal(
+      cold.headers.get("x-metagraph-artifact-source"),
+      "static-assets",
+    );
+  });
+
   test("serves metagraph latest as an R2-backed raw artifact", async () => {
     const r2KeysRequested = [];
     const metagraphLatest = {

--- a/workers/storage.mjs
+++ b/workers/storage.mjs
@@ -7,6 +7,7 @@
 import {
   artifactStorageTierForPath,
   ARTIFACT_STORAGE_TIERS,
+  isR2PreferredDualArtifactPath,
 } from "../src/artifact-storage.mjs";
 import { METAGRAPH_LATEST_KEY } from "./config.mjs";
 
@@ -68,6 +69,22 @@ export async function readArtifact(env, artifactPath) {
       r2_code: r2.code,
     });
     return readAsset(env, artifactPath, storageTier);
+  }
+
+  // R2-preferred dual artifacts (coverage/subnets): serve the fresh published R2
+  // copy so per-publish fields (native_snapshot_captured_at, coverage counts)
+  // are current, falling back to the committed baseline when R2 is cold. They
+  // stay dual so the changelog/ci-verify still read the committed copy.
+  if (isR2PreferredDualArtifactPath(artifactPath)) {
+    const r2Preferred = await readR2(env, artifactPath, storageTier);
+    if (r2Preferred.ok) {
+      return r2Preferred;
+    }
+    const assetFallback = await readAsset(env, artifactPath, storageTier);
+    if (assetFallback.ok) {
+      return assetFallback;
+    }
+    return r2Preferred.status !== 404 ? r2Preferred : assetFallback;
   }
 
   const asset = await readAsset(env, artifactPath, storageTier);


### PR DESCRIPTION
## Problem (verified HIGH data)
`/api/v1/coverage` and `/api/v1/subnets` served the committed copy (dual = ASSETS-first), so `native_snapshot_captured_at` was ~5h staler than `/freshness` reported it — a self-contradiction on the registry's two most-queried endpoints that undercuts the "trustworthy coverage" moat.

## Fix
Serving-only change: resolve coverage.json + subnets.json **R2-first** (the 6h publish writes a fresh R2 mirror), falling back to the committed copy when R2 is cold. They stay `dual`/committed so the changelog diff + ci-verify still read the committed baseline — only the resolution order changes, no contract/tier metadata moves. Staleness drops from hours/days to the ~5-min edge-cache window.

Adds unit coverage for `isR2PreferredDualArtifactPath` + an integration test (R2-warm serves fresh, R2-cold falls back to committed). 68 affected tests pass; lint + format clean.