### PR TITLE
feat(providers): curated/hand-picked provider logo_url (display-only)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1977,6 +1977,11 @@ export interface components {
             github_url?: string;
             id: string;
             kind: components["schemas"]["ProviderKind"];
+            /**
+             * Format: uri
+             * @description Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness.
+             */
+            logo_url?: string;
             name: string;
             /** @description Sorted unique netuids this provider operates a curated surface on (issue #347). Derived/reporting — never feeds completeness. */
             netuids?: number[];
@@ -6541,6 +6546,7 @@ export interface operations {
                      *           "github_url": "https://api.metagraph.sh/example",
                      *           "id": "example-subnet",
                      *           "kind": "subnet-team",
+                     *           "logo_url": "https://api.metagraph.sh/example",
                      *           "name": "Example Subnet",
                      *           "netuids": [
                      *             7

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3834,6 +3834,11 @@
           "kind": {
             "$ref": "#/components/schemas/ProviderKind"
           },
+          "logo_url": {
+            "description": "Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness.",
+            "format": "uri",
+            "type": "string"
+          },
           "name": {
             "minLength": 1,
             "type": "string"
@@ -14013,6 +14018,7 @@
                       "github_url": "https://api.metagraph.sh/example",
                       "id": "example-subnet",
                       "kind": "subnet-team",
+                      "logo_url": "https://api.metagraph.sh/example",
                       "name": "Example Subnet",
                       "netuids": [
                         7

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1977,6 +1977,11 @@ export interface components {
             github_url?: string;
             id: string;
             kind: components["schemas"]["ProviderKind"];
+            /**
+             * Format: uri
+             * @description Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness.
+             */
+            logo_url?: string;
             name: string;
             /** @description Sorted unique netuids this provider operates a curated surface on (issue #347). Derived/reporting — never feeds completeness. */
             netuids?: number[];
@@ -6541,6 +6546,7 @@ export interface operations {
                      *           "github_url": "https://api.metagraph.sh/example",
                      *           "id": "example-subnet",
                      *           "kind": "subnet-team",
+                     *           "logo_url": "https://api.metagraph.sh/example",
                      *           "name": "Example Subnet",
                      *           "netuids": [
                      *             7

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3812,6 +3812,11 @@
           "kind": {
             "$ref": "#/components/schemas/ProviderKind"
           },
+          "logo_url": {
+            "description": "Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness.",
+            "format": "uri",
+            "type": "string"
+          },
           "name": {
             "minLength": 1,
             "type": "string"

--- a/schemas/components/03-providers.schema.json
+++ b/schemas/components/03-providers.schema.json
@@ -42,6 +42,11 @@
             "type": "string",
             "format": "uri"
           },
+          "logo_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness."
+          },
           "team_url": {
             "type": "string",
             "format": "uri"

--- a/schemas/provider.schema.json
+++ b/schemas/provider.schema.json
@@ -45,6 +45,11 @@
       "type": "string",
       "format": "uri"
     },
+    "logo_url": {
+      "type": "string",
+      "format": "uri",
+      "description": "Curated/hand-picked provider logo (square, ideally >=128px). Display-only; the UI falls back to the website favicon when absent."
+    },
     "team_url": {
       "type": "string",
       "format": "uri"

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -744,8 +744,16 @@ const enrichedProviders = providers.map((provider) => {
   const clusterDomain = clusterDomainFromUrl(
     provider.team_url || provider.website_url,
   );
+  // Curated logo wins; else borrow the on-chain logo of the single subnet this
+  // provider operates (display-only, never feeds completeness). Multi-subnet
+  // providers stay logo-less — the UI resolves a favicon from website_url.
+  const logoUrl =
+    provider.logo_url ||
+    (netuids.length === 1 ? mergedByNetuid.get(netuids[0])?.logo_url : null) ||
+    null;
   return {
     ...provider,
+    ...(logoUrl ? { logo_url: logoUrl } : {}),
     netuids,
     subnet_count: netuids.length,
     surface_count: providerSurfaces.length,


### PR DESCRIPTION
## Why
Providers have no stored logo field (0/92). They already render fine in the UI because `BrandIcon` resolves a favicon from `website_url` — but there's no way to **hand-pick** a better logo, and single-subnet providers could inherit their subnet's on-chain logo automatically.

## What
- Adds optional **`logo_url`** to the provider schema — both the source (`provider.schema.json`) and the served artifact (`components/03-providers.schema.json`). Maintainers can now set a curated logo in `registry/providers/<slug>.json`.
- The build (`enrichedProviders`) sets `logo_url` = **curated value** if present, else **backfilled from the on-chain logo of the single subnet** the provider operates. Multi-subnet providers stay `null` (omitted) — the UI resolves a favicon. Display-only; never feeds completeness.
- Regenerated `openapi.json` + types (`generated/metagraphed-api.d.ts`, `public/metagraph/types.d.ts`).

Frontend reads it via the existing `BrandIcon iconUrl` path (a small `logo_url → icon_url` query mapping lands in metagraphed-ui).

## Validation
`validate:contract-drift` ✓ and `validate:schemas` ✓. (The full `validate`'s `coverage: surface_count mismatch` is pre-existing committed-data drift on main — confirmed by stashing this change — and is rebuilt fresh in CI, unrelated to this PR.)

Served provider `logo_url` populates on the next data refresh (R2), or trigger the publish workflow to apply immediately.