### PR TITLE
fix(data): QA pass — gradients timeout, junk descriptions, orphan providers

### DIFF
--- a/registry/providers/covenant.json
+++ b/registry/providers/covenant.json
@@ -1,9 +1,0 @@
-{
-  "authority": "community",
-  "id": "covenant",
-  "kind": "subnet-team",
-  "name": "Covenant AI",
-  "notes": "SN81 (Grail) — part of the Covenant AI ecosystem (also Templar, Basilica). Verified: www.covenant.ai lists Grail.",
-  "schema_version": 1,
-  "website_url": "https://www.covenant.ai"
-}

--- a/registry/providers/ditto.json
+++ b/registry/providers/ditto.json
@@ -1,9 +1,0 @@
-{
-  "authority": "community",
-  "id": "ditto",
-  "kind": "subnet-team",
-  "name": "Ditto",
-  "notes": "SN118 (Ditto) team. Verified from public sources: subnetalpha SN118 page, heyditto.ai, github.com/ditto-assistant (Omni Aura team).",
-  "schema_version": 1,
-  "website_url": "https://heyditto.ai"
-}

--- a/registry/providers/lium.json
+++ b/registry/providers/lium.json
@@ -1,9 +1,0 @@
-{
-  "authority": "community",
-  "id": "lium",
-  "kind": "subnet-team",
-  "name": "Lium",
-  "notes": "SN51 (lium.io) team — GPU compute marketplace. Verified from public sources: lium.io and its published OpenAPI.",
-  "schema_version": 1,
-  "website_url": "https://lium.io"
-}

--- a/registry/subnets/gradients.json
+++ b/registry/subnets/gradients.json
@@ -117,7 +117,7 @@
         "enabled": true,
         "method": "GET",
         "expect": "json",
-        "timeout_ms": 10000
+        "timeout_ms": 25000
       },
       "notes": "Read-only public performance endpoint from the Gradients OpenAPI schema."
     },
@@ -137,7 +137,7 @@
         "enabled": true,
         "method": "GET",
         "expect": "json",
-        "timeout_ms": 10000
+        "timeout_ms": 25000
       },
       "notes": "Read-only public performance endpoint from the Gradients OpenAPI schema."
     },
@@ -157,7 +157,7 @@
         "enabled": true,
         "method": "GET",
         "expect": "json",
-        "timeout_ms": 10000
+        "timeout_ms": 25000
       },
       "notes": "Read-only public performance endpoint from the Gradients OpenAPI schema."
     },

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1072,10 +1072,18 @@ export function nativeContactUrl(contact) {
 // Normalize a free-text description (chain SubnetIdentitiesV3 / overlay):
 // neutralize prompt-injection, strip URLs, collapse whitespace, drop empties.
 // Shared by the build + the reproducibility validator so the two never drift.
+// Bare placeholder words some subnets set as their ENTIRE on-chain description
+// ("deprecated", "none", "tbd", …) — treated as no description, mirroring
+// CONTACT_HANDLE_JUNK. Several deprecated subnets (sn3/39/81) carry a literal
+// "deprecated" description on-chain that should not leak into the served data.
+const JUNK_DESCRIPTION = /^(?:deprecated|none|null|n\/a|tbd|todo|test)$/i;
+
 export function cleanDescription(value) {
   if (typeof value !== "string") return null;
   const cleaned = stripUrls(sanitizeChainText(value).text);
-  return cleaned.length >= 2 ? cleaned : null;
+  if (cleaned.length < 2) return null;
+  if (JUNK_DESCRIPTION.test(cleaned.trim())) return null;
+  return cleaned;
 }
 
 // Domain/capability tag derivation (issue #345) lives in the worker-safe

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -54,6 +54,19 @@ describe("cleanDescription", () => {
     assert.equal(cleanDescription(null), null);
     assert.equal(cleanDescription("https://only-a-url.com"), null);
   });
+  test("drops bare placeholder/junk descriptions (deprecated/none/tbd)", () => {
+    // sn3/39/81 carry a literal "deprecated" description on-chain — junk, not a
+    // real description, so it must not leak into the served data.
+    assert.equal(cleanDescription("deprecated"), null);
+    assert.equal(cleanDescription("Deprecated"), null);
+    assert.equal(cleanDescription("  none  "), null);
+    assert.equal(cleanDescription("tbd"), null);
+    // a real description that merely CONTAINS the word is kept.
+    assert.equal(
+      cleanDescription("Deprecated v1 API gateway for subnet 7"),
+      "Deprecated v1 API gateway for subnet 7",
+    );
+  });
   test("normalizes real descriptions", () => {
     assert.equal(
       cleanDescription("  Autonomous   software   development  "),


### PR DESCRIPTION
From a full-stack live QA audit (every route/page tested). Backend API routes were **100% healthy** (all 58 pass); these are the real data/curation fixes found:

- **gradients (sn56) probe timeout** — the 3 `api.gradients.io/v1/performance/*` surfaces return HTTP 200 but take **8.7–10.6s** against a **10s** timeout, so they flapped and generated **~127 false "incidents"** + the lone `degraded` subnet. Raised `probe.timeout_ms` 10000 → 25000 (validator cap 30000). The endpoints are genuinely up, just slow.
- **junk `"deprecated"` descriptions** — leaked into served `description` for **sn3/39/81** (Templar/Basilica/Grail); overlays set `description:null` but the build fell back to the literal on-chain `"deprecated"`. `cleanDescription` now drops bare placeholder descriptions (deprecated/none/null/n-a/tbd/todo/test), mirroring `CONTACT_HANDLE_JUNK`. A description that merely *contains* the word is kept (tested).
- **3 orphan provider files** — removed `covenant`/`ditto`/`lium` (served `netuids=[]`, `surface_count=0`): `covenant` dups the wired `one-covenant` (4 refs), `ditto` dups `ditto-assistant` (2 refs), `lium` has no referencing surface. All 0-referenced; build + schemas + adapters clean.

1003 tests pass, coverage 98.09/90.39/97.95/98.23. Source-only (CI rebuilds artifacts — validate.yml builds before validating); fixes reach R2 on the next publish.