### PR TITLE
feat(registry): add SN74 Gittensor dash/stats data artifact

### DIFF
--- a/registry/candidates/community/community-sn-74-data-artifact-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-data-artifact-api-gittensor-io.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-data-artifact-api-gittensor-io",
+      "kind": "data-artifact",
+      "name": "Gittensor network statistics dashboard API",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gittensor.io/swagger",
+      "source_urls": [
+        "https://api.gittensor.io/swagger"
+      ],
+      "state": "schema-valid",
+      "url": "https://api.gittensor.io/dash/stats"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
## Summary
Community submission for **Subnet 74 (Gittensor)** — public `data-artifact` surface.

Adds exactly one candidate for the unauthenticated network statistics JSON at `/dash/stats`, documented in the public OpenAPI spec.

## Candidate
- **Kind:** `data-artifact`
- **URL:** https://api.gittensor.io/dash/stats
- **Source:** https://api.gittensor.io/swagger
- **Related:** complements #769 (`/dash/repos` subnet-api)

## Validation
```bash
npm run validate:candidate -- registry/candidates/community/community-sn-74-data-artifact-api-gittensor-io.json
```
