### PR TITLE
fix(release): verify release-please tags before publish

### DIFF
--- a/scripts/validate-client-release.sh
+++ b/scripts/validate-client-release.sh
@@ -20,16 +20,25 @@ if ! printf '%s' "$release_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
 fi
 
 release_tag="client-v$release_version"
-if git rev-parse "$release_tag" >/dev/null 2>&1; then
-  # release-please creates the tag BEFORE dispatching this publish, so a
-  # pre-existing tag is expected on that path. The npm-version check below is the
-  # real double-publish guard; only refuse on a stray tag in the manual flow.
-  if [ "${RELEASE_PLEASE_TRIGGERED:-}" = "true" ]; then
-    echo "Tag $release_tag already exists (created by release-please); continuing."
-  else
+release_tag_commit=""
+if release_tag_commit="$(git rev-parse "$release_tag^{commit}" 2>/dev/null)"; then
+  if [ "${RELEASE_PLEASE_TRIGGERED:-}" != "true" ]; then
     echo "::error::Release tag already exists: $release_tag"
     exit 1
   fi
+
+  if [ -z "${GITHUB_SHA:-}" ]; then
+    echo "::error::GITHUB_SHA is required for release-please-triggered releases."
+    exit 1
+  fi
+  if [ "$release_tag_commit" != "$GITHUB_SHA" ]; then
+    echo "::error::Release tag $release_tag points to $release_tag_commit, not the workflow commit $GITHUB_SHA."
+    exit 1
+  fi
+  echo "Tag $release_tag exists and points to the workflow commit; continuing."
+elif [ "${RELEASE_PLEASE_TRIGGERED:-}" = "true" ]; then
+  echo "::error::Release tag is required for release-please-triggered releases: $release_tag"
+  exit 1
 fi
 if npm view "@jsonbored/metagraphed@$release_version" version >/dev/null 2>&1; then
   echo "::error::npm version already exists: @jsonbored/metagraphed@$release_version"

--- a/scripts/validate-python-release.sh
+++ b/scripts/validate-python-release.sh
@@ -20,16 +20,25 @@ if ! printf '%s' "$release_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
 fi
 
 release_tag="python-v$release_version"
-if git rev-parse "$release_tag" >/dev/null 2>&1; then
-  # release-please creates the tag BEFORE dispatching this publish, so a
-  # pre-existing tag is expected on that path. The PyPI-version check below is the
-  # real double-publish guard; only refuse on a stray tag in the manual flow.
-  if [ "${RELEASE_PLEASE_TRIGGERED:-}" = "true" ]; then
-    echo "Tag $release_tag already exists (created by release-please); continuing."
-  else
+release_tag_commit=""
+if release_tag_commit="$(git rev-parse "$release_tag^{commit}" 2>/dev/null)"; then
+  if [ "${RELEASE_PLEASE_TRIGGERED:-}" != "true" ]; then
     echo "::error::Release tag already exists: $release_tag"
     exit 1
   fi
+
+  if [ -z "${GITHUB_SHA:-}" ]; then
+    echo "::error::GITHUB_SHA is required for release-please-triggered releases."
+    exit 1
+  fi
+  if [ "$release_tag_commit" != "$GITHUB_SHA" ]; then
+    echo "::error::Release tag $release_tag points to $release_tag_commit, not the workflow commit $GITHUB_SHA."
+    exit 1
+  fi
+  echo "Tag $release_tag exists and points to the workflow commit; continuing."
+elif [ "${RELEASE_PLEASE_TRIGGERED:-}" = "true" ]; then
+  echo "::error::Release tag is required for release-please-triggered releases: $release_tag"
+  exit 1
 fi
 if curl -fsS "https://pypi.org/pypi/metagraphed/$release_version/json" >/dev/null 2>&1; then
   echo "::error::PyPI version already exists: metagraphed==$release_version"


### PR DESCRIPTION
### Motivation
- Closing a provenance gap where `workflow_dispatch` input `released_by_release_please` could be set by a manual runner and allow publishing without an actual release-please tag or with a tag that points at a different commit.
- Ensure OIDC-backed publishes remain tied to the immutable tag/release created by release-please so release provenance is preserved.

### Description
- Update `scripts/validate-client-release.sh` to require that when `RELEASE_PLEASE_TRIGGERED=true` the expected `client-v<version>` tag exists and resolves to `GITHUB_SHA`, and to fail if the tag is missing or points elsewhere.
- Apply the same verification to `scripts/validate-python-release.sh` for the `python-v<version>` tag.
- Preserve the existing manual-run behavior by still rejecting pre-existing tags when `RELEASE_PLEASE_TRIGGERED` is not set.
- No workflow YAML changes were required; validators now independently verify tag existence and target commit.

### Testing
- Performed static shell checks with `bash -n scripts/validate-client-release.sh scripts/validate-python-release.sh` and `git diff --check`, which passed.
- Exercised validator logic with stubbed binaries to simulate remote registry calls and verified that a missing tag causes a `RELEASE_PLEASE_TRIGGERED=true` run to fail and that a tag pointing at `GITHUB_SHA` is accepted, and these scenarios succeeded.
- Committed the changes after running the above checks and scenario tests, and all automated validations in this environment passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee45a221c832a8adbc07e279cc642)