### PR TITLE
fix(rpc): isolate RPC response cache by network

### DIFF
--- a/tests/rpc-cache.test.mjs
+++ b/tests/rpc-cache.test.mjs
@@ -58,6 +58,19 @@ describe("RPC response cache flow", () => {
           },
         ],
       },
+      {
+        id: "test-rpc",
+        endpoints: [
+          {
+            id: "tx",
+            provider: "tx",
+            pool_eligible: true,
+            status: "ok",
+            score: 100,
+            url: "https://test.finney.opentensor.ai",
+          },
+        ],
+      },
     ],
   };
   const env = {
@@ -81,8 +94,8 @@ describe("RPC response cache flow", () => {
       },
     },
   };
-  const reqFor = (method, params, id = 1) =>
-    new Request("https://metagraph.sh/rpc/v1/finney", {
+  const reqFor = (method, params, id = 1, network = "finney") =>
+    new Request(`https://metagraph.sh/rpc/v1/${network}`, {
       method: "POST",
       body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
     });
@@ -186,6 +199,52 @@ describe("RPC response cache flow", () => {
         id: "victim-expected-id",
         result: "0xhash",
       });
+    });
+  });
+
+  test("cache entries are isolated by RPC network", async () => {
+    const cache = makeCache();
+    const seen = [];
+    const fetchImpl = async (url) => {
+      seen.push(url);
+      const result = url.includes("test.finney.opentensor.ai")
+        ? "TESTNET_CHAIN"
+        : "FINNEY_CHAIN";
+      return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result }), {
+        status: 200,
+      });
+    };
+    await withGlobals({ cache, fetchImpl }, async () => {
+      const waits = [];
+      const ctx = { waitUntil: (p) => waits.push(p) };
+      const testnet = await handleRequest(
+        reqFor("system_chain", [], "test-prime", "test"),
+        env,
+        ctx,
+      );
+      assert.equal(testnet.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.equal((await testnet.json()).result, "TESTNET_CHAIN");
+      await Promise.all(waits);
+
+      const finney = await handleRequest(
+        reqFor("system_chain", [], "finney-caller", "finney"),
+        env,
+        ctx,
+      );
+      assert.equal(finney.headers.get("x-metagraph-rpc-cache"), "miss");
+      assert.equal((await finney.json()).result, "FINNEY_CHAIN");
+      assert.equal(seen.length, 2, "finney must not reuse testnet cache entry");
+      assert.equal(cache.store.size, 2);
+      assert.ok(
+        [...cache.store.keys()].some((key) =>
+          key.includes("/test/system_chain/"),
+        ),
+      );
+      assert.ok(
+        [...cache.store.keys()].some((key) =>
+          key.includes("/finney/system_chain/"),
+        ),
+      );
     });
   });
 

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1949,7 +1949,7 @@ async function handleRpcProxyRequest(request, env, url, ctx = {}) {
   const cache = cachePolicy.cacheable ? globalThis.caches?.default : null;
   let cacheKey = null;
   if (cache) {
-    cacheKey = await rpcCacheKey(rpcBody.method, rpcBody.params);
+    cacheKey = await rpcCacheKey(network, rpcBody.method, rpcBody.params);
     const hit = await cache.match(cacheKey);
     if (hit) {
       // Only the JSON-RPC `result` is cached (never caller-controlled envelope
@@ -2137,8 +2137,9 @@ function rpcResultEnvelope(requestBody, result) {
   return envelope;
 }
 
-async function rpcCacheKey(method, params) {
+async function rpcCacheKey(network, method, params) {
   const normalized = JSON.stringify([
+    network,
     method,
     Array.isArray(params) ? params : [],
   ]);
@@ -2150,7 +2151,7 @@ async function rpcCacheKey(method, params) {
     .map((byte) => byte.toString(16).padStart(2, "0"))
     .join("");
   return new Request(
-    `https://rpc-cache.metagraph.internal/finney/${method}/${hash}`,
+    `https://rpc-cache.metagraph.internal/${network}/${method}/${hash}`,
   );
 }
 


### PR DESCRIPTION
### Motivation
- The proxy became network-aware (`/rpc/v1/{network}` → different pools) but cache keys were still network-blind, allowing cross-network cache poisoning (testnet results could be served to finney callers and vice versa). This change prevents cross-network data integrity confusion by scoping cache entries to the selected RPC network.

### Description
- Thread the selected `network` into the cache lookup by calling `rpcCacheKey(network, method, params)` when computing `cacheKey` in the RPC proxy flow (`workers/api.mjs`).
- Change `rpcCacheKey` to `rpcCacheKey(network, method, params)` and include `network` in the normalized digest input and in the cache URL namespace (`https://rpc-cache.metagraph.internal/${network}/${method}/${hash}`).
- Add a regression test and test-pool entries in `tests/rpc-cache.test.mjs` that primes `/rpc/v1/test` with a cacheable method and verifies `/rpc/v1/finney` does not hit that cache entry, ensuring per-network isolation.

### Testing
- Ran `npm test -- --run tests/rpc-cache.test.mjs tests/rpc-network-routing.test.mjs` and the test files passed (both files, all tests green).
- Ran `npm run lint -- --quiet` and lint completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fa4a66338832abed361b8489ba3a8)