### PR TITLE
feat(data): structured social accounts on provider profiles (#745)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1999,6 +1999,17 @@ export interface components {
             public_notes?: string;
             /** @constant */
             schema_version: 1;
+            /** @description Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness. */
+            social?: {
+                /** Format: uri */
+                reddit?: string;
+                /** Format: uri */
+                telegram?: string;
+                /** Format: uri */
+                x?: string;
+                /** Format: uri */
+                youtube?: string;
+            };
             /** @description Number of distinct subnets this provider operates (netuids.length). */
             subnet_count?: number;
             /** @description Number of curated surfaces attributed to this provider. */
@@ -6588,6 +6599,7 @@ export interface operations {
                      *           "notes": "Example description.",
                      *           "public_notes": "example",
                      *           "schema_version": 1,
+                     *           "social": {},
                      *           "subnet_count": 1,
                      *           "surface_count": 1,
                      *           "team_url": "https://api.metagraph.sh/example",

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3867,6 +3867,33 @@
           "schema_version": {
             "const": 1
           },
+          "social": {
+            "additionalProperties": false,
+            "description": "Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness.",
+            "properties": {
+              "reddit": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "telegram": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "x": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "youtube": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "subnet_count": {
             "description": "Number of distinct subnets this provider operates (netuids.length).",
             "minimum": 0,
@@ -14095,6 +14122,7 @@
                       "notes": "Example description.",
                       "public_notes": "example",
                       "schema_version": 1,
+                      "social": {},
                       "subnet_count": 1,
                       "surface_count": 1,
                       "team_url": "https://api.metagraph.sh/example",

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1999,6 +1999,17 @@ export interface components {
             public_notes?: string;
             /** @constant */
             schema_version: 1;
+            /** @description Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness. */
+            social?: {
+                /** Format: uri */
+                reddit?: string;
+                /** Format: uri */
+                telegram?: string;
+                /** Format: uri */
+                x?: string;
+                /** Format: uri */
+                youtube?: string;
+            };
             /** @description Number of distinct subnets this provider operates (netuids.length). */
             subnet_count?: number;
             /** @description Number of curated surfaces attributed to this provider. */
@@ -6588,6 +6599,7 @@ export interface operations {
                      *           "notes": "Example description.",
                      *           "public_notes": "example",
                      *           "schema_version": 1,
+                     *           "social": {},
                      *           "subnet_count": 1,
                      *           "surface_count": 1,
                      *           "team_url": "https://api.metagraph.sh/example",

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3845,6 +3845,33 @@
           "schema_version": {
             "const": 1
           },
+          "social": {
+            "additionalProperties": false,
+            "description": "Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness.",
+            "properties": {
+              "reddit": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "telegram": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "x": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "youtube": {
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              }
+            },
+            "type": "object"
+          },
           "subnet_count": {
             "description": "Number of distinct subnets this provider operates (netuids.length).",
             "minimum": 0,

--- a/schemas/components/03-providers.schema.json
+++ b/schemas/components/03-providers.schema.json
@@ -49,6 +49,33 @@
             "examples": ["https://example.com/logo.png"],
             "description": "Curated provider logo, else backfilled from the on-chain logo of the single subnet this provider operates. Display-only; never feeds completeness."
           },
+          "social": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Structured social links: a curated provider override, else borrowed from the single subnet this provider operates. Display-only; never feeds completeness.",
+            "properties": {
+              "x": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "telegram": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "reddit": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              },
+              "youtube": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+              }
+            }
+          },
           "team_url": {
             "type": "string",
             "format": "uri"

--- a/schemas/provider.schema.json
+++ b/schemas/provider.schema.json
@@ -52,6 +52,33 @@
       "examples": ["https://example.com/logo.png"],
       "description": "Curated/hand-picked provider logo (square, ideally >=128px). Display-only; the UI falls back to the website favicon when absent."
     },
+    "social": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Curated social links (#745) — wins over the single-subnet borrow. Display-only; never feeds completeness.",
+      "properties": {
+        "x": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+        },
+        "telegram": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+        },
+        "reddit": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+        },
+        "youtube": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+        }
+      }
+    },
     "team_url": {
       "type": "string",
       "format": "uri"

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -761,9 +761,17 @@ const enrichedProviders = providers.map((provider) => {
     curatedLogoUrl ||
     (netuids.length === 1 ? mergedByNetuid.get(netuids[0])?.logo_url : null) ||
     null;
+  // Structured social links (#745): a curated provider `social` override wins;
+  // else a single-subnet provider borrows that subnet's social (mirrors the
+  // logo_url borrow above). Display-only — never feeds completeness.
+  const social =
+    socialAccounts(null, provider.social) ||
+    (netuids.length === 1 ? mergedByNetuid.get(netuids[0])?.social : null) ||
+    null;
   return {
     ...provider,
     ...(logoUrl ? { logo_url: logoUrl } : {}),
+    ...(social ? { social } : {}),
     netuids,
     subnet_count: netuids.length,
     surface_count: providerSurfaces.length,

--- a/tests/artifacts.test.mjs
+++ b/tests/artifacts.test.mjs
@@ -1738,3 +1738,37 @@ test("#745 social accounts stay display-only and never feed completeness", () =>
     );
   }
 });
+
+test("#745 provider social is display-only and borrows from a single subnet", () => {
+  const { providers } = JSON.parse(
+    readFileSync(artifactFilePath("providers.json"), "utf8"),
+  );
+  const subnetSocialByNetuid = new Map(
+    JSON.parse(readFileSync(artifactFilePath("subnets.json"), "utf8"))
+      .subnets.filter((subnet) => subnet.social)
+      .map((subnet) => [subnet.netuid, subnet.social]),
+  );
+
+  for (const provider of providers.filter((entry) => entry.social)) {
+    assert.deepEqual(
+      Object.keys(provider.social).filter(
+        (key) => !["x", "telegram", "reddit", "youtube"].includes(key),
+      ),
+      [],
+      `provider ${provider.id} social carries unexpected keys`,
+    );
+    // A single-subnet provider with no curated override borrows that subnet's
+    // social verbatim (mirrors the logo_url borrow). When the subnet it operates
+    // also carries social, the two must agree.
+    if (provider.netuids.length === 1) {
+      const borrowed = subnetSocialByNetuid.get(provider.netuids[0]);
+      if (borrowed) {
+        assert.deepEqual(
+          provider.social,
+          borrowed,
+          `provider ${provider.id} should borrow SN${provider.netuids[0]} social`,
+        );
+      }
+    }
+  }
+});


### PR DESCRIPTION
Completes #745 (the subnet half shipped in #777). Adds the same `social` object — `{ x?, telegram?, reddit?, youtube? }` — to **provider** entries.

## Resolution order
1. **Curated override** — a maintainer sets `social` on the provider overlay (`registry/providers/*.json`, validated by `provider.schema.json`; flows to submissions via the `$ref`).
2. **Single-subnet borrow** — a provider that operates exactly one subnet borrows that subnet's `social` verbatim, mirroring the existing `logo_url` borrow.
3. **Multi-subnet** — left social-less (no aggregation), same as `logo_url`.

Display-only — a chain-claimed handle is not verification, and provider social never feeds completeness.

## Verification
- Build borrows correctly: `bitads`→SN16 (`x.com/bitads_ai`), `mobiusfund`→SN88 (`x.com/Investing88ai`), `nepher-robotics`→SN49 (`x.com/nepher_robotics`).
- `validate:schemas` / `validate:api` / `validate:openapi-examples` / `validate:contract-drift` green; full `npm run validate` green (92 providers).
- Artifact test asserts provider social keeps only the four display keys and that the single-subnet borrow agrees with the subnet's social.
- Data seed unchanged (ADR 0006 drift); lands live on the next publish.

Closes #745.