### PR TITLE
fix(health): persist live RPC block heights

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -380,6 +380,9 @@ export async function runHealthProber(env, ctx, overrides = {}) {
       latency_ms: Number.isFinite(base.latency_ms) ? base.latency_ms : null,
       status_code: Number.isInteger(base.status_code) ? base.status_code : null,
       archive_support: base.archive_support ?? null,
+      latest_block: Number.isFinite(base.latest_block)
+        ? base.latest_block
+        : null,
       checked_at_ms: runAt,
       last_ok_ms: lastOkMs,
       consecutive_failures: consecutiveFailures,

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -243,6 +243,7 @@ const probeImpl = async (input) =>
         latency_ms: 42,
         status_code: 200,
         archive_support: true,
+        latest_block: 12345,
       }
     : {
         status: "failed",
@@ -317,6 +318,7 @@ describe("runHealthProber", () => {
     assert.equal(pool.eligible_count, 1);
     assert.equal(pool.endpoints[0].pool_eligible, true);
     assert.equal(pool.endpoints[0].archive_support, true);
+    assert.equal(pool.endpoints[0].latest_block, 12345);
 
     const meta = kv.json(KV_HEALTH_META);
     assert.equal(meta.probed_count, 2);
@@ -1014,6 +1016,7 @@ describe("persistToKv via runHealthProber", () => {
             classification: "live",
             latency_ms: 10,
             archive_support: true,
+            latest_block: 76543,
           }
         : { status: "failed", classification: "dead", latency_ms: null };
     const kv = makeKv();
@@ -1040,6 +1043,10 @@ describe("persistToKv via runHealthProber", () => {
     assert.equal(
       pool.endpoints.find((e) => e.id === "rpc-ok").pool_eligible,
       true,
+    );
+    assert.equal(
+      pool.endpoints.find((e) => e.id === "rpc-ok").latest_block,
+      76543,
     );
     assert.equal(
       pool.endpoints.find((e) => e.id === "rpc-bad").pool_eligible,


### PR DESCRIPTION
### Motivation
- The RPC probe result `latest_block` was available from the probe core but not copied into the probed rows persisted to KV, causing `health:rpc-pool` to contain null or stale heights and breaking block-height-aware routing.

### Description
- Preserve the probe-provided block height by adding `latest_block: Number.isFinite(base.latest_block) ? base.latest_block : null` to the row built in `src/health-prober.mjs`.
- Add regression assertions in `tests/health-prober.test.mjs` to verify `KV_HEALTH_RPC_POOL` endpoints include the persisted `latest_block` values for single and multi-endpoint scenarios.
- No changes were required to `persistToKv` or downstream ordering logic because they already read `row.latest_block`/KV fields.

### Testing
- Ran the targeted health prober tests with `npm test -- --run tests/health-prober.test.mjs` and they passed (all tests in that file succeeded).
- Ran the full test suite with `npm test`, which fails in this checkout due to unrelated missing generated public/R2 artifacts and environment-dependent DNS/public-safety assertions, not because of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f9447cc9c832aa3cce0a4b8375dff)