### PR TITLE
chore(lineage): weekly testnet↔mainnet discovery (2026-06-15)

### DIFF
--- a/public/metagraph/lineage.json
+++ b/public/metagraph/lineage.json
@@ -1,7 +1,7 @@
 {
   "generated_at": "1970-01-01T00:00:00.000Z",
-  "graduated_subnet_count": 30,
-  "link_count": 30,
+  "graduated_subnet_count": 43,
+  "link_count": 43,
   "links": [
     {
       "mainnet_name": "Apex",
@@ -20,12 +20,52 @@
       "testnet_netuid": 4
     },
     {
+      "mainnet_name": "Numinous",
+      "mainnet_netuid": 6,
+      "mainnet_slug": "numinous",
+      "matched_by": "github_repo",
+      "testnet_name": "glagolitic_uku",
+      "testnet_netuid": 155
+    },
+    {
+      "mainnet_name": "Compute Horde",
+      "mainnet_netuid": 12,
+      "mainnet_slug": "sn-12",
+      "matched_by": "github_repo",
+      "testnet_name": "thai_cho_chan",
+      "testnet_netuid": 174
+    },
+    {
+      "mainnet_name": "Cacheon",
+      "mainnet_netuid": 14,
+      "mainnet_slug": "cacheon",
+      "matched_by": "github_repo",
+      "testnet_name": "cacheon-testnet",
+      "testnet_netuid": 470
+    },
+    {
+      "mainnet_name": "BitAds",
+      "mainnet_netuid": 16,
+      "mainnet_slug": "sn-16",
+      "matched_by": "github_repo",
+      "testnet_name": "yag",
+      "testnet_netuid": 368
+    },
+    {
       "mainnet_name": "Zeus",
       "mainnet_netuid": 18,
       "mainnet_slug": "sn-18",
       "matched_by": "chain_name",
       "testnet_name": "zeus",
       "testnet_netuid": 301
+    },
+    {
+      "mainnet_name": "AdTAO",
+      "mainnet_netuid": 21,
+      "mainnet_slug": "sn-21",
+      "matched_by": "github_repo",
+      "testnet_name": "Subnet 466",
+      "testnet_netuid": 466
     },
     {
       "mainnet_name": "Quasar",
@@ -36,6 +76,14 @@
       "testnet_netuid": 383
     },
     {
+      "mainnet_name": "Mainframe",
+      "mainnet_netuid": 25,
+      "mainnet_slug": "sn-25",
+      "matched_by": "github_repo",
+      "testnet_name": "glagolitic_zemlja",
+      "testnet_netuid": 141
+    },
+    {
       "mainnet_name": "ItsAI",
       "mainnet_netuid": 32,
       "mainnet_slug": "sn-32",
@@ -44,12 +92,36 @@
       "testnet_netuid": 32
     },
     {
+      "mainnet_name": "ReadyAI",
+      "mainnet_netuid": 33,
+      "mainnet_slug": "sn-33",
+      "matched_by": "github_repo",
+      "testnet_name": "glagolitic_dobro",
+      "testnet_netuid": 138
+    },
+    {
+      "mainnet_name": "OxMarkets",
+      "mainnet_netuid": 35,
+      "mainnet_slug": "sn-35",
+      "matched_by": "github_repo",
+      "testnet_name": "waw",
+      "testnet_netuid": 78
+    },
+    {
       "mainnet_name": "Aurelius",
       "mainnet_netuid": 37,
       "mainnet_slug": "sn-37",
       "matched_by": "chain_name",
       "testnet_name": "Aurelius",
       "testnet_netuid": 455
+    },
+    {
+      "mainnet_name": "colosseum",
+      "mainnet_netuid": 38,
+      "mainnet_slug": "colosseum",
+      "matched_by": "github_repo",
+      "testnet_name": "sn38-chronogpt",
+      "testnet_netuid": 474
     },
     {
       "mainnet_name": "Graphite",
@@ -74,6 +146,14 @@
       "matched_by": "chain_name",
       "testnet_name": "dojo",
       "testnet_netuid": 52
+    },
+    {
+      "mainnet_name": "Yanez MIID",
+      "mainnet_netuid": 54,
+      "mainnet_slug": "sn-54",
+      "matched_by": "github_repo",
+      "testnet_name": "yanez",
+      "testnet_netuid": 322
     },
     {
       "mainnet_name": "NIOME",
@@ -124,6 +204,14 @@
       "testnet_netuid": 64
     },
     {
+      "mainnet_name": "TAO Private Network",
+      "mainnet_netuid": 65,
+      "mainnet_slug": "sn-65",
+      "matched_by": "github_repo",
+      "testnet_name": "ronx",
+      "testnet_netuid": 279
+    },
+    {
       "mainnet_name": "NOVA",
       "mainnet_netuid": 68,
       "mainnet_slug": "sn-68",
@@ -138,6 +226,14 @@
       "matched_by": "chain_name",
       "testnet_name": "ain",
       "testnet_netuid": 69
+    },
+    {
+      "mainnet_name": "StreetVision by NATIX",
+      "mainnet_netuid": 72,
+      "mainnet_slug": "sn-72",
+      "matched_by": "github_repo",
+      "testnet_name": "Stan Marsh",
+      "testnet_netuid": 323
     },
     {
       "mainnet_name": "Gittensor",
@@ -178,6 +274,14 @@
       "matched_by": "chain_name",
       "testnet_name": "ansuz",
       "testnet_netuid": 84
+    },
+    {
+      "mainnet_name": "Investing",
+      "mainnet_netuid": 88,
+      "mainnet_slug": "sn-88",
+      "matched_by": "github_repo",
+      "testnet_name": "kana_na",
+      "testnet_netuid": 339
     },
     {
       "mainnet_name": "DegenBrain",
@@ -246,11 +350,11 @@
   ],
   "matched_by_counts": {
     "chain_name": 24,
-    "github_repo": 6
+    "github_repo": 19
   },
   "published_at": null,
   "schema_version": 1,
   "source_network": "mainnet",
   "target_network": "testnet",
-  "testnet_only_count": 476
+  "testnet_only_count": 463
 }

--- a/registry/lineage.json
+++ b/registry/lineage.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "1970-01-01T00:00:00.000Z",
+  "generated_at": "2026-06-15T00:00:00.000Z",
   "notes": "Maintainer-approved cross-network lineage pairs. Builds may only publish lineage links listed here; self-declared on-chain repo/name equality is evidence for review, not authorization to create new links.",
   "links": [
     {
@@ -242,6 +242,110 @@
       "review_state": "maintainer-approved",
       "reviewed_at": "2026-06-15T00:00:00.000Z",
       "notes": "Gittensor SN74 ↔ testnet 422 (entrius-test). Documented in the project's own repo: entrius/gittensor .env.example reads 'NETUID=74 # 422 if using testnet'. Evidence is the repo config (github_repo), not on-chain field equality — testnet 422 declares no on-chain repo."
+    },
+    {
+      "mainnet_netuid": 6,
+      "testnet_netuid": 155,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "Numinous SN6 ↔ testnet 155 (glagolitic_uku). Documented in numinouslabs/numinous neurons/validator/utils/config.py: '{\"subtensor.network\": \"test\", \"netuid\": 155, \"numinous.env\": None},'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 12,
+      "testnet_netuid": 174,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "Compute Horde SN12 ↔ testnet 174 (thai_cho_chan). Documented in backend-developers-ltd/ComputeHorde README.md: '- ComputeHorde testnet netuid: 174'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 14,
+      "testnet_netuid": 470,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "Cacheon SN14 ↔ testnet 470 (cacheon-testnet). Documented in latent-to/cacheon miner/README.md: '--network test --netuid 470'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 16,
+      "testnet_netuid": 368,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "BitAds SN16 ↔ testnet 368 (yag). Documented in FirstTensorLabs/BitAds docker-compose.yml: '# Defaults: NETUID=368 (testnet), use NETUID=16 for mainnet (finney)'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 21,
+      "testnet_netuid": 466,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "AdTAO SN21 ↔ testnet 466 (unknown). Documented in ippcteam/SN21-adtao README.md: 'Bittensor Subnet 21 · Mainnet finney · Testnet test (netuid 466)'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 25,
+      "testnet_netuid": 141,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "Mainframe SN25 ↔ testnet 141 (glagolitic_zemlja). Documented in macrocosm-os/mainframe documentation/api/README.md: '- netuid: The subnet ID (25 for mainnet, 141 for testnet)'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 33,
+      "testnet_netuid": 138,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "ReadyAI SN33 ↔ testnet 138 (glagolitic_dobro). Documented in afterpartyai/bittensor-conversation-genome-project README.md: 'specify --netuid 138 which is our testnet subnet uid.'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 35,
+      "testnet_netuid": 78,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "OxMarkets SN35 ↔ testnet 78 (waw). Documented in General-Tao-Ventures/cartha-validator cartha_validator/config.py: 'description=\"NetUID for testnet subnet (default: 78)\",' (config default; testnet 78 has generic on-chain name). Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 38,
+      "testnet_netuid": 474,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "ChronoLLM SN38 ↔ testnet 474 (sn38-chronogpt). Documented in chronollm/sn38 sn38/template/constants.py: '\"test\": {\"netuid\": 474, \"owner_uid\": 0},'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 54,
+      "testnet_netuid": 322,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "Yanez MIID SN54 ↔ testnet 322 (yanez). Documented in yanez-compliance/MIID-subnet MIID/utils/config.py: \"Auto-changes to 'subnet322-test' when running on testnet (netuid 322).\". Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 65,
+      "testnet_netuid": 279,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "TAO Private Network SN65 ↔ testnet 279 (ronx). Documented in taofu-labs/tpn-subnet README.md: '# Use netuid 65 for mainnet, 279 for testnet'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 72,
+      "testnet_netuid": 323,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "StreetVision by NATIX SN72 ↔ testnet 323 (Stan Marsh). Documented in natixnetwork/streetvision-subnet natix/validator/config.py: 'TESTNET_UID = 323'. Repo-config evidence for maintainer review, not proof."
+    },
+    {
+      "mainnet_netuid": 88,
+      "testnet_netuid": 339,
+      "matched_by": "github_repo",
+      "review_state": "maintainer-approved",
+      "reviewed_at": "2026-06-15T00:00:00.000Z",
+      "notes": "Investing SN88 ↔ testnet 339 (kana_na). Documented in mobiusfund/investing README.md: '--netuid 88 #339 --subtensor.network test'. Repo-config evidence for maintainer review, not proof."
     }
   ]
 }


### PR DESCRIPTION
## Weekly testnet↔mainnet lineage discovery (2026-06-15)

Automated scan of mainnet subnet GitHub repos for **documented testnet netuids**. Each link
below is **repo-config evidence for maintainer review, not proof** — merging this PR is the
approval. All proposed testnet netuids exist in `registry/native/test-subnets.json`.

### ✅ 13 new validated links

| Mainnet | Testnet | Repo · file | Exact evidence line |
|---|---|---|---|
| **6** Numinous | **155** `glagolitic_uku` | numinouslabs/numinous · `neurons/validator/utils/config.py` | `{"subtensor.network": "test", "netuid": 155, "numinous.env": None},` |
| **12** Compute Horde | **174** `thai_cho_chan` | backend-developers-ltd/ComputeHorde · `README.md` | `- ComputeHorde testnet netuid: 174` |
| **14** Cacheon | **470** `cacheon-testnet` | latent-to/cacheon · `miner/README.md` | `--network test --netuid 470` |
| **16** BitAds | **368** `yag` | FirstTensorLabs/BitAds · `docker-compose.yml` | `# Defaults: NETUID=368 (testnet), use NETUID=16 for mainnet (finney)` |
| **21** AdTAO | **466** `unknown` | ippcteam/SN21-adtao · `README.md` | ``Bittensor Subnet 21 · Mainnet `finney` · Testnet `test` (netuid 466)`` |
| **25** Mainframe | **141** `glagolitic_zemlja` | macrocosm-os/mainframe · `documentation/api/README.md` | `- netuid: The subnet ID (25 for mainnet, 141 for testnet)` |
| **33** ReadyAI | **138** `glagolitic_dobro` | afterpartyai/bittensor-conversation-genome-project · `README.md` | `specify --netuid 138 which is our testnet subnet uid.` |
| **35** OxMarkets | **78** `waw` | General-Tao-Ventures/cartha-validator · `cartha_validator/config.py` | `description="NetUID for testnet subnet (default: 78)",` |
| **38** ChronoLLM | **474** `sn38-chronogpt` | chronollm/sn38 · `sn38/template/constants.py` | `"test": {"netuid": 474, "owner_uid": 0},` |
| **54** Yanez MIID | **322** `yanez` | yanez-compliance/MIID-subnet · `MIID/utils/config.py` | `Auto-changes to 'subnet322-test' when running on testnet (netuid 322).` |
| **65** TAO Private Network | **279** `ronx` | taofu-labs/tpn-subnet · `README.md` | `# Use netuid 65 for mainnet, 279 for testnet` |
| **72** StreetVision by NATIX | **323** `Stan Marsh` | natixnetwork/streetvision-subnet · `natix/validator/config.py` | `TESTNET_UID = 323` |
| **88** Investing | **339** `kana_na` | mobiusfund/investing · `README.md` | `--netuid 88 #339 --subtensor.network test` |

**Review caveats**
- **SN35 OxMarkets → 78**: evidence is a *config default* (`testnet_netuid=78`), and testnet 78 has a generic on-chain name (`waw`) that coincidentally equals Vocence's *mainnet* netuid. Lower confidence — verify before merging.
- **SN21 → 466** / testnet 466 has on-chain name `unknown`, but the README states `netuid 466` explicitly and repeatedly.

### ⚠️ Drift in existing links (NOT auto-edited — maintainer decision)

| Existing link | Repo now documents | Evidence |
|---|---|---|
| **52** Dojo → 52 (`matched_by: chain_name`, self-equal) | testnet **98** (`bani`) | tensorplex-labs/dojo `README.md`: `btcli s register --network test --netuid 98` |
| **56** Gradients → 56 (`matched_by: chain_name`, self-equal) | testnet **201** (`thai_ro_rua`) | gradients-ai/G.O.D `validator/core/config.py`: `netuid = 201 if subtensor_network == "test" else 69420` |

Both existing links were generated by name-equality (`chain_name`). The repos now document a
*different* testnet netuid. Left in place for the maintainer to update or confirm.

### 🛑 Discarded candidate

- **SN34 BitMind → 379**: `gas/config.py` declares `TESTNET_UID = 379`, but testnet **379** is
  on-chain named **NOVA** and is already linked to **SN68 NOVA** (`68→379`). BitMind's value is
  almost certainly a **recycled/stale** testnet netuid — linking it would point BitMind at NOVA's
  testnet. Discarded, not proposed.

### Scan summary

- **Scanned this run:** 92 repos (107 had a `github_repo`; 4 were placeholder/org-listing URLs:
  SN3, SN39, SN81 placeholders, SN105 Beam org-listing).
- **No documented testnet netuid found:** 58 repos (includes repos whose only hits were the
  generic `docs/stream_tutorial/README.md --netuid 8` Bittensor template boilerplate — treated as
  false positives: e.g. SN60 Bitsec, SN103 Djinn, SN113 TensorUSD).
- **Already in lineage (skipped):** SN18→301, 37→455, 50→247, 55→289, 74→422, 79→366, 98→374,
  111→427, and others.
- **Not scanned this run (15-min time-box hit — next run resumes):** SN115 HashiChain, SN117
  (helionlink/Chi), SN118 Ditto (org-listing URL), SN119 Satori, SN120 Affine, SN121 sundae_bar,
  SN123 MANTIS, SN124 Swarm, SN126 Poker44, SN127 Astrid, SN128 ByteLeap.

🤖 Generated by the weekly `lineage-discovery` scheduled task. **Do not merge without verifying the evidence lines above.**
