### PR TITLE
docs(release): correct release-please publish-trigger comment

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,8 +5,10 @@ name: release-please
 # python → PyPI, "." → the hosted platform) that bumps the SemVer + regenerates
 # that component's CHANGELOG.md from the conventional commits. Merging a Release
 # PR tags the component (e.g. client-v0.3.0) and creates the GitHub Release with
-# the generated notes. The OIDC publish workflows (publish-client / publish-python)
-# trigger on those tags (and keep a manual workflow_dispatch override). Commits are
+# the generated notes. release-please then dispatches the OIDC publish workflows
+# (publish-client / publish-python) via workflow_dispatch — see the Dispatch steps
+# below. A tag-push trigger can't be used: GITHUB_TOKEN-created tags don't fire
+# workflows, and the validate gate requires GITHUB_REF=refs/heads/main. Commits are
 # already Conventional Commits, so the changelog is generated, not hand-maintained.
 on:
   push:


### PR DESCRIPTION
A code-scanning report flagged "Tag-triggered package releases cannot pass validation" (against commit `2ed6a79`). **The bug was already fixed by #619** — both `publish-client.yml` and `publish-python.yml` trigger on `workflow_dispatch` only (no `push: tags`), and `release-please.yml` dispatches them with `released_by_release_please=true`; `validate-*-release.sh` then accepts the pre-existing tag (and verifies it points at the workflow commit). Proven end-to-end today: `client-v0.3.1` published via `event=workflow_dispatch ref=main → success`.

The only residual was a **stale header comment** in `release-please.yml` claiming the publish workflows "trigger on those tags (and keep a manual workflow_dispatch override)" — backwards from reality, and likely what the report keyed on. This corrects it to match the (accurate) `publish-*.yml` comments. Comment-only; no behavior change.