### PR TITLE
feat(registry): add SN74 Gittensor dash/stats data artifact

### DIFF
--- a/registry/candidates/community/community-sn-74-data-artifact-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-data-artifact-api-gittensor-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-74-data-artifact-api-gittensor-io",
+      "kind": "data-artifact",
+      "name": "Gittensor network statistics dashboard API",
+      "netuid": 74,
+      "provider": "gittensor",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gittensor.io/swagger",
+      "source_urls": ["https://api.gittensor.io/swagger"],
+      "state": "schema-valid",
+      "url": "https://api.gittensor.io/dash/stats"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Community submission for **Subnet 74 (Gittensor)** — public `data-artifact` surface.

Adds exactly one candidate file for the unauthenticated network-statistics JSON at `/dash/stats`, documented in Gittensor's public OpenAPI/Swagger spec. Complements the merged `/dash/repos` subnet-api (#769).

## Candidate
- **Kind:** `data-artifact`
- **URL:** https://api.gittensor.io/dash/stats
- **Source:** https://api.gittensor.io/swagger (the OpenAPI spec documents `/dash/stats`)
- **Context:** subnet surface enrichment epic #427

## Validation
Verified the endpoint returns public JSON (HTTP 200, `application/json`, no auth) and that `/dash/stats` is documented in the live Swagger spec. Regenerated with `npm run candidate:new` so the file matches the repository JSON style, and passed the UGC preflight locally — `submission:pr` → `submit_pr` (non-blocking), plus `validate:candidate`, `validate:intake`, `scan:public-safety`, `validate:private-boundary`, and Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
