### PR TITLE
ci: prettier-ignore release-please CHANGELOGs

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,8 @@ registry/verification
 registry/adapters/latest
 migrations
 tmp
+
+# release-please regenerates these CHANGELOGs on every release in its own format;
+# they are machine-generated, not prettier-gated (python/CHANGELOG.md is covered by the `python` entry above).
+CHANGELOG.md
+packages/client/CHANGELOG.md


### PR DESCRIPTION
The #620 `format:check` gate (`prettier --check .`) turned main red after the first release: release-please regenerates component CHANGELOGs in its own non-prettier format, so #615's platform release made the root `CHANGELOG.md` fail format:check — and every future release would too. Prettier-ignore the release-please CHANGELOGs (root + packages/client; `python/` is already covered). Machine-generated, not format-gated. lint + format:check pass.