### PR TITLE
fix(ci): clear no-useless-assignment (validate was red on main)

### DIFF
--- a/scripts/discover-testnet-surfaces.mjs
+++ b/scripts/discover-testnet-surfaces.mjs
@@ -105,18 +105,24 @@ function looksLikeOpenApi(body) {
   );
 }
 
-async function classify(subnet) {
-  const url = subnet.url;
-  // Parse the host rather than substring-matching "github.com" (which would also
-  // match e.g. https://evil.com/?x=github.com). Non-URL inputs fall through to probing.
-  let host = "";
+// Parse the host rather than substring-matching "github.com" (which would also
+// match e.g. https://evil.com/?x=github.com). Returns "" for non-URL inputs so
+// they fall through to probing.
+function repoHostname(rawUrl) {
   try {
-    host = new URL(url.includes("://") ? url : `https://${url}`).hostname
+    return new URL(
+      rawUrl.includes("://") ? rawUrl : `https://${rawUrl}`,
+    ).hostname
       .replace(/^www\./, "")
       .toLowerCase();
   } catch {
-    host = "";
+    return "";
   }
+}
+
+async function classify(subnet) {
+  const url = subnet.url;
+  const host = repoHostname(url);
   if (host === "github.com" || host.endsWith(".github.com")) {
     return { ...subnet, classification: "repo", callable: false, status: null };
   }


### PR DESCRIPTION
`validate` → "Lint + format" has been **red on main**: eslint's `no-useless-assignment` (active on v10.4.1) flags the `#754` github-host check —

```
112:7  The value assigned to 'host' is not used in subsequent statements
```

`let host = ""` was always overwritten by the try/catch before any read, so the initializer is dead. Extracted a `repoHostname(rawUrl)` helper that returns the parsed host (or `""` on failure) — no dead assignment, more readable, identical behavior. This also unblocks the two renovate PRs (#658/#650) which inherited the same red lint.

eslint + prettier clean; **1005/1005 tests pass**.