### PR TITLE
fix(rpc): bound usage network telemetry

### DIFF
--- a/migrations/0004_rpc_proxy_usage.sql
+++ b/migrations/0004_rpc_proxy_usage.sql
@@ -13,7 +13,7 @@
 CREATE TABLE IF NOT EXISTS rpc_proxy_events (
   id           INTEGER PRIMARY KEY AUTOINCREMENT,
   observed_at  INTEGER NOT NULL,            -- epoch ms the proxy request started
-  network      TEXT    NOT NULL,            -- finney | test (path segment)
+  network      TEXT    NOT NULL CHECK (network IN ('finney')), -- supported RPC proxy network
   endpoint_id  TEXT,                        -- pool endpoint that served (NULL: cache hit / none eligible)
   provider     TEXT,                        -- served endpoint's provider label
   ok           INTEGER NOT NULL,            -- 1 if the proxy routed to a responding upstream (or cache hit)

--- a/migrations/0005_rpc_proxy_usage_network_check.sql
+++ b/migrations/0005_rpc_proxy_usage_network_check.sql
@@ -1,0 +1,55 @@
+-- Harden rpc_proxy_events against high-cardinality network labels.
+--
+-- 0004 originally documented the proxy network as a small enum but did not
+-- enforce it. The Worker now rejects unsupported /rpc/v1/{network} paths before
+-- recording telemetry; this migration normalizes existing D1 tables to the same
+-- invariant and adds a CHECK for future writes.
+
+DELETE FROM rpc_proxy_events
+WHERE network NOT IN ('finney');
+
+CREATE TABLE IF NOT EXISTS rpc_proxy_events_hardened (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  observed_at  INTEGER NOT NULL,
+  network      TEXT    NOT NULL CHECK (network IN ('finney')),
+  endpoint_id  TEXT,
+  provider     TEXT,
+  ok           INTEGER NOT NULL,
+  status       INTEGER,
+  attempts     INTEGER,
+  latency_ms   INTEGER,
+  cache        TEXT
+);
+
+INSERT INTO rpc_proxy_events_hardened (
+  id,
+  observed_at,
+  network,
+  endpoint_id,
+  provider,
+  ok,
+  status,
+  attempts,
+  latency_ms,
+  cache
+)
+SELECT
+  id,
+  observed_at,
+  network,
+  endpoint_id,
+  provider,
+  ok,
+  status,
+  attempts,
+  latency_ms,
+  cache
+FROM rpc_proxy_events;
+
+DROP TABLE rpc_proxy_events;
+ALTER TABLE rpc_proxy_events_hardened RENAME TO rpc_proxy_events;
+
+CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_observed
+  ON rpc_proxy_events (observed_at);
+CREATE INDEX IF NOT EXISTS idx_rpc_proxy_events_network_observed
+  ON rpc_proxy_events (network, observed_at);

--- a/tests/rpc-usage.test.mjs
+++ b/tests/rpc-usage.test.mjs
@@ -116,6 +116,7 @@ describe("/api/v1/rpc/usage route", () => {
   });
 
   test("aggregates volume, latency, endpoints, and networks from D1", async () => {
+    const networkSql = [];
     // One mock D1 that routes each of the four aggregation queries by SQL shape.
     const usageDb = {
       prepare: (sql) => ({
@@ -151,6 +152,7 @@ describe("/api/v1/rpc/usage route", () => {
               };
             }
             if (sql.includes("GROUP BY network")) {
+              networkSql.push(sql);
               return {
                 results: [{ network: "finney", requests: 500, ok_count: 480 }],
               };
@@ -172,6 +174,8 @@ describe("/api/v1/rpc/usage route", () => {
     assert.equal(body.data.summary.latency_ms.p95, 430);
     assert.equal(body.data.endpoints[0].endpoint_id, "fx");
     assert.equal(body.data.networks[0].network, "finney");
+    assert.match(networkSql[0], /network IN \('finney'\)/);
+    assert.match(networkSql[0], /LIMIT 10/);
   });
 });
 
@@ -258,6 +262,35 @@ describe("RPC proxy usage telemetry (recordRpcUsage)", () => {
     assert.equal(endpointId, "fx");
     assert.equal(ok, 1);
     assert.equal(cache, "bypass");
+  });
+
+  test("rejects unsupported RPC network paths before telemetry", async () => {
+    let prepared = false;
+    const env = {
+      ...baseEnv(),
+      METAGRAPH_HEALTH_DB: {
+        prepare() {
+          prepared = true;
+          return { bind: () => ({ run: async () => ({}) }) };
+        },
+      },
+    };
+    const res = await handleRequest(
+      new Request("https://metagraph.sh/rpc/v1/attacker-1", {
+        method: "POST",
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "system_health",
+          params: [],
+        }),
+      }),
+      env,
+      { waitUntil() {} },
+    );
+    assert.equal(res.status, 404);
+    assert.equal((await res.json()).error.code, "rpc_network_unsupported");
+    assert.equal(prepared, false);
   });
 
   test("a telemetry write that throws never breaks the proxied call", async () => {

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -767,6 +767,7 @@ const LOCAL_NETWORK_INFO = {
   },
   guide: "/skills/bittensor/SKILL.md",
 };
+const RPC_PROXY_NETWORKS = new Set(["finney"]);
 // Only an /api/v1/ or /metagraph/ path whose first segment is a known network
 // alias is treated as network-scoped; real routes (subnets, providers, …) never
 // collide with the alias set, so this never shadows an existing path.
@@ -1742,9 +1743,10 @@ async function handleRpcUsage(request, env, url) {
                 COUNT(*) AS requests,
                 SUM(CASE WHEN ok = 1 THEN 1 ELSE 0 END) AS ok_count
          FROM rpc_proxy_events
-         WHERE observed_at >= ?
+         WHERE observed_at >= ? AND network IN ('finney')
          GROUP BY network
-         ORDER BY requests DESC`,
+         ORDER BY requests DESC
+         LIMIT 10`,
         [since],
       ),
     ]);
@@ -1785,6 +1787,29 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
       "rpc_proxy_disabled",
       "Read-only RPC proxying is intentionally disabled until endpoint scoring, abuse controls, and method filtering are enabled.",
       501,
+    );
+  }
+
+  // The legacy /rpc/v1/wss route points at WebSocket-only endpoints that cannot
+  // be HTTP-POSTed, so reject it with a clear error instead of treating "wss" as
+  // an unsupported telemetry network.
+  if (url.pathname.endsWith("/wss")) {
+    return errorResponse(
+      "rpc_websocket_unsupported",
+      "WebSocket JSON-RPC is not available through this HTTP proxy. POST to /rpc/v1/finney for HTTP JSON-RPC, or connect to a public WSS endpoint directly.",
+      400,
+    );
+  }
+
+  const network = url.pathname.split("/")[3] || "finney";
+  if (!RPC_PROXY_NETWORKS.has(network)) {
+    return errorResponse(
+      "rpc_network_unsupported",
+      "Unsupported RPC proxy network. POST to /rpc/v1/finney for HTTP JSON-RPC.",
+      404,
+      {
+        allowed_networks: [...RPC_PROXY_NETWORKS].sort(),
+      },
     );
   }
 
@@ -1878,17 +1903,6 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
     );
   }
 
-  // The proxy forwards an HTTP JSON-RPC POST, so it can only reach HTTP(S)
-  // upstreams. The /wss route points at WebSocket-only endpoints that cannot be
-  // HTTP-POSTed, so reject it with a clear error instead of failing the upstream
-  // fetch (which would surface as a 500).
-  if (url.pathname.endsWith("/wss")) {
-    return errorResponse(
-      "rpc_websocket_unsupported",
-      "WebSocket JSON-RPC is not available through this HTTP proxy. POST to /rpc/v1/finney for HTTP JSON-RPC, or connect to a public WSS endpoint directly.",
-      400,
-    );
-  }
   const poolId = "finney-rpc";
   const staticPool = (poolArtifact.data.pools || []).find(
     (candidate) => candidate.id === poolId,
@@ -1898,10 +1912,9 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   // the static pool when the live snapshot is cold.
   const liveRpcPool = await readHealthKv(env, KV_HEALTH_RPC_POOL);
   const pool = overlayRpcPoolEligibility(staticPool, liveRpcPool);
-  // Usage telemetry (B3): network = the /rpc/v1/{network} path segment; startedAt
-  // anchors end-to-end proxy latency. recordRpcUsage is best-effort + async, so it
-  // never adds latency to — or can fail — the proxied call (see the helper).
-  const network = url.pathname.split("/")[3] || "finney";
+  // Usage telemetry (B3): network is validated above so untrusted path segments
+  // cannot create high-cardinality D1 labels. recordRpcUsage is best-effort +
+  // async, so it never adds latency to — or can fail — the proxied call.
   const startedAt = Date.now();
   const { endpoints: candidates, unsafeEndpoint } = orderSafeRpcEndpoints(pool);
   if (!candidates.length) {


### PR DESCRIPTION
### Motivation
- Prevent untrusted high-cardinality path segments under `/rpc/v1/{network}` from being persisted and returned by `/api/v1/rpc/usage`, which can be abused to exhaust D1/Worker resources.
- Preserve existing proxy behaviour (including the legacy `/rpc/v1/wss` error path) while hardening telemetry and DB invariants.

### Description
- Add an allowlist for RPC proxy networks via `RPC_PROXY_NETWORKS` and reject unsupported `/rpc/v1/{network}` paths early in `handleRpcProxyRequest` (returns `rpc_network_unsupported`).
- Preserve legacy WebSocket rejection by keeping `/rpc/v1/.../wss` handling returning `rpc_websocket_unsupported`.
- Bound the public usage aggregation query in `handleRpcUsage` to `network IN ('finney')` and add `LIMIT 10` to cap returned rows.
- Add schema-level enforcement by adding a `CHECK (network IN ('finney'))` to `migrations/0004_rpc_proxy_usage.sql` and provide migration `migrations/0005_rpc_proxy_usage_network_check.sql` that removes unsupported rows and rebuilds the table with the CHECK.
- Add regression tests in `tests/rpc-usage.test.mjs` that assert the network-query is filtered/capped and that unsupported `/rpc/v1/{network}` paths are rejected before any telemetry write.

### Testing
- Ran `npm test -- tests/rpc-usage.test.mjs`, and the test file passed (all tests green).
- Ran linter with `npm run lint -- workers/api.mjs tests/rpc-usage.test.mjs`, which completed without errors.
- A broader run including `tests/worker-runtime.test.mjs` surfaced existing fixture-dependent 404 failures in this environment unrelated to the telemetry fix; those failures were present during iteration and are not caused by the network-allowlist change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f96a354d0832a891cd6b909b2ee84)