### PR TITLE
feat(python): retry/backoff + pagination + RPC helpers + single-source version

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -46,7 +46,29 @@ Every response is the standard envelope:
 ```
 
 On a network failure or non-2xx response, a `MetagraphedError` is raised (with
-`.status` for HTTP errors).
+`.status` for HTTP errors, and the API error code/message in the message).
+
+### Retries, pagination, and the RPC proxy
+
+```python
+from metagraphed import (
+    MetagraphedClient,
+    metagraphed_paginate,
+    metagraphed_rpc,
+)
+
+# Opt-in retry/backoff for idempotent GETs (retries 429/5xx + network errors,
+# honoring a numeric Retry-After). Disabled by default.
+client = MetagraphedClient(retries=3)
+
+# Iterate every page of a list endpoint (follows meta.pagination.next_cursor):
+for page in client.paginate("/api/v1/subnets", query={"limit": 100}):
+    for subnet in page["data"]["subnets"]:
+        print(subnet["netuid"])
+
+# Call the read-only Subtensor RPC proxy and get back the JSON-RPC result:
+info = metagraphed_rpc("finney", "system_health")
+```
 
 ## Versioning & stability
 

--- a/python/src/metagraphed/__init__.py
+++ b/python/src/metagraphed/__init__.py
@@ -7,6 +7,8 @@ from .client import (
     MetagraphedError,
     __version__,
     metagraphed_fetch,
+    metagraphed_paginate,
+    metagraphed_rpc,
 )
 
 __all__ = [
@@ -15,5 +17,7 @@ __all__ = [
     "MetagraphedClient",
     "MetagraphedError",
     "metagraphed_fetch",
+    "metagraphed_paginate",
+    "metagraphed_rpc",
     "__version__",
 ]

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -9,13 +9,25 @@ from __future__ import annotations
 
 import json
 import re
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
-from typing import Any, Mapping, Optional
+from importlib.metadata import PackageNotFoundError, version as _package_version
+from typing import Any, Iterator, Mapping, Optional, Sequence
 
-__version__ = "0.1.1"
+# Single source of truth = the package metadata (pyproject.toml `version`, which
+# release-please bumps); read it at runtime so the User-Agent can never disagree
+# with the published wheel. Falls back when running uninstalled from source.
+try:
+    __version__ = _package_version("metagraphed")
+except PackageNotFoundError:
+    __version__ = "0.0.0+local"
+
 DEFAULT_BASE_URL = "https://api.metagraph.sh"
+# Transient HTTP statuses worth retrying for idempotent GETs (opt-in via the
+# ``retries`` argument). 429/503 may carry a Retry-After header we honor.
+_RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
 # A descriptive User-Agent is required: api.metagraph.sh sits behind a Cloudflare
 # managed bot rule that returns HTTP 403 for stdlib urllib's default
 # "Python-urllib/<ver>" UA. Callers may override it via the ``headers`` argument.
@@ -53,12 +65,18 @@ def metagraphed_fetch(
     query: Optional[Mapping[str, Any]] = None,
     headers: Optional[Mapping[str, str]] = None,
     timeout: float = 30.0,
+    retries: int = 0,
+    backoff: float = 0.5,
 ) -> Any:
     """GET ``path`` against metagraphed and return the parsed JSON envelope.
 
     ``path`` may contain ``{name}`` segments filled from ``path_params``.
     ``query`` values that are ``None`` are dropped. Raises
     :class:`MetagraphedError` on a network failure or a non-2xx response.
+
+    Set ``retries`` > 0 to retry idempotent GETs on transient errors (HTTP
+    429/5xx and network failures) with exponential ``backoff`` seconds, honoring
+    a numeric ``Retry-After`` header. Retries are opt-in (default 0).
     """
     url = base_url.rstrip("/") + _interpolate(path, path_params)
     if query:
@@ -74,16 +92,27 @@ def metagraphed_fetch(
     for key, value in merged_headers.items():
         request.add_header(key, value)
 
-    try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
-            body = response.read().decode("utf-8")
-    except urllib.error.HTTPError as error:
-        raise MetagraphedError(
-            f"GET {url} failed: HTTP {error.code}{_error_detail(error)}",
-            status=error.code,
-        ) from error
-    except urllib.error.URLError as error:
-        raise MetagraphedError(f"GET {url} failed: {error.reason}") from error
+    attempt = 0
+    while True:
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                body = response.read().decode("utf-8")
+            break
+        except urllib.error.HTTPError as error:
+            if attempt < retries and error.code in _RETRY_STATUSES:
+                time.sleep(_retry_delay(error, attempt, backoff))
+                attempt += 1
+                continue
+            raise MetagraphedError(
+                f"GET {url} failed: HTTP {error.code}{_error_detail(error)}",
+                status=error.code,
+            ) from error
+        except urllib.error.URLError as error:
+            if attempt < retries:
+                time.sleep(backoff * (2**attempt))
+                attempt += 1
+                continue
+            raise MetagraphedError(f"GET {url} failed: {error.reason}") from error
 
     try:
         return json.loads(body)
@@ -91,6 +120,23 @@ def metagraphed_fetch(
         raise MetagraphedError(
             f"GET {url} returned a non-JSON response"
         ) from error
+
+
+def _retry_delay(
+    error: "urllib.error.HTTPError", attempt: int, backoff: float
+) -> float:
+    """Seconds to wait before a retry: a numeric Retry-After if present, else
+    exponential backoff. Never raises."""
+    try:
+        retry_after = error.headers.get("Retry-After")
+    except Exception:
+        retry_after = None
+    if retry_after:
+        try:
+            return max(0.0, float(int(retry_after)))
+        except (TypeError, ValueError):
+            pass
+    return backoff * (2**attempt)
 
 
 def _error_detail(error: "urllib.error.HTTPError") -> str:
@@ -117,14 +163,124 @@ def _error_detail(error: "urllib.error.HTTPError") -> str:
     return f": {raw[:200]}"
 
 
+def metagraphed_paginate(
+    path: str,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    path_params: Optional[Mapping[str, Any]] = None,
+    query: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    timeout: float = 30.0,
+    retries: int = 0,
+) -> Iterator[Any]:
+    """Yield each page's envelope for a list endpoint, following
+    ``meta.pagination.next_cursor`` until it is exhausted."""
+    base_query = dict(query or {})
+    cursor = base_query.get("cursor")
+    while True:
+        page_query = dict(base_query)
+        if cursor is not None:
+            page_query["cursor"] = cursor
+        page = metagraphed_fetch(
+            path,
+            base_url=base_url,
+            path_params=path_params,
+            query=page_query,
+            headers=headers,
+            timeout=timeout,
+            retries=retries,
+        )
+        yield page
+        pagination = (
+            page.get("meta", {}).get("pagination")
+            if isinstance(page, dict)
+            else None
+        )
+        cursor = (
+            pagination.get("next_cursor") if isinstance(pagination, dict) else None
+        )
+        if cursor is None:
+            return
+
+
+def metagraphed_rpc(
+    network: str,
+    method: str,
+    params: Optional[Sequence[Any]] = None,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    headers: Optional[Mapping[str, str]] = None,
+    timeout: float = 30.0,
+    request_id: Any = 1,
+) -> Any:
+    """Call the read-only Subtensor RPC proxy (POST ``/rpc/v1/<network>``) and
+    return the JSON-RPC ``result``. Raises :class:`MetagraphedError` on a network
+    failure, a non-2xx response, or a JSON-RPC-level error object."""
+    url = (
+        base_url.rstrip("/")
+        + "/rpc/v1/"
+        + urllib.parse.quote(str(network), safe="")
+    )
+    payload = json.dumps(
+        {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": list(params or []),
+        }
+    ).encode("utf-8")
+
+    merged_headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+        "User-Agent": DEFAULT_USER_AGENT,
+    }
+    merged_headers.update(headers or {})
+
+    request = urllib.request.Request(url, data=payload, method="POST")
+    for key, value in merged_headers.items():
+        request.add_header(key, value)
+
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            body = response.read().decode("utf-8")
+    except urllib.error.HTTPError as error:
+        raise MetagraphedError(
+            f"RPC {method} failed: HTTP {error.code}{_error_detail(error)}",
+            status=error.code,
+        ) from error
+    except urllib.error.URLError as error:
+        raise MetagraphedError(f"RPC {method} failed: {error.reason}") from error
+
+    try:
+        parsed = json.loads(body)
+    except ValueError as error:
+        raise MetagraphedError(
+            f"RPC {method} returned a non-JSON response"
+        ) from error
+
+    rpc_error = parsed.get("error") if isinstance(parsed, dict) else None
+    if rpc_error:
+        message = (
+            rpc_error.get("message") if isinstance(rpc_error, dict) else None
+        )
+        raise MetagraphedError(f"RPC {method} error: {message or rpc_error}")
+    return parsed.get("result") if isinstance(parsed, dict) else None
+
+
 class MetagraphedClient:
-    """Convenience wrapper binding a ``base_url`` + default ``timeout``."""
+    """Convenience wrapper binding a ``base_url`` + default ``timeout``/``retries``."""
 
     def __init__(
-        self, base_url: str = DEFAULT_BASE_URL, *, timeout: float = 30.0
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        *,
+        timeout: float = 30.0,
+        retries: int = 0,
     ) -> None:
         self.base_url = base_url
         self.timeout = timeout
+        self.retries = retries
 
     def fetch(
         self,
@@ -134,7 +290,7 @@ class MetagraphedClient:
         query: Optional[Mapping[str, Any]] = None,
         headers: Optional[Mapping[str, str]] = None,
     ) -> Any:
-        """GET ``path`` using this client's ``base_url`` + ``timeout``."""
+        """GET ``path`` using this client's ``base_url`` + ``timeout`` + ``retries``."""
         return metagraphed_fetch(
             path,
             base_url=self.base_url,
@@ -142,4 +298,44 @@ class MetagraphedClient:
             query=query,
             headers=headers,
             timeout=self.timeout,
+            retries=self.retries,
+        )
+
+    def paginate(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Iterator[Any]:
+        """Iterate every page of a list endpoint (follows ``next_cursor``)."""
+        return metagraphed_paginate(
+            path,
+            base_url=self.base_url,
+            path_params=path_params,
+            query=query,
+            headers=headers,
+            timeout=self.timeout,
+            retries=self.retries,
+        )
+
+    def rpc(
+        self,
+        network: str,
+        method: str,
+        params: Optional[Sequence[Any]] = None,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        request_id: Any = 1,
+    ) -> Any:
+        """Call the read-only RPC proxy and return the JSON-RPC ``result``."""
+        return metagraphed_rpc(
+            network,
+            method,
+            params,
+            base_url=self.base_url,
+            headers=headers,
+            timeout=self.timeout,
+            request_id=request_id,
         )

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -5,7 +5,13 @@ import unittest
 import urllib.error
 from unittest import mock
 
-from metagraphed import MetagraphedClient, MetagraphedError, metagraphed_fetch
+from metagraphed import (
+    MetagraphedClient,
+    MetagraphedError,
+    metagraphed_fetch,
+    metagraphed_paginate,
+    metagraphed_rpc,
+)
 
 
 class _FakeResponse:
@@ -163,6 +169,85 @@ class ClientTest(unittest.TestCase):
         ):
             with self.assertRaises(MetagraphedError):
                 metagraphed_fetch("/api/v1/health")
+
+    def test_retries_transient_error_then_succeeds(self):
+        calls = {"n": 0}
+
+        def fake_urlopen(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise urllib.error.HTTPError(request.full_url, 503, "busy", {}, None)
+            return _FakeResponse({"ok": True, "data": {"healthy": True}})
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            out = metagraphed_fetch("/api/v1/health", retries=1, backoff=0)
+
+        self.assertEqual(calls["n"], 2)
+        self.assertTrue(out["data"]["healthy"])
+
+    def test_retries_exhausted_raises(self):
+        def fake_urlopen(request, timeout=None):
+            raise urllib.error.HTTPError(request.full_url, 503, "busy", {}, None)
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            with self.assertRaises(MetagraphedError) as ctx:
+                metagraphed_fetch("/api/v1/health", retries=2, backoff=0)
+        self.assertEqual(ctx.exception.status, 503)
+
+    def test_paginate_follows_next_cursor(self):
+        pages = [
+            {"ok": True, "data": [1], "meta": {"pagination": {"next_cursor": "2"}}},
+            {"ok": True, "data": [2], "meta": {"pagination": {"next_cursor": None}}},
+        ]
+        captured_urls = []
+        state = {"i": 0}
+
+        def fake_urlopen(request, timeout=None):
+            captured_urls.append(request.full_url)
+            page = pages[state["i"]]
+            state["i"] += 1
+            return _FakeResponse(page)
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            seen = [
+                page["data"][0]
+                for page in metagraphed_paginate("/api/v1/subnets", query={"limit": 1})
+            ]
+
+        self.assertEqual(seen, [1, 2])
+        self.assertIn("cursor=2", captured_urls[1])
+
+    def test_rpc_posts_jsonrpc_and_returns_result(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            captured["method"] = request.get_method()
+            captured["body"] = request.data
+            return _FakeResponse({"jsonrpc": "2.0", "id": 1, "result": {"peers": 40}})
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            result = metagraphed_rpc("finney", "system_health")
+
+        self.assertEqual(result, {"peers": 40})
+        self.assertEqual(captured["url"], "https://api.metagraph.sh/rpc/v1/finney")
+        self.assertEqual(captured["method"], "POST")
+        self.assertEqual(json.loads(captured["body"])["method"], "system_health")
+
+    def test_rpc_jsonrpc_error_raises(self):
+        def fake_urlopen(request, timeout=None):
+            return _FakeResponse(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32601, "message": "Method not found"},
+                }
+            )
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            with self.assertRaises(MetagraphedError) as ctx:
+                metagraphed_rpc("finney", "nope")
+        self.assertIn("Method not found", str(ctx.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Changes (verified MEDIUM, published PyPI package)
- **Opt-in retry/backoff** on `metagraphed_fetch` for idempotent GETs (429/5xx + network errors, honoring numeric `Retry-After`; default 0 → no behavior change).
- **`metagraphed_paginate`** (follows `meta.pagination.next_cursor`) + **`metagraphed_rpc`** (POST the read-only `/rpc/v1/<network>` proxy → JSON-RPC result, raises on HTTP/JSON-RPC errors). Both also on `MetagraphedClient`.
- **Version de-duplication:** `__version__` now reads from installed package metadata, so it can't drift from the wheel. pyproject.toml stays the single static source **release-please bumps** (kept it this way rather than dynamic-from-client.py so the release flow from #619 keeps working).
- 5 new hermetic tests (15 total) + README docs.

All 15 `unittest` tests pass locally.