### PR TITLE
feat(data): structured social accounts on subnet index + detail (#745)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2787,6 +2787,17 @@ export interface components {
             };
             registered_at_block?: number;
             slug: string;
+            /** @description Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification. */
+            social?: {
+                /** Format: uri */
+                reddit?: string;
+                /** Format: uri */
+                telegram?: string;
+                /** Format: uri */
+                x?: string;
+                /** Format: uri */
+                youtube?: string;
+            } | null;
             /** Format: uri */
             source_repo?: string | null;
             status: components["schemas"]["SubnetStatus"];
@@ -2875,6 +2886,17 @@ export interface components {
             /** @description Count of low-trust registry-observed (harvested) surfaces for this subnet. */
             registry_observed_count?: number;
             slug: string;
+            /** @description Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification. */
+            social?: {
+                /** Format: uri */
+                reddit?: string;
+                /** Format: uri */
+                telegram?: string;
+                /** Format: uri */
+                x?: string;
+                /** Format: uri */
+                youtube?: string;
+            } | null;
             /** Format: uri */
             source_repo?: string | null;
             status: components["schemas"]["SubnetStatus"];
@@ -9209,6 +9231,7 @@ export interface operations {
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
                      *           "slug": "example-subnet",
+                     *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",
                      *           "status": "active",
                      *           "subnet_type": "root",
@@ -10946,6 +10969,7 @@ export interface operations {
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
                      *           "slug": "example-subnet",
+                     *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",
                      *           "status": "active",
                      *           "subnet_type": "root",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -7264,6 +7264,36 @@
           "slug": {
             "type": "string"
           },
+          "social": {
+            "additionalProperties": false,
+            "description": "Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification.",
+            "properties": {
+              "reddit": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "telegram": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "x": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "youtube": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "source_repo": {
             "format": "uri",
             "type": [
@@ -7611,6 +7641,36 @@
           },
           "slug": {
             "type": "string"
+          },
+          "social": {
+            "additionalProperties": false,
+            "description": "Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification.",
+            "properties": {
+              "reddit": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "telegram": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "x": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "youtube": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "source_repo": {
             "format": "uri",
@@ -18475,6 +18535,7 @@
                       "provenance": {},
                       "registered_at_block": 5000000,
                       "slug": "example-subnet",
+                      "social": {},
                       "source_repo": "https://api.metagraph.sh/example",
                       "status": "active",
                       "subnet_type": "root",
@@ -20937,6 +20998,7 @@
                       "provenance": {},
                       "registered_at_block": 5000000,
                       "slug": "example-subnet",
+                      "social": {},
                       "source_repo": "https://api.metagraph.sh/example",
                       "status": "active",
                       "subnet_type": "root",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2787,6 +2787,17 @@ export interface components {
             };
             registered_at_block?: number;
             slug: string;
+            /** @description Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification. */
+            social?: {
+                /** Format: uri */
+                reddit?: string;
+                /** Format: uri */
+                telegram?: string;
+                /** Format: uri */
+                x?: string;
+                /** Format: uri */
+                youtube?: string;
+            } | null;
             /** Format: uri */
             source_repo?: string | null;
             status: components["schemas"]["SubnetStatus"];
@@ -2875,6 +2886,17 @@ export interface components {
             /** @description Count of low-trust registry-observed (harvested) surfaces for this subnet. */
             registry_observed_count?: number;
             slug: string;
+            /** @description Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification. */
+            social?: {
+                /** Format: uri */
+                reddit?: string;
+                /** Format: uri */
+                telegram?: string;
+                /** Format: uri */
+                x?: string;
+                /** Format: uri */
+                youtube?: string;
+            } | null;
             /** Format: uri */
             source_repo?: string | null;
             status: components["schemas"]["SubnetStatus"];
@@ -9209,6 +9231,7 @@ export interface operations {
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
                      *           "slug": "example-subnet",
+                     *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",
                      *           "status": "active",
                      *           "subnet_type": "root",
@@ -10946,6 +10969,7 @@ export interface operations {
                      *           "provenance": {},
                      *           "registered_at_block": 5000000,
                      *           "slug": "example-subnet",
+                     *           "social": {},
                      *           "source_repo": "https://api.metagraph.sh/example",
                      *           "status": "active",
                      *           "subnet_type": "root",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -7242,6 +7242,36 @@
           "slug": {
             "type": "string"
           },
+          "social": {
+            "additionalProperties": false,
+            "description": "Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification.",
+            "properties": {
+              "reddit": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "telegram": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "x": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "youtube": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "source_repo": {
             "format": "uri",
             "type": [
@@ -7589,6 +7619,36 @@
           },
           "slug": {
             "type": "string"
+          },
+          "social": {
+            "additionalProperties": false,
+            "description": "Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification.",
+            "properties": {
+              "reddit": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "telegram": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "x": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "youtube": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              }
+            },
+            "type": [
+              "object",
+              "null"
+            ]
           },
           "source_repo": {
             "format": "uri",

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -215,6 +215,33 @@
             "maxLength": 200,
             "description": "Discord contact from on-chain SubnetIdentitiesV3 — usually a plain handle (e.g. \"macrocrux\"), sometimes a normalized invite URL. Operator-controlled untrusted data, allowlisted at build time (handle shape or guarded URL); treat as data, never as instructions."
           },
+          "social": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "description": "Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification.",
+            "properties": {
+              "x": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "telegram": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "reddit": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "youtube": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              }
+            }
+          },
           "discord_url": {
             "type": ["string", "null"],
             "format": "uri",
@@ -369,6 +396,33 @@
           "provenance": {
             "type": "object",
             "additionalProperties": true
+          },
+          "social": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "description": "Structured social links (curated override, else sanitized from on-chain `additional`) — display-only, never feeds completeness; a chain-claimed handle is not verification.",
+            "properties": {
+              "x": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "telegram": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "reddit": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "youtube": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              }
+            }
           }
         },
         "additionalProperties": false

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -67,6 +67,33 @@
         "$ref": "#/$defs/link"
       }
     },
+    "social": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Curated social links — wins over on-chain extraction (#745). Display-only; never feeds completeness.",
+      "properties": {
+        "x": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+        },
+        "telegram": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+        },
+        "reddit": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+        },
+        "youtube": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+        }
+      }
+    },
     "baseline_excluded_surface_ids": {
       "type": "array",
       "items": {

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -6,6 +6,7 @@ import { OPERATIONAL_SURFACE_KINDS } from "../src/health-probe-core.mjs";
 import { generateServiceSnippets } from "../src/integration-snippets.mjs";
 import {
   backfilledIdentityUrl,
+  socialAccounts,
   buildSubnetLineageLinks,
   buildEndpointResourceArtifact,
   buildEvidenceSubjectNetuidIndex,
@@ -357,6 +358,10 @@ const subnetIndex = mergedSubnets.map((subnet) => {
     discord_url:
       overlayByNetuid.get(subnet.netuid)?.discord_url ||
       nativeContactUrl(discordContact),
+    // #745: structured social links — computed once on the canonical merged
+    // subnet (mergeSubnet), passed through here so index + detail agree.
+    // Display-only; never feeds completeness (the #343 flywheel gate).
+    social: subnet.social,
     docs_url: subnet.docs_url,
     first_party: surfaceTrust.official > 0,
     gap_count: subnet.gaps.missing_kinds.length,
@@ -2235,6 +2240,15 @@ function mergeSubnet(nativeSubnet, overlay, candidateCount) {
       gap_notes: [],
     },
     links: overlay?.links || [],
+    // Structured social handles (#745): curated overlay wins over on-chain
+    // SubnetIdentitiesV3 `additional` extraction. Display/search-only — never
+    // feeds completeness (the #343 flywheel gate). Lives on the canonical
+    // merged subnet so the detail artifact, index projection, and
+    // buildExpectedGeneratedSubnet (validate) all agree.
+    social: socialAccounts(
+      nativeSubnet.chain_identity?.additional,
+      overlay?.social,
+    ),
   };
 }
 

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -929,6 +929,70 @@ export function backfilledIdentityUrl(overlayValue, chainValue) {
   return normalized;
 }
 
+// Social platforms recognized in the free-text on-chain `additional` field, by
+// canonical host (#745).
+const SOCIAL_HOSTS = {
+  x: ["x.com", "twitter.com"],
+  telegram: ["t.me", "telegram.me", "telegram.org"],
+  reddit: ["reddit.com"],
+  youtube: ["youtube.com", "youtu.be"],
+};
+const SOCIAL_KEYS = Object.keys(SOCIAL_HOSTS);
+
+function socialHostKey(host) {
+  const h = host.replace(/^www\./, "").toLowerCase();
+  for (const key of SOCIAL_KEYS) {
+    if (SOCIAL_HOSTS[key].some((d) => h === d || h.endsWith(`.${d}`))) {
+      return key;
+    }
+  }
+  return null;
+}
+
+// Resolve a subnet/provider's structured social links: a curated overlay
+// `social` object wins per platform; otherwise extract from the free-text
+// on-chain `additional` content (sanitized + junk-guarded via
+// normalizePublicHttpUrl). Returns a { x?, telegram?, reddit?, youtube? } object
+// or null. Shared by build-artifacts (mergeSubnet) and validate
+// (buildExpectedGeneratedSubnet) so the chain extraction can't drift.
+// Display-only: a chain-claimed handle is NOT verification, and this NEVER feeds
+// completeness_score/missing_* (the flywheel's gaps stay the product).
+export function socialAccounts(additionalText, overlaySocial = null) {
+  const out = {};
+  const text = typeof additionalText === "string" ? additionalText : "";
+  const re =
+    /\b(?:https?:\/\/)?(?:www\.)?(?:x\.com|twitter\.com|t\.me|telegram\.(?:me|org)|reddit\.com|youtube\.com|youtu\.be)\/[^\s"'<>)\]]+/gi;
+  for (const raw of text.match(re) || []) {
+    const normalized = normalizePublicHttpUrl(raw.replace(/[.,;]+$/, ""));
+    if (!normalized || isPlaceholderIdentityUrl(normalized)) {
+      continue;
+    }
+    let host;
+    try {
+      host = new URL(normalized).hostname;
+    } catch {
+      continue;
+    }
+    const key = socialHostKey(host);
+    if (key && !out[key]) {
+      out[key] = normalized;
+    }
+  }
+  if (
+    overlaySocial &&
+    typeof overlaySocial === "object" &&
+    !Array.isArray(overlaySocial)
+  ) {
+    for (const key of SOCIAL_KEYS) {
+      const curated = normalizePublicHttpUrl(overlaySocial[key]);
+      if (curated) {
+        out[key] = curated;
+      }
+    }
+  }
+  return Object.keys(out).length ? out : null;
+}
+
 export function registrySurfaceKey(entry) {
   const normalizedUrl = normalizePublicUrl(entry?.url);
   return [

--- a/scripts/validate.mjs
+++ b/scripts/validate.mjs
@@ -3,6 +3,7 @@ import { promises as fs } from "node:fs";
 import path from "node:path";
 import {
   backfilledIdentityUrl,
+  socialAccounts,
   flattenSurfaces,
   loadCandidates,
   loadVerification,
@@ -791,6 +792,12 @@ function buildExpectedGeneratedSubnet(nativeSnapshot, overlay, candidateCount) {
       gap_notes: [],
     },
     links: overlay?.links || [],
+    // Mirror mergeSubnet's #745 social backfill (overlay wins, else sanitized
+    // on-chain `additional`) so the reproducibility check matches the generator.
+    social: socialAccounts(
+      nativeSubnet.chain_identity?.additional,
+      overlay?.social,
+    ),
   };
 }
 

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1685,3 +1685,56 @@ function restoreSupportArtifacts(snapshot) {
     writeFileSync(filePath, content);
   }
 }
+
+test("#745 social accounts stay display-only and never feed completeness", () => {
+  const index = JSON.parse(
+    readFileSync(artifactFilePath("subnets.json"), "utf8"),
+  );
+  const withSocial = index.subnets.filter((subnet) => subnet.social);
+  // The on-chain `additional` corpus currently yields a handful of handles. If a
+  // snapshot ever yields zero, the lib-helpers unit tests still pin extraction;
+  // this invariant guards the build wiring whenever the data is present.
+  for (const entry of withSocial) {
+    assert.deepEqual(
+      Object.keys(entry.social).filter(
+        (key) => !["x", "telegram", "reddit", "youtube"].includes(key),
+      ),
+      [],
+      `SN${entry.netuid} social carries unexpected keys`,
+    );
+
+    // The detail artifact must embed the same social object as the index.
+    const detail = JSON.parse(
+      readFileSync(artifactFilePath(`subnets/${entry.netuid}.json`), "utf8"),
+    );
+    assert.deepEqual(
+      detail.subnet.social,
+      entry.social,
+      `SN${entry.netuid} detail/index social disagree`,
+    );
+
+    // The completeness + gap surface must never reference social — it is not a
+    // gap signal and must not move completeness_score (#343 flywheel gate).
+    const profilePath = artifactFilePath(`profiles/${entry.netuid}.json`);
+    if (!existsSync(profilePath)) {
+      continue;
+    }
+    const { profile } = JSON.parse(readFileSync(profilePath, "utf8"));
+    const completenessSurface = JSON.stringify({
+      completeness: profile.completeness,
+      completeness_score: profile.completeness_score,
+      gap_reasons: profile.gap_reasons,
+      missing_identity: profile.missing_identity,
+      missing_operational: profile.missing_operational,
+      missing_required: profile.missing_required,
+      missing_critical_count: profile.missing_critical_count,
+      primary_links: profile.primary_links,
+      suggested_submission_kinds: profile.suggested_submission_kinds,
+    });
+    assert.doesNotMatch(
+      completenessSurface,
+      /social/i,
+      `SN${entry.netuid} completeness surface must not reference social`,
+    );
+  }
+});

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -21,6 +21,7 @@ import {
   sanitizeOpenApiDocument,
   isPlaceholderIdentityUrl,
   backfilledIdentityUrl,
+  socialAccounts,
   nativeContactHandle,
   nativeDisplayName,
   nativeContactUrl,
@@ -844,5 +845,93 @@ describe("clusterDomainFromUrl", () => {
     assert.equal(clusterDomainFromUrl("not a url"), null);
     assert.equal(clusterDomainFromUrl(null), null);
     assert.equal(clusterDomainFromUrl(undefined), null);
+  });
+});
+
+describe("socialAccounts (#745)", () => {
+  test("extracts handles from on-chain `additional` free text", () => {
+    assert.deepEqual(
+      socialAccounts("Follow us at https://x.com/bitads_ai for updates"),
+      { x: "https://x.com/bitads_ai" },
+    );
+    assert.deepEqual(
+      socialAccounts(
+        "x https://x.com/foo tg https://t.me/bar yt https://youtu.be/abc123",
+      ),
+      {
+        x: "https://x.com/foo",
+        telegram: "https://t.me/bar",
+        youtube: "https://youtu.be/abc123",
+      },
+    );
+  });
+
+  test("maps twitter.com -> x and youtube.com -> youtube", () => {
+    const out = socialAccounts(
+      "https://twitter.com/legacy and https://www.youtube.com/@chan",
+    );
+    assert.equal(out.x, "https://twitter.com/legacy");
+    assert.equal(out.youtube, "https://www.youtube.com/@chan");
+  });
+
+  test("first handle per platform wins (chain text is left-to-right)", () => {
+    assert.deepEqual(
+      socialAccounts("https://x.com/first then https://x.com/second"),
+      { x: "https://x.com/first" },
+    );
+  });
+
+  test("strips trailing punctuation from extracted URLs", () => {
+    assert.deepEqual(socialAccounts("see https://x.com/handle."), {
+      x: "https://x.com/handle",
+    });
+  });
+
+  test("curated overlay wins per platform and can add platforms", () => {
+    assert.deepEqual(
+      socialAccounts("https://x.com/from_chain", {
+        x: "https://x.com/curated",
+        telegram: "https://t.me/curated",
+      }),
+      { x: "https://x.com/curated", telegram: "https://t.me/curated" },
+    );
+    // overlay-only (no chain text) still resolves
+    assert.deepEqual(
+      socialAccounts(null, { reddit: "https://reddit.com/r/x" }),
+      {
+        reddit: "https://reddit.com/r/x",
+      },
+    );
+  });
+
+  test("ignores non-social hosts, junk URLs, and unusable overlay values", () => {
+    assert.equal(
+      socialAccounts("homepage https://example.com and repo github.com/a/b"),
+      null,
+    );
+    assert.equal(socialAccounts(null, { x: "not a url" }), null);
+    assert.equal(socialAccounts(null, { x: "" }), null);
+  });
+
+  test("returns null for empty / non-string input", () => {
+    assert.equal(socialAccounts(""), null);
+    assert.equal(socialAccounts("just words, no links"), null);
+    assert.equal(socialAccounts(null), null);
+    assert.equal(socialAccounts(undefined), null);
+    assert.equal(socialAccounts(42), null);
+  });
+
+  test("only ever emits the four known display-only keys (flywheel-safe)", () => {
+    const out = socialAccounts(
+      "https://x.com/a https://t.me/b https://reddit.com/r/c https://youtu.be/d",
+    );
+    // No score/gap/completeness keys can leak out of this helper — its entire
+    // surface is the display-only social object (the #343 flywheel gate).
+    assert.deepEqual(Object.keys(out).sort(), [
+      "reddit",
+      "telegram",
+      "x",
+      "youtube",
+    ]);
   });
 });


### PR DESCRIPTION
## What

Adds an optional \`social\` object — \`{ x?, telegram?, reddit?, youtube? }\` — to the subnet **index** (\`SubnetIndexEntry\`) and **detail** (\`SubnetDetail\`).

- **Curated overlay wins per platform.** A maintainer can set \`social\` in the subnet manifest; otherwise links are sanitized out of the on-chain \`SubnetIdentitiesV3.additional\` free text.
- **Junk-guarded extraction.** \`socialAccounts()\` (new, in \`scripts/lib.mjs\`) matches only the known social hosts (x/twitter, t.me/telegram, reddit, youtube/youtu.be), runs each candidate through \`normalizePublicHttpUrl\` + \`isPlaceholderIdentityUrl\`, strips trailing punctuation, and takes the first handle per platform.
- **Computed once** on the canonical merged subnet (\`mergeSubnet\`), so the index projection, the per-subnet detail artifact, and validate's \`buildExpectedGeneratedSubnet\` all agree — per-subnet detail artifacts stay reproducible.

## Flywheel-safe (display-only)

A chain-claimed handle is **not** verification. \`social\` is display/search-only and **never** feeds \`completeness_score\` / \`missing_*\` — the #343 flywheel gate stays the product. Enforced by:
- \`socialAccounts\` unit tests (extraction, twitter→x / youtu.be→youtube mapping, first-wins, overlay-wins, junk + non-social-host rejection, null cases, and a "only the four display keys ever emit" assertion).
- An artifact invariant in \`artifacts.test.mjs\`: for every subnet that has \`social\`, the index/detail objects agree and the profile's completeness + gap surface (\`completeness\`, \`completeness_score\`, \`gap_reasons\`, \`missing_*\`, \`primary_links\`, \`suggested_submission_kinds\`) never references social.

## Data seed

The committed \`public/metagraph/subnets.json\` cold-start seed is intentionally left unchanged (ADR 0006 drift; \`probed_surface_count\` is non-reproducible across environments). \`social\` lands in live data on the next publish, which runs this build code. The contract (openapi/types) advertises \`social\` now; it's optional, so the seed stays valid.

## Verification

- \`npm run build\` + \`npm run validate\` green (per-subnet detail reproducibility holds).
- \`validate:schemas\`, \`validate:api\`, \`validate:openapi-examples\`, \`validate:contract-drift\` all pass.
- \`npm run test:coverage\`: 1063 passed; gate holds (98.1% stmts / 90.5% branches).
- Real extraction confirmed on chain data: SN16 → \`x.com/bitads_ai\`, SN35 → \`x.com/0x_Markets\`, SN49 → \`x.com/nepher_robotics\`, SN88 → \`x.com/Investing88ai\`.

Part of the growth roadmap (#740).