### PR TITLE
feat(rpc): proxy usage analytics — D1 telemetry + /api/v1/rpc/usage (B3)

### DIFF
--- a/docs/backend-artifact-contracts.md
+++ b/docs/backend-artifact-contracts.md
@@ -77,6 +77,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/metagraph/subnets/{netuid}/uptime.json`: schema for the long-term daily uptime history per operational surface (90d/1y window), served live from the `surface_uptime_daily` D1 rollup at `GET /api/v1/subnets/{netuid}/uptime` (no static file).
 - `/metagraph/incidents.json`: schema for recent cross-subnet downtime incidents reconstructed from probe history, served live from D1 at `GET /api/v1/incidents` (no static file).
 - `/metagraph/registry/leaderboards.json`: schema for the registry leaderboards served live from D1 + registry projections at `GET /api/v1/registry/leaderboards` (no static file).
+- `/metagraph/rpc/usage.json`: schema for RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution), served live from the `rpc_proxy_events` D1 telemetry at `GET /api/v1/rpc/usage` (no static file).
 - `/metagraph/schema-drift.json`: OpenAPI snapshot/drift status.
 - `/metagraph/schemas/index.json`: captured machine-readable schema index.
 - `/metagraph/schemas/{surface_id}.json`: captured machine-readable OpenAPI/Swagger schema snapshot detail. R2-backed.
@@ -112,6 +113,7 @@ Metagraphed v1 is backend-first. The public contract is static JSON under `https
 - `/api/v1/subnets/{netuid}/trajectory`: fetch the week-over-week structural trajectory (completeness + counts) from daily snapshots (live from D1).
 - `/api/v1/subnets/{netuid}/uptime`: fetch long-term daily uptime history per operational surface over a 90d/1y window (live from the `surface_uptime_daily` D1 rollup).
 - `/api/v1/registry/leaderboards`: fetch registry leaderboards (`board=healthiest|fastest-rpc|most-complete|fastest-growing`, or omit for all).
+- `/api/v1/rpc/usage`: fetch RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution) over a 7d/30d window (live from the `rpc_proxy_events` D1 telemetry).
 - `/api/v1/surfaces`: list curated public surfaces.
 - `/api/v1/subnets/{netuid}/surfaces`: list curated public surfaces for one subnet.
 - `/api/v1/endpoints`: list generalized endpoint resources and monitored public surfaces.

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -633,6 +633,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/rpc/usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry). */
+        get: operations["rpcUsage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/schemas": {
         parameters: {
             query?: never;
@@ -2545,6 +2562,53 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file). */
+        RpcUsageArtifact: {
+            endpoints: ({
+                avg_latency_ms?: number | null;
+                endpoint_id: string | null;
+                error_rate?: number | null;
+                ok_requests: number;
+                provider?: string | null;
+                rank?: number;
+                requests: number;
+            } & {
+                [key: string]: unknown;
+            })[];
+            networks: ({
+                error_rate?: number | null;
+                network: string;
+                ok_requests: number;
+                requests: number;
+            } & {
+                [key: string]: unknown;
+            })[];
+            observed_at?: string | null;
+            schema_version: number;
+            source: string;
+            summary: {
+                cache_hit_rate?: number | null;
+                cache_hits?: number;
+                error_rate?: number | null;
+                error_requests: number;
+                failover_rate?: number | null;
+                failover_requests?: number;
+                latency_ms?: {
+                    avg?: number | null;
+                    p50?: number | null;
+                    p95?: number | null;
+                } & {
+                    [key: string]: unknown;
+                };
+                ok_requests: number;
+                total_requests: number;
+            } & {
+                [key: string]: unknown;
+            };
+            window?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         SchemaDriftArtifact: components["schemas"]["ArtifactBase"] & ({
             openapi_surface_count: number;
             schema_backed_surface_count: number;
@@ -8213,6 +8277,131 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RpcPoolsArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    rpcUsage: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "endpoints": [
+                     *           {
+                     *             "endpoint_id": "https://api.metagraph.sh/example",
+                     *             "ok_requests": 1,
+                     *             "requests": 1
+                     *           }
+                     *         ],
+                     *         "networks": [
+                     *           {
+                     *             "network": "example",
+                     *             "ok_requests": 1,
+                     *             "requests": 1
+                     *           }
+                     *         ],
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "summary": {
+                     *           "cache_hit_rate": 0.5,
+                     *           "cache_hits": 1,
+                     *           "error_rate": 0.5,
+                     *           "error_requests": 1,
+                     *           "failover_rate": 0.5,
+                     *           "failover_requests": 1,
+                     *           "latency_ms": {},
+                     *           "ok_requests": 1,
+                     *           "total_requests": 1
+                     *         },
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["RpcUsageArtifact"];
                     };
                 };
             };

--- a/migrations/0004_rpc_proxy_usage.sql
+++ b/migrations/0004_rpc_proxy_usage.sql
@@ -1,0 +1,29 @@
+-- RPC reverse-proxy usage telemetry (B3).
+--
+-- One row per proxied /rpc/v1/{network} request, written best-effort and async
+-- (ctx.waitUntil) by handleRpcProxyRequest so telemetry never adds latency to —
+-- or can fail — a proxied call. Powers /api/v1/rpc/usage (request volume,
+-- latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint
+-- request distribution that answers "is the load balancer actually balancing").
+--
+-- Like surface_checks this is a hot time-series, not a long-term store: the
+-- hourly cron prunes it to the same 30-day window (pruneHealthHistory) so it
+-- stays bounded regardless of proxy traffic. Never retained beyond the window.
+
+CREATE TABLE IF NOT EXISTS rpc_proxy_events (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  observed_at  INTEGER NOT NULL,            -- epoch ms the proxy request started
+  network      TEXT    NOT NULL,            -- finney | test (path segment)
+  endpoint_id  TEXT,                        -- pool endpoint that served (NULL: cache hit / none eligible)
+  provider     TEXT,                        -- served endpoint's provider label
+  ok           INTEGER NOT NULL,            -- 1 if the proxy routed to a responding upstream (or cache hit)
+  status       INTEGER,                     -- HTTP status returned to the caller
+  attempts     INTEGER,                     -- upstream attempts (>1 = failover occurred)
+  latency_ms   INTEGER,                     -- end-to-end proxy latency
+  cache        TEXT                         -- hit | miss | bypass
+);
+
+CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_observed
+  ON rpc_proxy_events (observed_at);
+CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_network_observed
+  ON rpc_proxy_events (network, observed_at);

--- a/public/metagraph/api-index.json
+++ b/public/metagraph/api-index.json
@@ -345,6 +345,13 @@
     },
     {
       "contract_version": "2026-06-06.1",
+      "id": "rpc-usage",
+      "path": "/metagraph/rpc/usage.json",
+      "schema_ref": "#/components/schemas/RpcUsageArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "contract_version": "2026-06-06.1",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",
       "schema_ref": "#/components/schemas/RpcEndpointsArtifact",
@@ -3464,6 +3471,29 @@
             "maximum": 100,
             "minimum": 1,
             "type": "integer"
+          }
+        }
+      ]
+    },
+    {
+      "artifact_path": "/metagraph/rpc/usage.json",
+      "cache": "short",
+      "description": "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry).",
+      "id": "rpc-usage",
+      "method": "GET",
+      "path": "/api/v1/rpc/usage",
+      "public": true,
+      "query_collection": null,
+      "query_filter_names": [],
+      "query_parameters": [
+        {
+          "name": "window",
+          "schema": {
+            "enum": [
+              "7d",
+              "30d"
+            ],
+            "type": "string"
           }
         }
       ]

--- a/public/metagraph/contracts.json
+++ b/public/metagraph/contracts.json
@@ -444,6 +444,15 @@
     {
       "content_type": "application/json",
       "contract_version": "2026-06-06.1",
+      "description": "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
+      "id": "rpc-usage",
+      "path": "/metagraph/rpc/usage.json",
+      "schema_ref": "#/components/schemas/RpcUsageArtifact",
+      "storage_tier": "r2"
+    },
+    {
+      "content_type": "application/json",
+      "contract_version": "2026-06-06.1",
       "description": "Bittensor base-layer RPC endpoint registry and probe status.",
       "id": "rpc-endpoints",
       "path": "/metagraph/rpc-endpoints.json",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -6383,6 +6383,192 @@
           }
         ]
       },
+      "RpcUsageArtifact": {
+        "additionalProperties": true,
+        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file).",
+        "properties": {
+          "endpoints": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "avg_latency_ms": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "endpoint_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "error_rate": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "ok_requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "provider": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "rank": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "endpoint_id",
+                "requests",
+                "ok_requests"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "networks": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "error_rate": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "network": {
+                  "type": "string"
+                },
+                "ok_requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "network",
+                "requests",
+                "ok_requests"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "summary": {
+            "additionalProperties": true,
+            "properties": {
+              "cache_hit_rate": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "cache_hits": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "error_rate": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "error_requests": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "failover_rate": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "failover_requests": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "latency_ms": {
+                "additionalProperties": true,
+                "properties": {
+                  "avg": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "p50": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "p95": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "ok_requests": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_requests": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "total_requests",
+              "ok_requests",
+              "error_requests"
+            ],
+            "type": "object"
+          },
+          "window": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "source",
+          "summary",
+          "endpoints",
+          "networks"
+        ],
+        "type": "object"
+      },
       "SchemaDriftArtifact": {
         "allOf": [
           {
@@ -17057,6 +17243,162 @@
         "summary": "Fetch endpoint pool scores.",
         "tags": [
           "rpc"
+        ]
+      }
+    },
+    "/api/v1/rpc/usage": {
+      "get": {
+        "operationId": "rpcUsage",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "window",
+            "required": false,
+            "schema": {
+              "enum": [
+                "7d",
+                "30d"
+              ],
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "example": {
+                  "data": {
+                    "endpoints": [
+                      {
+                        "endpoint_id": "https://api.metagraph.sh/example",
+                        "ok_requests": 1,
+                        "requests": 1
+                      }
+                    ],
+                    "networks": [
+                      {
+                        "network": "example",
+                        "ok_requests": 1,
+                        "requests": 1
+                      }
+                    ],
+                    "observed_at": "2026-06-01T00:00:00.000Z",
+                    "schema_version": 1,
+                    "source": "live-cron-prober",
+                    "summary": {
+                      "cache_hit_rate": 0.5,
+                      "cache_hits": 1,
+                      "error_rate": 0.5,
+                      "error_requests": 1,
+                      "failover_rate": 0.5,
+                      "failover_requests": 1,
+                      "latency_ms": {},
+                      "ok_requests": 1,
+                      "total_requests": 1
+                    },
+                    "window": "30d"
+                  },
+                  "meta": {
+                    "artifact_path": "example",
+                    "cache": "short",
+                    "contract_version": "2026-06-06.1",
+                    "generated_at": "2026-06-01T00:00:00.000Z",
+                    "pagination": {
+                      "collection": "example",
+                      "cursor": 1,
+                      "limit": 1,
+                      "next_cursor": 1,
+                      "order": "asc",
+                      "returned": 1,
+                      "sort": "example",
+                      "total": 1
+                    },
+                    "published_at": "2026-06-01T00:00:00.000Z",
+                    "source": "live-cron-prober"
+                  },
+                  "ok": true,
+                  "schema_version": 1
+                },
+                "schema": {
+                  "allOf": [
+                    {
+                      "$ref": "#/components/schemas/SuccessEnvelope"
+                    },
+                    {
+                      "properties": {
+                        "data": {
+                          "$ref": "#/components/schemas/RpcUsageArtifact"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  ]
+                }
+              }
+            },
+            "description": "Canonical artifact wrapped in the Metagraphed API envelope.",
+            "headers": {
+              "cache-control": {
+                "$ref": "#/components/headers/CacheControl"
+              },
+              "etag": {
+                "$ref": "#/components/headers/ETag"
+              },
+              "x-metagraph-contract-version": {
+                "$ref": "#/components/headers/ContractVersion"
+              }
+            }
+          },
+          "304": {
+            "description": "ETag matched and the cached response is still valid."
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Query parameters were malformed or unsupported."
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Artifact or API route was not found."
+          },
+          "405": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "HTTP method is not supported."
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorEnvelope"
+                }
+              }
+            },
+            "description": "Unexpected backend error."
+          }
+        },
+        "summary": "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry).",
+        "tags": [
+          "rpc",
+          "analytics",
+          "operations"
         ]
       }
     },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -633,6 +633,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/rpc/usage": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry). */
+        get: operations["rpcUsage"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/schemas": {
         parameters: {
             query?: never;
@@ -2545,6 +2562,53 @@ export interface components {
         } & {
             [key: string]: unknown;
         });
+        /** @description RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file). */
+        RpcUsageArtifact: {
+            endpoints: ({
+                avg_latency_ms?: number | null;
+                endpoint_id: string | null;
+                error_rate?: number | null;
+                ok_requests: number;
+                provider?: string | null;
+                rank?: number;
+                requests: number;
+            } & {
+                [key: string]: unknown;
+            })[];
+            networks: ({
+                error_rate?: number | null;
+                network: string;
+                ok_requests: number;
+                requests: number;
+            } & {
+                [key: string]: unknown;
+            })[];
+            observed_at?: string | null;
+            schema_version: number;
+            source: string;
+            summary: {
+                cache_hit_rate?: number | null;
+                cache_hits?: number;
+                error_rate?: number | null;
+                error_requests: number;
+                failover_rate?: number | null;
+                failover_requests?: number;
+                latency_ms?: {
+                    avg?: number | null;
+                    p50?: number | null;
+                    p95?: number | null;
+                } & {
+                    [key: string]: unknown;
+                };
+                ok_requests: number;
+                total_requests: number;
+            } & {
+                [key: string]: unknown;
+            };
+            window?: string | null;
+        } & {
+            [key: string]: unknown;
+        };
         SchemaDriftArtifact: components["schemas"]["ArtifactBase"] & ({
             openapi_surface_count: number;
             schema_backed_surface_count: number;
@@ -8213,6 +8277,131 @@ export interface operations {
                      */
                     "application/json": components["schemas"]["SuccessEnvelope"] & {
                         data?: components["schemas"]["RpcPoolsArtifact"];
+                    };
+                };
+            };
+            /** @description ETag matched and the cached response is still valid. */
+            304: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Query parameters were malformed or unsupported. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Artifact or API route was not found. */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description HTTP method is not supported. */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+            /** @description Unexpected backend error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorEnvelope"];
+                };
+            };
+        };
+    };
+    rpcUsage: {
+        parameters: {
+            query?: {
+                window?: "7d" | "30d";
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Canonical artifact wrapped in the Metagraphed API envelope. */
+            200: {
+                headers: {
+                    "cache-control": components["headers"]["CacheControl"];
+                    etag: components["headers"]["ETag"];
+                    "x-metagraph-contract-version": components["headers"]["ContractVersion"];
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "data": {
+                     *         "endpoints": [
+                     *           {
+                     *             "endpoint_id": "https://api.metagraph.sh/example",
+                     *             "ok_requests": 1,
+                     *             "requests": 1
+                     *           }
+                     *         ],
+                     *         "networks": [
+                     *           {
+                     *             "network": "example",
+                     *             "ok_requests": 1,
+                     *             "requests": 1
+                     *           }
+                     *         ],
+                     *         "observed_at": "2026-06-01T00:00:00.000Z",
+                     *         "schema_version": 1,
+                     *         "source": "live-cron-prober",
+                     *         "summary": {
+                     *           "cache_hit_rate": 0.5,
+                     *           "cache_hits": 1,
+                     *           "error_rate": 0.5,
+                     *           "error_requests": 1,
+                     *           "failover_rate": 0.5,
+                     *           "failover_requests": 1,
+                     *           "latency_ms": {},
+                     *           "ok_requests": 1,
+                     *           "total_requests": 1
+                     *         },
+                     *         "window": "30d"
+                     *       },
+                     *       "meta": {
+                     *         "artifact_path": "example",
+                     *         "cache": "short",
+                     *         "contract_version": "2026-06-06.1",
+                     *         "generated_at": "2026-06-01T00:00:00.000Z",
+                     *         "pagination": {
+                     *           "collection": "example",
+                     *           "cursor": 1,
+                     *           "limit": 1,
+                     *           "next_cursor": 1,
+                     *           "order": "asc",
+                     *           "returned": 1,
+                     *           "sort": "example",
+                     *           "total": 1
+                     *         },
+                     *         "published_at": "2026-06-01T00:00:00.000Z",
+                     *         "source": "live-cron-prober"
+                     *       },
+                     *       "ok": true,
+                     *       "schema_version": 1
+                     *     }
+                     */
+                    "application/json": components["schemas"]["SuccessEnvelope"] & {
+                        data?: components["schemas"]["RpcUsageArtifact"];
                     };
                 };
             };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -6361,6 +6361,192 @@
           }
         ]
       },
+      "RpcUsageArtifact": {
+        "additionalProperties": true,
+        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file).",
+        "properties": {
+          "endpoints": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "avg_latency_ms": {
+                  "type": [
+                    "integer",
+                    "null"
+                  ]
+                },
+                "endpoint_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "error_rate": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "ok_requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "provider": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "rank": {
+                  "minimum": 1,
+                  "type": "integer"
+                },
+                "requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "endpoint_id",
+                "requests",
+                "ok_requests"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "networks": {
+            "items": {
+              "additionalProperties": true,
+              "properties": {
+                "error_rate": {
+                  "type": [
+                    "number",
+                    "null"
+                  ]
+                },
+                "network": {
+                  "type": "string"
+                },
+                "ok_requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                },
+                "requests": {
+                  "minimum": 0,
+                  "type": "integer"
+                }
+              },
+              "required": [
+                "network",
+                "requests",
+                "ok_requests"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "observed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "schema_version": {
+            "type": "integer"
+          },
+          "source": {
+            "type": "string"
+          },
+          "summary": {
+            "additionalProperties": true,
+            "properties": {
+              "cache_hit_rate": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "cache_hits": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "error_rate": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "error_requests": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "failover_rate": {
+                "type": [
+                  "number",
+                  "null"
+                ]
+              },
+              "failover_requests": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "latency_ms": {
+                "additionalProperties": true,
+                "properties": {
+                  "avg": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "p50": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  },
+                  "p95": {
+                    "type": [
+                      "integer",
+                      "null"
+                    ]
+                  }
+                },
+                "type": "object"
+              },
+              "ok_requests": {
+                "minimum": 0,
+                "type": "integer"
+              },
+              "total_requests": {
+                "minimum": 0,
+                "type": "integer"
+              }
+            },
+            "required": [
+              "total_requests",
+              "ok_requests",
+              "error_requests"
+            ],
+            "type": "object"
+          },
+          "window": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "schema_version",
+          "source",
+          "summary",
+          "endpoints",
+          "networks"
+        ],
+        "type": "object"
+      },
       "SchemaDriftArtifact": {
         "allOf": [
           {

--- a/schemas/components/06-health.schema.json
+++ b/schemas/components/06-health.schema.json
@@ -630,6 +630,79 @@
         },
         "additionalProperties": true
       },
+      "RpcUsageArtifact": {
+        "type": "object",
+        "description": "RPC reverse-proxy usage analytics over a 7d/30d window: request volume, latency percentiles, failover + error rate, cache-hit rate, and the per-endpoint request distribution. Computed live from the rpc_proxy_events telemetry (no static file).",
+        "required": [
+          "schema_version",
+          "source",
+          "summary",
+          "endpoints",
+          "networks"
+        ],
+        "properties": {
+          "schema_version": { "type": "integer" },
+          "window": { "type": ["string", "null"] },
+          "observed_at": { "type": ["string", "null"] },
+          "source": { "type": "string" },
+          "summary": {
+            "type": "object",
+            "required": ["total_requests", "ok_requests", "error_requests"],
+            "properties": {
+              "total_requests": { "type": "integer", "minimum": 0 },
+              "ok_requests": { "type": "integer", "minimum": 0 },
+              "error_requests": { "type": "integer", "minimum": 0 },
+              "error_rate": { "type": ["number", "null"] },
+              "failover_requests": { "type": "integer", "minimum": 0 },
+              "failover_rate": { "type": ["number", "null"] },
+              "cache_hits": { "type": "integer", "minimum": 0 },
+              "cache_hit_rate": { "type": ["number", "null"] },
+              "latency_ms": {
+                "type": "object",
+                "properties": {
+                  "p50": { "type": ["integer", "null"] },
+                  "p95": { "type": ["integer", "null"] },
+                  "avg": { "type": ["integer", "null"] }
+                },
+                "additionalProperties": true
+              }
+            },
+            "additionalProperties": true
+          },
+          "endpoints": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["endpoint_id", "requests", "ok_requests"],
+              "properties": {
+                "rank": { "type": "integer", "minimum": 1 },
+                "endpoint_id": { "type": ["string", "null"] },
+                "provider": { "type": ["string", "null"] },
+                "requests": { "type": "integer", "minimum": 0 },
+                "ok_requests": { "type": "integer", "minimum": 0 },
+                "error_rate": { "type": ["number", "null"] },
+                "avg_latency_ms": { "type": ["integer", "null"] }
+              },
+              "additionalProperties": true
+            }
+          },
+          "networks": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["network", "requests", "ok_requests"],
+              "properties": {
+                "network": { "type": "string" },
+                "requests": { "type": "integer", "minimum": 0 },
+                "ok_requests": { "type": "integer", "minimum": 0 },
+                "error_rate": { "type": ["number", "null"] }
+              },
+              "additionalProperties": true
+            }
+          }
+        },
+        "additionalProperties": true
+      },
       "ReliabilityScore": {
         "type": "object",
         "description": "Composite reliability score (0-100) from durable uptime history: sample-weighted uptime with a mild latency penalty. Null when no probe data exists.",

--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -84,6 +84,15 @@ const checks = [
     },
   ],
   [
+    "/api/v1/rpc/usage",
+    (body) => {
+      assert.equal(body.data.source, "rpc-proxy");
+      assert.equal(typeof body.data.summary.total_requests, "number");
+      assert.equal(Array.isArray(body.data.endpoints), true);
+      assert.equal(Array.isArray(body.data.networks), true);
+    },
+  ],
+  [
     "/api/v1/profiles?profile_level=adapter-backed",
     (body) =>
       assert.equal(

--- a/scripts/validate-schemas.mjs
+++ b/scripts/validate-schemas.mjs
@@ -27,6 +27,7 @@ const COMPUTED_ARTIFACTS = new Set([
   "subnet-trajectory",
   "subnet-uptime",
   "registry-leaderboards",
+  "rpc-usage",
   "global-incidents",
   // Live-only operational health (served from KV/D1, no static file on disk).
   "health-latest",

--- a/src/artifact-storage.mjs
+++ b/src/artifact-storage.mjs
@@ -34,6 +34,9 @@ const R2_ONLY_PATTERNS = [
   /^subnets\/(?:\d+|\{netuid\})\/trajectory\.json$/,
   /^subnets\/(?:\d+|\{netuid\})\/uptime\.json$/,
   /^registry\/leaderboards\.json$/,
+  // RPC reverse-proxy usage analytics (B3), computed live from D1 telemetry at
+  // /api/v1/rpc/usage — never written as a file.
+  /^rpc\/usage\.json$/,
   // Per-subnet agent capability catalog (full service detail) — large, built.
   /^agent-catalog\/(?:\d+|\{netuid\})\.json$/,
   /^metagraph\/latest\.json$/,

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -823,6 +823,12 @@ export const PUBLIC_ARTIFACTS = [
     "RegistryLeaderboardsArtifact",
   ),
   artifact(
+    "rpc-usage",
+    "/metagraph/rpc/usage.json",
+    "RPC reverse-proxy usage analytics (request volume, latency p50/p95, failover + error rate, cache-hit rate, per-endpoint distribution) over a 7d/30d window, computed live from the rpc_proxy_events telemetry at /api/v1/rpc/usage (no static file).",
+    "RpcUsageArtifact",
+  ),
+  artifact(
     "rpc-endpoints",
     "/metagraph/rpc-endpoints.json",
     "Bittensor base-layer RPC endpoint registry and probe status.",
@@ -1385,6 +1391,17 @@ export const API_ROUTES = [
       },
       { name: "limit", schema: { type: "integer", minimum: 1, maximum: 100 } },
     ],
+    [],
+  ),
+  route(
+    "rpc-usage",
+    "GET",
+    "/api/v1/rpc/usage",
+    "/metagraph/rpc/usage.json",
+    "Fetch RPC reverse-proxy usage analytics — request volume, latency p50/p95, failover + error rate, cache-hit rate, and the per-endpoint request distribution — over a 7d or 30d window (computed live from D1 telemetry).",
+    "short",
+    ["rpc", "analytics", "operations"],
+    [{ name: "window", schema: { type: "string", enum: ["7d", "30d"] } }],
     [],
   ),
   route(

--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -616,6 +616,17 @@ export async function pruneHealthHistory(env, overrides = {}) {
       .prepare(`DELETE FROM surface_checks WHERE checked_at < ?`)
       .bind(cutoff)
       .run();
+    // Prune RPC proxy usage telemetry (B3) to the same 30-day hot window. Wrapped
+    // separately + best-effort so a not-yet-migrated rpc_proxy_events table never
+    // blocks the surface_checks prune (the table arrives with the 0004 migration).
+    try {
+      await db
+        .prepare(`DELETE FROM rpc_proxy_events WHERE observed_at < ?`)
+        .bind(cutoff)
+        .run();
+    } catch {
+      // rpc_proxy_events absent or transient error — skip the telemetry prune.
+    }
     return { pruned: true, cutoff, changes: result?.meta?.changes ?? null };
   } catch {
     return { pruned: false };

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -360,6 +360,73 @@ export function formatPercentiles({ netuid, window, observedAt, rows }) {
   };
 }
 
+// RPC reverse-proxy usage analytics (B3) from the rpc_proxy_events telemetry.
+// `totals`: one aggregate row { total, ok_count, failover_count, cache_hits,
+// avg_latency_ms }. `latency`: one row { p50, p95 } (window percentiles).
+// `endpointRows`/`networkRows`: per-endpoint / per-network breakdowns ordered by
+// request volume. Cold/unmigrated D1 yields a schema-stable zeroed payload (every
+// arg may be empty/undefined), so the route never errors before the table exists.
+export function formatRpcUsage({
+  window,
+  observedAt,
+  totals,
+  latency,
+  endpointRows,
+  networkRows,
+}) {
+  const total = Number(totals?.total) || 0;
+  const okCount = Number(totals?.ok_count) || 0;
+  const failoverCount = Number(totals?.failover_count) || 0;
+  const cacheHits = Number(totals?.cache_hits) || 0;
+  const errorCount = Math.max(0, total - okCount);
+  const ratioOf = (numerator, denominator) =>
+    denominator ? round4(numerator / denominator) : null;
+  return {
+    schema_version: 1,
+    window: window || null,
+    observed_at: observedAt || null,
+    source: "rpc-proxy",
+    summary: {
+      total_requests: total,
+      ok_requests: okCount,
+      error_requests: errorCount,
+      error_rate: ratioOf(errorCount, total),
+      failover_requests: failoverCount,
+      failover_rate: ratioOf(failoverCount, total),
+      cache_hits: cacheHits,
+      cache_hit_rate: ratioOf(cacheHits, total),
+      latency_ms: {
+        p50: roundInt(latency?.p50),
+        p95: roundInt(latency?.p95),
+        avg: roundInt(totals?.avg_latency_ms),
+      },
+    },
+    endpoints: (endpointRows || []).map((row, index) => {
+      const requests = Number(row.requests) || 0;
+      const ok = Number(row.ok_count) || 0;
+      return {
+        rank: index + 1,
+        endpoint_id: row.endpoint_id,
+        provider: row.provider || null,
+        requests,
+        ok_requests: ok,
+        error_rate: ratioOf(requests - ok, requests),
+        avg_latency_ms: roundInt(row.avg_latency_ms),
+      };
+    }),
+    networks: (networkRows || []).map((row) => {
+      const requests = Number(row.requests) || 0;
+      const ok = Number(row.ok_count) || 0;
+      return {
+        network: row.network,
+        requests,
+        ok_requests: ok,
+        error_rate: ratioOf(requests - ok, requests),
+      };
+    }),
+  };
+}
+
 // SLA + downtime incidents per surface. `slaRows`: [{ surface_id, total,
 // ok_count }]. `incidentRows`: [{ surface_id, started_at, ended_at,
 // failed_samples }] — one row PER INCIDENT (gap-islands grouped in SQL).

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -379,6 +379,35 @@ describe("pruneHealthHistory", () => {
     assert.match(db.calls.runs[0].sql, /DELETE FROM surface_checks/);
     assert.equal(db.calls.runs[0].binds[0], 100_000_000 - 1000);
   });
+
+  test("also prunes rpc_proxy_events to the same cutoff (B3)", async () => {
+    const db = makeDb();
+    await pruneHealthHistory(
+      {},
+      { now: () => 100_000_000, db, retentionMs: 1000 },
+    );
+    assert.match(db.calls.runs[1].sql, /DELETE FROM rpc_proxy_events/);
+    assert.equal(db.calls.runs[1].binds[0], 100_000_000 - 1000);
+  });
+
+  test("a missing rpc_proxy_events table (pre-migration) does not fail the prune", async () => {
+    // surface_checks DELETE succeeds; the rpc_proxy_events DELETE throws (no such
+    // table) — the prune must still report success for the surface_checks window.
+    const db = {
+      prepare: (sql) => ({
+        bind: () => ({
+          async run() {
+            if (/rpc_proxy_events/.test(sql)) {
+              throw new Error("no such table: rpc_proxy_events");
+            }
+            return { meta: { changes: 3 } };
+          },
+        }),
+      }),
+    };
+    const result = await pruneHealthHistory({}, { now: () => 5_000, db });
+    assert.equal(result.pruned, true);
+  });
 });
 
 describe("handleScheduled dispatch", () => {

--- a/tests/rpc-usage.test.mjs
+++ b/tests/rpc-usage.test.mjs
@@ -1,0 +1,345 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+import { formatRpcUsage } from "../src/health-serving.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+// --- formatRpcUsage (pure) --------------------------------------------------
+
+describe("formatRpcUsage", () => {
+  test("cold/unmigrated D1 yields a schema-stable zeroed payload", () => {
+    const out = formatRpcUsage({ window: "7d", observedAt: null });
+    assert.equal(out.schema_version, 1);
+    assert.equal(out.source, "rpc-proxy");
+    assert.equal(out.window, "7d");
+    assert.equal(out.summary.total_requests, 0);
+    assert.equal(out.summary.error_rate, null); // no requests → undefined rate
+    assert.equal(out.summary.cache_hit_rate, null);
+    assert.equal(out.summary.latency_ms.p50, null);
+    assert.deepEqual(out.endpoints, []);
+    assert.deepEqual(out.networks, []);
+  });
+
+  test("computes rates, ranks endpoints, and rounds latency", () => {
+    const out = formatRpcUsage({
+      window: "30d",
+      observedAt: "2026-06-14T00:00:00Z",
+      totals: {
+        total: 1000,
+        ok_count: 950,
+        failover_count: 40,
+        cache_hits: 250,
+        avg_latency_ms: 160.7,
+      },
+      latency: { p50: 120.4, p95: 480.9 },
+      endpointRows: [
+        {
+          endpoint_id: "fx",
+          provider: "onfinality",
+          requests: 700,
+          ok_count: 690,
+          avg_latency_ms: 140.2,
+        },
+        {
+          endpoint_id: "nx",
+          provider: null,
+          requests: 300,
+          ok_count: 260,
+          avg_latency_ms: 220.8,
+        },
+      ],
+      networkRows: [
+        { network: "finney", requests: 900, ok_count: 870 },
+        { network: "test", requests: 100, ok_count: 80 },
+      ],
+    });
+    assert.equal(out.summary.error_requests, 50);
+    assert.equal(out.summary.error_rate, 0.05);
+    assert.equal(out.summary.failover_rate, 0.04);
+    assert.equal(out.summary.cache_hit_rate, 0.25);
+    assert.equal(out.summary.latency_ms.p50, 120);
+    assert.equal(out.summary.latency_ms.p95, 481);
+    assert.equal(out.summary.latency_ms.avg, 161);
+    // Endpoints keep the SQL order (by volume) and are ranked.
+    assert.equal(out.endpoints[0].rank, 1);
+    assert.equal(out.endpoints[0].endpoint_id, "fx");
+    assert.equal(out.endpoints[0].provider, "onfinality");
+    assert.equal(out.endpoints[1].rank, 2);
+    assert.equal(out.endpoints[1].provider, null);
+    assert.equal(out.endpoints[1].error_rate, 0.1333);
+    assert.equal(out.endpoints[1].avg_latency_ms, 221);
+    assert.equal(out.networks[1].network, "test");
+    assert.equal(out.networks[1].error_rate, 0.2);
+  });
+
+  test("a zero-request endpoint/network row reports a null rate (no divide-by-zero)", () => {
+    const out = formatRpcUsage({
+      totals: { total: 0, ok_count: 0 },
+      endpointRows: [{ endpoint_id: "idle", requests: 0, ok_count: 0 }],
+      networkRows: [{ network: "finney", requests: 0, ok_count: 0 }],
+    });
+    assert.equal(out.window, null);
+    assert.equal(out.endpoints[0].error_rate, null);
+    assert.equal(out.networks[0].error_rate, null);
+  });
+});
+
+// --- /api/v1/rpc/usage route ------------------------------------------------
+
+async function getJson(url, env) {
+  const res = await handleRequest(new Request(url), env, {});
+  return { status: res.status, body: await res.json() };
+}
+
+describe("/api/v1/rpc/usage route", () => {
+  test("cold local D1 returns an empty-but-valid envelope", async () => {
+    const { status, body } = await getJson(
+      "https://api.metagraph.sh/api/v1/rpc/usage",
+      createLocalArtifactEnv(),
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.source, "rpc-proxy");
+    assert.equal(body.data.summary.total_requests, 0);
+    assert.deepEqual(body.data.endpoints, []);
+    assert.deepEqual(body.data.networks, []);
+  });
+
+  test("rejects unsupported windows and stray query params", async () => {
+    for (const query of ["window=bogus", "window=90d", "cacheBust=x"]) {
+      const { status, body } = await getJson(
+        `https://api.metagraph.sh/api/v1/rpc/usage?${query}`,
+        createLocalArtifactEnv(),
+      );
+      assert.equal(status, 400);
+      assert.equal(body.error.code, "invalid_query");
+    }
+  });
+
+  test("aggregates volume, latency, endpoints, and networks from D1", async () => {
+    // One mock D1 that routes each of the four aggregation queries by SQL shape.
+    const usageDb = {
+      prepare: (sql) => ({
+        bind: () => ({
+          async all() {
+            if (sql.includes("COUNT(*) AS total")) {
+              return {
+                results: [
+                  {
+                    total: 500,
+                    ok_count: 480,
+                    failover_count: 12,
+                    cache_hits: 100,
+                    avg_latency_ms: 150,
+                  },
+                ],
+              };
+            }
+            if (sql.includes("ranked")) {
+              return { results: [{ p50: 110, p95: 430 }] };
+            }
+            if (sql.includes("GROUP BY endpoint_id")) {
+              return {
+                results: [
+                  {
+                    endpoint_id: "fx",
+                    provider: "onfinality",
+                    requests: 500,
+                    ok_count: 480,
+                    avg_latency_ms: 150,
+                  },
+                ],
+              };
+            }
+            if (sql.includes("GROUP BY network")) {
+              return {
+                results: [{ network: "finney", requests: 500, ok_count: 480 }],
+              };
+            }
+            return { results: [] };
+          },
+        }),
+      }),
+    };
+    const env = { ...createLocalArtifactEnv(), METAGRAPH_HEALTH_DB: usageDb };
+    const { status, body } = await getJson(
+      "https://api.metagraph.sh/api/v1/rpc/usage?window=30d",
+      env,
+    );
+    assert.equal(status, 200);
+    assert.equal(body.data.window, "30d");
+    assert.equal(body.data.summary.total_requests, 500);
+    assert.equal(body.data.summary.error_requests, 20);
+    assert.equal(body.data.summary.latency_ms.p95, 430);
+    assert.equal(body.data.endpoints[0].endpoint_id, "fx");
+    assert.equal(body.data.networks[0].network, "finney");
+  });
+});
+
+// --- recordRpcUsage telemetry (via the live proxy) --------------------------
+
+describe("RPC proxy usage telemetry (recordRpcUsage)", () => {
+  const pool = {
+    pools: [
+      {
+        id: "finney-rpc",
+        endpoints: [
+          {
+            id: "fx",
+            provider: "onfinality",
+            pool_eligible: true,
+            status: "ok",
+            score: 100,
+            url: "https://bittensor-finney.api.onfinality.io/public",
+          },
+        ],
+      },
+    ],
+  };
+  // rpc/pools.json is an R2-tier artifact, so the proxy reads it from
+  // METAGRAPH_ARCHIVE (R2), not ASSETS.
+  const baseEnv = () => ({
+    METAGRAPH_ENABLE_RPC_PROXY: "true",
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          async json() {
+            return pool;
+          },
+        };
+      },
+    },
+  });
+  const reqFor = (method, params = []) =>
+    new Request("https://metagraph.sh/rpc/v1/finney", {
+      method: "POST",
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method, params }),
+    });
+
+  function withFetch(fetchImpl, run) {
+    const original = globalThis.fetch;
+    globalThis.fetch = fetchImpl;
+    return Promise.resolve(run()).finally(() => {
+      globalThis.fetch = original;
+    });
+  }
+
+  test("records a served request (endpoint, ok, latency, bypass cache)", async () => {
+    const captured = [];
+    const db = {
+      prepare: (sql) => ({
+        bind: (...binds) => ({
+          async run() {
+            captured.push({ sql, binds });
+            return { meta: {} };
+          },
+        }),
+      }),
+    };
+    const env = { ...baseEnv(), METAGRAPH_HEALTH_DB: db };
+    const waits = [];
+    const ctx = { waitUntil: (p) => waits.push(p) };
+    await withFetch(
+      async () =>
+        new Response(
+          JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }),
+          { status: 200 },
+        ),
+      async () => {
+        // system_health is uncacheable → cache "bypass", recorded after failover.
+        const res = await handleRequest(reqFor("system_health"), env, ctx);
+        assert.equal(res.status, 200);
+        await Promise.all(waits);
+      },
+    );
+    assert.equal(captured.length, 1);
+    assert.match(captured[0].sql, /INSERT INTO rpc_proxy_events/);
+    const [, network, endpointId, , ok, , , , cache] = captured[0].binds;
+    assert.equal(network, "finney");
+    assert.equal(endpointId, "fx");
+    assert.equal(ok, 1);
+    assert.equal(cache, "bypass");
+  });
+
+  test("a telemetry write that throws never breaks the proxied call", async () => {
+    const env = {
+      ...baseEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          throw new Error("telemetry binding exploded");
+        },
+      },
+    };
+    const ctx = { waitUntil() {} };
+    await withFetch(
+      async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1" }), {
+          status: 200,
+        }),
+      async () => {
+        const res = await handleRequest(reqFor("system_health"), env, ctx);
+        assert.equal(res.status, 200);
+      },
+    );
+  });
+
+  test("no telemetry without a ctx.waitUntil (no-op, proxy still serves)", async () => {
+    let prepared = false;
+    const env = {
+      ...baseEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          prepared = true;
+          return { bind: () => ({ run: async () => ({}) }) };
+        },
+      },
+    };
+    await withFetch(
+      async () =>
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: "0x1" }), {
+          status: 200,
+        }),
+      async () => {
+        const res = await handleRequest(reqFor("system_health"), env, {});
+        assert.equal(res.status, 200);
+      },
+    );
+    assert.equal(prepared, false);
+  });
+
+  test("records a routing failure (no eligible endpoint → 503)", async () => {
+    const captured = [];
+    const emptyPool = { pools: [{ id: "finney-rpc", endpoints: [] }] };
+    const env = {
+      METAGRAPH_ENABLE_RPC_PROXY: "true",
+      METAGRAPH_ARCHIVE: {
+        async get() {
+          return {
+            async json() {
+              return emptyPool;
+            },
+          };
+        },
+      },
+      METAGRAPH_HEALTH_DB: {
+        prepare: (sql) => ({
+          bind: (...binds) => ({
+            async run() {
+              captured.push({ sql, binds });
+              return { meta: {} };
+            },
+          }),
+        }),
+      },
+    };
+    const waits = [];
+    const res = await handleRequest(reqFor("system_health"), env, {
+      waitUntil: (p) => waits.push(p),
+    });
+    assert.equal(res.status, 503);
+    await Promise.all(waits);
+    assert.equal(captured.length, 1);
+    const [, , endpointId, , ok] = captured[0].binds;
+    assert.equal(endpointId, null);
+    assert.equal(ok, 0);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -49,6 +49,7 @@ import {
   formatIncidents,
   formatLeaderboards,
   formatPercentiles,
+  formatRpcUsage,
   formatTrajectory,
   formatTrends,
   formatUptime,
@@ -289,6 +290,11 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // Registry leaderboards (D1 + registry projections; fileless-D1 pattern).
   if (url.pathname === "/api/v1/registry/leaderboards") {
     return handleLeaderboards(request, env, url);
+  }
+
+  // RPC reverse-proxy usage analytics (D1 telemetry; fileless-D1 pattern, B3).
+  if (url.pathname === "/api/v1/rpc/usage") {
+    return handleRpcUsage(request, env, url);
   }
 
   if (url.pathname === "/api/v1" || url.pathname.startsWith("/api/v1/")) {
@@ -1648,6 +1654,119 @@ async function handleLeaderboards(request, env, url) {
   );
 }
 
+// Best-effort, async usage telemetry for the RPC proxy (B3). A telemetry write
+// must never add latency to, or fail, a proxied call — so it runs under
+// ctx.waitUntil and swallows every error (notably "no such table" before the
+// 0004 migration is applied). When the binding/ctx is absent (tests, local dev)
+// it is a no-op. The proxy degrades to "no analytics", never to "broken".
+function recordRpcUsage(env, ctx, event) {
+  const db = env.METAGRAPH_HEALTH_DB;
+  if (!db?.prepare || typeof ctx?.waitUntil !== "function") return;
+  try {
+    const write = db
+      .prepare(
+        `INSERT INTO rpc_proxy_events
+           (observed_at, network, endpoint_id, provider, ok, status, attempts, latency_ms, cache)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        event.observed_at,
+        event.network,
+        event.endpoint_id ?? null,
+        event.provider ?? null,
+        event.ok ? 1 : 0,
+        event.status ?? null,
+        event.attempts ?? null,
+        event.latency_ms ?? null,
+        event.cache ?? null,
+      )
+      .run();
+    ctx.waitUntil(Promise.resolve(write).catch(() => {}));
+  } catch {
+    // prepare/bind threw synchronously (malformed binding); drop the sample.
+  }
+}
+
+// RPC reverse-proxy usage analytics (B3): request volume, latency p50/p95,
+// failover + error rate, cache-hit rate, and the per-endpoint distribution that
+// shows whether the load balancer is actually spreading traffic. Computed live
+// from the rpc_proxy_events D1 telemetry; cold/unmigrated D1 returns a
+// schema-stable zeroed payload (d1All swallows the missing-table error).
+async function handleRpcUsage(request, env, url) {
+  const { label, days, error } = analyticsWindow(url);
+  if (error) return analyticsQueryError(error);
+  const since = Date.now() - days * DAY_MS;
+  const [totalsRows, latencyRows, endpointRows, networkRows] =
+    await Promise.all([
+      d1All(
+        env,
+        `SELECT COUNT(*) AS total,
+                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count,
+                SUM(CASE WHEN attempts > 1 THEN 1 ELSE 0 END) AS failover_count,
+                SUM(CASE WHEN cache = 'hit' THEN 1 ELSE 0 END) AS cache_hits,
+                AVG(latency_ms) AS avg_latency_ms
+         FROM rpc_proxy_events
+         WHERE observed_at >= ?`,
+        [since],
+      ),
+      d1All(
+        env,
+        `WITH ranked AS (
+           SELECT latency_ms,
+                  ROW_NUMBER() OVER (ORDER BY latency_ms) AS rn,
+                  COUNT(*) OVER () AS cnt
+           FROM rpc_proxy_events
+           WHERE observed_at >= ? AND latency_ms IS NOT NULL
+         )
+         SELECT MAX(CASE WHEN rn = CAST(0.50 * cnt AS INTEGER) + 1 THEN latency_ms END) AS p50,
+                MAX(CASE WHEN rn = CAST(0.95 * cnt AS INTEGER) + 1 THEN latency_ms END) AS p95
+         FROM ranked`,
+        [since],
+      ),
+      d1All(
+        env,
+        `SELECT endpoint_id, provider,
+                COUNT(*) AS requests,
+                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count,
+                AVG(latency_ms) AS avg_latency_ms
+         FROM rpc_proxy_events
+         WHERE observed_at >= ? AND endpoint_id IS NOT NULL
+         GROUP BY endpoint_id, provider
+         ORDER BY requests DESC
+         LIMIT 50`,
+        [since],
+      ),
+      d1All(
+        env,
+        `SELECT network,
+                COUNT(*) AS requests,
+                SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count
+         FROM rpc_proxy_events
+         WHERE observed_at >= ?
+         GROUP BY network
+         ORDER BY requests DESC`,
+        [since],
+      ),
+    ]);
+  const meta = await readHealthKv(env, KV_HEALTH_META);
+  const data = formatRpcUsage({
+    window: label,
+    observedAt: meta?.last_run_at || null,
+    totals: totalsRows[0],
+    latency: latencyRows[0],
+    endpointRows,
+    networkRows,
+  });
+  return envelopeResponse(
+    request,
+    {
+      data,
+      meta: await analyticsMeta(env, "/metagraph/rpc/usage.json", null),
+    },
+    "short",
+  );
+}
+
 async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   if (request.method !== "POST") {
     return errorResponse(
@@ -1779,8 +1898,24 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   // the static pool when the live snapshot is cold.
   const liveRpcPool = await readHealthKv(env, KV_HEALTH_RPC_POOL);
   const pool = overlayRpcPoolEligibility(staticPool, liveRpcPool);
+  // Usage telemetry (B3): network = the /rpc/v1/{network} path segment; startedAt
+  // anchors end-to-end proxy latency. recordRpcUsage is best-effort + async, so it
+  // never adds latency to — or can fail — the proxied call (see the helper).
+  const network = url.pathname.split("/")[3] || "finney";
+  const startedAt = Date.now();
   const { endpoints: candidates, unsafeEndpoint } = orderSafeRpcEndpoints(pool);
   if (!candidates.length) {
+    recordRpcUsage(env, ctx, {
+      observed_at: startedAt,
+      network,
+      endpoint_id: null,
+      provider: null,
+      ok: false,
+      status: unsafeEndpoint ? 502 : 503,
+      attempts: 0,
+      latency_ms: Date.now() - startedAt,
+      cache: "bypass",
+    });
     if (unsafeEndpoint) {
       return errorResponse(
         "rpc_endpoint_unsafe",
@@ -1821,6 +1956,17 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
         headers.set("cache-control", "no-store");
         headers.set("x-metagraph-rpc-cache", "hit");
         setRpcRateLimitHeaders(headers);
+        recordRpcUsage(env, ctx, {
+          observed_at: startedAt,
+          network,
+          endpoint_id: null,
+          provider: null,
+          ok: true,
+          status: 200,
+          attempts: 0,
+          latency_ms: Date.now() - startedAt,
+          cache: "hit",
+        });
         return new Response(
           JSON.stringify(rpcResultEnvelope(rpcBody, cachedPayload.result)),
           { status: 200, headers },
@@ -1830,6 +1976,24 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   }
 
   const response = await proxyWithFailover(candidates, { bodyText, poolId });
+  // The endpoint headers are set ONLY when an upstream served (streamRpcResponse);
+  // the all-failed path returns a bare 502, so a missing endpoint-id header marks
+  // a routing failure (ok=false). Recorded once here — every downstream return
+  // reuses this same response, so its served-endpoint/status/attempts are stable.
+  const servedEndpointId = response.headers.get("x-metagraph-rpc-endpoint-id");
+  recordRpcUsage(env, ctx, {
+    observed_at: startedAt,
+    network,
+    endpoint_id: servedEndpointId,
+    provider: response.headers.get("x-metagraph-rpc-provider"),
+    ok: Boolean(servedEndpointId),
+    status: response.status,
+    attempts:
+      Number(response.headers.get("x-metagraph-rpc-attempts")) ||
+      candidates.length,
+    latency_ms: Date.now() - startedAt,
+    cache: cacheKey ? "miss" : "bypass",
+  });
   if (!cacheKey) {
     return response;
   }


### PR DESCRIPTION
## What

Instruments the `/rpc/v1` reverse proxy with usage analytics and exposes them at **`GET /api/v1/rpc/usage`** — the "analytics data for the proxy" that didn't exist before. This is the load-balanced reverse-proxy feature finally getting the observability it warranted.

Surfaced metrics (7d/30d window):
- **Request volume** + ok/error counts and **error rate**
- **Latency p50/p95** (+ avg)
- **Failover rate** (requests that needed >1 upstream attempt)
- **Cache-hit rate**
- **Per-endpoint distribution** (ranked) — shows whether the load balancer is actually spreading traffic, with each endpoint's request share, error rate, and avg latency
- **Per-network** breakdown (finney/test)

## How

- **`migrations/0004_rpc_proxy_usage.sql`** — `rpc_proxy_events` hot time-series, pruned to the same 30-day window as `surface_checks`.
- **`recordRpcUsage`** — writes one row per proxied request via `ctx.waitUntil` (never blocks the call). Swallows every error, including a pre-migration `no such table`, so telemetry can never add latency to — or break — a proxied request. No `ctx`/binding → clean no-op.
- Reads back the `x-metagraph-rpc-endpoint-id/-provider/-attempts` headers that the proxy already sets (B2), so the served-endpoint distribution is accurate without re-plumbing `proxyWithFailover`.
- **`handleRpcUsage`** — fileless-D1 route (`R2_ONLY` + `COMPUTED`), cold/unmigrated D1 → schema-stable zeroed payload (`d1All` swallows the missing-table read).
- `RpcUsageArtifact` schema + contract/route registration + docs + the api/schema/docs/openapi-example validators all wired (**58 routes**).

## Storage note

There is **no Analytics Engine binding** on this Worker, so this reuses the existing `METAGRAPH_HEALTH_DB` D1 binding (same pattern as incidents/percentiles/leaderboards). The `0004` migration is applied **out-of-band** (wrangler/MCP); the code tolerates its absence until then.

## Verification

- `npm run test:coverage` → 997 tests pass; coverage **98.13 / 90.43 / 98.2 / 98.27** (stmts/branches/funcs/lines, all above the gate).
- All validators green: contract-drift, api (58), schemas, openapi + examples (58/58), types, ai, mcp, docs, private-boundary, lint, format.
- New tests: `tests/rpc-usage.test.mjs` (formatRpcUsage unit, route cold/populated/bad-window, telemetry served/throws/no-ctx/routing-failure) + `pruneHealthHistory` rpc-prune branches.

Source-only commit for the regenerated data artifacts (datasets/llms/agent-catalog reverted; CI rebuilds + R2 reconciles); contract artifacts (openapi/types/contracts/api-index) committed in-sync per the drift gate.