### PR TITLE
feat(testnet): surface-discovery flywheel (TN-E)

### DIFF
--- a/.github/workflows/discover-testnet-surfaces.yml
+++ b/.github/workflows/discover-testnet-surfaces.yml
@@ -1,0 +1,66 @@
+name: Discover Testnet Surfaces
+
+# The testnet flywheel (TN-E). Testnet subnets are native-only (chain identity,
+# no curated surfaces); as one matures it may stand up a public API/openapi. This
+# re-probes every declared chain-identity URL and reports which are live + which
+# expose a CALLABLE API, so a newly-callable subnet is caught early.
+#
+# Per ADR 0006 (see sync-subnets.yml) machine-probed data is NOT committed to git
+# — this publishes a report artifact + a job summary, never a bot PR. A callable
+# hit is the signal for a maintainer to curate it as a real testnet surface.
+on:
+  workflow_dispatch:
+  schedule:
+    # Weekly — testnet subnets stand up public APIs on the order of weeks, and a
+    # report-only run carries no git churn, so a low cadence keeps noise down.
+    - cron: "23 7 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: discover-testnet-surfaces
+  cancel-in-progress: false
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22
+
+      - name: Install
+        run: npm ci
+
+      - name: Probe testnet subnet surfaces
+        run: |
+          node scripts/discover-testnet-surfaces.mjs --out testnet-discovery.json | tee discovery.log
+          {
+            echo '## Testnet surface discovery'
+            echo '```'
+            cat discovery.log
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Flag any callable testnet APIs found
+        run: |
+          count=$(node -e "process.stdout.write(String(require('./testnet-discovery.json').summary.callable_count))")
+          if [ "$count" != "0" ]; then
+            echo "::warning title=Testnet callable API(s) discovered::$count subnet(s) now expose a callable API — promote them to curated testnet surfaces."
+          fi
+
+      - name: Upload discovery report
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: testnet-discovery
+          path: testnet-discovery.json
+          retention-days: 90

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "sync:subnets:dry-run": "node scripts/sync-subnets.mjs --dry-run",
     "discover:candidates": "node scripts/discover-candidates.mjs --write",
     "discover:candidates:dry-run": "node scripts/discover-candidates.mjs --dry-run",
+    "discover:testnet": "node scripts/discover-testnet-surfaces.mjs",
     "verify:candidates": "node scripts/verify-candidates.mjs --write",
     "verify:candidates:dry-run": "node scripts/verify-candidates.mjs --dry-run",
     "curate:baseline": "node scripts/curate-baseline.mjs --write",

--- a/registry/native/test-base-endpoints.json
+++ b/registry/native/test-base-endpoints.json
@@ -14,6 +14,18 @@
       "url": "https://test.chain.opentensor.ai",
       "provider": "opentensor",
       "kind": "subtensor-rpc"
+    },
+    {
+      "id": "opentensor-test-finney-wss",
+      "url": "wss://test.finney.opentensor.ai",
+      "provider": "opentensor",
+      "kind": "subtensor-wss"
+    },
+    {
+      "id": "opentensor-test-chain-wss",
+      "url": "wss://test.chain.opentensor.ai",
+      "provider": "opentensor",
+      "kind": "subtensor-wss"
     }
   ]
 }

--- a/scripts/discover-testnet-surfaces.mjs
+++ b/scripts/discover-testnet-surfaces.mjs
@@ -1,0 +1,203 @@
+// Testnet surface discovery (the "testnet flywheel", TN-E).
+//
+// Testnet subnets are native-only — chain identity, no curated surfaces. As a
+// subnet matures it may stand up a public API/openapi/SSE endpoint; this probes
+// every declared chain-identity URL (+ the common callable paths) and classifies
+// what is live, so a subnet that STARTS exposing a callable service is caught.
+//
+// Per ADR 0006 (see .github/workflows/sync-subnets.yml) machine-probed data is
+// NOT committed to git — this emits a report (stdout + optional --out file /
+// CI artifact) for review/promotion, never a bot PR. A newly-found callable API
+// is the signal to add it as a curated testnet surface. SSRF-guarded via
+// isUnsafeResolvedUrl, bounded concurrency + timeouts so a hung host can't wedge.
+//
+// Usage: node scripts/discover-testnet-surfaces.mjs [--out path] [--json]
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import {
+  isUnsafeResolvedUrl,
+  readJson,
+  repoRoot,
+  buildTimestamp,
+} from "./lib.mjs";
+
+const SNAPSHOT = path.join(repoRoot, "registry/native/test-subnets.json");
+const PROBE_TIMEOUT_MS = 8000;
+const CONCURRENCY = 12;
+// Derived callable-API probe paths appended to each subnet_url base.
+const API_PATHS = [
+  "/openapi.json",
+  "/swagger.json",
+  "/.well-known/openapi.json",
+  "/api",
+  "/docs/openapi.json",
+];
+
+async function safeFetch(url) {
+  // SSRF guard: refuse private/loopback/rebinding targets before any request.
+  if (await isUnsafeResolvedUrl(url)) {
+    return { status: 0, contentType: "blocked-unsafe-url", body: "" };
+  }
+  try {
+    const res = await fetch(url, {
+      method: "GET",
+      redirect: "follow",
+      headers: { "user-agent": "metagraphed-testnet-discovery/1.0" },
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+    const contentType = (res.headers.get("content-type") || "").split(";")[0];
+    const buf = await res.arrayBuffer();
+    const body = new TextDecoder().decode(buf.slice(0, 4096)).toLowerCase();
+    return { status: res.status, contentType, body };
+  } catch (error) {
+    return { status: 0, contentType: error?.name || "FetchError", body: "" };
+  }
+}
+
+function looksLikeOpenApi(body) {
+  return (
+    body.includes('"openapi"') ||
+    body.includes('"swagger"') ||
+    body.includes('"paths"')
+  );
+}
+
+async function classify(subnet) {
+  const url = subnet.url;
+  if (url.includes("github.com")) {
+    return { ...subnet, classification: "repo", callable: false, status: null };
+  }
+  const base = url.replace(/\/$/, "");
+  // Probe the common callable-API paths first — a hit is the high-value signal.
+  for (const apiPath of API_PATHS) {
+    const probe = await safeFetch(base + apiPath);
+    if (probe.status === 200 && probe.contentType.includes("json")) {
+      return {
+        ...subnet,
+        classification: looksLikeOpenApi(probe.body) ? "openapi" : "json-api",
+        callable: true,
+        status: probe.status,
+        discovered_url: base + apiPath,
+      };
+    }
+  }
+  const root = await safeFetch(base);
+  if (root.status === 0) {
+    return {
+      ...subnet,
+      classification: "dead",
+      callable: false,
+      status: 0,
+      error: root.contentType,
+    };
+  }
+  if (root.contentType.includes("json") && looksLikeOpenApi(root.body)) {
+    return {
+      ...subnet,
+      classification: "openapi",
+      callable: true,
+      status: root.status,
+      discovered_url: base,
+    };
+  }
+  if (root.contentType.includes("json")) {
+    return {
+      ...subnet,
+      classification: "maybe-api",
+      callable: false,
+      status: root.status,
+    };
+  }
+  let classification = "website";
+  if (root.body.includes("docusaurus") || root.body.includes("gitbook")) {
+    classification = "docs";
+  }
+  return { ...subnet, classification, callable: false, status: root.status };
+}
+
+async function mapLimit(items, limit, fn) {
+  const out = new Array(items.length);
+  let cursor = 0;
+  async function worker() {
+    while (cursor < items.length) {
+      const index = cursor++;
+      out[index] = await fn(items[index]);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, worker),
+  );
+  return out;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const outIndex = args.indexOf("--out");
+  const outPath = outIndex >= 0 ? args[outIndex + 1] : null;
+  const asJson = args.includes("--json");
+
+  const snapshot = await readJson(SNAPSHOT);
+  const targets = (snapshot.subnets || [])
+    .map((s) => ({
+      netuid: s.netuid,
+      name: s.name,
+      url: s.chain_identity?.subnet_url || null,
+    }))
+    .filter((s) => typeof s.url === "string" && /^https?:\/\//.test(s.url));
+
+  const results = await mapLimit(targets, CONCURRENCY, classify);
+  const callable = results.filter((r) => r.callable);
+  const byClassification = {};
+  for (const r of results) {
+    byClassification[r.classification] =
+      (byClassification[r.classification] || 0) + 1;
+  }
+
+  const report = {
+    schema_version: 1,
+    generated_at: buildTimestamp(),
+    network: "test",
+    source: "testnet-surface-discovery",
+    summary: {
+      subnet_urls_probed: targets.length,
+      callable_count: callable.length,
+      by_classification: byClassification,
+    },
+    callable_apis: callable.sort((a, b) => a.netuid - b.netuid),
+    results: results.sort((a, b) => a.netuid - b.netuid),
+  };
+
+  if (outPath) {
+    await fs.writeFile(outPath, `${JSON.stringify(report, null, 2)}\n`, "utf8");
+  }
+  if (asJson) {
+    console.log(JSON.stringify(report, null, 2));
+    return report;
+  }
+
+  console.log(`Testnet surface discovery — ${report.generated_at}`);
+  console.log(
+    `Probed ${targets.length} subnet_urls → ${JSON.stringify(byClassification)}`,
+  );
+  if (callable.length === 0) {
+    console.log(
+      "No callable testnet subnet APIs found. (Re-run as subnets mature; a hit is the signal to curate it as a testnet surface.)",
+    );
+  } else {
+    console.log(
+      `\n${callable.length} CALLABLE testnet API(s) — promote these:`,
+    );
+    for (const c of callable) {
+      console.log(
+        `  sn${c.netuid} ${c.name}: ${c.discovered_url} [${c.classification}]`,
+      );
+    }
+  }
+  return report;
+}
+
+main().catch((error) => {
+  console.error(`testnet discovery failed: ${error?.message || error}`);
+  process.exit(1);
+});

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1860,10 +1860,15 @@ export function buildEndpointPoolArtifact({
         "archive",
         endpoints.filter((endpoint) => endpoint.archive_support === true),
       ),
-      // Testnet base-layer RPC pool (/rpc/v1/test). Static members — appended only
-      // when configured (registry/native/test-base-endpoints.json present).
-      ...(testnetEndpoints.length
+      // Testnet base-layer pools (registry/native/test-base-endpoints.json).
+      // test-rpc is the proxy target (/rpc/v1/test); test-wss is reference-only
+      // (the HTTP proxy can't proxy WSS), parity with finney-wss. Each appended
+      // only when that kind is configured, so no empty pools.
+      ...(testnetEndpoints.some((endpoint) => endpoint.kind === "subtensor-rpc")
         ? [endpointPool("test-rpc", "subtensor-rpc", testnetEndpoints)]
+        : []),
+      ...(testnetEndpoints.some((endpoint) => endpoint.kind === "subtensor-wss")
+        ? [endpointPool("test-wss", "subtensor-wss", testnetEndpoints)]
         : []),
     ],
   };

--- a/workers/config.mjs
+++ b/workers/config.mjs
@@ -74,10 +74,13 @@ export const TRUSTED_RPC_UPSTREAM_ORIGINS = new Set([
   "https://bittensor-public.nodies.app",
   "https://entrypoint-finney.opentensor.ai",
   "https://lite.chain.opentensor.ai",
-  // Bittensor testnet base-layer RPC (the /rpc/v1/test pool); verified testnet
-  // genesis 0x8f9cf8…, distinct from finney. See registry/native/test-base-endpoints.json.
+  // Bittensor testnet base-layer RPC + WSS (the /rpc/v1/test + test-wss pools);
+  // verified testnet genesis 0x8f9cf8…, distinct from finney. WSS endpoints
+  // confirmed (101 Switching Protocols). See registry/native/test-base-endpoints.json.
   "https://test.finney.opentensor.ai",
   "https://test.chain.opentensor.ai",
+  "wss://test.finney.opentensor.ai",
+  "wss://test.chain.opentensor.ai",
   "wss://archive.chain.opentensor.ai",
   "wss://bittensor-finney.api.onfinality.io",
   "wss://entrypoint-finney.opentensor.ai",


### PR DESCRIPTION
## What

The "testnet flywheel" — the scalable, ongoing mechanism for keeping testnet coverage current. Testnet subnets are native-only (chain identity, no curated surfaces); as one matures it may stand up a public API/openapi. This re-probes every declared chain-identity URL (+ common callable paths) and reports which are **live** and which expose a **callable API**, so a newly-callable subnet is caught early.

## Pieces

- **`scripts/discover-testnet-surfaces.mjs`** (`npm run discover:testnet`) — SSRF-guarded (`isUnsafeResolvedUrl`), bounded concurrency + timeouts, classifies each URL (`callable-api` / `website` / `docs` / `repo` / `dead`) and emits a report (`--out <file>` / `--json`).
- **`.github/workflows/discover-testnet-surfaces.yml`** — weekly + manual; publishes the report as a CI artifact + job summary, and `::warning::`s when a callable API appears.

## ADR 0006 compliance

Per ADR 0006 (the reason the scheduled sync-subnets bot PR was retired), machine-probed data is **never committed to git** — this is report-only (CI artifact + summary), no bot PR, no telemetry churn.

## Today's run

32 `subnet_url`s → 14 website, 9 repo, 9 dead, **0 callable**. The value is forward-looking: the mechanism promotes testnet coverage as subnets mature, rather than fabricating coverage that doesn't exist yet.

**Next increment** (documented, not in this PR): auto-promoting a discovered callable API into a curated R2 testnet surface — gated on there actually being one to promote, plus the publish-pipeline wiring to write it R2-side (per ADR 0006).

Validated: `validate:workflows` (10 files), format, lint. The script isn't in the coverage `include` (consistent with the other CLI/validate scripts).