### PR TITLE
fix(python): cap Retry-After and guard against OverflowError in retry backoff

### DIFF
--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -28,6 +28,9 @@ DEFAULT_BASE_URL = "https://api.metagraph.sh"
 # Transient HTTP statuses worth retrying for idempotent GETs (opt-in via the
 # ``retries`` argument). 429/503 may carry a Retry-After header we honor.
 _RETRY_STATUSES = frozenset({429, 500, 502, 503, 504})
+# Cap server-supplied retry delays so a malicious Retry-After cannot tie up
+# callers that opt into retries for an unbounded amount of time.
+_MAX_RETRY_AFTER_SECONDS = 60.0
 # A descriptive User-Agent is required: api.metagraph.sh sits behind a Cloudflare
 # managed bot rule that returns HTTP 403 for stdlib urllib's default
 # "Python-urllib/<ver>" UA. Callers may override it via the ``headers`` argument.
@@ -76,7 +79,8 @@ def metagraphed_fetch(
 
     Set ``retries`` > 0 to retry idempotent GETs on transient errors (HTTP
     429/5xx and network failures) with exponential ``backoff`` seconds, honoring
-    a numeric ``Retry-After`` header. Retries are opt-in (default 0).
+    a numeric ``Retry-After`` header capped at 60 seconds. Retries are opt-in
+    (default 0).
     """
     url = base_url.rstrip("/") + _interpolate(path, path_params)
     if query:
@@ -133,8 +137,8 @@ def _retry_delay(
         retry_after = None
     if retry_after:
         try:
-            return max(0.0, float(int(retry_after)))
-        except (TypeError, ValueError):
+            return min(_MAX_RETRY_AFTER_SECONDS, max(0.0, float(int(retry_after))))
+        except (OverflowError, TypeError, ValueError):
             pass
     return backoff * (2**attempt)
 

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -185,6 +185,38 @@ class ClientTest(unittest.TestCase):
         self.assertEqual(calls["n"], 2)
         self.assertTrue(out["data"]["healthy"])
 
+    def test_retry_after_is_capped_and_overflow_safe(self):
+        sleeps = []
+        calls = {"n": 0}
+
+        def fake_urlopen(request, timeout=None):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise urllib.error.HTTPError(
+                    request.full_url,
+                    503,
+                    "busy",
+                    {"Retry-After": "315360000"},
+                    None,
+                )
+            if calls["n"] == 2:
+                raise urllib.error.HTTPError(
+                    request.full_url,
+                    503,
+                    "busy",
+                    {"Retry-After": "9" * 400},
+                    None,
+                )
+            return _FakeResponse({"ok": True})
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen), mock.patch(
+            "time.sleep", lambda seconds: sleeps.append(seconds)
+        ):
+            out = metagraphed_fetch("/api/v1/health", retries=2, backoff=0)
+
+        self.assertEqual(out, {"ok": True})
+        self.assertEqual(sleeps, [60.0, 0])
+
     def test_retries_exhausted_raises(self):
         def fake_urlopen(request, timeout=None):
             raise urllib.error.HTTPError(request.full_url, 503, "busy", {}, None)


### PR DESCRIPTION
### Motivation
- The retry logic used an untrusted `Retry-After` header directly, which could cause callers that opt into retries to sleep for an unbounded time or raise an uncaught `OverflowError` when parsing excessively large numeric headers. 
- The change intends to bound server-controlled delays and preserve the promise that `_retry_delay` "never raises" by falling back to exponential backoff on parse errors or overflows.

### Description
- Add a maximum server-supplied retry delay constant `_MAX_RETRY_AFTER_SECONDS = 60.0` in `python/src/metagraphed/client.py` and update the `metagraphed_fetch` docstring to note the cap. 
- Clamp parsed numeric `Retry-After` values with `min(_MAX_RETRY_AFTER_SECONDS, ...)` so attacker-controlled headers cannot force arbitrarily long sleeps. 
- Catch `OverflowError` in addition to `TypeError`/`ValueError` inside `_retry_delay` so extremely large numeric headers fall back to exponential backoff instead of propagating an exception. 
- Add a hermetic regression test `test_retry_after_is_capped_and_overflow_safe` in `python/tests/test_client.py` that verifies capped sleeps for a large numeric `Retry-After` and safe handling of an overflow-producing header.

### Testing
- Ran the unit test suite with `PYTHONPATH=python/src python -m unittest discover -s python/tests`, and all tests passed (`Ran 16 tests ... OK`).
- The added test `test_retry_after_is_capped_and_overflow_safe` verifies both the capped sleep behavior and overflow-safe parsing and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2eeadb7634832a89359609614290eb)