### PR TITLE
fix(provider): validate logo_url safety

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1980,6 +1980,7 @@ export interface components {
             /**
              * Format: uri
              * @description Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness.
+             * @example https://example.com/logo.png
              */
             logo_url?: string;
             name: string;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3836,7 +3836,11 @@
           },
           "logo_url": {
             "description": "Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness.",
+            "examples": [
+              "https://example.com/logo.png"
+            ],
             "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
             "type": "string"
           },
           "name": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1980,6 +1980,7 @@ export interface components {
             /**
              * Format: uri
              * @description Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness.
+             * @example https://example.com/logo.png
              */
             logo_url?: string;
             name: string;

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3814,7 +3814,11 @@
           },
           "logo_url": {
             "description": "Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness.",
+            "examples": [
+              "https://example.com/logo.png"
+            ],
             "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
             "type": "string"
           },
           "name": {

--- a/schemas/components/03-providers.schema.json
+++ b/schemas/components/03-providers.schema.json
@@ -45,6 +45,8 @@
           "logo_url": {
             "type": "string",
             "format": "uri",
+            "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+            "examples": ["https://example.com/logo.png"],
             "description": "Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness."
           },
           "team_url": {

--- a/schemas/provider.schema.json
+++ b/schemas/provider.schema.json
@@ -48,6 +48,8 @@
     "logo_url": {
       "type": "string",
       "format": "uri",
+      "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+      "examples": ["https://example.com/logo.png"],
       "description": "Curated/hand-picked provider logo (square, ideally >=128px). Display-only; the UI falls back to the website favicon when absent."
     },
     "team_url": {

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -33,6 +33,7 @@ import {
   nativeDisplayName,
   nativeNameQuality,
   netuidForEvidenceClaim,
+  normalizePublicHttpUrl,
   normalizePublicUrl,
   publishedAt,
   readJson,
@@ -747,8 +748,9 @@ const enrichedProviders = providers.map((provider) => {
   // Curated logo wins; else borrow the on-chain logo of the single subnet this
   // provider operates (display-only, never feeds completeness). Multi-subnet
   // providers stay logo-less — the UI resolves a favicon from website_url.
+  const curatedLogoUrl = normalizePublicHttpUrl(provider.logo_url);
   const logoUrl =
-    provider.logo_url ||
+    curatedLogoUrl ||
     (netuids.length === 1 ? mergedByNetuid.get(netuids[0])?.logo_url : null) ||
     null;
   return {

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -894,6 +894,16 @@ export function normalizePublicUrl(value) {
   }
 }
 
+export function normalizePublicHttpUrl(value) {
+  const normalized = normalizePublicUrl(value);
+  if (!normalized) {
+    return null;
+  }
+
+  const protocol = new URL(normalized).protocol;
+  return ["http:", "https:"].includes(protocol) ? normalized : null;
+}
+
 // Placeholder/junk identity URLs some subnets carry on-chain (e.g. the
 // deprecated subnets' "https://deprecated.png" + "github.com/username/repo",
 // or "example.com" stubs). These must never surface as real links.

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -1,6 +1,7 @@
 import {
   clusterDomainFromUrl,
   flattenSurfaces,
+  normalizePublicHttpUrl,
   normalizePublicUrl,
   registrySurfaceKey,
   slugify,
@@ -1243,6 +1244,7 @@ export function validateProviderForSubmission({
   const githubUrl = normalizePublicUrl(provider?.github_url);
   const teamUrl = normalizePublicUrl(provider?.team_url);
   const contactUrl = normalizePublicUrl(provider?.contact_url);
+  const logoUrl = normalizePublicHttpUrl(provider?.logo_url);
 
   if (!provider || typeof provider !== "object") {
     return {
@@ -1292,6 +1294,7 @@ export function validateProviderForSubmission({
     ["github_url", githubUrl],
     ["team_url", teamUrl],
     ["contact_url", contactUrl],
+    ["logo_url", logoUrl],
   ]) {
     if (provider[field] && !normalized) {
       errors.push({

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -11,6 +11,7 @@ import {
   loadSubnets,
   isCredentialedUrl,
   isValidUrl,
+  normalizePublicHttpUrl,
   nativeDisplayName,
   nativeNameQuality,
   listJsonFilesRecursive,
@@ -141,6 +142,12 @@ function validateProvider(provider) {
       continue;
     }
     assert(isValidUrl(provider[key]), `${provider.id}: ${key} must be a URL`);
+  }
+  if (provider.logo_url !== undefined) {
+    assert(
+      normalizePublicHttpUrl(provider.logo_url),
+      `${provider.id}: logo_url must be a public HTTP(S) URL`,
+    );
   }
   assert(
     authorities.has(provider.authority),

--- a/src/openapi-sample.mjs
+++ b/src/openapi-sample.mjs
@@ -29,6 +29,10 @@ function valueForPattern(pattern) {
       return "/api/v1/example";
     case "^#/components/schemas/[A-Za-z0-9]+$":
       return "#/components/schemas/Example";
+    case "^[Hh][Tt][Tt][Pp][Ss]?://":
+      // http(s)-only guard (e.g. provider logo_url) — keep the sample a valid
+      // absolute URL so it satisfies both the pattern and format: uri.
+      return "https://api.metagraph.sh/example";
     default:
       return "example";
   }


### PR DESCRIPTION
### Motivation
- The new `provider.logo_url` field accepted generic URIs and was not covered by existing URL safety guards, allowing non-public or unsafe schemes to be published.
- Curated `logo_url` was emitted unchanged into public artifacts, creating stored XSS/SSRF-adjacent risk for downstream consumers.

### Description
- Constrain `logo_url` in source and served schemas to HTTP(S) by adding a `pattern` (and `examples`) to `schemas/provider.schema.json` and `schemas/components/03-providers.schema.json`, and propagate those updates into bundled OpenAPI/types artifacts.
- Add `normalizePublicHttpUrl` in `scripts/lib.mjs` that reuses `normalizePublicUrl` then enforces `http:`/`https:` protocols.
- Use `normalizePublicHttpUrl` in semantic validation (`scripts/validate.mjs`) and submission preflight (`scripts/submission-policy.mjs`) so `logo_url` is normalized and rejected if unsafe or non-public.
- Normalize curated `provider.logo_url` in artifact generation (`scripts/build-artifacts.mjs`) before emitting into public provider artifacts so unsafe values are not copied through.

### Testing
- Ran a targeted Node script to verify schema rejects unsafe schemes and that `normalizePublicHttpUrl` + submission preflight reject unsafe/logo values; those checks passed.
- Rebundled schemas and regenerated OpenAPI/types with `npm run schemas:bundle` / `npm run openapi:generate` / `npm run types:generate` and validated with `npm run validate:schemas`, which passed.
- Ran unit tests `npx vitest run tests/submission-gate.test.mjs tests/lib-helpers.test.mjs` and they passed.
- Note: a full `npm run validate` was attempted but failed due to the repository's artifact manifest requirement (`R2 manifest: generated type definitions must be uploaded`), and `tests/public-safety.test.mjs` exhibited an environment-dependent DNS/public-host resolution failure during an earlier run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a307e599618832aad518f1e4392ce02)