### PR TITLE
style(mcp): prettier-format the #742 code (un-red validate)

### DIFF
--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1648,7 +1648,10 @@ export function listPromptDefinitions() {
 function getPrompt(params) {
   const prompt = PROMPTS_BY_NAME.get(params?.name);
   if (!prompt) {
-    throw toolError("invalid_params", `Unknown prompt: ${String(params?.name)}`);
+    throw toolError(
+      "invalid_params",
+      `Unknown prompt: ${String(params?.name)}`,
+    );
   }
   const args = params?.arguments || {};
   for (const arg of prompt.arguments) {

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -246,14 +246,11 @@ describe("MCP resources (#742)", () => {
     });
     const tpls = res.body.result.resourceTemplates;
     assert.equal(tpls.length, 3);
-    assert.deepEqual(
-      tpls.map((t) => t.uriTemplate).sort(),
-      [
-        "metagraph://provider/{slug}",
-        "metagraph://schema/{surface_id}",
-        "metagraph://subnet/{netuid}",
-      ],
-    );
+    assert.deepEqual(tpls.map((t) => t.uriTemplate).sort(), [
+      "metagraph://provider/{slug}",
+      "metagraph://schema/{surface_id}",
+      "metagraph://subnet/{netuid}",
+    ]);
     for (const t of tpls) {
       assert.ok(t.name && t.title && t.description && t.mimeType);
     }
@@ -272,7 +269,10 @@ describe("MCP resources (#742)", () => {
       },
       "/metagraph/schemas/index.json": {
         schemas: [
-          { surface_id: "7:subnet-api:allways", content_type: "application/json" },
+          {
+            surface_id: "7:subnet-api:allways",
+            content_type: "application/json",
+          },
         ],
       },
     });


### PR DESCRIPTION
The #742 merge turned `validate` red on the **Lint + format** step — CI runs `prettier --check` and the new `mcp-server.mjs` + test code wasn't prettier-conformant (my local check only ran eslint). `prettier --write` on the two files; whole-repo format:check + lint + mcp tests all green. Formatting only.