### PR TITLE
test(coverage): restore the 98% gate (overlay edge-cache + HEAD probe)

### DIFF
--- a/tests/api-coverage.test.mjs
+++ b/tests/api-coverage.test.mjs
@@ -1156,3 +1156,59 @@ describe("logEvent", () => {
     assert.equal(res.status, 504);
   });
 });
+
+// --- overlay edge-cache (cacheable overlay route) -----------------------------
+describe("overlay edge-cache", () => {
+  test("serves an overlay cache hit and honors if-none-match (304)", async () => {
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_CONTROL: makeKv({
+        "health:meta": { last_run_at: "2026-06-15T00:00:00.000Z" },
+      }),
+    };
+    const etag = '"overlay-test-etag"';
+    const cachedBody = JSON.stringify({ ok: true, data: { endpoints: [] } });
+    const cache = {
+      async match() {
+        return new Response(cachedBody, {
+          status: 200,
+          headers: { etag, "content-type": "application/json" },
+        });
+      },
+      async put() {},
+    };
+    await withGlobals({ cache }, async () => {
+      // (a) no if-none-match → the cached overlay response is returned as-is.
+      const hit = await handleRequest(req("/api/v1/endpoints"), env, {});
+      assert.equal(hit.status, 200);
+      assert.equal(hit.headers.get("etag"), etag);
+      // (b) matching if-none-match → 304 Not Modified.
+      const notModified = await handleRequest(
+        req("/api/v1/endpoints", { headers: { "if-none-match": etag } }),
+        env,
+        {},
+      );
+      assert.equal(notModified.status, 304);
+    });
+  });
+});
+
+// --- HEAD probe on an AI route -------------------------------------------------
+describe("semantic-search HEAD probe", () => {
+  test("HEAD returns a headers-only 200 without running inference", async () => {
+    const env = {
+      ...createLocalArtifactEnv(),
+      METAGRAPH_ENABLE_AI: "true",
+      AI: { run: async () => ({}) },
+      VECTORIZE: { query: async () => ({ matches: [] }) },
+    };
+    const res = await handleRequest(
+      req("/api/v1/search/semantic?q=x", { method: "HEAD" }),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.equal(res.headers.get("cache-control"), "no-store");
+    assert.equal(await res.text(), "");
+  });
+});


### PR DESCRIPTION
## Why

`main`'s **Validate** check has been red since the recent SDK/MCP/perf merges (#621–#637) drifted global coverage to **97.8% statements / 97.92% lines**, under the deliberate **98% gate** ([#259](https://github.com/JSONbored/metagraphed/pull/259)). Nothing is broken in production (the Worker deploys via Workers Builds independently), but the gate blocks clean CI.

## Fix

The biggest uncovered cluster was the new per-cron **overlay edge-cache** path (`workers/api.mjs`, #637) — never hit in tests because the env had no `globalThis.caches`. Two targeted tests:
- overlay edge-cache **hit** + `if-none-match` **304** against the cacheable `endpoints` route (caches.default mock + a `health:meta` KV with `last_run_at`);
- **HEAD** on `/api/v1/search/semantic` returns a headers-only 200 without inference.

## Result

Coverage restored to **98.1% statements / 98.25% lines** (branches 90.41%, functions 98.3%) — all four thresholds green. `lint` + `format:check` clean.