### PR TITLE
feat(rpc): block-height-aware proxy routing + scope endpoint-incidents to callable kinds

### DIFF
--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1898,6 +1898,19 @@ function endpointPool(id, kind, endpoints) {
   };
 }
 
+// Only callable infrastructure (RPC/WSS + the agent-callable surface kinds) can
+// have a meaningful "down" incident. Docs / dashboards / websites / repos are
+// reference links, not endpoints — a website that returns HTML probes as
+// "unsupported" and must NOT be reported as an incident.
+const CALLABLE_ENDPOINT_KINDS = new Set([
+  "subtensor-rpc",
+  "subtensor-wss",
+  "subnet-api",
+  "openapi",
+  "sse",
+  "data-artifact",
+]);
+
 export function buildEndpointIncidentArtifact({
   endpointArtifact,
   generatedAt,
@@ -1905,6 +1918,7 @@ export function buildEndpointIncidentArtifact({
 }) {
   const endpoints = endpointArtifact?.endpoints || [];
   const incidents = endpoints
+    .filter((endpoint) => CALLABLE_ENDPOINT_KINDS.has(endpoint.kind))
     .filter((endpoint) => endpoint.monitoring_status === "monitored")
     .filter((endpoint) => ["failed", "degraded"].includes(endpoint.status))
     .map((endpoint) => {

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -506,6 +506,9 @@ async function persistToKv(kv, probed, runAt) {
       status: row.status,
       classification: row.classification,
       latency_ms: row.latency_ms,
+      // Fresh tip height (from chain_getHeader) so the proxy can prefer the
+      // most-synced node and demote laggards. Null when the probe couldn't read.
+      latest_block: row.latest_block ?? null,
       archive_support: row.archive_support,
       last_ok: iso(row.last_ok_ms),
       consecutive_failures: row.consecutive_failures,

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -230,6 +230,7 @@ export function overlayRpcPoolEligibility(pool, liveRpcPool) {
         ...endpoint,
         status: live.status,
         latency_ms: live.latency_ms ?? endpoint.latency_ms,
+        latest_block: live.latest_block ?? endpoint.latest_block ?? null,
         health_source: "live-cron-prober",
         pool_eligible:
           Boolean(endpoint.pool_eligible) && !wrongChain && !sustainedDown,

--- a/tests/rpc-endpoint-selection.test.mjs
+++ b/tests/rpc-endpoint-selection.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { describe, test } from "vitest";
 import {
+  orderSafeRpcEndpoints,
   selectSafeRpcEndpoint,
   weightedPickEndpoint,
 } from "../workers/api.mjs";
@@ -96,5 +97,45 @@ describe("weightedPickEndpoint", () => {
     ];
     assert.equal(weightedPickEndpoint(eps, () => 0).id, "a");
     assert.equal(weightedPickEndpoint(eps, () => 0.6).id, "b");
+  });
+});
+
+describe("orderSafeRpcEndpoints — block-height routing", () => {
+  const opts = { healthMap: new Map(), now: 0 };
+
+  test("demotes a node lagging the freshest tip behind the synced set", () => {
+    const pool = {
+      endpoints: [
+        ep("lag", SAFE_A, { latest_block: 8_399_000 }), // 1000 behind → lagging
+        ep("fresh", SAFE_B, { latest_block: 8_400_000 }), // at the tip
+      ],
+    };
+    const { endpoints } = orderSafeRpcEndpoints(pool, () => 0, opts);
+    assert.equal(endpoints[0].id, "fresh");
+    assert.equal(endpoints[endpoints.length - 1].id, "lag");
+  });
+
+  test("keeps nodes within tolerance together in the synced band", () => {
+    const pool = {
+      endpoints: [
+        ep("a", SAFE_A, { latest_block: 8_400_000 }),
+        ep("b", SAFE_B, { latest_block: 8_399_995 }), // 5 behind → within tolerance
+      ],
+    };
+    const { endpoints } = orderSafeRpcEndpoints(pool, () => 0, opts);
+    assert.equal(endpoints.length, 2);
+    assert.deepEqual(endpoints.map((e) => e.id).sort(), ["a", "b"]);
+  });
+
+  test("does not judge endpoints with no readable block height", () => {
+    const pool = {
+      endpoints: [
+        ep("known", SAFE_A, { latest_block: 8_400_000 }),
+        ep("nullblock", SAFE_B, { latest_block: null }),
+      ],
+    };
+    const { endpoints } = orderSafeRpcEndpoints(pool, () => 0, opts);
+    // null-block endpoint isn't demoted (can't judge) — both stay in the pool.
+    assert.equal(endpoints.length, 2);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1879,6 +1879,11 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
 const RPC_MAX_ATTEMPTS = 3;
 const RPC_ATTEMPT_TIMEOUT_MS = 6000;
 const RPC_CLASSIFY_BODY_LIMIT_BYTES = 64 * 1024;
+// Max blocks an endpoint may trail the freshest reported tip before the proxy
+// demotes it behind synced nodes. Bittensor block time is ~12s, so ~10 blocks
+// (~2 min) tolerates cross-provider probe-timing skew while still routing around
+// a genuinely stalled/lagging node.
+const BLOCK_LAG_TOLERANCE = 10;
 
 // JSON-RPC error codes that signal node trouble (retry another upstream) rather
 // than a client/application error (return immediately so we don't mask a real
@@ -3065,7 +3070,27 @@ export function orderSafeRpcEndpoints(
   const ejected = shuffled.filter((e) =>
     isRpcEndpointEjected(healthMap, e.id, now),
   );
-  const ordered = [...live, ...ejected];
+  // Prefer the most-synced live nodes (like cosmos.directory's "most up-to-date"
+  // routing): any endpoint more than BLOCK_LAG_TOLERANCE behind the freshest
+  // reported tip is demoted behind the synced set — it would serve stale reads.
+  // Endpoints with no readable block height keep their place (can't judge them);
+  // the weighted-random order within each band is preserved for load spread.
+  const liveBlocks = live
+    .map((e) => Number(e.latest_block))
+    .filter((b) => Number.isFinite(b) && b > 0);
+  const maxBlock = liveBlocks.length ? Math.max(...liveBlocks) : null;
+  const isLagging = (endpoint) => {
+    const block = Number(endpoint.latest_block);
+    return (
+      maxBlock != null &&
+      Number.isFinite(block) &&
+      block > 0 &&
+      maxBlock - block > BLOCK_LAG_TOLERANCE
+    );
+  };
+  const synced = live.filter((endpoint) => !isLagging(endpoint));
+  const lagging = live.filter(isLagging);
+  const ordered = [...synced, ...lagging, ...ejected];
   return {
     endpoints: ordered,
     unsafeEndpoint: ordered.length ? null : unsafeEndpoint,


### PR DESCRIPTION
First of the /endpoints-improvement work (the others: proxy usage analytics, then the frontend reframe).

## B1 — endpoint-incidents only for callable infrastructure

`buildEndpointIncidentArtifact` flagged **any** monitored surface in `failed`/`degraded` — including **websites / docs / dashboards / repos** that probe as "unsupported" simply because they return HTML, not JSON. Those are reference *links*, not endpoints, and can't have a "down" incident. Scoped to `CALLABLE_ENDPOINT_KINDS` (rpc/wss/subnet-api/openapi/sse/data-artifact). **All 9 current endpoint-incidents were non-API surfaces → now 0.**

## B2 — block-height-aware routing (cosmos.directory's "most up-to-date")

The proxy ordered live endpoints by health + score-weighted random but **ignored sync state**, so it could route a read to a node lagging the chain tip. Now:
- the **cron carries fresh `chain_getHeader` `latest_block`** into the live RPC-pool KV (it was captured but dropped before the write);
- `overlayRpcPoolEligibility` threads it onto the served pool;
- `orderSafeRpcEndpoints` **demotes any endpoint > `BLOCK_LAG_TOLERANCE` (10 blocks, ~2 min) behind the freshest tip** behind the synced set. No-block-reading endpoints keep their place; weighted-random load spread within each band is preserved.

## Verification

- New tests cover demotion, the in-tolerance band, and the null-block case (12/12 in the selection suite).
- All gates green; coverage **98.1%** lines. Source-only (artifacts regenerate on publish; the proxy reads the new field once the next cron writes it).

Next: **proxy usage analytics** (the "analytics data for the proxy" — doesn't exist today) + the **`/endpoints` frontend reframe** (proxy-hero + callable-only).