### PR TITLE
feat(rpc): testnet WSS reference pool (test-wss)

### DIFF
--- a/registry/native/test-base-endpoints.json
+++ b/registry/native/test-base-endpoints.json
@@ -14,6 +14,18 @@
       "url": "https://test.chain.opentensor.ai",
       "provider": "opentensor",
       "kind": "subtensor-rpc"
+    },
+    {
+      "id": "opentensor-test-finney-wss",
+      "url": "wss://test.finney.opentensor.ai",
+      "provider": "opentensor",
+      "kind": "subtensor-wss"
+    },
+    {
+      "id": "opentensor-test-chain-wss",
+      "url": "wss://test.chain.opentensor.ai",
+      "provider": "opentensor",
+      "kind": "subtensor-wss"
     }
   ]
 }

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1860,10 +1860,15 @@ export function buildEndpointPoolArtifact({
         "archive",
         endpoints.filter((endpoint) => endpoint.archive_support === true),
       ),
-      // Testnet base-layer RPC pool (/rpc/v1/test). Static members — appended only
-      // when configured (registry/native/test-base-endpoints.json present).
-      ...(testnetEndpoints.length
+      // Testnet base-layer pools (registry/native/test-base-endpoints.json).
+      // test-rpc is the proxy target (/rpc/v1/test); test-wss is reference-only
+      // (the HTTP proxy can't proxy WSS), parity with finney-wss. Each appended
+      // only when that kind is configured, so no empty pools.
+      ...(testnetEndpoints.some((endpoint) => endpoint.kind === "subtensor-rpc")
         ? [endpointPool("test-rpc", "subtensor-rpc", testnetEndpoints)]
+        : []),
+      ...(testnetEndpoints.some((endpoint) => endpoint.kind === "subtensor-wss")
+        ? [endpointPool("test-wss", "subtensor-wss", testnetEndpoints)]
         : []),
     ],
   };

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -74,10 +74,13 @@ export const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
   "https://bittensor-public.nodies.app",
   "https://entrypoint-finney.opentensor.ai",
   "https://lite.chain.opentensor.ai",
-  // Bittensor testnet base-layer RPC (the /rpc/v1/test pool); verified testnet
-  // genesis 0x8f9cf8…, distinct from finney. See registry/native/test-base-endpoints.json.
+  // Bittensor testnet base-layer RPC + WSS (the /rpc/v1/test + test-wss pools);
+  // verified testnet genesis 0x8f9cf8…, distinct from finney. WSS endpoints
+  // confirmed (101 Switching Protocols). See registry/native/test-base-endpoints.json.
   "https://test.finney.opentensor.ai",
   "https://test.chain.opentensor.ai",
+  "wss://test.finney.opentensor.ai",
+  "wss://test.chain.opentensor.ai",
   "wss://archive.chain.opentensor.ai",
   "wss://bittensor-finney.api.onfinality.io",
   "wss://entrypoint-finney.opentensor.ai",


### PR DESCRIPTION
Adds the two public testnet WSS endpoints (`wss://test.finney` + `wss://test.chain`, both verified live — 101 Switching Protocols) as a `test-wss` pool, mirroring mainnet's `finney-wss`. Reference-only: the HTTP proxy can't proxy WSS (it rejects `/rpc/v1/test/wss`), so this is the displayed endpoint for SDK users connecting a WebSocket directly. Origins allowlisted; R2-only artifact (reaches R2 on the next publish). Schemas + rpc tests pass.