### PR TITLE
fix(publish): write the KV latest-pointer last to avoid a torn pointer set

### DIFF
--- a/scripts/kv-publish-pointer.mjs
+++ b/scripts/kv-publish-pointer.mjs
@@ -63,11 +63,17 @@ const sourceFreshness = {
   freshness: freshness.summary,
   source_health: sourceHealth.summary,
 };
+// Order matters: metagraph:latest is the pointer the Worker reads to resolve the
+// live R2 run, so it is written LAST. The sidecar records (feature-flags,
+// endpoint-pools, source-freshness) go first, so a mid-sequence wrangler failure
+// (process.exit in putKv) can never leave the pointer advanced ahead of its
+// sidecars — the Worker keeps serving the previous, internally-consistent run
+// until the final pointer write succeeds.
 const kvEntries = [
-  ["metagraph:latest", pointer],
   ["metagraph:feature-flags", featureFlags],
   ["metagraph:endpoint-pools", endpointPoolStatus],
   ["metagraph:source-freshness", sourceFreshness],
+  ["metagraph:latest", pointer],
 ];
 
 if (!write) {


### PR DESCRIPTION
`kv-publish-pointer` wrote `metagraph:latest` **first** in a sequential 4-key loop; a mid-loop wrangler failure left the pointer advanced ahead of its sidecars (feature-flags/endpoint-pools/source-freshness) — a torn control set.

Fix: write the sidecars first and `metagraph:latest` **last**. Since the pointer is what the Worker reads to resolve the live R2 run, advancing it only after every sidecar is written means a partial failure keeps serving the previous, consistent run. Dry-run confirms the new order; lint + format clean.

Auto-rollback on a post-publish smoke failure is deferred (larger workflow change; the prior R2 prefix remains for a manual re-point).