### PR TITLE
fix: stop contract drift validation before unsafe typegen

### DIFF
--- a/scripts/validate-contract-drift.mjs
+++ b/scripts/validate-contract-drift.mjs
@@ -23,10 +23,16 @@ const currentOpenApi = await readJson(
 const expectedOpenApi = await buildCanonicalOpenApiArtifact(
   currentOpenApi["x-metagraphed"]?.generated_at,
 );
+const openApiMatches =
+  stableStringify(currentOpenApi) === stableStringify(expectedOpenApi);
 check(
-  stableStringify(currentOpenApi) === stableStringify(expectedOpenApi),
+  openApiMatches,
   "public/metagraph/openapi.json is stale. Run npm run build.",
 );
+
+if (!openApiMatches) {
+  failWithErrors();
+}
 
 const typegen = spawnSync(
   "npx",
@@ -80,6 +86,12 @@ for (const [routePath, methods] of Object.entries(currentOpenApi.paths || {})) {
 }
 
 if (errors.length > 0) {
+  failWithErrors();
+}
+
+console.log("Contract drift validation passed.");
+
+function failWithErrors() {
   console.error(
     `Contract drift validation failed with ${errors.length} issue(s):`,
   );
@@ -88,8 +100,6 @@ if (errors.length > 0) {
   }
   process.exit(1);
 }
-
-console.log("Contract drift validation passed.");
 
 function check(condition, message) {
   if (!condition) {


### PR DESCRIPTION
### Motivation
- The contract-drift validator invoked `openapi-typescript` on the committed `public/metagraph/openapi.json` even when the file was detected as stale, which could let PR-controlled OpenAPI artifacts trigger network resolution and cause blind SSRF/probing from CI.

### Description
- Change `scripts/validate-contract-drift.mjs` to compute the drift result once and exit immediately when the committed OpenAPI artifact differs from the canonical generated artifact, preventing further processing of the untrusted file. 
- Add a shared `failWithErrors()` helper so early drift failures and later validation failures report consistently before calling `process.exit(1)`. 
- Move the success logging so it only prints when no errors are present and ensure `openapi-typescript` is not invoked after an early drift failure. 

### Testing
- Ran `npm run validate:contract-drift` and it succeeded when artifacts matched. (success)
- Ran `npm run format:check -- scripts/validate-contract-drift.mjs` and `npm run lint -- scripts/validate-contract-drift.mjs` to ensure style and linting are clean. (success)
- Performed a manual negative test by inserting a remote `$ref` into `public/metagraph/openapi.json`, placing a fake `npx` earlier in `PATH`, and running `npm run validate:contract-drift` to verify the script fails early and the fake `npx` was not invoked. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee450d498832aab4cdd5fd4fe2b1d)