### PR TITLE
fix(security): patch js-yaml + ws via overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2912,10 +2912,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -4188,9 +4198,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -111,6 +111,8 @@
     "wrangler": "4.93.1"
   },
   "overrides": {
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "js-yaml": "^4.2.0",
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
Closes the open backend Dependabot **js-yaml** alert (GHSA-h67p-54hq-rp68) and the `ws` audit finding (GHSA-96hv-2xvq-fx4p) surfaced by the lockfile refresh.

| dep | advisory | sev | reachability | fix |
|---|---|---|---|---|
| js-yaml | GHSA-h67p-54hq-rp68 (merge-key DoS) | medium | **build-only** — `@redocly/openapi-core` → `openapi-typescript` (type-gen) | override `^4.2.0` |
| ws | GHSA-96hv-2xvq-fx4p (fragment-DoS) | high | **dev/CLI-only** — `miniflare` → `wrangler`; not in the deployed Worker | override `^8.21.0` |

`ws` override is **non-breaking** — it pulls the patched ws into miniflare without the `npm audit fix --force` wrangler downgrade.

**Verification:** `npm audit` 3 high + 1 mod → **0**; `wrangler deploy --dry-run` bundles clean; only `package.json` + `package-lock.json` changed (no contract drift).