### PR TITLE
fix(safety): scope fixture doc-field exemptions

### DIFF
--- a/scripts/scan-public-safety.mjs
+++ b/scripts/scan-public-safety.mjs
@@ -176,13 +176,13 @@ function scanCapturedFixtureBody(relativePath, content) {
       if (pattern.soft && !pattern.scanFixtureBody) {
         continue;
       }
-      // OpenAPI/JSON documentation fields (description/summary/title) are human
-      // API docs the subnet published — a captured spec's parameter description
-      // routinely reads "Your wallet path…"/"do not share your private key". Those
-      // are docs, not leaked secret VALUES, so exempt them from the SOFT wording
-      // heuristics. Hard secret patterns (keys/tokens) still scan these fields
-      // below, so a real secret can't hide in a description.
-      if (pattern.soft && isDocumentationField(valuePath)) {
+      // OpenAPI documentation fields (description/summary/title) are human API
+      // docs the subnet published — a captured spec's parameter description can
+      // legitimately read "Your wallet path…". Keep this SOFT wording exemption
+      // scoped to OpenAPI-shaped paths so generic response fields named
+      // description/summary/title are still scanned for wallet/key disclosures.
+      // Hard secret patterns (keys/tokens) still scan these fields below.
+      if (pattern.soft && isOpenApiDocumentationField(valuePath, body)) {
         continue;
       }
       if (pattern.regex.test(value)) {
@@ -194,11 +194,37 @@ function scanCapturedFixtureBody(relativePath, content) {
   }
 }
 
-function isDocumentationField(valuePath) {
-  return (
+function isOpenApiDocumentationField(valuePath, body) {
+  const isDocumentationField =
     valuePath.endsWith(".description") ||
     valuePath.endsWith(".summary") ||
-    valuePath.endsWith(".title")
+    valuePath.endsWith(".title");
+  if (!isDocumentationField || !isOpenApiBody(body)) {
+    return false;
+  }
+
+  return (
+    valuePath.startsWith(".openapi.") ||
+    valuePath.startsWith(".swagger.") ||
+    valuePath.startsWith(".info.") ||
+    valuePath.startsWith(".components.") ||
+    valuePath.startsWith(".definitions.") ||
+    valuePath.startsWith(".tags[") ||
+    valuePath.startsWith(".externalDocs.") ||
+    valuePath.startsWith(".paths.")
+  );
+}
+
+function isOpenApiBody(body) {
+  return (
+    body &&
+    typeof body === "object" &&
+    !Array.isArray(body) &&
+    (typeof body.openapi === "string" ||
+      typeof body.swagger === "string" ||
+      (body.paths &&
+        typeof body.paths === "object" &&
+        !Array.isArray(body.paths)))
   );
 }
 

--- a/tests/public-safety.test.mjs
+++ b/tests/public-safety.test.mjs
@@ -118,6 +118,20 @@ describe("captured-fixture body scan", () => {
     );
   });
 
+  test("flags wallet/key wording in a generic description fixture body value", async () => {
+    await writeTestFixture({
+      description:
+        "seed phrase: abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about",
+    });
+    const output = runScanOutput();
+    assert.ok(
+      output.includes(
+        `${TEST_FIXTURE}:response.body.description: wallet/key wording`,
+      ),
+      `sensitive wallet/key wording must fire in generic description fields; got:\n${output}`,
+    );
+  });
+
   test("does not flag wallet/key wording in an OpenAPI documentation field", async () => {
     // Regression for the sn-97 publish wedge: a captured openapi parameter
     // description reads "…your wallet path / seed phrase…" — public API docs the


### PR DESCRIPTION
### Motivation
- The soft wording exemption for captured fixture bodies treated any field named `description`, `summary`, or `title` as documentation and allowed wallet/key terminology to bypass the soft scan, creating a CI/public-artifact safety gate bypass.
- The intent is to keep OpenAPI documentation fields exempt while ensuring generic response fields with those names are still scanned for sensitive wallet/key wording.

### Description
- Narrow the soft exemption by replacing `isDocumentationField` with `isOpenApiDocumentationField(valuePath, body)` and add `isOpenApiBody(body)` so the exemption only applies when the fixture `response.body` looks like an OpenAPI/Swagger spec.
- Keep hard secret regexes unchanged so real tokens/keys still trigger regardless of field location.
- Add a regression test that ensures a generic `description` value containing seed-phrase wording is flagged, while the existing OpenAPI documentation-field test remains and continues to be exempt.

### Testing
- Ran the captured-fixture safety tests: `npm test -- public-safety -t "captured-fixture body scan"`, and they passed. 
- Ran the scanner manually with `node scripts/scan-public-safety.mjs` and checked formatting/linting with `npx prettier --check` and `npm run lint`, which succeeded after formatting.
- Running the full `npm test -- public-safety` in this environment showed a DNS-dependent assertion failure unrelated to the fixture-scoping fix, while the fixture-safety tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa3734480832a846c0ac09a08730f)