### PR TITLE
feat(registry): add SN58 Handshake58 directory providers API

### DIFF
--- a/registry/candidates/community/community-sn-58-subnet-api-handshake58-com.json
+++ b/registry/candidates/community/community-sn-58-subnet-api-handshake58-com.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-58-subnet-api-handshake58-com",
+      "kind": "subnet-api",
+      "name": "Handshake58 Bittensor provider directory API",
+      "netuid": 58,
+      "provider": "handshake58",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://handshake58.com/openapi.json",
+      "source_urls": [
+        "https://handshake58.com/openapi.json"
+      ],
+      "state": "schema-valid",
+      "url": "https://handshake58.com/api/directory/providers"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
## Summary
Community submission for **Subnet 58 (Handshake58)** — public `subnet-api` surface.

Adds exactly one candidate for the Bittensor-tier provider directory at `/api/directory/providers`, listed in the official OpenAPI schema (distinct from `/api/mcp/providers`).

## Candidate
- **Kind:** `subnet-api`
- **URL:** https://handshake58.com/api/directory/providers
- **Source:** https://handshake58.com/openapi.json
- **Issue context:** #721 (surface enrichment epic #427)

## Validation
```bash
npm run validate:candidate -- registry/candidates/community/community-sn-58-subnet-api-handshake58-com.json
```
