### PR TITLE
docs(contributing): spotlight enrichment buffer + provider-slug hint

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ Skipping the rebuild trips `validate:contract-drift` in CI. Schemas are the sour
 
 ## Where to start
 
-- **Issues** labeled [`good first issue`](https://github.com/JSONbored/metagraphed/labels/good%20first%20issue) and [`help wanted`](https://github.com/JSONbored/metagraphed/labels/help%20wanted) are scoped and ready.
+- **Enrich a subnet** (the best first PR) — we track one scoped task per subnet under the [surface-enrichment epic #427](https://github.com/JSONbored/metagraphed/issues/427). Browse [`good first issue`](https://github.com/JSONbored/metagraphed/labels/good%20first%20issue) + [`help wanted`](https://github.com/JSONbored/metagraphed/labels/help%20wanted): pick a subnet, find its real public API / OpenAPI / data artifact, and submit one candidate file ([Community submissions](#community-submissions) below). Each issue links the exact `candidate:new` command.
 - **Data gaps** — generate the current curation queue: `npm run curation:brief` (add `-- --limit 20` for more, `-- --json` for machine-readable). Start with profile-light subnets: directory-only entries, missing websites or source repos, public APIs with no OpenAPI metadata yet. See [`docs/curation-playbook.md`](docs/curation-playbook.md).
 
 ## Community submissions

--- a/scripts/enrichment-issues.mjs
+++ b/scripts/enrichment-issues.mjs
@@ -143,6 +143,7 @@ function issueBody(netuid, name, kinds) {
 Search for the subnet's official ${kindList} (project site / GitHub / docs / Bittensor). Confirm each link is real, public, no-auth, and genuinely SN${netuid}'s — cross-reference the subnet name + Bittensor. ⚠️ Many subnets simply don't expose a public API yet, and on-chain identity links are often **stale/dead** — verify each link actually resolves before submitting. If the subnet genuinely exposes no such public surface, comment here so a maintainer can close it.
 
 ### Submit — one candidate per surface, one file
+First find the provider slug for the team/operator behind the surface (a wrong slug is the #1 validation failure): \`npm run providers:list\`. Then generate one candidate file:
 \`\`\`bash
 npm run candidate:new -- --netuid ${netuid} --kind ${primary} \\
   --url <real-public-url> --source-url <link-that-proves-it> \\


### PR DESCRIPTION
Readiness polish for the gittensor contributor wave (repo accepted as emission-weighted today).

- **CONTRIBUTING "Where to start"** now leads with the per-subnet enrichment epic (#427) + the `good first issue` / `help wanted` buffer, so a cold-landing contributor immediately sees "pick a subnet → find its public surface → submit one candidate file."
- **`scripts/enrichment-issues.mjs`** issue body now tells contributors to run `npm run providers:list` first — a wrong/missing provider slug is the #1 candidate-validation failure (CONTRIBUTING already flags it). Every future generated "Enrich SN<n>" issue carries the hint.

Context: 128 open "Enrich SNxx" issues now (52 prior + 76 created today via the generator) cover every subnet's missing operational surfaces. No schema/contract change. `node --check` + `prettier --check` clean.