### PR TITLE
fix(public-safety): scan sensitive fixture body wording

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -42,7 +42,13 @@ const patterns = [
   // apply to those files.
   {
     name: "wallet/key wording",
-    regex: /\b(coldkey|wallet path|private key|seed phrase|mnemonic)\b/i,
+    regex: /\b(wallet path|private key|seed phrase|mnemonic)\b/i,
+    soft: true,
+    scanFixtureBody: true,
+  },
+  {
+    name: "Bittensor key terminology",
+    regex: /\bcoldkey\b/i,
     soft: true,
   },
   {
@@ -62,9 +68,9 @@ const patterns = [
 // guard. The hard secret patterns above still apply to these files. Captured
 // fixture response bodies additionally get a structural HARD-secret scan below
 // (parsed JSON string values, so a real key/token can't hide under a generic
-// JSON key); soft terminology stays exempt there too, since it is the same
-// public API vocabulary the subnet documents — soft-scanning mirrored bodies
-// guarantees false positives ("The miner hotkey to look up") and wedges publish.
+// JSON key). Fixture body soft scans stay limited to security-sensitive
+// wallet/key phrases because broad Bittensor terminology is legitimate upstream
+// API vocabulary ("The miner hotkey to look up") and wedges publish.
 function isMirroredExternalSpec(relativePath) {
   return [
     /^public\/metagraph\/schemas\/(?!index\.json$)[^/]+\.json$/,
@@ -164,10 +170,10 @@ function scanCapturedFixtureBody(relativePath, content) {
 
   for (const { valuePath, value } of walkJsonStrings(body)) {
     for (const pattern of patterns) {
-      // Only HARD secret patterns apply to mirrored fixture bodies. Soft
-      // terminology (hotkey/wallet/coldkey wording) is legitimate upstream API
-      // documentation here, exactly as it is exempted for the line scan.
-      if (pattern.soft) {
+      // Keep broad Bittensor terminology exempt for mirrored fixture bodies, but
+      // still scan security-sensitive wallet/key phrases that can appear under
+      // generic live-response keys after sanitization.
+      if (pattern.soft && !pattern.scanFixtureBody) {
         continue;
       }
       if (pattern.regex.test(value)) {

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -96,6 +96,17 @@ describe("captured-fixture body scan", () => {
     );
   });
 
+  test("flags sensitive wallet/key wording hidden in a fixture body value", async () => {
+    await writeTestFixture({
+      note: "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    });
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_FIXTURE}:response.body.note: wallet/key wording`),
+      `sensitive wallet/key wording must still fire on fixture body values; got:\n${output}`,
+    );
+  });
+
   test("still flags a hard secret hidden in a fixture body value", async () => {
     await writeTestFixture({
       note: "token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",


### PR DESCRIPTION
### Motivation
- The structural scan for captured fixture `response.body` was skipping all `soft` terminology patterns, which allowed security-sensitive wallet/key wording like `seed phrase` and `private key` to evade detection when they appeared under generic JSON keys.
- Captured fixtures are populated from live no-auth GET responses and are published as public artifacts, so sensitive wording in generic fields is a real public-safety concern.

### Description
- Split the `soft` patterns so security-sensitive wallet/key phrases (`wallet path`, `private key`, `seed phrase`, `mnemonic`) carry a new `scanFixtureBody: true` flag while broader Bittensor vocabulary (`coldkey`) stays exempt from fixture-body scans; changes live in `scripts/scan-public-safety.mjs`.
- Update `scanCapturedFixtureBody` to skip `pattern.soft` only when the pattern does not set `scanFixtureBody`, restoring checks for sensitive wallet/key wording while keeping documentation vocabulary exempt.
- Revise explanatory comments to clarify the scoped exemption for mirrored docs versus sensitive fixture-body scanning.
- Add a regression test in `tests/public-safety.test.mjs` that asserts `seed phrase` text under a generic `response.body` key is flagged, alongside the existing hard-secret and Bittensor-terminology tests.

### Testing
- Ran `node --check scripts/scan-public-safety.mjs` and `node --check tests/public-safety.test.mjs`, both succeeded.
- Ran the captured-fixture test group with `npm test -- --run tests/public-safety.test.mjs -t "captured-fixture body scan"` and the fixture-body tests passed (new sensitive-wording test plus hard-secret control passed).
- Running the full `npm test -- --run tests/public-safety.test.mjs` in this environment produced a DNS-dependent failure unrelated to the change (`isUnsafeResolvedUrl` test for `https://example.com/`), but the public-safety captured-fixture assertions succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee55a3b3c832a9f93854e58a0a5d7)