### PR TITLE
feat(rpc): network-aware proxy + live testnet RPC pool (/rpc/v1/test)

### DIFF
--- a/registry/native/test-base-endpoints.json
+++ b/registry/native/test-base-endpoints.json
@@ -1,0 +1,19 @@
+{
+  "schema_version": 1,
+  "network": "test",
+  "notes": "Bittensor testnet base-layer public RPC endpoints, backing the /rpc/v1/test load-balanced reverse proxy. This is a STATIC pool (not probe-derived): liveness is handled by the proxy's in-isolate circuit breaker + failover, and observability by /api/v1/rpc/usage (per-network). Both endpoints were verified live with genesis 0x8f9cf856bf558a14440e75569c9e58594757048d7b3a84b5d25f6bd978263105 (the testnet genesis, distinct from finney's 0x2f0555…), in-sync with the test-subnets.json snapshot. Probe-based pool health is intentionally deferred — the netuid-keyed health DB would need network threading to avoid polluting finney's root health.",
+  "endpoints": [
+    {
+      "id": "opentensor-test-finney-rpc",
+      "url": "https://test.finney.opentensor.ai",
+      "provider": "opentensor",
+      "kind": "subtensor-rpc"
+    },
+    {
+      "id": "opentensor-test-chain-rpc",
+      "url": "https://test.chain.opentensor.ai",
+      "provider": "opentensor",
+      "kind": "subtensor-rpc"
+    }
+  ]
+}

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1766,12 +1766,43 @@ for (const subnet of mergedSubnets) {
     claims: claimsByNetuid.get(subnet.netuid) || [],
   });
 }
+// Testnet base-layer RPC endpoints → the static /rpc/v1/test pool (see
+// registry/native/test-base-endpoints.json). Mapped to the probe-derived endpoint
+// shape with static eligibility/score so the proxy can route immediately; the
+// in-isolate breaker + failover handle liveness, /api/v1/rpc/usage the analytics.
+const testnetBaseEndpoints = await readOptionalJson(
+  path.join(repoRoot, "registry/native/test-base-endpoints.json"),
+);
+const testnetRpcPoolEndpoints = (testnetBaseEndpoints?.endpoints || []).map(
+  (endpoint) => ({
+    id: endpoint.id,
+    kind: endpoint.kind || "subtensor-rpc",
+    url: endpoint.url,
+    provider: endpoint.provider || "unknown",
+    layer: "bittensor-base",
+    score: 100,
+    pool_eligible: true,
+    status: "unknown",
+    health_source: "not-monitored",
+    health_stale: true,
+    latency_ms: null,
+    latest_block: null,
+    observed_at: null,
+    last_ok: null,
+    archive_support: false,
+    score_reasons: [{ reason: "static-testnet-base-layer", points: 0 }],
+    pool_eligibility_reasons: [
+      "static testnet pool member; liveness via proxy breaker + failover",
+    ],
+  }),
+);
 await writeJson(
   artifactFile("rpc/pools.json"),
   buildEndpointPoolArtifact({
     generatedAt,
     contractVersion,
     rpcArtifact: rpcEndpoints,
+    testnetEndpoints: testnetRpcPoolEndpoints,
   }),
 );
 await writeJson(

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1789,6 +1789,11 @@ export function buildEndpointPoolArtifact({
   contractVersion,
   rpcArtifact = null,
   endpointArtifact = null,
+  // Static, non-default-network base-layer RPC endpoints (e.g. testnet). These
+  // are NOT probe-derived: they carry static pool_eligible/score so /rpc/v1/{net}
+  // can route immediately, with the proxy's in-isolate breaker + failover handling
+  // liveness. Shape matches the mapped `endpoints` below (see test-base-endpoints).
+  testnetEndpoints = [],
 }) {
   const sourceArtifact = endpointArtifact || rpcArtifact || { endpoints: [] };
   const endpoints = (sourceArtifact.endpoints || []).map((endpoint) => {
@@ -1855,6 +1860,11 @@ export function buildEndpointPoolArtifact({
         "archive",
         endpoints.filter((endpoint) => endpoint.archive_support === true),
       ),
+      // Testnet base-layer RPC pool (/rpc/v1/test). Static members — appended only
+      // when configured (registry/native/test-base-endpoints.json present).
+      ...(testnetEndpoints.length
+        ? [endpointPool("test-rpc", "subtensor-rpc", testnetEndpoints)]
+        : []),
     ],
   };
 }

--- a/tests/rpc-network-routing.test.mjs
+++ b/tests/rpc-network-routing.test.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import { handleRequest } from "../workers/api.mjs";
+
+// Network-aware proxy routing: /rpc/v1/{network} selects its pool from
+// rpc/pools.json (finney → finney-rpc, test → test-rpc). The testnet endpoints
+// are a static pool (test.finney.opentensor.ai is in TRUSTED_RPC_UPSTREAM_ORIGINS).
+describe("RPC proxy — network-aware pool selection", () => {
+  const pools = {
+    pools: [
+      {
+        id: "finney-rpc",
+        endpoints: [
+          {
+            id: "fx",
+            provider: "onfinality",
+            pool_eligible: true,
+            status: "ok",
+            score: 100,
+            url: "https://bittensor-finney.api.onfinality.io/public",
+          },
+        ],
+      },
+      {
+        id: "test-rpc",
+        endpoints: [
+          {
+            id: "opentensor-test-finney-rpc",
+            provider: "opentensor",
+            pool_eligible: true,
+            status: "unknown",
+            score: 100,
+            url: "https://test.finney.opentensor.ai",
+          },
+        ],
+      },
+    ],
+  };
+  const env = {
+    METAGRAPH_ENABLE_RPC_PROXY: "true",
+    METAGRAPH_ARCHIVE: {
+      async get() {
+        return {
+          async json() {
+            return pools;
+          },
+        };
+      },
+    },
+  };
+  const reqFor = (network) =>
+    new Request(`https://metagraph.sh/rpc/v1/${network}`, {
+      method: "POST",
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "system_health",
+        params: [],
+      }),
+    });
+
+  function withFetch(capture, run) {
+    const original = globalThis.fetch;
+    globalThis.fetch = async (url) => {
+      capture.push(url);
+      return new Response(
+        JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }),
+        { status: 200 },
+      );
+    };
+    return Promise.resolve(run()).finally(() => {
+      globalThis.fetch = original;
+    });
+  }
+
+  test("/rpc/v1/test routes to the test-rpc pool's testnet upstream", async () => {
+    const seen = [];
+    await withFetch(seen, async () => {
+      const res = await handleRequest(reqFor("test"), env, { waitUntil() {} });
+      assert.equal(res.status, 200);
+      assert.equal(
+        res.headers.get("x-metagraph-rpc-endpoint-id"),
+        "opentensor-test-finney-rpc",
+      );
+    });
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0], "https://test.finney.opentensor.ai");
+  });
+
+  test("/rpc/v1/finney still routes to the finney pool", async () => {
+    const seen = [];
+    await withFetch(seen, async () => {
+      const res = await handleRequest(reqFor("finney"), env, {
+        waitUntil() {},
+      });
+      assert.equal(res.status, 200);
+      assert.equal(res.headers.get("x-metagraph-rpc-endpoint-id"), "fx");
+    });
+    assert.equal(seen[0], "https://bittensor-finney.api.onfinality.io/public");
+  });
+
+  test("an unknown network 404s instead of falling back to mainnet", async () => {
+    const seen = [];
+    await withFetch(seen, async () => {
+      const res = await handleRequest(reqFor("mainnet"), env, {
+        waitUntil() {},
+      });
+      assert.equal(res.status, 404);
+      const body = await res.json();
+      assert.equal(body.error.code, "rpc_network_unsupported");
+      assert.deepEqual(body.meta.supported_networks, ["finney", "test"]);
+    });
+    assert.equal(seen.length, 0); // never reached an upstream
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1889,19 +1889,30 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
       400,
     );
   }
-  const poolId = "finney-rpc";
+  // Network-aware pool selection: /rpc/v1/{network} → its pool (finney→finney-rpc,
+  // test→test-rpc). An unknown network 404s instead of silently routing to
+  // mainnet. `network` also tags the B3 usage telemetry below.
+  const network = url.pathname.split("/")[3] || "";
+  const poolId = RPC_PROXY_POOLS[network];
+  if (!poolId) {
+    return errorResponse(
+      "rpc_network_unsupported",
+      `Unknown RPC network "${network || "(none)"}". Supported networks: ${Object.keys(RPC_PROXY_POOLS).join(", ")}.`,
+      404,
+      { supported_networks: Object.keys(RPC_PROXY_POOLS) },
+    );
+  }
   const staticPool = (poolArtifact.data.pools || []).find(
     (candidate) => candidate.id === poolId,
   );
   // Overlay the 2-minute cron health so the proxy avoids sustained-down endpoints
   // (the in-isolate breaker still handles instantaneous failures). Falls back to
-  // the static pool when the live snapshot is cold.
+  // the static pool when the live snapshot is cold (always the case for the static
+  // testnet pool, which is intentionally not probe-derived).
   const liveRpcPool = await readHealthKv(env, KV_HEALTH_RPC_POOL);
   const pool = overlayRpcPoolEligibility(staticPool, liveRpcPool);
-  // Usage telemetry (B3): network = the /rpc/v1/{network} path segment; startedAt
-  // anchors end-to-end proxy latency. recordRpcUsage is best-effort + async, so it
-  // never adds latency to — or can fail — the proxied call (see the helper).
-  const network = url.pathname.split("/")[3] || "finney";
+  // startedAt anchors end-to-end proxy latency for the B3 usage telemetry; the
+  // recorder is best-effort + async (never adds latency to / fails the call).
   const startedAt = Date.now();
   const { endpoints: candidates, unsafeEndpoint } = orderSafeRpcEndpoints(pool);
   if (!candidates.length) {
@@ -2043,6 +2054,9 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
 const RPC_MAX_ATTEMPTS = 3;
 const RPC_ATTEMPT_TIMEOUT_MS = 6000;
 const RPC_CLASSIFY_BODY_LIMIT_BYTES = 64 * 1024;
+// /rpc/v1/{network} → the pool id served from rpc/pools.json. Adding a network
+// here (plus its pool + allowlisted origins) is all the proxy needs to serve it.
+const RPC_PROXY_POOLS = { finney: "finney-rpc", test: "test-rpc" };
 // Max blocks an endpoint may trail the freshest reported tip before the proxy
 // demotes it behind synced nodes. Bittensor block time is ~12s, so ~10 blocks
 // (~2 min) tolerates cross-provider probe-timing skew while still routing around

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -74,6 +74,10 @@ export const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
   "https://bittensor-public.nodies.app",
   "https://entrypoint-finney.opentensor.ai",
   "https://lite.chain.opentensor.ai",
+  // Bittensor testnet base-layer RPC (the /rpc/v1/test pool); verified testnet
+  // genesis 0x8f9cf8…, distinct from finney. See registry/native/test-base-endpoints.json.
+  "https://test.finney.opentensor.ai",
+  "https://test.chain.opentensor.ai",
   "wss://archive.chain.opentensor.ai",
   "wss://bittensor-finney.api.onfinality.io",
   "wss://entrypoint-finney.opentensor.ai",


### PR DESCRIPTION
## What

Makes `/rpc/v1/test` a **real load-balanced testnet RPC proxy** instead of a stub that silently routed to the finney pool (`poolId` was hardcoded). Answers "get the testnet pool live."

## Findings (from the investigation)

- Testnet today = a chain-identity *directory* (`/api/v1/test/subnets` serves 506 real subnets) with **zero operational infrastructure**: no endpoints, no health, and the proxy's `/rpc/v1/test` path routed to **finney**.
- A discovery pass over all 506 testnet subnets found **no callable subnet-level services** — of 184 with chain identity, 34 `subnet_url`s are websites and 62 `github_repo`s are source (both already surfaced as display-only links). Nothing callable to register at the subnet layer.
- But there **are** real base-layer resources: two public HTTPS testnet RPC endpoints (`test.finney` + `test.chain.opentensor.ai`), both verified live with the testnet genesis `0x8f9cf8…` (distinct from finney's `0x2f0555…`) and in-sync with the snapshot.

## Changes

- **`TRUSTED_RPC_UPSTREAM_ORIGINS`** — allowlist the two testnet origins.
- **`registry/native/test-base-endpoints.json`** — the static testnet pool definition; `build-artifacts` maps it into `rpc/pools.json` as a `test-rpc` pool (static eligibility/score, `health_source: not-monitored`).
- **`handleRpcProxyRequest`** — pick the pool by the `/rpc/v1/{network}` segment via `RPC_PROXY_POOLS` (`finney→finney-rpc`, `test→test-rpc`); an unknown network **404s** instead of silently using mainnet.

**B2 block-height routing and B3 per-network usage analytics work for testnet for free** — the proxy already records `network` per request, so `/api/v1/rpc/usage` will show a `test` network breakdown.

## Deliberately deferred (not an oversight)

**Probe-based testnet pool health.** The netuid-keyed health DB would need `network` threading to avoid polluting finney's root (netuid 0) health. For a 2-endpoint, same-provider, in-sync pool, the proxy's in-isolate circuit breaker + failover already handle liveness, and `/api/v1/rpc/usage` provides the observability. Worth doing later if testnet grows more endpoints/providers.

## Verification

- 1000 tests pass; coverage **98.13 / 90.4 / 98.2 / 98.27**. New `tests/rpc-network-routing.test.mjs` covers `/rpc/v1/test` → test-rpc, `/rpc/v1/finney` unchanged, and unknown-network 404.
- All validators green (schemas, api 58 routes, openapi-examples, docs, contract-drift, lint, format).
- `rpc/pools.json` is R2-only, so this reaches R2 on the next data refresh (I'll trigger it after merge); no contract change.