### PR TITLE
feat(api): embeddable SVG readiness badges (#744)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ curl https://api.metagraph.sh/api/v1/subnets
 | Drop-in skill         | [`/skills/bittensor/SKILL.md`](https://api.metagraph.sh/skills/bittensor/SKILL.md)                                                                                                    |
 | Resources index       | [`/metagraph/agent-resources.json`](https://api.metagraph.sh/metagraph/agent-resources.json)                                                                                          |
 | Content feeds         | [`/api/v1/feeds/registry`](https://api.metagraph.sh/api/v1/feeds/registry) — registry changes + incidents, as RSS / Atom / JSON Feed (per-subnet at `/api/v1/feeds/subnets/{netuid}`) |
+| Readiness badge       | `![metagraphed](https://api.metagraph.sh/api/v1/subnets/{netuid}/badge.svg)` — embeddable SVG (also `/providers/{slug}/badge.svg`)                                                    |
 
 ## This repo
 

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1283,6 +1283,7 @@ const llmsHeader = [
   `- [MCP server](${llmsApiBase}/mcp): Model Context Protocol endpoint — agents query the registry as tools. Install: \`claude mcp add --transport http metagraphed ${llmsApiBase}/mcp\``,
   `- [MCP server card](${llmsApiBase}/.well-known/mcp/server-card.json): machine-readable server descriptor (tools, transport, protocol versions)`,
   `- [Content feeds](${llmsApiBase}/api/v1/feeds/registry): RSS 2.0 / Atom 1.0 / JSON Feed 1.1 of registry changes + incidents (per-subnet at /api/v1/feeds/subnets/{netuid}). Content-negotiated via Accept, or append .rss/.atom/.json.`,
+  `- Embeddable readiness badges: \`${llmsApiBase}/api/v1/subnets/{netuid}/badge.svg\` and \`/api/v1/providers/{slug}/badge.svg\` — SVG integration-readiness badge for READMEs.`,
   `- [Bittensor skill](${llmsApiBase}/skills/bittensor/SKILL.md): drop-in agent skill for "what subnet does X, is it up, how do I call it"`,
   `- [Semantic search](${llmsApiBase}/api/v1/search/semantic?q=): natural-language vector search over subnets/surfaces`,
   `- [Ask](${llmsApiBase}/api/v1/ask): POST { question } for a grounded, cited answer over the registry`,

--- a/src/badge.mjs
+++ b/src/badge.mjs
@@ -1,0 +1,148 @@
+// Embeddable shields.io-style SVG badges (#744) — a distribution flywheel: a
+// subnet/provider drops `![metagraphed](…/badge.svg)` in its README, creating a
+// backlink + social pressure to improve the score we already compute.
+//
+//   GET /api/v1/subnets/{netuid}/badge.svg   → that subnet's integration readiness
+//   GET /api/v1/providers/{slug}/badge.svg   → mean readiness across its subnets
+//
+// Worker-computed (image/svg+xml, not a JSON-envelope route), read-only, edge-
+// cached. Unknown entities degrade to an "n/a" badge (HTTP 200) so an embedded
+// <img> never shows a broken image.
+
+const BADGE_CACHE_SECONDS = 3600;
+const BADGE_LABEL = "metagraphed";
+
+function escapeXml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+// Approximate px width of text in the 11px sans the badge renders with. Per-char
+// widths are a safe overestimate so text never overflows its segment.
+function textWidth(text) {
+  let w = 0;
+  for (const ch of String(text)) {
+    if (/[ilj.,:'!|]/.test(ch)) w += 3;
+    else if (/[A-Z0-9mw%@]/.test(ch)) w += 8;
+    else w += 6.5;
+  }
+  return Math.ceil(w);
+}
+
+// Accessible score → color (green / amber / red; gray for unknown).
+export function scoreColor(score) {
+  if (typeof score !== "number" || Number.isNaN(score)) return "#9f9f9f";
+  if (score >= 80) return "#2ea44f";
+  if (score >= 50) return "#dfb317";
+  return "#e05d44";
+}
+
+// Render a flat two-segment badge: gray label + colored message.
+export function renderBadge(message, color, label = BADGE_LABEL) {
+  const eLabel = escapeXml(label);
+  const eMsg = escapeXml(message);
+  const pad = 12;
+  const labelW = textWidth(label) + pad;
+  const msgW = textWidth(message) + pad;
+  const total = labelW + msgW;
+  const labelMid = labelW / 2;
+  const msgMid = labelW + msgW / 2;
+  return [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${total}" height="20" role="img" aria-label="${eLabel}: ${eMsg}">`,
+    `<title>${eLabel}: ${eMsg}</title>`,
+    `<linearGradient id="s" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>`,
+    `<clipPath id="r"><rect width="${total}" height="20" rx="3" fill="#fff"/></clipPath>`,
+    `<g clip-path="url(#r)">`,
+    `<rect width="${labelW}" height="20" fill="#555"/>`,
+    `<rect x="${labelW}" width="${msgW}" height="20" fill="${color}"/>`,
+    `<rect width="${total}" height="20" fill="url(#s)"/>`,
+    `</g>`,
+    `<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="11">`,
+    `<text x="${labelMid}" y="15" fill="#010101" fill-opacity=".3">${eLabel}</text>`,
+    `<text x="${labelMid}" y="14">${eLabel}</text>`,
+    `<text x="${msgMid}" y="15" fill="#010101" fill-opacity=".3">${eMsg}</text>`,
+    `<text x="${msgMid}" y="14">${eMsg}</text>`,
+    `</g>`,
+    `</svg>`,
+    ``,
+  ].join("\n");
+}
+
+async function readData(readArtifact, env, path) {
+  try {
+    const result = await readArtifact(env, path);
+    return result?.ok ? result.data : null;
+  } catch {
+    return null;
+  }
+}
+
+// Mean integration_readiness across a provider's subnets, rounded — or null when
+// none of them resolve to a numeric score.
+function averageReadiness(netuids, subnetsIndex) {
+  const byNetuid = new Map(
+    (subnetsIndex?.subnets || []).map((s) => [
+      s.netuid,
+      s.integration_readiness,
+    ]),
+  );
+  const scores = (netuids || [])
+    .map((n) => byNetuid.get(n))
+    .filter((v) => typeof v === "number");
+  if (!scores.length) return null;
+  return Math.round(scores.reduce((a, b) => a + b, 0) / scores.length);
+}
+
+export function parseBadgePath(pathname) {
+  let m = /^\/api\/v1\/subnets\/(\d+)\/badge\.svg$/.exec(pathname);
+  if (m) return { kind: "subnet", netuid: Number(m[1]) };
+  m = /^\/api\/v1\/providers\/([a-z0-9][a-z0-9._-]*)\/badge\.svg$/i.exec(
+    pathname,
+  );
+  if (m) return { kind: "provider", slug: m[1].toLowerCase() };
+  return null;
+}
+
+export async function handleBadgeRequest(request, env, url, deps = {}) {
+  const readArtifact = deps.readArtifact;
+  const target = parseBadgePath(url.pathname);
+  let score = null;
+
+  if (target && typeof readArtifact === "function") {
+    if (target.kind === "subnet") {
+      const index = await readData(
+        readArtifact,
+        env,
+        "/metagraph/subnets.json",
+      );
+      const s = (index?.subnets || []).find((x) => x.netuid === target.netuid);
+      if (s && typeof s.integration_readiness === "number") {
+        score = s.integration_readiness;
+      }
+    } else {
+      const [providers, index] = await Promise.all([
+        readData(readArtifact, env, "/metagraph/providers.json"),
+        readData(readArtifact, env, "/metagraph/subnets.json"),
+      ]);
+      const p = (providers?.providers || []).find(
+        (x) => (x.slug || x.id) === target.slug,
+      );
+      if (p) score = averageReadiness(p.netuids, index);
+    }
+  }
+
+  const message = typeof score === "number" ? `${score}/100` : "n/a";
+  const svg = renderBadge(message, scoreColor(score));
+  return new Response(request.method === "HEAD" ? null : svg, {
+    status: 200,
+    headers: {
+      "content-type": "image/svg+xml; charset=utf-8",
+      "cache-control": `public, max-age=${BADGE_CACHE_SECONDS}`,
+      "x-content-type-options": "nosniff",
+    },
+  });
+}

--- a/tests/badge.test.mjs
+++ b/tests/badge.test.mjs
@@ -1,0 +1,150 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  handleBadgeRequest,
+  renderBadge,
+  scoreColor,
+  parseBadgePath,
+} from "../src/badge.mjs";
+import { handleRequest } from "../workers/api.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
+
+const SUBNETS = {
+  subnets: [
+    { netuid: 7, integration_readiness: 92 },
+    { netuid: 12, integration_readiness: 40 },
+    { netuid: 3, integration_readiness: 0 },
+    { netuid: 9 }, // no score
+  ],
+};
+const PROVIDERS = {
+  providers: [
+    { slug: "datura", netuids: [7, 12] }, // mean(92,40) = 66
+    { id: "byid", netuids: [9] }, // only a scoreless subnet → n/a
+  ],
+};
+
+function makeReadArtifact(fixtures) {
+  return (_env, path) =>
+    Promise.resolve(
+      Object.prototype.hasOwnProperty.call(fixtures, path)
+        ? { ok: true, data: fixtures[path] }
+        : { ok: false, code: "artifact_not_found" },
+    );
+}
+
+async function badge(pathname, { method = "GET" } = {}) {
+  const url = new URL(`https://api.metagraph.sh${pathname}`);
+  const res = await handleBadgeRequest(new Request(url, { method }), {}, url, {
+    readArtifact: makeReadArtifact({
+      "/metagraph/subnets.json": SUBNETS,
+      "/metagraph/providers.json": PROVIDERS,
+    }),
+  });
+  return { res, text: await res.text() };
+}
+
+describe("badge — rendering", () => {
+  test("renderBadge produces a valid two-segment SVG with the message", () => {
+    const svg = renderBadge("92/100", "#2ea44f");
+    assert.match(svg, /^<svg xmlns="http:\/\/www\.w3\.org\/2000\/svg"/);
+    assert.match(svg, /<\/svg>\s*$/);
+    assert.match(svg, /role="img"/);
+    assert.match(svg, /aria-label="metagraphed: 92\/100"/);
+    assert.match(svg, /fill="#2ea44f"/);
+    assert.ok((svg.match(/<text /g) || []).length === 4); // label + msg, each w/ shadow
+  });
+
+  test("renderBadge escapes message + label (SVG injection-safe)", () => {
+    const svg = renderBadge('"><script>x</script>', "#000", "a&b");
+    assert.ok(!svg.includes("<script>"));
+    assert.match(svg, /&lt;script&gt;/);
+    assert.match(svg, /a&amp;b/);
+  });
+
+  test("scoreColor thresholds (green / amber / red / gray)", () => {
+    assert.equal(scoreColor(92), "#2ea44f");
+    assert.equal(scoreColor(80), "#2ea44f");
+    assert.equal(scoreColor(50), "#dfb317");
+    assert.equal(scoreColor(49), "#e05d44");
+    assert.equal(scoreColor(0), "#e05d44");
+    assert.equal(scoreColor(null), "#9f9f9f");
+    assert.equal(scoreColor(NaN), "#9f9f9f");
+  });
+
+  test("parseBadgePath resolves subnet/provider + rejects others", () => {
+    assert.deepEqual(parseBadgePath("/api/v1/subnets/7/badge.svg"), {
+      kind: "subnet",
+      netuid: 7,
+    });
+    assert.deepEqual(parseBadgePath("/api/v1/providers/Datura/badge.svg"), {
+      kind: "provider",
+      slug: "datura",
+    });
+    assert.equal(parseBadgePath("/api/v1/subnets/7"), null);
+    assert.equal(parseBadgePath("/api/v1/subnets/abc/badge.svg"), null);
+  });
+});
+
+describe("badge — handleBadgeRequest", () => {
+  test("subnet badge shows the real score + score color + svg headers", async () => {
+    const { res, text } = await badge("/api/v1/subnets/7/badge.svg");
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /image\/svg\+xml/);
+    assert.match(res.headers.get("cache-control"), /max-age=3600/);
+    assert.match(text, /92\/100/);
+    assert.match(text, /#2ea44f/); // green (>= 80)
+  });
+
+  test("a low score gets the red color", async () => {
+    const { text } = await badge("/api/v1/subnets/3/badge.svg");
+    assert.match(text, /0\/100/);
+    assert.match(text, /#e05d44/);
+  });
+
+  test("unknown subnet degrades to an n/a badge (still 200)", async () => {
+    const { res, text } = await badge("/api/v1/subnets/999/badge.svg");
+    assert.equal(res.status, 200);
+    assert.match(text, /n\/a/);
+    assert.match(text, /#9f9f9f/);
+  });
+
+  test("a subnet with no score is n/a", async () => {
+    const { text } = await badge("/api/v1/subnets/9/badge.svg");
+    assert.match(text, /n\/a/);
+  });
+
+  test("provider badge is the mean readiness across its subnets", async () => {
+    const { text } = await badge("/api/v1/providers/datura/badge.svg");
+    assert.match(text, /66\/100/); // round(mean(92, 40))
+    assert.match(text, /#dfb317/); // amber (50..79)
+  });
+
+  test("provider with only scoreless subnets is n/a", async () => {
+    const { text } = await badge("/api/v1/providers/byid/badge.svg");
+    assert.match(text, /n\/a/);
+  });
+
+  test("HEAD returns headers with no body", async () => {
+    const { res, text } = await badge("/api/v1/subnets/7/badge.svg", {
+      method: "HEAD",
+    });
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /image\/svg\+xml/);
+    assert.equal(text, "");
+  });
+});
+
+describe("badge — Worker dispatch integration", () => {
+  test("handleRequest routes /api/v1/subnets/{netuid}/badge.svg to a badge", async () => {
+    const env = createLocalArtifactEnv();
+    const res = await handleRequest(
+      new Request("https://api.metagraph.sh/api/v1/subnets/7/badge.svg"),
+      env,
+      {},
+    );
+    assert.equal(res.status, 200);
+    assert.match(res.headers.get("content-type"), /image\/svg\+xml/);
+    assert.match(await res.text(), /<svg /);
+  });
+});

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -69,6 +69,7 @@ import {
 } from "../src/health-serving.mjs";
 import { handleMcpRequest, listToolDefinitions } from "../src/mcp-server.mjs";
 import { handleFeedRequest, feedLinkHeader } from "../src/feeds.mjs";
+import { handleBadgeRequest } from "../src/badge.mjs";
 import {
   buildAgentToolsIndex,
   buildAnthropicToolSpecs,
@@ -251,6 +252,15 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // the static assets. Read-only, content-negotiated, edge-cached.
   if (url.pathname.startsWith("/api/v1/feeds/")) {
     return handleFeedRequest(request, env, url, { readArtifact });
+  }
+
+  // Embeddable SVG readiness badges (#744) — /api/v1/{subnets/{netuid}|
+  // providers/{slug}}/badge.svg. Worker-computed image, caught before the generic
+  // entity routing so `badge.svg` isn't resolved as an entity sub-resource.
+  if (
+    /^\/api\/v1\/(?:subnets|providers)\/[^/]+\/badge\.svg$/.test(url.pathname)
+  ) {
+    return handleBadgeRequest(request, env, url, { readArtifact });
   }
 
   // Agent/AI discovery surfaces. The homepage advertises the machine resources


### PR DESCRIPTION
Closes #744 (Phase 1 of the growth roadmap #740).

Embeddable shields.io-style **SVG badges** showing integration readiness (data we already compute) — a distribution flywheel: a subnet/provider drops `![metagraphed](…/badge.svg)` in its README → backlink + social pressure to improve.

- `GET /api/v1/subnets/{netuid}/badge.svg` → that subnet's `integration_readiness`
- `GET /api/v1/providers/{slug}/badge.svg` → mean readiness across its `netuids[]`

### Design
- **Worker-computed** (`image/svg+xml`, edge-cached 1h), caught **before** the generic entity routing so `badge.svg` isn't resolved as a sub-resource — same non-JSON-envelope pattern as the content feeds, so it correctly sits outside the JSON-contract machinery.
- Accessible green/amber/red/gray thresholds; **all text XML-escaped** (injection-safe).
- Unknown/scoreless entity → an `n/a` badge at **HTTP 200**, so an embedded `<img>` never breaks.

### Completion requirements ✅
- [x] `*/badge.svg` → valid cacheable SVG with the real score + label; graceful unknown fallback
- [x] accessible thresholds; `Cache-Control` + `Content-Type: image/svg+xml`
- [x] SVG injection-safe (escaped)
- [x] tests (12) + Worker dispatch; **1054 pass**, validate + coverage gates green
- [x] docs (README + llms.txt); Conventional Commit; no secrets
- [ ] Frontend 'copy badge' snippet → follow-up metagraphed-ui PR

Verified end-to-end: subnet 7 → `metagraphed: 100/100`, unknown → `metagraphed: n/a` (both 200 SVG).