### PR TITLE
fix(health): validate live RPC block heights

### DIFF
--- a/src/health-prober.mjs
+++ b/src/health-prober.mjs
@@ -31,8 +31,37 @@ const RPC_KINDS = new Set(["subtensor-rpc", "subtensor-wss", "archive"]);
 const DNS_JSON_ENDPOINT = "https://cloudflare-dns.com/dns-query";
 const DNS_RECORD_TYPES = ["A", "AAAA"];
 const DNS_TIMEOUT_MS = 4000;
+const RPC_BLOCK_PLAUSIBILITY_TOLERANCE = 10;
 
 const iso = (ms) => (Number.isFinite(ms) ? new Date(ms).toISOString() : null);
+
+function safeRpcBlockNumber(value) {
+  if (value == null) return null;
+  const block = Number(value);
+  return Number.isSafeInteger(block) && block > 0 ? block : null;
+}
+
+function rpcBlockMedianFloor(blocks) {
+  if (!blocks.length) return null;
+  const sorted = [...blocks].sort((a, b) => a - b);
+  return sorted[Math.floor((sorted.length - 1) / 2)];
+}
+
+function sanitizeRpcLatestBlocks(rows) {
+  const rpcRows = rows.filter((row) => RPC_KINDS.has(row.kind));
+  const blocks = rpcRows
+    .map((row) => safeRpcBlockNumber(row.latest_block))
+    .filter((block) => block != null);
+  const median = rpcBlockMedianFloor(blocks);
+  for (const row of rpcRows) {
+    const block = safeRpcBlockNumber(row.latest_block);
+    row.latest_block =
+      block != null &&
+      (median == null || block <= median + RPC_BLOCK_PLAUSIBILITY_TOLERANCE)
+        ? block
+        : null;
+  }
+}
 
 // --- DNS-aware SSRF guard for the Worker prober (codex #255) -------------------
 // The literal `isUnsafePublicUrl` guard can't see DNS rebinding (a public-looking
@@ -380,14 +409,14 @@ export async function runHealthProber(env, ctx, overrides = {}) {
       latency_ms: Number.isFinite(base.latency_ms) ? base.latency_ms : null,
       status_code: Number.isInteger(base.status_code) ? base.status_code : null,
       archive_support: base.archive_support ?? null,
-      latest_block: Number.isFinite(base.latest_block)
-        ? base.latest_block
-        : null,
+      latest_block: safeRpcBlockNumber(base.latest_block),
       checked_at_ms: runAt,
       last_ok_ms: lastOkMs,
       consecutive_failures: consecutiveFailures,
     };
   });
+
+  sanitizeRpcLatestBlocks(probed);
 
   await persistToD1(db, probed, runAt);
   await persistToKv(kv, probed, runAt);

--- a/tests/health-prober.test.mjs
+++ b/tests/health-prober.test.mjs
@@ -325,6 +325,59 @@ describe("runHealthProber", () => {
     assert.equal(meta.last_run_at, new Date(50000).toISOString());
   });
 
+  test("rejects unsafe or implausibly high live RPC block heights", async () => {
+    const kv = makeKv();
+    const rpcSurfaces = [
+      {
+        ...SURFACES[1],
+        surface_id: "honest-rpc",
+        url: "https://honest.example/rpc",
+      },
+      {
+        ...SURFACES[1],
+        surface_id: "forged-rpc",
+        url: "https://forged.example/rpc",
+      },
+      {
+        ...SURFACES[1],
+        surface_id: "unsafe-rpc",
+        url: "https://unsafe.example/rpc",
+      },
+    ];
+    await runHealthProber(
+      {},
+      {},
+      {
+        now: () => 50000,
+        db: makeDb(),
+        kv,
+        loadSurfaces: async () => rpcSurfaces,
+        probeSurface: async (input) => ({
+          status: "ok",
+          classification: "live",
+          latency_ms: 42,
+          status_code: 200,
+          latest_block:
+            input.id === "honest-rpc"
+              ? 8_400_000
+              : input.id === "forged-rpc"
+                ? 9_007_199_254_740_991
+                : 9_007_199_254_740_992,
+        }),
+        probeOptions: {},
+      },
+    );
+
+    const byId = new Map(
+      kv
+        .json(KV_HEALTH_RPC_POOL)
+        .endpoints.map((endpoint) => [endpoint.id, endpoint]),
+    );
+    assert.equal(byId.get("honest-rpc").latest_block, 8_400_000);
+    assert.equal(byId.get("forged-rpc").latest_block, null);
+    assert.equal(byId.get("unsafe-rpc").latest_block, null);
+  });
+
   test("bumps consecutive_failures from prior state for the breaker", async () => {
     const db = makeDb({
       priorStatus: [


### PR DESCRIPTION
### Motivation

- Prevent untrusted or malformed `latest_block` values from live probes from biasing RPC proxy routing by requiring safe integers and removing implausible outliers before they are persisted.

### Description

- Add `safeRpcBlockNumber()` to accept only positive `Number.isSafeInteger` block heights and return `null` otherwise.
- Add `rpcBlockMedianFloor()` and `sanitizeRpcLatestBlocks()` to null out RPC probe `latest_block` values that are implausibly higher than the median plus a tolerance (`RPC_BLOCK_PLAUSIBILITY_TOLERANCE` = 10).
- Use `safeRpcBlockNumber()` when building each probe row and run `sanitizeRpcLatestBlocks()` over the probed set before writing D1/KV snapshots so the live `health:rpc-pool` cannot be biased by single high outliers.
- Add a regression test `rejects unsafe or implausibly high live RPC block heights` in `tests/health-prober.test.mjs` that verifies honest heights are retained while forged/unsafe high values are nulled.

### Testing

- Ran the targeted test file with `npm test -- --run tests/health-prober.test.mjs`, which completed successfully (1 test file, 62 tests passed). 
- Ran linter with `npm run lint`, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307feba960832abcee8345bc4c7e16)