### PR TITLE
feat(registry): add SN74 Gittensor dash/repos public API candidate

### DIFF
--- a/registry/candidates/community/community-sn-74-subnet-api-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-subnet-api-api-gittensor-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-subnet-api-api-gittensor-io",
+      "kind": "subnet-api",
+      "name": "Gittensor community subnet-api",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gittensor.io/swagger",
+      "source_urls": ["https://api.gittensor.io/swagger"],
+      "state": "schema-valid",
+      "url": "https://api.gittensor.io/dash/repos"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
## Summary
Community submission for **Subnet 74 (Gittensor)** — public `subnet-api` surface.

Adds exactly one candidate file for the unauthenticated repositories dashboard API documented in the public OpenAPI spec.

## Candidate
- **Kind:** `subnet-api`
- **URL:** https://api.gittensor.io/dash/repos
- **Source:** https://api.gittensor.io/swagger (OpenAPI documents `/dash/repos`)
- **Issue context:** SN74 public API gap (surface enrichment epic #427)

## Validation
```bash
npm run validate:candidate -- registry/candidates/community/community-sn-74-subnet-api-api-gittensor-io.json
```

Verified the endpoint returns public JSON (200) and is listed in the live Swagger spec.
