### PR TITLE
feat(client): throw on errors + add timeout, RPC, and pagination helpers

### DIFF
--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -61,14 +61,76 @@ export interface MetagraphedFetchOptions<Path extends ApiPath>
   baseUrl?: string;
   pathParams?: PathParams<Path>;
   query?: QueryParams<Path>;
+  /** Abort the request after this many ms (default 30000). Pass 0 to disable. An explicit `signal` takes precedence. */
+  timeoutMs?: number;
 }
 
+/** Thrown on a non-2xx response (or a JSON-RPC error). Carries the HTTP status, the API error code, and the parsed error envelope. Mirrors the Python client's MetagraphedError. */
+export class MetagraphedError extends Error {
+  readonly status: number;
+  readonly code: string | undefined;
+  readonly envelope: ErrorEnvelope | undefined;
+  constructor(
+    message: string,
+    status: number,
+    code?: string,
+    envelope?: ErrorEnvelope,
+  ) {
+    super(message);
+    this.name = "MetagraphedError";
+    this.status = status;
+    this.code = code;
+    this.envelope = envelope;
+  }
+}
+
+function isErrorEnvelope(body: unknown): body is ErrorEnvelope {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    (body as { ok?: unknown }).ok === false
+  );
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function resolveSignal(
+  signal: AbortSignal | null | undefined,
+  timeoutMs: number,
+): AbortSignal | undefined {
+  if (signal) {
+    return signal;
+  }
+  return timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+}
+
+/**
+ * Fetch a typed GET endpoint. Resolves to the success envelope on 2xx and
+ * THROWS a MetagraphedError (carrying status + error code + envelope) on any
+ * non-2xx, so a resolved value is always a success.
+ */
 export async function metagraphedFetch<Path extends ApiPath>(
   path: Path,
   options: MetagraphedFetchOptions<Path> = {},
 ): Promise<JsonResponse<Path>> {
-  const { baseUrl = "https://api.metagraph.sh", pathParams, query, ...init } =
-    options;
+  const {
+    baseUrl = "https://api.metagraph.sh",
+    pathParams,
+    query,
+    timeoutMs = 30000,
+    signal,
+    ...init
+  } = options;
   const resolvedPath = interpolatePath(
     String(path),
     pathParams as Record<string, string | number> | undefined,
@@ -86,8 +148,119 @@ export async function metagraphedFetch<Path extends ApiPath>(
       accept: "application/json",
       ...(init.headers || {}),
     },
+    signal: resolveSignal(signal, timeoutMs),
   });
-  return (await response.json()) as JsonResponse<Path>;
+  const body = await readJsonBody(response);
+  if (!response.ok) {
+    const envelope = isErrorEnvelope(body) ? body : undefined;
+    throw new MetagraphedError(
+      envelope?.error?.message ??
+        `GET ${url.pathname} failed with status ${response.status}`,
+      response.status,
+      envelope?.error?.code,
+      envelope,
+    );
+  }
+  return body as JsonResponse<Path>;
+}
+
+/**
+ * Follow cursor pagination for a list endpoint, yielding each page's success
+ * envelope until meta.pagination.next_cursor is exhausted.
+ */
+export async function* metagraphedPaginate<Path extends ApiPath>(
+  path: Path,
+  options: MetagraphedFetchOptions<Path> = {},
+): AsyncGenerator<JsonResponse<Path>, void, unknown> {
+  const baseQuery: Record<string, unknown> = {
+    ...(options.query as Record<string, unknown> | undefined),
+  };
+  let cursor: unknown = baseQuery.cursor;
+  for (;;) {
+    if (cursor !== undefined && cursor !== null) {
+      baseQuery.cursor = cursor;
+    }
+    const page = await metagraphedFetch(path, {
+      ...options,
+      query: baseQuery as unknown as QueryParams<Path>,
+    });
+    yield page;
+    const next = (
+      page as { meta?: { pagination?: { next_cursor?: unknown } } }
+    )?.meta?.pagination?.next_cursor;
+    if (next === undefined || next === null) {
+      return;
+    }
+    cursor = next;
+  }
+}
+
+export interface JsonRpcRequest {
+  method: string;
+  params?: unknown[];
+}
+
+export interface MetagraphedRpcOptions {
+  baseUrl?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal | null;
+  id?: number | string;
+}
+
+/**
+ * Call the read-only Subtensor RPC proxy (POST /rpc/v1/<network>) and return the
+ * JSON-RPC result. Throws MetagraphedError on an HTTP or JSON-RPC-level error.
+ */
+export async function metagraphedRpc<Result = unknown>(
+  network: string,
+  request: JsonRpcRequest,
+  options: MetagraphedRpcOptions = {},
+): Promise<Result> {
+  const {
+    baseUrl = "https://api.metagraph.sh",
+    timeoutMs = 30000,
+    signal,
+    id = 1,
+  } = options;
+  const url = new URL(`/rpc/v1/${encodeURIComponent(network)}`, baseUrl);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: request.method,
+      params: request.params ?? [],
+    }),
+    signal: resolveSignal(signal, timeoutMs),
+  });
+  const body = await readJsonBody(response);
+  if (!response.ok) {
+    const envelope = isErrorEnvelope(body) ? body : undefined;
+    throw new MetagraphedError(
+      envelope?.error?.message ??
+        `RPC ${request.method} failed with status ${response.status}`,
+      response.status,
+      envelope?.error?.code,
+      envelope,
+    );
+  }
+  const rpcError = (
+    body as { error?: { code?: unknown; message?: unknown } }
+  )?.error;
+  if (rpcError) {
+    throw new MetagraphedError(
+      typeof rpcError.message === "string" ? rpcError.message : "JSON-RPC error",
+      response.status,
+      rpcError.code === undefined || rpcError.code === null
+        ? undefined
+        : String(rpcError.code),
+    );
+  }
+  return (body as { result?: Result })?.result as Result;
 }
 
 function interpolatePath(

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -30,13 +30,62 @@ const overview = await metagraphedFetch("/api/v1/subnets/{netuid}/overview", {
   pathParams: { netuid: 7 },
 });
 
-// Point at a different origin (e.g. a preview deployment).
+// Point at a different origin, and tune/disable the request timeout.
 const health = await metagraphedFetch("/api/v1/health", {
   baseUrl: "https://metagraph.sh",
+  timeoutMs: 5000, // default 30000; pass 0 to disable; an explicit `signal` wins
 });
 ```
 
-Every response is the standard envelope `{ ok, schema_version, data, meta }`
+A resolved value is always a **success** envelope. On any non-2xx the client
+**throws** a `MetagraphedError` carrying the HTTP status, the API error code, and
+the parsed error envelope — so you branch with try/catch, not on `ok`:
+
+```ts
+import { metagraphedFetch, MetagraphedError } from "@jsonbored/metagraphed";
+
+try {
+  const subnet = await metagraphedFetch("/api/v1/subnets/{netuid}", {
+    pathParams: { netuid: 7 },
+  });
+  console.log(subnet.data);
+} catch (error) {
+  if (error instanceof MetagraphedError) {
+    // error.status (e.g. 404), error.code (e.g. "artifact_not_found"), error.envelope
+    if (error.code === "rate_limited") {
+      /* back off and retry */
+    }
+  }
+}
+```
+
+### Paginate a list endpoint
+
+`metagraphedPaginate` follows `meta.pagination.next_cursor` until it's exhausted:
+
+```ts
+import { metagraphedPaginate } from "@jsonbored/metagraphed";
+
+for await (const page of metagraphedPaginate("/api/v1/subnets", {
+  query: { limit: 100 },
+})) {
+  for (const subnet of page.data) console.log(subnet.netuid);
+}
+```
+
+### Call the read-only RPC proxy
+
+`metagraphedRpc` POSTs a JSON-RPC request to the Subtensor proxy
+(`/rpc/v1/<network>`) and returns the `result`, throwing `MetagraphedError` on an
+HTTP or JSON-RPC-level error:
+
+```ts
+import { metagraphedRpc } from "@jsonbored/metagraphed";
+
+const healthInfo = await metagraphedRpc("finney", { method: "system_health" });
+```
+
+Every REST response is the standard envelope `{ ok, schema_version, data, meta }`
 (`meta.pagination` on list routes, `meta.published_at` for freshness). See the
 [API stability guide](https://github.com/JSONbored/metagraphed/blob/main/docs/api-stability.md)
 for the envelope, pagination, caching, error codes, and `x-metagraph-*` headers.

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -81,14 +81,76 @@ export interface MetagraphedFetchOptions<Path extends ApiPath>
   baseUrl?: string;
   pathParams?: PathParams<Path>;
   query?: QueryParams<Path>;
+  /** Abort the request after this many ms (default 30000). Pass 0 to disable. An explicit \`signal\` takes precedence. */
+  timeoutMs?: number;
 }
 
+/** Thrown on a non-2xx response (or a JSON-RPC error). Carries the HTTP status, the API error code, and the parsed error envelope. Mirrors the Python client's MetagraphedError. */
+export class MetagraphedError extends Error {
+  readonly status: number;
+  readonly code: string | undefined;
+  readonly envelope: ErrorEnvelope | undefined;
+  constructor(
+    message: string,
+    status: number,
+    code?: string,
+    envelope?: ErrorEnvelope,
+  ) {
+    super(message);
+    this.name = "MetagraphedError";
+    this.status = status;
+    this.code = code;
+    this.envelope = envelope;
+  }
+}
+
+function isErrorEnvelope(body: unknown): body is ErrorEnvelope {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    (body as { ok?: unknown }).ok === false
+  );
+}
+
+async function readJsonBody(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    return text;
+  }
+}
+
+function resolveSignal(
+  signal: AbortSignal | null | undefined,
+  timeoutMs: number,
+): AbortSignal | undefined {
+  if (signal) {
+    return signal;
+  }
+  return timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+}
+
+/**
+ * Fetch a typed GET endpoint. Resolves to the success envelope on 2xx and
+ * THROWS a MetagraphedError (carrying status + error code + envelope) on any
+ * non-2xx, so a resolved value is always a success.
+ */
 export async function metagraphedFetch<Path extends ApiPath>(
   path: Path,
   options: MetagraphedFetchOptions<Path> = {},
 ): Promise<JsonResponse<Path>> {
-  const { baseUrl = "https://api.metagraph.sh", pathParams, query, ...init } =
-    options;
+  const {
+    baseUrl = "https://api.metagraph.sh",
+    pathParams,
+    query,
+    timeoutMs = 30000,
+    signal,
+    ...init
+  } = options;
   const resolvedPath = interpolatePath(
     String(path),
     pathParams as Record<string, string | number> | undefined,
@@ -106,8 +168,119 @@ export async function metagraphedFetch<Path extends ApiPath>(
       accept: "application/json",
       ...(init.headers || {}),
     },
+    signal: resolveSignal(signal, timeoutMs),
   });
-  return (await response.json()) as JsonResponse<Path>;
+  const body = await readJsonBody(response);
+  if (!response.ok) {
+    const envelope = isErrorEnvelope(body) ? body : undefined;
+    throw new MetagraphedError(
+      envelope?.error?.message ??
+        \`GET \${url.pathname} failed with status \${response.status}\`,
+      response.status,
+      envelope?.error?.code,
+      envelope,
+    );
+  }
+  return body as JsonResponse<Path>;
+}
+
+/**
+ * Follow cursor pagination for a list endpoint, yielding each page's success
+ * envelope until meta.pagination.next_cursor is exhausted.
+ */
+export async function* metagraphedPaginate<Path extends ApiPath>(
+  path: Path,
+  options: MetagraphedFetchOptions<Path> = {},
+): AsyncGenerator<JsonResponse<Path>, void, unknown> {
+  const baseQuery: Record<string, unknown> = {
+    ...(options.query as Record<string, unknown> | undefined),
+  };
+  let cursor: unknown = baseQuery.cursor;
+  for (;;) {
+    if (cursor !== undefined && cursor !== null) {
+      baseQuery.cursor = cursor;
+    }
+    const page = await metagraphedFetch(path, {
+      ...options,
+      query: baseQuery as unknown as QueryParams<Path>,
+    });
+    yield page;
+    const next = (
+      page as { meta?: { pagination?: { next_cursor?: unknown } } }
+    )?.meta?.pagination?.next_cursor;
+    if (next === undefined || next === null) {
+      return;
+    }
+    cursor = next;
+  }
+}
+
+export interface JsonRpcRequest {
+  method: string;
+  params?: unknown[];
+}
+
+export interface MetagraphedRpcOptions {
+  baseUrl?: string;
+  timeoutMs?: number;
+  signal?: AbortSignal | null;
+  id?: number | string;
+}
+
+/**
+ * Call the read-only Subtensor RPC proxy (POST /rpc/v1/<network>) and return the
+ * JSON-RPC result. Throws MetagraphedError on an HTTP or JSON-RPC-level error.
+ */
+export async function metagraphedRpc<Result = unknown>(
+  network: string,
+  request: JsonRpcRequest,
+  options: MetagraphedRpcOptions = {},
+): Promise<Result> {
+  const {
+    baseUrl = "https://api.metagraph.sh",
+    timeoutMs = 30000,
+    signal,
+    id = 1,
+  } = options;
+  const url = new URL(\`/rpc/v1/\${encodeURIComponent(network)}\`, baseUrl);
+  const response = await fetch(url, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id,
+      method: request.method,
+      params: request.params ?? [],
+    }),
+    signal: resolveSignal(signal, timeoutMs),
+  });
+  const body = await readJsonBody(response);
+  if (!response.ok) {
+    const envelope = isErrorEnvelope(body) ? body : undefined;
+    throw new MetagraphedError(
+      envelope?.error?.message ??
+        \`RPC \${request.method} failed with status \${response.status}\`,
+      response.status,
+      envelope?.error?.code,
+      envelope,
+    );
+  }
+  const rpcError = (
+    body as { error?: { code?: unknown; message?: unknown } }
+  )?.error;
+  if (rpcError) {
+    throw new MetagraphedError(
+      typeof rpcError.message === "string" ? rpcError.message : "JSON-RPC error",
+      response.status,
+      rpcError.code === undefined || rpcError.code === null
+        ? undefined
+        : String(rpcError.code),
+    );
+  }
+  return (body as { result?: Result })?.result as Result;
 }
 
 function interpolatePath(

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -1,0 +1,186 @@
+// Hermetic tests for the published @jsonbored/metagraphed TS client (global fetch
+// mocked, no network). Mirrors python/tests/test_client.py and covers the
+// throw-on-error contract, timeout signal, RPC helper, and cursor pagination.
+import { afterEach, describe, expect, test, vi } from "vitest";
+import {
+  MetagraphedError,
+  metagraphedFetch,
+  metagraphedPaginate,
+  metagraphedRpc,
+} from "../generated/metagraphed-client";
+
+function stubFetch(
+  impl: (url: URL, init: RequestInit) => Promise<Response>,
+): ReturnType<typeof vi.fn> {
+  const fn = vi.fn(impl);
+  globalThis.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+function jsonResponse(payload: unknown, status = 200): Response {
+  return new Response(JSON.stringify(payload), { status });
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("metagraphedFetch", () => {
+  test("interpolates path params, sets accept, builds the URL", async () => {
+    const fetchMock = stubFetch(async () =>
+      jsonResponse({
+        ok: true,
+        schema_version: 1,
+        data: { netuid: 7 },
+        meta: {},
+      }),
+    );
+    const out = await metagraphedFetch("/api/v1/subnets/{netuid}" as never, {
+      pathParams: { netuid: 7 } as never,
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe("https://api.metagraph.sh/api/v1/subnets/7");
+    expect((init.headers as Record<string, string>).accept).toBe(
+      "application/json",
+    );
+    expect((out as { data: unknown }).data).toEqual({ netuid: 7 });
+  });
+
+  test("drops undefined/null query params, applies the rest", async () => {
+    const fetchMock = stubFetch(async () =>
+      jsonResponse({ ok: true, data: [], meta: {} }),
+    );
+    await metagraphedFetch("/api/v1/subnets" as never, {
+      query: { limit: 2, cursor: undefined, q: null } as never,
+    });
+    const url = fetchMock.mock.calls[0][0] as URL;
+    expect(url.searchParams.get("limit")).toBe("2");
+    expect(url.searchParams.has("cursor")).toBe(false);
+    expect(url.searchParams.has("q")).toBe(false);
+  });
+
+  test("honors a baseUrl override", async () => {
+    const fetchMock = stubFetch(async () =>
+      jsonResponse({ ok: true, data: {}, meta: {} }),
+    );
+    await metagraphedFetch("/api/v1/health" as never, {
+      baseUrl: "https://staging.example.com",
+    });
+    expect((fetchMock.mock.calls[0][0] as URL).toString()).toBe(
+      "https://staging.example.com/api/v1/health",
+    );
+  });
+
+  test("throws MetagraphedError surfacing the error envelope on non-2xx", async () => {
+    stubFetch(async () =>
+      jsonResponse(
+        {
+          ok: false,
+          schema_version: 1,
+          data: null,
+          error: { code: "artifact_not_found", message: "No subnet 99999" },
+        },
+        404,
+      ),
+    );
+    const error = await metagraphedFetch("/api/v1/subnets/{netuid}" as never, {
+      pathParams: { netuid: 99999 } as never,
+    }).catch((caught: unknown) => caught);
+    expect(error).toBeInstanceOf(MetagraphedError);
+    expect(error).toMatchObject({
+      status: 404,
+      code: "artifact_not_found",
+      message: "No subnet 99999",
+    });
+  });
+
+  test("throws on a missing path parameter", async () => {
+    stubFetch(async () => jsonResponse({ ok: true, data: {}, meta: {} }));
+    await expect(
+      metagraphedFetch("/api/v1/subnets/{netuid}" as never, {
+        pathParams: {} as never,
+      }),
+    ).rejects.toThrow(/Missing path parameter/);
+  });
+
+  test("passes an abort signal by default and none when timeoutMs is 0", async () => {
+    const fetchMock = stubFetch(async () =>
+      jsonResponse({ ok: true, data: {}, meta: {} }),
+    );
+    await metagraphedFetch("/api/v1/health" as never, {});
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal).toBeInstanceOf(
+      AbortSignal,
+    );
+    await metagraphedFetch("/api/v1/health" as never, { timeoutMs: 0 });
+    expect((fetchMock.mock.calls[1][1] as RequestInit).signal).toBeUndefined();
+  });
+});
+
+describe("metagraphedPaginate", () => {
+  test("follows next_cursor until exhausted, carrying the cursor", async () => {
+    const pages = [
+      { ok: true, data: [1], meta: { pagination: { next_cursor: "2" } } },
+      { ok: true, data: [2], meta: { pagination: { next_cursor: null } } },
+    ];
+    let index = 0;
+    const fetchMock = stubFetch(async () => jsonResponse(pages[index++]));
+    const seen: number[] = [];
+    for await (const page of metagraphedPaginate("/api/v1/subnets" as never, {
+      query: { limit: 1 } as never,
+    })) {
+      seen.push((page as { data: number[] }).data[0]);
+    }
+    expect(seen).toEqual([1, 2]);
+    expect((fetchMock.mock.calls[1][0] as URL).searchParams.get("cursor")).toBe(
+      "2",
+    );
+  });
+});
+
+describe("metagraphedRpc", () => {
+  test("posts a JSON-RPC body and returns the result", async () => {
+    const fetchMock = stubFetch(async () =>
+      jsonResponse({ jsonrpc: "2.0", id: 1, result: { peers: 40 } }),
+    );
+    const result = await metagraphedRpc<{ peers: number }>("finney", {
+      method: "system_health",
+    });
+    expect(result).toEqual({ peers: 40 });
+    const [url, init] = fetchMock.mock.calls[0] as [URL, RequestInit];
+    expect(url.toString()).toBe("https://api.metagraph.sh/rpc/v1/finney");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      jsonrpc: "2.0",
+      method: "system_health",
+      params: [],
+    });
+  });
+
+  test("throws MetagraphedError on a JSON-RPC-level error", async () => {
+    stubFetch(async () =>
+      jsonResponse({
+        jsonrpc: "2.0",
+        id: 1,
+        error: { code: -32601, message: "Method not found" },
+      }),
+    );
+    await expect(
+      metagraphedRpc("finney", { method: "nope" }),
+    ).rejects.toMatchObject({ name: "MetagraphedError", code: "-32601" });
+  });
+
+  test("throws MetagraphedError on an HTTP error, surfacing the envelope", async () => {
+    stubFetch(async () =>
+      jsonResponse(
+        {
+          ok: false,
+          error: { code: "rpc_method_blocked", message: "blocked" },
+        },
+        403,
+      ),
+    );
+    await expect(
+      metagraphedRpc("finney", { method: "author_submitExtrinsic" }),
+    ).rejects.toMatchObject({ status: 403, code: "rpc_method_blocked" });
+  });
+});


### PR DESCRIPTION
## Problem (verified HIGH + medium DX, published npm package)
`metagraphedFetch` never checked `response.ok` and typed **every** response as guaranteed-success, so a 4xx/5xx silently returned an error envelope the types claimed was success data — `if (!res.ok)` was statically unreachable. Python already raises; this brings TS to parity. Also: no timeout, no pagination helper, the RPC proxy was unreachable, and the client had **zero tests**.

## Changes (all in the generator template → regenerated + contract-gated)
- **Throw `MetagraphedError`** (carrying `status`, `code`, `envelope`) on non-2xx; a resolved value is always a success.
- **Default 30s timeout** via `AbortSignal.timeout` (`timeoutMs`, `0` disables, explicit `signal` wins).
- **`metagraphedPaginate`** — async generator following `meta.pagination.next_cursor`.
- **`metagraphedRpc`** — POST the read-only `/rpc/v1/<network>` proxy, returns the JSON-RPC result.
- **10-test hermetic vitest suite** (mirrors the Python suite) + README updated to model try/catch + the helpers.

⚠️ Behavior change for consumers who relied on the old buggy error-envelope-as-success return (documented). validate:generated-client + contract-drift pass; 10/10 tests pass; tsup `--dts` type-check clean.