### PR TITLE
fix(safety): exempt OpenAPI doc fields from soft wallet/key fixture scan

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -176,6 +176,15 @@ function scanCapturedFixtureBody(relativePath, content) {
       if (pattern.soft && !pattern.scanFixtureBody) {
         continue;
       }
+      // OpenAPI/JSON documentation fields (description/summary/title) are human
+      // API docs the subnet published — a captured spec's parameter description
+      // routinely reads "Your wallet path…"/"do not share your private key". Those
+      // are docs, not leaked secret VALUES, so exempt them from the SOFT wording
+      // heuristics. Hard secret patterns (keys/tokens) still scan these fields
+      // below, so a real secret can't hide in a description.
+      if (pattern.soft && isDocumentationField(valuePath)) {
+        continue;
+      }
       if (pattern.regex.test(value)) {
         findings.push(
           `${relativePath}:response.body${valuePath}: ${pattern.name}`,
@@ -183,6 +192,14 @@ function scanCapturedFixtureBody(relativePath, content) {
       }
     }
   }
+}
+
+function isDocumentationField(valuePath) {
+  return (
+    valuePath.endsWith(".description") ||
+    valuePath.endsWith(".summary") ||
+    valuePath.endsWith(".title")
+  );
 }
 
 function* walkJsonStrings(node, valuePath = "") {

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -117,4 +117,46 @@ describe("captured-fixture body scan", () => {
       `hard secret patterns must still fire on fixture body values; got:\n${output}`,
     );
   });
+
+  test("does not flag wallet/key wording in an OpenAPI documentation field", async () => {
+    // Regression for the sn-97 publish wedge: a captured openapi parameter
+    // description reads "…your wallet path / seed phrase…" — public API docs the
+    // subnet published, not a leaked secret value.
+    await writeTestFixture({
+      paths: {
+        "/user/credits": {
+          get: {
+            parameters: [
+              {
+                description:
+                  "Provide your wallet path or seed phrase to authenticate the request.",
+              },
+            ],
+          },
+        },
+      },
+    });
+    const output = runScanOutput();
+    assert.equal(
+      output.includes(TEST_FIXTURE),
+      false,
+      `wallet/key wording in a documentation field should be exempt; got:\n${output}`,
+    );
+  });
+
+  test("still flags a hard secret even inside a documentation field", async () => {
+    // The doc-field exemption is soft-only: a real token in a description is
+    // still caught by the hard secret patterns.
+    await writeTestFixture({
+      info: {
+        description:
+          "Example call: token=ghp_abcdefghijklmnopqrstuvwxyz0123456789",
+      },
+    });
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(`${TEST_FIXTURE}:response.body`),
+      `hard secrets must fire even inside doc fields; got:\n${output}`,
+    );
+  });
 });


### PR DESCRIPTION
## Why

The data publish (`publish-cloudflare.yml`) is **wedged** — every run fails the Public-safety scan, which means no fresh data reaches R2/KV and the testnet `test-rpc` pool ([#647](https://github.com/JSONbored/metagraphed/pull/647)) can't go live. I caught it via the publish I triggered:

```
Public-safety scan found 1 issue(s):
- dist/metagraph-r2/metagraph/fixtures/sn-97-website-common-openapi-json.json:response.body.paths./user/credits.get.parameters[0].description: wallet/key wording
```

The previous scheduled publish succeeded; **mainnet sn-97 changed their API docs** since then, and a freshly-captured `/user/credits` parameter `description` now contains one of "wallet path / private key / seed phrase / mnemonic" — public API **documentation** the subnet published, not a leaked secret value. It's a captured third-party openapi spec, so it re-captures (and re-fails) every publish.

## Fix

Exempt OpenAPI/JSON **documentation fields** (`description` / `summary` / `title`) from the **soft** `wallet/key wording` heuristic in captured fixture bodies. A parameter description is human text, never an actual key.

Security is preserved: the **hard** secret patterns (`BEGIN … PRIVATE KEY`, `ghp_…`, `sk-…`, token assignments) still scan these fields — a new test confirms a `ghp_` token inside a `description` is still flagged. The narrower soft heuristics that already skip mirrored-spec terminology are unchanged.

## Tests

`tests/public-safety.test.mjs` — added:
- wallet/key wording in a `description` (the sn-97 shape: `paths./user/credits.get.parameters[0].description`) → **exempt**.
- a `ghp_` token inside a `description` → **still flagged** (proves the exemption is soft-only).

All 10 public-safety tests pass; lint + format clean.