### PR TITLE
fix(health): only count sustained downtime as an incident + retire 2 dead surfaces

### DIFF
--- a/registry/subnets/ninja.json
+++ b/registry/subnets/ninja.json
@@ -125,9 +125,9 @@
       "id": "sn-66-ninja-health",
       "kind": "subnet-api",
       "name": "Ninja health endpoint",
-      "notes": "Public read-only health endpoint for the Ninja service.",
+      "notes": "Health path returns HTTP 404 (the host is up; the /health route does not exist) — verified 2026-06-15. Probe disabled pending a valid health URL.",
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "expect": "any",
         "method": "GET",
         "timeout_ms": 10000

--- a/registry/subnets/root.json
+++ b/registry/subnets/root.json
@@ -187,16 +187,16 @@
       "kind": "subtensor-rpc",
       "url": "https://bittensor-public.nodies.app",
       "provider": "nodies",
-      "auth_required": false,
+      "auth_required": true,
       "authority": "community",
-      "public_safe": true,
+      "public_safe": false,
       "source_urls": [
         "https://www.comparenodes.com/library/public-endpoints/bittensor/",
         "https://docs.nodies.app/rpc-services/public-endpoints"
       ],
-      "rate_limit_notes": "Public endpoint discovered from endpoint directories and verified with read-only JSON-RPC probes.",
+      "rate_limit_notes": "No longer a free public endpoint: returns HTTP 403 'requires a paid subscription plan' (verified 2026-06-15). Demoted out of the public RPC pool; probe disabled.",
       "probe": {
-        "enabled": true,
+        "enabled": false,
         "method": "JSON-RPC",
         "expect": "json",
         "timeout_ms": 12000

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -315,6 +315,15 @@ export function formatTrends({ netuid, observedAt, windows }) {
 // the incidents handler.
 export const INCIDENT_GAP_MS = 6 * 60 * 1000;
 
+// Minimum consecutive failed probes for a gap-island to count as an incident.
+// A single failed probe that recovers on the next (~2 min later) is transient
+// noise — a momentary timeout / rate-limit / 5xx — not downtime, and it
+// dominated the ledger (~76% of rows were single-sample, zero-duration). This
+// mirrors the Cosmos liveness model: an isolated missed block is tolerated;
+// only sustained misses (MinSignedPerWindow) count as downtime. At 2 (≥ ~4 min
+// sustained) the ledger reflects real dips, not prober flapping.
+export const MIN_INCIDENT_SAMPLES = 2;
+
 function round4(value) {
   return value == null ? null : Number(Number(value).toFixed(4));
 }

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -510,6 +510,9 @@ describe("analytics routes (fake D1 with data)", () => {
     );
     assert.ok(incidentQuery.sql.includes("LIMIT ?"));
     assert.equal(incidentQuery.params.at(-1), 1000);
+    // Single-probe blips are excluded: an incident needs >= 2 consecutive fails.
+    assert.ok(incidentQuery.sql.includes("HAVING COUNT(*) >= ?"));
+    assert.equal(incidentQuery.params.at(-2), 2);
   });
 
   test("global incidents SQL bounds source rows before window grouping", async () => {
@@ -541,6 +544,9 @@ describe("analytics routes (fake D1 with data)", () => {
     assert.ok(incidentQuery.sql.includes("LIMIT ?"));
     assert.equal(incidentQuery.params[1], 5000);
     assert.equal(incidentQuery.params.at(-1), 1000);
+    // Single-probe blips are excluded: an incident needs >= 2 consecutive fails.
+    assert.ok(incidentQuery.sql.includes("HAVING COUNT(*) >= ?"));
+    assert.equal(incidentQuery.params.at(-2), 2);
   });
 
   test("trajectory computes deltas from snapshots", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -53,6 +53,7 @@ import {
   formatTrends,
   formatUptime,
   INCIDENT_GAP_MS,
+  MIN_INCIDENT_SAMPLES,
   LEADERBOARD_BOARDS,
   mergeFreshness,
   mergeRpcEndpoints,
@@ -1333,9 +1334,10 @@ async function handleHealthIncidents(request, env, netuid, url) {
               COUNT(*) AS failed_samples
        FROM grouped
        GROUP BY surface_id, grp
+       HAVING COUNT(*) >= ?
        ORDER BY surface_id, started_at
        LIMIT ?`,
-      [netuid, since, INCIDENT_GAP_MS, MAX_INCIDENT_ROWS],
+      [netuid, since, INCIDENT_GAP_MS, MIN_INCIDENT_SAMPLES, MAX_INCIDENT_ROWS],
     ),
   ]);
   const meta = await readHealthKv(env, KV_HEALTH_META);
@@ -1398,12 +1400,14 @@ async function handleGlobalIncidents(request, env, url) {
             COUNT(*) AS failed_samples
      FROM grouped
      GROUP BY netuid, surface_id, grp
+     HAVING COUNT(*) >= ?
      ORDER BY started_at DESC
      LIMIT ?`,
     [
       since,
       MAX_GLOBAL_INCIDENT_SOURCE_ROWS,
       INCIDENT_GAP_MS,
+      MIN_INCIDENT_SAMPLES,
       MAX_INCIDENT_ROWS,
     ],
   );


### PR DESCRIPTION
## Why

The `/status` page showed ~700 "incidents", which read as a system in crisis. Investigation: the incident ledger counted **every** failed probe as an incident with **no minimum threshold** — and **76% (552 of 728) were single-probe blips** (`failed_samples: 1`, `duration_ms: 0`): one probe failed and the *next* one (~2 min later) succeeded. That's transient noise (a momentary timeout / rate-limit / 5xx), **not downtime**.

## Layer 1 — incident threshold

The gap-island reconstruction SQL (both `/api/v1/incidents` and `/api/v1/subnets/{n}/health/incidents`) now requires **`HAVING COUNT(*) >= 2`** — **≥2 consecutive failed probes** (~≥4 min sustained) before a span is an incident. This mirrors the **Cosmos liveness model** the registry takes after: an isolated missed block is tolerated (`MinSignedPerWindow`); only *sustained* misses are downtime. New `MIN_INCIDENT_SAMPLES` constant. This drops the 552 single-probe blips → ~176 real dips. Tests assert the `HAVING` clause + threshold param in both queries.

## Layer 2 — retire the 2 chronic surfaces (stale data, not outages)

The only 2 surfaces with a >6h continuous "incident" were both **our stale data**, verified live:
- **`nodies-finney-rpc`** → **HTTP 403 "requires a paid subscription plan"** — no longer a free public endpoint. Set `public_safe: false`, `auth_required: true`, `probe.enabled: false` → now `pool_eligible: false` (never served as a callable RPC, no longer probed).
- **`sn-66-ninja-health`** → **HTTP 404** (the host is up; the `/health` path doesn't exist). `probe.enabled: false` pending a valid URL.

Both stop generating false incidents; their historical spans age out of the 7d/30d window.

## Verification

- All gates green (`validate:api/schemas/mcp/docs/openapi/contract-drift`, `scan:public-safety`, lint, reproducibility) · coverage **98.1%** lines.
- Confirmed nodies is now `pool_eligible: false` (reasons: `not-public-safe, auth-required`) and excluded from the served pool.
- Source-only PR (registry + SQL); artifacts regenerate on the next publish (R2 is the served tier).

Frontend `/status` presentation (uptime-led, ongoing vs resolved) follows in a metagraphed-ui PR.