### PR TITLE
fix(serving): serve the agent-catalog discovery index R2-first

### DIFF
--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -121,13 +121,20 @@ const DUAL_PATTERNS = [
 
 // Dual-tier artifacts (committed + mirrored to R2) whose SERVING should prefer
 // the fresh R2 copy over the committed baseline. They carry per-publish data
-// (native_snapshot_captured_at, coverage counts) that the 6h refresh advances,
-// but the committed copy only changes on a code push — so the default
-// ASSETS-first dual resolution pins them to a stale snapshot, contradicting
-// /freshness on the same field. We keep them committed (the changelog diff +
-// ci-verify read the committed baseline) but serve R2-first, falling back to the
-// committed copy when R2 is cold (local/dev/CI).
-const R2_PREFERRED_DUAL_PATTERNS = [/^coverage\.json$/, /^subnets\.json$/];
+// (native_snapshot_captured_at, coverage counts, the callable-surface set) that
+// the 6h refresh advances, but the committed copy only changes on a code push —
+// so the default ASSETS-first dual resolution pins them to a stale snapshot. We
+// keep them committed (cold-start + the changelog diff / ci-verify read the
+// committed baseline) but serve R2-first, falling back to the committed copy
+// when R2 is cold (local/dev/CI). agent-catalog/agent-resources are included so
+// the MCP discovery tools (find_subnets_by_capability, find_subnet_for_task,
+// get_agent_catalog) reflect the refreshed callable set, not the frozen index.
+const R2_PREFERRED_DUAL_PATTERNS = [
+  /^coverage\.json$/,
+  /^subnets\.json$/,
+  /^agent-catalog\.json$/,
+  /^agent-resources\.json$/,
+];
 
 export function isR2PreferredDualArtifactPath(artifactPath = "") {
   const normalized = artifactRelativePath(artifactPath);

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -640,6 +640,16 @@ describe("script utility contracts", () => {
       isR2PreferredDualArtifactPath("/metagraph/subnets.json"),
       true,
     );
+    // The agent-catalog/agent-resources discovery indexes are R2-preferred too so
+    // MCP discovery reflects the refreshed callable set.
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/agent-catalog.json"),
+      true,
+    );
+    assert.equal(
+      isR2PreferredDualArtifactPath("/metagraph/agent-resources.json"),
+      true,
+    );
     // Other dual artifacts stay committed-first; R2-only artifacts are not "dual".
     assert.equal(
       isR2PreferredDualArtifactPath("/metagraph/contracts.json"),


### PR DESCRIPTION
`agent-catalog.json` + `agent-resources.json` are dual-tier served ASSETS-first, so the committed cold-start index shadowed the 6h R2 refresh — the MCP discovery tools (find_subnets_by_capability, find_subnet_for_task, get_agent_catalog) served a frozen callable set updating only on code push, while per-subnet detail was fresh. Add them to the R2-preferred dual set (reusing the #621 serving mechanism), keeping the committed copy as cold-start fallback. Full suite 975 passed; lint + format clean.