### PR TITLE
fix(testnet): guard discovery redirects

### DIFF
--- a/scripts/discover-testnet-surfaces.mjs
+++ b/scripts/discover-testnet-surfaces.mjs
@@ -25,6 +25,9 @@ import {
 const SNAPSHOT = path.join(repoRoot, "registry/native/test-subnets.json");
 const PROBE_TIMEOUT_MS = 8000;
 const CONCURRENCY = 12;
+const MAX_REDIRECTS = 5;
+const MAX_BODY_BYTES = 4096;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 // Derived callable-API probe paths appended to each subnet_url base.
 const API_PATHS = [
   "/openapi.json",
@@ -34,21 +37,60 @@ const API_PATHS = [
   "/docs/openapi.json",
 ];
 
-async function safeFetch(url) {
-  // SSRF guard: refuse private/loopback/rebinding targets before any request.
+async function readBodySnippet(res) {
+  if (!res.body) {
+    return "";
+  }
+
+  const reader = res.body.getReader();
+  const chunks = [];
+  let bytesRead = 0;
+  try {
+    while (bytesRead < MAX_BODY_BYTES) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      const remaining = MAX_BODY_BYTES - bytesRead;
+      chunks.push(
+        value.byteLength > remaining ? value.slice(0, remaining) : value,
+      );
+      bytesRead += Math.min(value.byteLength, remaining);
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+
+  return new TextDecoder().decode(Buffer.concat(chunks)).toLowerCase();
+}
+
+async function safeFetch(url, redirectCount = 0) {
+  // SSRF guard: refuse private/loopback/rebinding targets before every request,
+  // including each manually-followed redirect target.
   if (await isUnsafeResolvedUrl(url)) {
     return { status: 0, contentType: "blocked-unsafe-url", body: "" };
   }
   try {
     const res = await fetch(url, {
       method: "GET",
-      redirect: "follow",
+      redirect: "manual",
       headers: { "user-agent": "metagraphed-testnet-discovery/1.0" },
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
     });
+
+    const location = res.headers.get("location");
+    if (REDIRECT_STATUSES.has(res.status) && location) {
+      await res.body?.cancel();
+      if (redirectCount >= MAX_REDIRECTS) {
+        return { status: 0, contentType: "too-many-redirects", body: "" };
+      }
+      const redirectTarget = new URL(location, url).toString();
+      return safeFetch(redirectTarget, redirectCount + 1);
+    }
+
     const contentType = (res.headers.get("content-type") || "").split(";")[0];
-    const buf = await res.arrayBuffer();
-    const body = new TextDecoder().decode(buf.slice(0, 4096)).toLowerCase();
+    const body = await readBodySnippet(res);
     return { status: res.status, contentType, body };
   } catch (error) {
     return { status: 0, contentType: error?.name || "FetchError", body: "" };


### PR DESCRIPTION
### Motivation
- The testnet discovery probe previously validated only the original URL and used `fetch` with `redirect: "follow"`, allowing attacker-controlled redirects to bypass the DNS-aware SSRF guard and reach internal/link-local hosts.
- The script runs automatically from CI and iterates attacker-influenced chain identity URLs, so unguarded redirects constitute a high-severity SSRF risk.

### Description
- Change `safeFetch` to use `redirect: "manual"` and re-run `isUnsafeResolvedUrl` for each redirect hop to ensure every resolved destination is validated.
- Add a `MAX_REDIRECTS` limit and return a safe failure (`"too-many-redirects"`) when exceeded to prevent redirect loops.
- Introduce `readBodySnippet` with `MAX_BODY_BYTES` and use it instead of buffering the full response to bound response parsing and memory use.
- Add a `REDIRECT_STATUSES` set and propagate safe failure codes for blocked/unsafe redirects.

### Testing
- Ran `node --check scripts/discover-testnet-surfaces.mjs` which succeeded.
- Ran `npm run format:check -- scripts/discover-testnet-surfaces.mjs` (Prettier) which passed after formatting changes.
- Ran a quick runtime check of `isUnsafeResolvedUrl` via `node -e "import('./scripts/lib.mjs').then(async ({isUnsafeResolvedUrl}) => { console.log(await isUnsafeResolvedUrl('http://127.0.0.1:18182/openapi.json')); console.log(await isUnsafeResolvedUrl('http://169.254.169.254/latest/meta-data/')); })"` which returned `true` for blocked targets as expected.
- Ran `npm run lint -- scripts/discover-testnet-surfaces.mjs` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2fad09d5ec832abd7312a6fbe0b4f2)