### PR TITLE
feat(api): content feeds — RSS / Atom / JSON Feed (#741)

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,13 @@ curl https://api.metagraph.sh/api/v1/subnets
 
 ## For agents
 
-| Resource              | URL                                                                                          |
-| --------------------- | -------------------------------------------------------------------------------------------- |
-| Copyable agent prompt | [`/agent.md`](https://api.metagraph.sh/agent.md)                                             |
-| Machine index         | [`/llms.txt`](https://api.metagraph.sh/llms.txt)                                             |
-| Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)           |
-| Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json) |
+| Resource              | URL                                                                                                                                                                                   |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Copyable agent prompt | [`/agent.md`](https://api.metagraph.sh/agent.md)                                                                                                                                      |
+| Machine index         | [`/llms.txt`](https://api.metagraph.sh/llms.txt)                                                                                                                                      |
+| Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)                                                                                                    |
+| Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json)                                                                                          |
+| Content feeds         | [`/api/v1/feeds/registry`](https://api.metagraph.sh/api/v1/feeds/registry) — registry changes + incidents, as RSS / Atom / JSON Feed (per-subnet at `/api/v1/feeds/subnets/{netuid}`) |
 
 ## This repo
 

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1282,6 +1282,7 @@ const llmsHeader = [
   `- [Copyable AI agent](${llmsApiBase}/agent.md): paste-ready system prompt that turns any agent into a metagraphed-powered Bittensor integration agent. Every AI resource indexed at [/api/v1/agent-resources](${llmsApiBase}/api/v1/agent-resources).`,
   `- [MCP server](${llmsApiBase}/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: \`claude mcp add --transport http metagraphed ${llmsApiBase}/mcp\``,
   `- [MCP server card](${llmsApiBase}/.well-known/mcp/server-card.json): machine-readable server descriptor (tools, transport, protocol versions)`,
+  `- [Content feeds](${llmsApiBase}/api/v1/feeds/registry): RSS 2.0 / Atom 1.0 / JSON Feed 1.1 of registry changes + incidents (per-subnet at /api/v1/feeds/subnets/{netuid}). Content-negotiated via Accept, or append .rss/.atom/.json.`,
   `- [Bittensor skill](${llmsApiBase}/skills/bittensor/SKILL.md): drop-in agent skill for "what subnet does X, is it up, how do I call it"`,
   `- [Semantic search](${llmsApiBase}/api/v1/search/semantic?q=): natural-language vector search over subnets/surfaces`,
   `- [Ask](${llmsApiBase}/api/v1/ask): POST { question } for a grounded, cited answer over the registry`,

--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -1,0 +1,412 @@
+// Public content feeds (#741) — RSS 2.0 / Atom 1.0 / JSON Feed 1.1 over data we
+// ALREADY compute (the 6h changelog deltas + reconstructed incident history), so
+// agents, readers, crawlers, and newsletters can subscribe to registry changes
+// and incidents. Worker-computed at request time from the served artifacts — no
+// new committed artifact, no new data collection. Read-only.
+//
+// Routes (all GET, content-negotiated):
+//   /api/v1/feeds/registry[.rss|.atom|.json]
+//   /api/v1/feeds/incidents[.rss|.atom|.json]
+//   /api/v1/feeds/subnets/{netuid}[.rss|.atom|.json]
+// Format precedence: explicit .rss/.atom/.json suffix > Accept header > JSON Feed.
+
+const SITE_URL = "https://metagraph.sh";
+const API_URL = "https://api.metagraph.sh";
+const FEED_MAX_ITEMS = 50;
+const FEED_CACHE_SECONDS = 600;
+
+const FEED_CONTENT_TYPES = {
+  json: "application/feed+json; charset=utf-8",
+  rss: "application/rss+xml; charset=utf-8",
+  atom: "application/atom+xml; charset=utf-8",
+};
+
+// ── text helpers ────────────────────────────────────────────────────────────
+
+// XML 1.0 doesn't allow most C0 control chars even when escaped; strip them. The
+// served artifacts are already build-sanitized (sanitizeChainText), so this is
+// defense-in-depth on the public surface, not the primary trust boundary.
+function stripControl(value) {
+  // Drop XML-illegal C0 control chars (keep tab/newline/CR) without a
+  // control-char regexp (eslint no-control-regex). Served data is already
+  // build-sanitized; this is defense-in-depth on the public surface.
+  let out = "";
+  for (const ch of String(value ?? "")) {
+    const code = ch.codePointAt(0);
+    if (code < 32 && code !== 9 && code !== 10 && code !== 13) continue;
+    out += ch;
+  }
+  return out;
+}
+
+function escapeXml(value) {
+  return stripControl(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+function clamp(value, max = 500) {
+  const s = stripControl(value).trim();
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+// Accept an ISO string or epoch-ms; return a normalized ISO string or null.
+function toIso(value) {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value).toISOString();
+  }
+  if (typeof value === "string") {
+    const t = Date.parse(value);
+    if (!Number.isNaN(t)) return new Date(t).toISOString();
+  }
+  return null;
+}
+
+function toRfc822(iso) {
+  return new Date(iso).toUTCString();
+}
+
+// ── item builders (from existing served artifacts) ──────────────────────────
+
+// Registry feed: the latest changelog window's subnet + artifact + coverage
+// changes. `netuid` (optional) filters to one subnet.
+function registryItems(changelog, netuid) {
+  const at = toIso(changelog?.generated_at) || new Date().toISOString();
+  const items = [];
+
+  // changelog.subnets is { added: [...], removed: [...], renamed: [...] }, each
+  // entry a netuid or { netuid, name }.
+  const subnets = changelog?.subnets || {};
+  for (const change of ["added", "removed", "renamed"]) {
+    for (const entry of subnets[change] || []) {
+      const n = typeof entry === "number" ? entry : entry?.netuid;
+      if (typeof n !== "number") continue;
+      if (netuid != null && n !== netuid) continue;
+      const name = typeof entry === "object" ? entry?.name : null;
+      items.push({
+        id: `registry:subnet:${n}:${change}:${at}`,
+        url: `${SITE_URL}/subnets/${n}`,
+        title: `Subnet ${n} ${change}${name ? ` — ${clamp(name, 80)}` : ""}`,
+        summary: clamp(`Subnet ${n} ${change} in the registry.`),
+        timestamp: at,
+        tags: ["registry", "subnet", change],
+      });
+    }
+  }
+
+  // Per-subnet feeds are subnet-scoped only; the global registry feed also lists
+  // artifact + coverage deltas. changelog.artifacts is { added, modified, removed }.
+  if (netuid == null) {
+    const artifacts = changelog?.artifacts || {};
+    const verb = { added: "Added", modified: "Updated", removed: "Removed" };
+    for (const change of ["added", "modified", "removed"]) {
+      for (const a of artifacts[change] || []) {
+        const path = a?.path || a?.artifact_path || a?.id;
+        if (!path) continue;
+        const cleanPath = String(path).replace(/^\/?(?:metagraph\/)?/, "");
+        items.push({
+          id: `registry:artifact:${change}:${path}:${at}`,
+          url: `${API_URL}/metagraph/${cleanPath}`,
+          title: `${verb[change]} ${clamp(path, 80)}`,
+          summary: clamp(`Artifact ${path} ${change}.`),
+          timestamp: at,
+          tags: ["registry", "artifact", change],
+        });
+      }
+    }
+    const cov = changelog?.summary?.coverage_delta;
+    const surfaceDelta = cov?.surface_count?.delta || 0;
+    const candidateDelta = cov?.candidate_count?.delta || 0;
+    if (surfaceDelta || candidateDelta) {
+      const sign = (n) => (n >= 0 ? `+${n}` : `${n}`);
+      items.push({
+        id: `registry:coverage:${at}`,
+        url: `${SITE_URL}/gaps`,
+        title: `Coverage updated: ${sign(surfaceDelta)} surfaces, ${sign(candidateDelta)} candidates`,
+        summary: clamp(
+          `Surfaces ${cov.surface_count?.before}→${cov.surface_count?.after}; ` +
+            `candidates ${cov.candidate_count?.before}→${cov.candidate_count?.after}.`,
+        ),
+        timestamp: at,
+        tags: ["registry", "coverage"],
+      });
+    }
+  }
+
+  return items;
+}
+
+// Incidents feed: each reconstructed incident from the served incidents artifact.
+// `netuid` (optional) filters to one subnet.
+function incidentItems(incidents, netuid) {
+  const items = [];
+  for (const surface of incidents?.surfaces || []) {
+    if (netuid != null && surface?.netuid !== netuid) continue;
+    for (const inc of surface?.incidents || []) {
+      const started = toIso(inc.started_at);
+      const ended = toIso(inc.ended_at);
+      const ongoing = !ended;
+      const minutes = Math.round((inc.duration_ms || 0) / 60000);
+      items.push({
+        id: `incident:${surface.surface_id}:${inc.started_at}`,
+        url: `${SITE_URL}/subnets/${surface.netuid}`,
+        title: `${ongoing ? "Ongoing" : "Resolved"} incident — ${clamp(surface.surface_id, 80)}`,
+        summary: clamp(
+          `Surface ${surface.surface_id} (sn${surface.netuid}) ` +
+            `${ongoing ? "is currently down" : `was down for ~${minutes}m`}` +
+            `${inc.failed_samples ? `, ${inc.failed_samples} failed probes` : ""}.`,
+        ),
+        timestamp: ended || started || new Date().toISOString(),
+        tags: [
+          "incident",
+          `sn${surface.netuid}`,
+          ongoing ? "ongoing" : "resolved",
+        ],
+      });
+    }
+  }
+  return items;
+}
+
+// ── serializers ─────────────────────────────────────────────────────────────
+
+function sortAndCap(items) {
+  return [...items]
+    .sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp))
+    .slice(0, FEED_MAX_ITEMS);
+}
+
+function jsonFeed(meta, items) {
+  return `${JSON.stringify(
+    {
+      version: "https://jsonfeed.org/version/1.1",
+      title: meta.title,
+      home_page_url: meta.homeUrl,
+      feed_url: meta.feedUrl,
+      description: meta.description,
+      items: items.map((it) => ({
+        id: it.id,
+        url: it.url,
+        title: it.title,
+        content_text: it.summary,
+        date_published: it.timestamp,
+        tags: it.tags,
+      })),
+    },
+    null,
+    2,
+  )}\n`;
+}
+
+function rssFeed(meta, items) {
+  const body = items
+    .map((it) =>
+      [
+        "    <item>",
+        `      <guid isPermaLink="false">${escapeXml(it.id)}</guid>`,
+        `      <link>${escapeXml(it.url)}</link>`,
+        `      <title>${escapeXml(it.title)}</title>`,
+        `      <description>${escapeXml(it.summary)}</description>`,
+        `      <pubDate>${toRfc822(it.timestamp)}</pubDate>`,
+        ...(it.tags || []).map(
+          (t) => `      <category>${escapeXml(t)}</category>`,
+        ),
+        "    </item>",
+      ].join("\n"),
+    )
+    .join("\n");
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">',
+    "  <channel>",
+    `    <title>${escapeXml(meta.title)}</title>`,
+    `    <link>${escapeXml(meta.homeUrl)}</link>`,
+    `    <atom:link href="${escapeXml(meta.feedUrl)}" rel="self" type="application/rss+xml"/>`,
+    `    <description>${escapeXml(meta.description)}</description>`,
+    `    <lastBuildDate>${toRfc822(meta.updated)}</lastBuildDate>`,
+    body,
+    "  </channel>",
+    "</rss>",
+    "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+function atomFeed(meta, items) {
+  const body = items
+    .map((it) =>
+      [
+        "  <entry>",
+        `    <id>urn:metagraphed:${escapeXml(it.id)}</id>`,
+        `    <title>${escapeXml(it.title)}</title>`,
+        `    <link href="${escapeXml(it.url)}"/>`,
+        `    <updated>${it.timestamp}</updated>`,
+        `    <summary>${escapeXml(it.summary)}</summary>`,
+        ...(it.tags || []).map((t) => `    <category term="${escapeXml(t)}"/>`),
+        "  </entry>",
+      ].join("\n"),
+    )
+    .join("\n");
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<feed xmlns="http://www.w3.org/2005/Atom">',
+    `  <title>${escapeXml(meta.title)}</title>`,
+    `  <link href="${escapeXml(meta.homeUrl)}"/>`,
+    `  <link href="${escapeXml(meta.feedUrl)}" rel="self" type="application/atom+xml"/>`,
+    `  <id>${escapeXml(meta.feedUrl)}</id>`,
+    `  <updated>${meta.updated}</updated>`,
+    `  <subtitle>${escapeXml(meta.description)}</subtitle>`,
+    body,
+    "</feed>",
+    "",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+const SERIALIZERS = { json: jsonFeed, rss: rssFeed, atom: atomFeed };
+
+// ── request handling ────────────────────────────────────────────────────────
+
+export function resolveFeedFormat(pathname, accept) {
+  if (pathname.endsWith(".rss")) return "rss";
+  if (pathname.endsWith(".atom")) return "atom";
+  if (pathname.endsWith(".json")) return "json";
+  const a = String(accept || "").toLowerCase();
+  if (a.includes("application/rss+xml")) return "rss";
+  if (a.includes("application/atom+xml")) return "atom";
+  return "json";
+}
+
+// Parse `/api/v1/feeds/...` into { kind, netuid } or null for an unknown feed.
+export function parseFeedPath(pathname) {
+  const rest = pathname
+    .replace(/^\/api\/v1\/feeds\/?/, "")
+    .replace(/\.(rss|atom|json)$/, "")
+    .replace(/\/$/, "");
+  if (rest === "registry") return { kind: "registry" };
+  if (rest === "incidents") return { kind: "incidents" };
+  const subnet = /^subnets\/(\d+)$/.exec(rest);
+  if (subnet) return { kind: "subnet", netuid: Number(subnet[1]) };
+  return null;
+}
+
+function feedError(code, message, status) {
+  return new Response(JSON.stringify({ ok: false, error: { code, message } }), {
+    status,
+    headers: { "content-type": "application/json; charset=utf-8" },
+  });
+}
+
+async function readData(readArtifact, env, path) {
+  try {
+    const result = await readArtifact(env, path);
+    return result?.ok ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function handleFeedRequest(request, env, url, deps = {}) {
+  const readArtifact = deps.readArtifact;
+  const target = parseFeedPath(url.pathname);
+  if (!target || typeof readArtifact !== "function") {
+    return feedError(
+      "feed_not_found",
+      "Unknown feed. Available: /api/v1/feeds/registry, /api/v1/feeds/incidents, /api/v1/feeds/subnets/{netuid} (each as .rss/.atom/.json or via Accept).",
+      404,
+    );
+  }
+  const format = resolveFeedFormat(url.pathname, request.headers.get("accept"));
+
+  let items;
+  let title;
+  let description;
+  let homeUrl = SITE_URL;
+  let updatedSource;
+
+  if (target.kind === "registry") {
+    const changelog = await readData(
+      readArtifact,
+      env,
+      "/metagraph/changelog.json",
+    );
+    items = registryItems(changelog);
+    title = "metagraphed — registry changes";
+    description =
+      "New and updated Bittensor subnets, surfaces, and coverage from the metagraphed registry.";
+    updatedSource = changelog?.generated_at;
+  } else if (target.kind === "incidents") {
+    const incidents = await readData(
+      readArtifact,
+      env,
+      "/metagraph/incidents.json",
+    );
+    items = incidentItems(incidents);
+    title = "metagraphed — surface incidents";
+    description =
+      "Operational incidents across Bittensor subnet surfaces (probe-detected downtime).";
+    updatedSource = incidents?.observed_at;
+  } else {
+    const [changelog, incidents] = await Promise.all([
+      readData(readArtifact, env, "/metagraph/changelog.json"),
+      readData(readArtifact, env, "/metagraph/incidents.json"),
+    ]);
+    items = [
+      ...registryItems(changelog, target.netuid),
+      ...incidentItems(incidents, target.netuid),
+    ];
+    title = `metagraphed — subnet ${target.netuid} feed`;
+    description = `Registry changes and incidents for Bittensor subnet ${target.netuid}.`;
+    homeUrl = `${SITE_URL}/subnets/${target.netuid}`;
+    updatedSource = changelog?.generated_at;
+  }
+
+  items = sortAndCap(items);
+  const meta = {
+    title,
+    description,
+    homeUrl,
+    feedUrl: `${url.origin}${url.pathname}`,
+    updated:
+      items[0]?.timestamp || toIso(updatedSource) || new Date().toISOString(),
+  };
+
+  const body = SERIALIZERS[format](meta, items);
+  return new Response(request.method === "HEAD" ? null : body, {
+    status: 200,
+    headers: {
+      "content-type": FEED_CONTENT_TYPES[format],
+      "cache-control": `public, max-age=${FEED_CACHE_SECONDS}`,
+      "x-content-type-options": "nosniff",
+    },
+  });
+}
+
+// RFC 8288 Link header value advertising the feeds for an entity endpoint, so a
+// crawler/agent on /api/v1/subnets or a subnet profile discovers them.
+export function feedLinkHeader(originUrl, netuid) {
+  const base =
+    netuid != null
+      ? `${originUrl}/api/v1/feeds/subnets/${netuid}`
+      : `${originUrl}/api/v1/feeds/registry`;
+  return (
+    `<${base}.json>; rel="alternate"; type="application/feed+json", ` +
+    `<${base}.rss>; rel="alternate"; type="application/rss+xml", ` +
+    `<${base}.atom>; rel="alternate"; type="application/atom+xml"`
+  );
+}
+
+// Exported for unit tests.
+export const __test = {
+  registryItems,
+  incidentItems,
+  jsonFeed,
+  rssFeed,
+  atomFeed,
+  escapeXml,
+};

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -1,0 +1,321 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  handleFeedRequest,
+  parseFeedPath,
+  resolveFeedFormat,
+  feedLinkHeader,
+  __test,
+} from "../src/feeds.mjs";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+const { registryItems, incidentItems, jsonFeed, rssFeed, atomFeed, escapeXml } =
+  __test;
+
+const CHANGELOG = {
+  generated_at: "2026-06-15T00:00:00.000Z",
+  subnets: {
+    added: [{ netuid: 7, name: "Allways" }],
+    removed: [],
+    renamed: [
+      { netuid: 12 }, // no name → title fallback
+      { name: "no-netuid" }, // skipped (no numeric netuid)
+    ],
+  },
+  artifacts: {
+    added: [],
+    modified: [{ path: "subnets.json" }, {}], // 2nd skipped (no path)
+    removed: [{ path: "/metagraph/coverage.json" }],
+  },
+  summary: {
+    coverage_delta: {
+      surface_count: { before: 100, after: 103, delta: 3 },
+      candidate_count: { before: 50, after: 49, delta: -1 },
+    },
+  },
+};
+
+const INCIDENTS = {
+  observed_at: "2026-06-15T00:00:00.000Z",
+  surfaces: [
+    {
+      netuid: 7,
+      surface_id: "allways-api",
+      incidents: [
+        {
+          started_at: 1781266255266,
+          ended_at: 1781499480737,
+          duration_ms: 233225471,
+          failed_samples: 1945,
+        },
+      ],
+    },
+    {
+      netuid: 12,
+      surface_id: "compute-rpc",
+      incidents: [{ started_at: 1781499480000 }], // ongoing, no failed_samples
+    },
+    { netuid: 3, surface_id: "no-incidents" }, // no incidents[]
+  ],
+};
+
+function makeReadArtifact(fixtures) {
+  return (_env, path) =>
+    Promise.resolve(
+      Object.prototype.hasOwnProperty.call(fixtures, path)
+        ? { ok: true, data: fixtures[path] }
+        : { ok: false, code: "artifact_not_found" },
+    );
+}
+
+async function feed(pathname, { accept, deps, method = "GET" } = {}) {
+  const url = new URL(`https://api.metagraph.sh${pathname}`);
+  const request = new Request(url, {
+    method,
+    headers: accept ? { accept } : {},
+  });
+  const readArtifact =
+    deps ||
+    makeReadArtifact({
+      "/metagraph/changelog.json": CHANGELOG,
+      "/metagraph/incidents.json": INCIDENTS,
+      "/metagraph/health/incidents/7.json": INCIDENTS,
+    });
+  const res = await handleFeedRequest(request, {}, url, { readArtifact });
+  return { res, text: await res.text() };
+}
+
+describe("feeds — path + format parsing", () => {
+  test("parseFeedPath resolves the three feed kinds + rejects unknown", () => {
+    assert.deepEqual(parseFeedPath("/api/v1/feeds/registry"), {
+      kind: "registry",
+    });
+    assert.deepEqual(parseFeedPath("/api/v1/feeds/incidents.rss"), {
+      kind: "incidents",
+    });
+    assert.deepEqual(parseFeedPath("/api/v1/feeds/subnets/7.atom"), {
+      kind: "subnet",
+      netuid: 7,
+    });
+    assert.equal(parseFeedPath("/api/v1/feeds/bogus"), null);
+    assert.equal(parseFeedPath("/api/v1/feeds/subnets/abc"), null);
+  });
+
+  test("resolveFeedFormat: suffix > Accept > json default", () => {
+    assert.equal(resolveFeedFormat("/x.rss", "application/json"), "rss");
+    assert.equal(resolveFeedFormat("/x.atom", ""), "atom");
+    assert.equal(resolveFeedFormat("/x.json", ""), "json");
+    assert.equal(resolveFeedFormat("/x", "application/rss+xml"), "rss");
+    assert.equal(resolveFeedFormat("/x", "application/atom+xml"), "atom");
+    assert.equal(resolveFeedFormat("/x", "text/html"), "json");
+  });
+
+  test("feedLinkHeader advertises all three formats, global + per-subnet", () => {
+    const global = feedLinkHeader("https://api.metagraph.sh");
+    assert.match(global, /feeds\/registry\.json>.*application\/feed\+json/);
+    assert.match(global, /feeds\/registry\.rss>.*application\/rss\+xml/);
+    assert.match(global, /feeds\/registry\.atom>.*application\/atom\+xml/);
+    const subnet = feedLinkHeader("https://api.metagraph.sh", 7);
+    assert.match(subnet, /feeds\/subnets\/7\.rss>/);
+  });
+});
+
+describe("feeds — item builders", () => {
+  test("registryItems builds subnet, artifact, and coverage items", () => {
+    const items = registryItems(CHANGELOG);
+    const titles = items.map((i) => i.title);
+    assert.ok(titles.some((t) => t === "Subnet 7 added — Allways"));
+    assert.ok(titles.some((t) => t === "Subnet 12 renamed")); // no-name fallback
+    assert.ok(!titles.some((t) => t.includes("no-netuid"))); // skipped
+    assert.ok(titles.some((t) => t === "Updated subnets.json"));
+    assert.ok(titles.some((t) => t === "Removed /metagraph/coverage.json"));
+    assert.ok(
+      titles.some((t) => t.startsWith("Coverage updated: +3 surfaces, -1")),
+    );
+    for (const it of items) {
+      assert.ok(it.id && it.url && it.title && it.timestamp);
+      assert.ok(Array.isArray(it.tags));
+    }
+  });
+
+  test("registryItems filtered by netuid omits artifacts + coverage", () => {
+    const items = registryItems(CHANGELOG, 7);
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, "Subnet 7 added — Allways");
+  });
+
+  test("registryItems tolerates empty/missing changelog", () => {
+    assert.deepEqual(registryItems(null), []);
+    assert.deepEqual(registryItems({}), []);
+  });
+
+  test("incidentItems marks ongoing vs resolved + filters by netuid", () => {
+    const all = incidentItems(INCIDENTS);
+    assert.equal(all.length, 2); // the no-incidents surface contributes none
+    const resolved = all.find((i) => i.tags.includes("resolved"));
+    const ongoing = all.find((i) => i.tags.includes("ongoing"));
+    assert.match(resolved.title, /^Resolved incident/);
+    assert.match(resolved.summary, /was down for ~\d+m, 1945 failed probes/);
+    assert.match(ongoing.title, /^Ongoing incident/);
+    assert.match(ongoing.summary, /is currently down\.$/);
+    const onlySn7 = incidentItems(INCIDENTS, 7);
+    assert.equal(onlySn7.length, 1);
+    assert.equal(incidentItems(null).length, 0);
+  });
+});
+
+describe("feeds — serializers", () => {
+  const meta = {
+    title: "t",
+    description: "d",
+    homeUrl: "https://metagraph.sh",
+    feedUrl: "https://api.metagraph.sh/api/v1/feeds/registry",
+    updated: "2026-06-15T00:00:00.000Z",
+  };
+  const items = registryItems(CHANGELOG);
+
+  test("jsonFeed is valid JSON Feed 1.1", () => {
+    const parsed = JSON.parse(jsonFeed(meta, items));
+    assert.equal(parsed.version, "https://jsonfeed.org/version/1.1");
+    assert.equal(parsed.title, "t");
+    assert.ok(Array.isArray(parsed.items) && parsed.items.length > 0);
+    for (const it of parsed.items) {
+      assert.ok(it.id && it.title && it.date_published);
+    }
+  });
+
+  test("rssFeed has the required channel + item structure", () => {
+    const xml = rssFeed(meta, items);
+    assert.match(xml, /^<\?xml version="1\.0" encoding="UTF-8"\?>/);
+    assert.match(xml, /<rss version="2\.0"/);
+    assert.match(xml, /<channel>[\s\S]*<\/channel>/);
+    assert.ok((xml.match(/<item>/g) || []).length === items.length);
+    assert.match(xml, /<pubDate>.*GMT<\/pubDate>/);
+  });
+
+  test("atomFeed has the required feed + entry structure", () => {
+    const xml = atomFeed(meta, items);
+    assert.match(xml, /<feed xmlns="http:\/\/www\.w3\.org\/2005\/Atom">/);
+    assert.match(xml, /<id>https:\/\/api\.metagraph\.sh/);
+    assert.ok((xml.match(/<entry>/g) || []).length === items.length);
+  });
+
+  test("escapeXml neutralizes markup + strips control chars", () => {
+    assert.equal(
+      escapeXml(`<a href="x">&'</a>`),
+      "&lt;a href=&quot;x&quot;&gt;&amp;&apos;&lt;/a&gt;",
+    );
+    assert.equal(escapeXml("a\u0000b\u0007c"), "abc"); // control stripped
+    assert.equal(escapeXml("keep\ttab\nnewline"), "keep\ttab\nnewline");
+    // a script payload in a feed title can't break out of the element
+    const xml = rssFeed(meta, [
+      {
+        id: "x",
+        url: "https://x",
+        title: "<script>alert(1)</script>",
+        summary: "s",
+        timestamp: "2026-06-15T00:00:00.000Z",
+        tags: [],
+      },
+    ]);
+    assert.ok(!xml.includes("<script>"));
+    assert.match(xml, /&lt;script&gt;/);
+  });
+});
+
+describe("feeds — handleFeedRequest", () => {
+  test("registry feed defaults to JSON Feed", async () => {
+    const { res, text } = await feed("/api/v1/feeds/registry");
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/feed\+json/);
+    assert.match(res.headers.get("cache-control"), /max-age=600/);
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.version, "https://jsonfeed.org/version/1.1");
+    assert.equal(
+      parsed.feed_url,
+      "https://api.metagraph.sh/api/v1/feeds/registry",
+    );
+  });
+
+  test("explicit .rss + .atom suffixes win over Accept", async () => {
+    const rss = await feed("/api/v1/feeds/registry.rss", {
+      accept: "application/feed+json",
+    });
+    assert.match(rss.res.headers.get("content-type"), /application\/rss\+xml/);
+    assert.match(rss.text, /<rss version="2\.0"/);
+    const atom = await feed("/api/v1/feeds/incidents.atom");
+    assert.match(
+      atom.res.headers.get("content-type"),
+      /application\/atom\+xml/,
+    );
+    assert.match(atom.text, /<feed xmlns/);
+  });
+
+  test("Accept header negotiates rss/atom without a suffix", async () => {
+    const { res } = await feed("/api/v1/feeds/registry", {
+      accept: "text/html, application/rss+xml",
+    });
+    assert.match(res.headers.get("content-type"), /application\/rss\+xml/);
+  });
+
+  test("per-subnet feed merges registry + incident items for that netuid", async () => {
+    const { res, text } = await feed("/api/v1/feeds/subnets/7");
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.ok(parsed.items.some((i) => i.id.startsWith("registry:subnet:7")));
+    assert.ok(parsed.items.some((i) => i.id.startsWith("incident:")));
+    assert.equal(parsed.home_page_url, "https://metagraph.sh/subnets/7");
+  });
+
+  test("unknown feed → 404, missing readArtifact → 404", async () => {
+    const { res } = await feed("/api/v1/feeds/nope");
+    assert.equal(res.status, 404);
+    const url = new URL("https://api.metagraph.sh/api/v1/feeds/registry");
+    const bad = await handleFeedRequest(new Request(url), {}, url, {});
+    assert.equal(bad.status, 404);
+  });
+
+  test("HEAD returns headers with no body", async () => {
+    const { res, text } = await feed("/api/v1/feeds/registry", {
+      method: "HEAD",
+    });
+    assert.equal(res.status, 200);
+    assert.equal(text, "");
+  });
+
+  test("a feed with no underlying data still serializes validly (empty)", async () => {
+    const empty = makeReadArtifact({});
+    const { res, text } = await feed("/api/v1/feeds/incidents", {
+      deps: empty,
+    });
+    assert.equal(res.status, 200);
+    const parsed = JSON.parse(text);
+    assert.equal(parsed.items.length, 0);
+    assert.ok(parsed.title && parsed.feed_url);
+  });
+});
+
+describe("feeds — Worker dispatch integration", () => {
+  test("handleRequest routes /api/v1/feeds/* to the feed handler", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/registry.rss"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /application\/rss\+xml/);
+    assert.match(await res.text(), /<rss version="2\.0"/);
+  });
+
+  test("an unknown feed path is a 404 (not a static-asset fall-through)", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/feeds/nonexistent"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 404);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -68,6 +68,7 @@ import {
   subnetBadgeStatus,
 } from "../src/health-serving.mjs";
 import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.mjs";
+import { handleFeedRequest, feedLinkHeader } from "../src/feeds.mjs";
 import {
   buildAgentToolsIndex,
   buildAnthropicToolSpecs,
@@ -242,6 +243,14 @@ export async function handleRequest(request, env = {}, ctx = {}) {
         allow: "GET, HEAD, OPTIONS",
       },
     );
+  }
+
+  // Public content feeds (#741) — RSS 2.0 / Atom 1.0 / JSON Feed 1.1 over the
+  // changelog + incident data we already compute. GET-only (runs after the
+  // method gate); `/api/*` is run_worker_first so these never fall through to
+  // the static assets. Read-only, content-negotiated, edge-cached.
+  if (url.pathname.startsWith("/api/v1/feeds/")) {
+    return handleFeedRequest(request, env, url, { readArtifact });
   }
 
   // Agent/AI discovery surfaces. The homepage advertises the machine resources
@@ -3043,6 +3052,8 @@ const DISCOVERY_LINK_HEADER = [
   `<${DISCOVERY_LINK_BASE}/agent.md>; rel="service-doc"; type="text/markdown"`,
   `<${DISCOVERY_LINK_BASE}/health>; rel="status"; type="application/json"`,
   `<${DISCOVERY_LINK_BASE}/.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"`,
+  // Content feeds (#741) — registry changes, content-negotiated (json/rss/atom).
+  feedLinkHeader(DISCOVERY_LINK_BASE),
 ].join(", ");
 
 const HOMEPAGE_HTML = `<!doctype html>
@@ -3058,6 +3069,8 @@ const HOMEPAGE_HTML = `<!doctype html>
 <link rel="service-doc" href="/agent.md" type="text/markdown">
 <link rel="status" href="/health" type="application/json">
 <link rel="describedby" href="/.well-known/mcp/server-card.json" type="application/json">
+<link rel="alternate" href="/api/v1/feeds/registry.rss" type="application/rss+xml" title="metagraphed registry changes">
+<link rel="alternate" href="/api/v1/feeds/registry.json" type="application/feed+json" title="metagraphed registry changes">
 </head>
 <body>
 <main>
@@ -3071,6 +3084,7 @@ const HOMEPAGE_HTML = `<!doctype html>
 <li><a href="/.well-known/mcp/server-card.json">MCP server card</a> — <code>POST /mcp</code></li>
 <li><a href="/.well-known/agent-skills/index.json">Agent Skills index</a></li>
 <li><a href="/.well-known/agent-tools/index.json">Agent tool specs</a> — paste-ready OpenAI + Anthropic tools</li>
+<li><a href="/api/v1/feeds/registry">Content feeds</a> — registry changes + incidents (RSS / Atom / JSON Feed)</li>
 <li><a href="/api/v1">REST API index</a> · <a href="/sitemap.xml">sitemap.xml</a> · <a href="/auth.md">auth.md</a></li>
 <li><a href="https://metagraph.sh">metagraph.sh</a> — human web app</li>
 </ul>


### PR DESCRIPTION
Closes #741 (Phase 1 of the growth roadmap #740) — the second half of the epic's #1 "feeds + MCP" pair (#742 shipped the MCP half).

Public, content-negotiated **RSS 2.0 / Atom 1.0 / JSON Feed 1.1** feeds over data we **already compute** (the 6h changelog deltas + reconstructed incident history). Drives SEO (indexable change URLs), agent automation (subscribe to "new callable APIs"), and distribution (readers / Slack / newsletters).

### Routes (worker-computed, GET, edge-cached)
- `/api/v1/feeds/registry` — new/updated subnets, surfaces, coverage deltas
- `/api/v1/feeds/incidents` — probe-detected surface downtime
- `/api/v1/feeds/subnets/{netuid}` — one subnet's changes + incidents
- Format: explicit `.rss`/`.atom`/`.json` suffix **>** `Accept` **>** JSON Feed default

### Design
- **No new committed artifact, non-JSON-envelope** → correctly sits *outside* the API_ROUTES contract machinery (the worker-computed pattern, like `/.well-known/*`). `/api/*` is already `run_worker_first`, so it never falls through to static assets.
- On-chain text is XML-escaped + control-stripped (served data is already build-sanitized).
- **Discovery:** RFC 8288 `Link` header + `<link rel=alternate>` on the homepage, plus `llms.txt` + README entries.

### Completion requirements ✅
- [x] registry + per-subnet + incidents feeds, each valid RSS 2.0 / Atom 1.0 / JSON Feed 1.1
- [x] items built only from existing data; stable id, url, title, ISO timestamp, tags
- [x] feed discovery via Link header + homepage + llms.txt
- [x] sanitized untrusted text; no secrets; Conventional Commit; docs updated
- [x] tests (22) for serialization + content negotiation + Worker dispatch; **1042 pass**, validate + coverage gates green

Verified end-to-end against the committed artifacts (all three feeds → 200, correct content-types).