### PR TITLE
test: make the suite deterministic + idempotent vs committed-artifact drift

### DIFF
--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -1008,25 +1008,35 @@ async function validateGeneratedArtifacts(
   }
 
   assert(
-    coverageArtifact.chain_subnet_count === nativeSnapshot.subnets.length,
-    "coverage: chain_subnet_count mismatch",
-  );
-  assert(
-    coverageArtifact.curated_overlay_count === nativeSnapshot.subnets.length,
-    "coverage: curated_overlay_count mismatch",
-  );
-  assert(
     coverageArtifact.native_only_count === 0,
     "coverage: native_only_count must be 0",
   );
-  assert(
-    coverageArtifact.surface_count === surfacesArtifact.surfaces.length,
-    "coverage: surface_count mismatch",
-  );
-  assert(
-    coverageArtifact.candidate_count === candidates.length,
-    "coverage: candidate_count mismatch",
-  );
+  // The committed coverage.json is an inert cold-start seed (ADR 0006) that
+  // legitimately drifts from live source as candidate PRs merge — the 6h refresh
+  // advances R2/D1, not the committed copy. These committed-vs-fresh count-parity
+  // checks are a post-build freshness guarantee (CI builds before validating, and
+  // pipeline:refresh rebuilds), so they are meaningless against the stale seed in
+  // a no-build context. METAGRAPH_ALLOW_SEED_DRIFT lets the no-build test suite
+  // validate structure without them; CI/pipeline never set it, so freshness stays
+  // enforced where the artifacts are actually fresh.
+  if (process.env.METAGRAPH_ALLOW_SEED_DRIFT !== "1") {
+    assert(
+      coverageArtifact.chain_subnet_count === nativeSnapshot.subnets.length,
+      "coverage: chain_subnet_count mismatch",
+    );
+    assert(
+      coverageArtifact.curated_overlay_count === nativeSnapshot.subnets.length,
+      "coverage: curated_overlay_count mismatch",
+    );
+    assert(
+      coverageArtifact.surface_count === surfacesArtifact.surfaces.length,
+      "coverage: surface_count mismatch",
+    );
+    assert(
+      coverageArtifact.candidate_count === candidates.length,
+      "coverage: candidate_count mismatch",
+    );
+  }
   assert(
     candidatesArtifact.candidates.length === candidates.length,
     "candidates artifact: count mismatch",

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -4,6 +4,7 @@ import {
   chmodSync,
   cpSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
@@ -12,7 +13,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { test } from "vitest";
+import { afterAll, beforeAll, test } from "vitest";
 import {
   artifactDirectoryPath,
   artifactFilePath,
@@ -37,8 +38,62 @@ function runNode(script) {
     cwd: process.cwd(),
     encoding: "utf8",
     stdio: "pipe",
+    // The committed artifacts are an inert cold-start seed (ADR 0006) that drifts
+    // from live source between publishes. This no-build suite validates structure;
+    // committed-vs-fresh freshness parity is gated in CI (post-build) instead.
+    env: { ...process.env, METAGRAPH_ALLOW_SEED_DRIFT: "1" },
   });
 }
+
+// Snapshot/restore the served public/ tree so the build-running tests below leave
+// the working tree exactly as they found it. build-artifacts.mjs regenerates from
+// current source (which drifts from the committed seed), so restoring exact bytes
+// keeps `npm test` idempotent — a contributor can't accidentally commit drift.
+const PUBLIC_TREE = path.join(process.cwd(), "public");
+
+function walkFilesRecursive(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...walkFilesRecursive(full));
+    } else if (entry.isFile()) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function snapshotPublicTree() {
+  if (!existsSync(PUBLIC_TREE)) {
+    return new Map();
+  }
+  return new Map(
+    walkFilesRecursive(PUBLIC_TREE).map((file) => [file, readFileSync(file)]),
+  );
+}
+
+function restorePublicTree(snapshot) {
+  if (existsSync(PUBLIC_TREE)) {
+    for (const file of walkFilesRecursive(PUBLIC_TREE)) {
+      if (!snapshot.has(file)) {
+        rmSync(file);
+      }
+    }
+  }
+  for (const [file, bytes] of snapshot) {
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, bytes);
+  }
+}
+
+let publicTreeSnapshot;
+beforeAll(() => {
+  publicTreeSnapshot = snapshotPublicTree();
+});
+afterAll(() => {
+  restorePublicTree(publicTreeSnapshot);
+});
 
 test("registry validates", () => {
   runNode("scripts/validate.mjs");


### PR DESCRIPTION
## Problem (verified HIGH)
`npm test` was ~50% RED on a clean checkout and left 13 `public/` files dirty:
1. `registry validates` ran validate.mjs's coverage **count-parity** asserts, which compare the committed coverage.json (an inert ADR-0006 seed that drifts as candidate PRs merge) against freshly-loaded source — flipping red based on test ordering.
2. The build-running tests regenerated artifacts from source and restored only 3 files, leaving the rest drifted (a contributor running `npm test` then `git add -A` would commit drift).

## Fix
- Gate the four committed-vs-fresh coverage count-parity asserts behind `METAGRAPH_ALLOW_SEED_DRIFT` (the no-build suite sets it; **CI never does**, so freshness stays enforced post-build). The structural `native_only_count` check stays unconditional.
- Add a `beforeAll`/`afterAll` exact-byte snapshot+restore of `public/` so the suite is idempotent.

## Verified
- `node scripts/validate.mjs` (no flag) still **fails on drift** → enforcement intact.
- Full `npm test` = **961/961**; two consecutive runs leave **0** artifact files dirty.