### PR TITLE
feat(mcp): structured error codes, clean not-found, registry version sync

### DIFF
--- a/scripts/validate-mcp.mjs
+++ b/scripts/validate-mcp.mjs
@@ -6,6 +6,7 @@
 // MCP endpoint is not artifact-backed and must not enter the
 // `checks.length === API_ROUTES.length` invariant.
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import Ajv2020 from "ajv/dist/2020.js";
 import { handleRequest } from "../workers/api.mjs";
 import {
@@ -122,6 +123,16 @@ assert.equal(
   init.body.result.serverInfo.version,
   MCP_SERVER_VERSION,
   "serverInfo.version must match the MCP_SERVER_VERSION constant",
+);
+// The MCP Registry listing (server.json) must advertise the same version the
+// live server reports, so registry discovery and a direct connect agree.
+const serverManifestVersion = JSON.parse(
+  readFileSync("server.json", "utf8"),
+).version;
+assert.equal(
+  serverManifestVersion,
+  MCP_SERVER_VERSION,
+  "server.json version (MCP Registry listing) must match MCP_SERVER_VERSION",
 );
 assert.ok(
   init.body.result.capabilities.tools,

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.JSONbored/metagraphed",
   "title": "metagraphed — Bittensor subnet operational registry",
   "description": "Live operational + integration registry for Bittensor subnets: APIs, schemas, health.",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "websiteUrl": "https://metagraph.sh",
   "repository": {
     "url": "https://github.com/JSONbored/metagraphed",

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -139,10 +139,19 @@ function toolError(code, message) {
 async function loadArtifactData(ctx, artifactPath) {
   const result = await ctx.readArtifact(ctx.env, artifactPath);
   if (!result || !result.ok) {
-    throw toolError(
-      result?.code || "artifact_unavailable",
-      result?.message || `Artifact is not available: ${artifactPath}`,
-    );
+    const code = result?.code || "artifact_unavailable";
+    if (code === "artifact_not_found") {
+      // Map to a clean, agent-actionable domain error. Never echo result.message
+      // — it embeds the internal R2 key (e.g. "latest/overview/99999.json").
+      throw toolError(
+        "not_found",
+        "No resource at the requested identifier. Use search_subnets or " +
+          "list_subnet_apis to discover valid netuids / surface ids.",
+      );
+    }
+    // For other failures (timeout, missing binding) surface the public artifact
+    // path + code, not result.message (which also embeds the R2 key).
+    throw toolError(code, `Could not load ${artifactPath} (${code}).`);
   }
   return result.data;
 }
@@ -1236,6 +1245,12 @@ async function callTool(params, ctx) {
     if (error?.toolError) {
       return {
         content: [{ type: "text", text: `${error.code}: ${error.message}` }],
+        // Machine-readable error so an agent can branch on a stable code
+        // (rate_limited → back off, ai_unavailable → keyword fallback, etc.)
+        // instead of substring-parsing the prose.
+        structuredContent: {
+          error: { code: error.code, message: error.message },
+        },
         isError: true,
       };
     }

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -551,10 +551,16 @@ describe("MCP tools (injected deps)", () => {
     assert.equal(res.body.result.isError, true);
   });
 
-  test("get_subnet surfaces an artifact-unavailable error", async () => {
+  test("get_subnet maps a missing artifact to a clean not_found (no R2 key leak)", async () => {
     const res = await callTool("get_subnet", { netuid: 999 }, { deps });
     assert.equal(res.body.result.isError, true);
-    assert.ok(res.body.result.content[0].text.includes("artifact_not_found"));
+    const text = res.body.result.content[0].text;
+    assert.ok(text.includes("not_found"));
+    // Must not echo the internal artifact path / R2 key.
+    assert.equal(text.includes("/metagraph/overview/999.json"), false);
+    assert.equal(text.includes("latest/"), false);
+    // Machine-readable error code for agents to branch on.
+    assert.equal(res.body.result.structuredContent.error.code, "not_found");
   });
 
   test("get_subnet_health is live-only — ignores the static artifact, reports unknown when the live store is cold", async () => {


### PR DESCRIPTION
Verified MEDIUM/low MCP agent-readiness fixes:
- **Structured error codes**: `structuredContent { error: { code, message } }` on the isError path so agents branch on a stable code, not prose.
- **Clean not-found**: `loadArtifactData` maps a missing artifact to an actionable `not_found` and stops leaking the internal R2 key (`latest/...`) in the message.
- **Registry version sync**: `server.json` 0.1.0 → 1.0.0 to match the live `serverInfo.version`; `validate-mcp` now asserts they agree.

validate:mcp passes; 83 MCP tests pass; lint + format clean. A paginated `list_subnets` tool is deferred as a larger contract-surface follow-up.