### PR TITLE
fix(client): reject non-json success responses

### DIFF
--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -100,7 +100,10 @@ async function readJsonBody(response: Response): Promise<unknown> {
   try {
     return JSON.parse(text) as unknown;
   } catch {
-    return text;
+    throw new MetagraphedError(
+      `Response body was not valid JSON (status ${response.status})`,
+      response.status,
+    );
   }
 }
 

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -120,7 +120,10 @@ async function readJsonBody(response: Response): Promise<unknown> {
   try {
     return JSON.parse(text) as unknown;
   } catch {
-    return text;
+    throw new MetagraphedError(
+      \`Response body was not valid JSON (status \${response.status})\`,
+      response.status,
+    );
   }
 }
 

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -71,6 +71,24 @@ describe("metagraphedFetch", () => {
     );
   });
 
+  test("throws MetagraphedError when a 2xx response is not JSON", async () => {
+    stubFetch(
+      async () =>
+        new Response("<html>maintenance page</html>", {
+          status: 200,
+          headers: { "content-type": "text/html" },
+        }),
+    );
+
+    await expect(
+      metagraphedFetch("/api/v1/health" as never),
+    ).rejects.toMatchObject({
+      name: "MetagraphedError",
+      status: 200,
+      message: "Response body was not valid JSON (status 200)",
+    });
+  });
+
   test("throws MetagraphedError surfacing the error envelope on non-2xx", async () => {
     stubFetch(async () =>
       jsonResponse(


### PR DESCRIPTION
### Motivation
- The TypeScript client previously returned raw text for 2xx non-JSON responses and cast it to the typed success envelope, which could let HTML/error pages or malformed JSON be treated as valid API data and cause downstream crashes. 
- The intent is to make the client behavior symmetric with the Python client by rejecting malformed/non-JSON success responses so a resolved value is always a true success envelope.

### Description
- Change `readJsonBody` in `generated/metagraphed-client.ts` to throw a `MetagraphedError` on JSON parse failure instead of returning the raw text. 
- Mirror the same change in the generator template `scripts/generate-client.mjs` so regenerated clients preserve the fix. 
- Add a regression test in `tests/client-sdk.test.ts` that asserts a `200 text/html` response now rejects with `MetagraphedError` rather than resolving as typed API data. 
- Preserve existing behavior for non-2xx responses (they still throw `MetagraphedError` and surface any parsed error envelope).

### Testing
- Ran `npm run validate:generated-client`, which succeeded and reported the generated client is current. 
- Ran the targeted unit tests with `npx vitest run tests/client-sdk.test.ts --reporter=dot`, and the test file passed (`11` tests passed). 
- Ran `npx prettier --check generated/metagraphed-client.ts scripts/generate-client.mjs tests/client-sdk.test.ts`, which passed formatting checks after applying `prettier --write` to the new test. 
- Ran the full suite with `npm test`, which failed due to unrelated environment/fixture issues (missing generated/public artifacts such as `public/metagraph/providers.json`), so only the focused client tests are relied on for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ee96530c0832a989a887d9843b436)