### PR TITLE
feat(testnet): surface discord contact on the native subnet detail

### DIFF
--- a/scripts/build-network-registry.mjs
+++ b/scripts/build-network-registry.mjs
@@ -83,6 +83,11 @@ function buildNativeSubnet(nativeSubnet, snapshot) {
   const supportedKinds = new Set();
   if (sourceRepo) supportedKinds.add("source-repo");
   if (websiteUrl) supportedKinds.add("website");
+  // Contact handle (issue #344) — already surfaced on the index entry; carry it
+  // on the detail too so the testnet subnet profile matches the index.
+  const discordHandle = nativeContactHandle(
+    nativeSubnet.chain_identity?.discord,
+  );
 
   return {
     block: nativeSubnet.block,
@@ -94,6 +99,8 @@ function buildNativeSubnet(nativeSubnet, snapshot) {
     dashboard_url: null,
     description:
       cleanDescription(nativeSubnet.chain_identity?.description) || null,
+    discord: discordHandle,
+    discord_url: nativeContactUrl(discordHandle),
     docs_url: null,
     gaps: {
       missing_kinds: EXPECTED_GAP_KINDS.filter(


### PR DESCRIPTION
Small completeness fix from the testnet analysis: the chain-identity discord handle was on the testnet subnet **index** but missing from the per-subnet **detail**, so the testnet profile dropped a contact the list showed. Carry it on the detail too (sanitized via `nativeContactHandle`, like the index). Schema already allows `discord`/`discord_url` — no contract change. Testnet detail is R2-only; reaches R2 on the next data publish.