### PR TITLE
feat(data): structured rate_limit metadata on callable surfaces (#747)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,8 @@ A clean accepted example to copy: [#87](https://github.com/JSONbored/metagraphed
 
 Prefer issues? Use the `interface-submission`, `profile-correction`, `endpoint-submission`, `provider-submission`, or `status-report` template — an approved issue opens the candidate PR for you. Full contract in [`docs/submission-gate.md`](docs/submission-gate.md).
 
+Callable surface with documented limits? Add an optional structured `rate_limit` — `{ requests, window, burst?, scope?, cost_notes? }` (`requests` + `window` required) — so agents and SDKs can pace calls. It's integration-only: metagraphed never enforces it and it doesn't feed completeness. See the example in [`docs/submission-gate.md`](docs/submission-gate.md).
+
 ## Pull requests
 
 - Short and focused, Conventional Commit-style titles.

--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -73,11 +73,24 @@ The file must contain exactly one candidate:
       "auth_required": false,
       "public_safe": true,
       "rate_limit_notes": "",
+      "rate_limit": {
+        "requests": 60,
+        "window": "60s",
+        "scope": "per-ip"
+      },
       "review_notes": "Community-submitted public interface candidate."
     }
   ]
 }
 ```
+
+`rate_limit` is **optional** and integration-only — include it only when the
+provider documents concrete limits. `requests` + `window` are required when the
+object is present; `burst`, `scope` (`per-key` / `per-ip` / `global` /
+`unknown`), and `cost_notes` are optional. metagraphed never enforces the limit
+and it does not feed completeness — it's a machine-readable hint so agents and
+SDKs can pace their calls. Leave it off when you only have prose, and use
+`rate_limit_notes` for that.
 
 Provider profile review files must contain exactly one provider profile:
 

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1223,6 +1223,22 @@ export interface components {
             netuid: number;
             provider: string;
             public_safe: boolean;
+            /** @description Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness. */
+            rate_limit?: {
+                /** @description Optional short-term burst allowance above the steady rate. */
+                burst?: number;
+                /** @description Notes on weighted/credit costs or tier differences. */
+                cost_notes?: string;
+                /** @description Permitted requests per window. */
+                requests: number;
+                /**
+                 * @description What the limit is counted against.
+                 * @enum {unknown}
+                 */
+                scope?: "per-key" | "per-ip" | "global" | "unknown";
+                /** @description Window the request budget applies to, e.g. "60s", "1m", "1h", "1d". */
+                window: string;
+            };
             rate_limit_notes?: string;
             review_notes?: string;
             /** @constant */
@@ -3194,6 +3210,22 @@ export interface components {
                 redirected?: boolean;
                 source_tier?: components["schemas"]["SourceTier"];
                 transient_failure?: boolean;
+            };
+            /** @description Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness. */
+            rate_limit?: {
+                /** @description Optional short-term burst allowance above the steady rate. */
+                burst?: number;
+                /** @description Notes on weighted/credit costs or tier differences. */
+                cost_notes?: string;
+                /** @description Permitted requests per window. */
+                requests: number;
+                /**
+                 * @description What the limit is counted against.
+                 * @enum {unknown}
+                 */
+                scope?: "per-key" | "per-ip" | "global" | "unknown";
+                /** @description Window the request budget applies to, e.g. "60s", "1m", "1h", "1d". */
+                window: string;
             };
             rate_limit_notes?: string;
             /** @enum {unknown} */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -835,6 +835,45 @@
           "public_safe": {
             "type": "boolean"
           },
+          "rate_limit": {
+            "additionalProperties": false,
+            "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+            "properties": {
+              "burst": {
+                "description": "Optional short-term burst allowance above the steady rate.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cost_notes": {
+                "description": "Notes on weighted/credit costs or tier differences.",
+                "type": "string"
+              },
+              "requests": {
+                "description": "Permitted requests per window.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "scope": {
+                "description": "What the limit is counted against.",
+                "enum": [
+                  "per-key",
+                  "per-ip",
+                  "global",
+                  "unknown"
+                ]
+              },
+              "window": {
+                "description": "Window the request budget applies to, e.g. \"60s\", \"1m\", \"1h\", \"1d\".",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "requests",
+              "window"
+            ],
+            "type": "object"
+          },
           "rate_limit_notes": {
             "type": "string"
           },
@@ -8881,6 +8920,45 @@
                 "type": "boolean"
               }
             },
+            "type": "object"
+          },
+          "rate_limit": {
+            "additionalProperties": false,
+            "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+            "properties": {
+              "burst": {
+                "description": "Optional short-term burst allowance above the steady rate.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cost_notes": {
+                "description": "Notes on weighted/credit costs or tier differences.",
+                "type": "string"
+              },
+              "requests": {
+                "description": "Permitted requests per window.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "scope": {
+                "description": "What the limit is counted against.",
+                "enum": [
+                  "per-key",
+                  "per-ip",
+                  "global",
+                  "unknown"
+                ]
+              },
+              "window": {
+                "description": "Window the request budget applies to, e.g. \"60s\", \"1m\", \"1h\", \"1d\".",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "requests",
+              "window"
+            ],
             "type": "object"
           },
           "rate_limit_notes": {

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1223,6 +1223,22 @@ export interface components {
             netuid: number;
             provider: string;
             public_safe: boolean;
+            /** @description Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness. */
+            rate_limit?: {
+                /** @description Optional short-term burst allowance above the steady rate. */
+                burst?: number;
+                /** @description Notes on weighted/credit costs or tier differences. */
+                cost_notes?: string;
+                /** @description Permitted requests per window. */
+                requests: number;
+                /**
+                 * @description What the limit is counted against.
+                 * @enum {unknown}
+                 */
+                scope?: "per-key" | "per-ip" | "global" | "unknown";
+                /** @description Window the request budget applies to, e.g. "60s", "1m", "1h", "1d". */
+                window: string;
+            };
             rate_limit_notes?: string;
             review_notes?: string;
             /** @constant */
@@ -3194,6 +3210,22 @@ export interface components {
                 redirected?: boolean;
                 source_tier?: components["schemas"]["SourceTier"];
                 transient_failure?: boolean;
+            };
+            /** @description Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness. */
+            rate_limit?: {
+                /** @description Optional short-term burst allowance above the steady rate. */
+                burst?: number;
+                /** @description Notes on weighted/credit costs or tier differences. */
+                cost_notes?: string;
+                /** @description Permitted requests per window. */
+                requests: number;
+                /**
+                 * @description What the limit is counted against.
+                 * @enum {unknown}
+                 */
+                scope?: "per-key" | "per-ip" | "global" | "unknown";
+                /** @description Window the request budget applies to, e.g. "60s", "1m", "1h", "1d". */
+                window: string;
             };
             rate_limit_notes?: string;
             /** @enum {unknown} */

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -821,6 +821,45 @@
           "public_safe": {
             "type": "boolean"
           },
+          "rate_limit": {
+            "additionalProperties": false,
+            "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+            "properties": {
+              "burst": {
+                "description": "Optional short-term burst allowance above the steady rate.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cost_notes": {
+                "description": "Notes on weighted/credit costs or tier differences.",
+                "type": "string"
+              },
+              "requests": {
+                "description": "Permitted requests per window.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "scope": {
+                "description": "What the limit is counted against.",
+                "enum": [
+                  "per-key",
+                  "per-ip",
+                  "global",
+                  "unknown"
+                ]
+              },
+              "window": {
+                "description": "Window the request budget applies to, e.g. \"60s\", \"1m\", \"1h\", \"1d\".",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "requests",
+              "window"
+            ],
+            "type": "object"
+          },
           "rate_limit_notes": {
             "type": "string"
           },
@@ -8859,6 +8898,45 @@
                 "type": "boolean"
               }
             },
+            "type": "object"
+          },
+          "rate_limit": {
+            "additionalProperties": false,
+            "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+            "properties": {
+              "burst": {
+                "description": "Optional short-term burst allowance above the steady rate.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "cost_notes": {
+                "description": "Notes on weighted/credit costs or tier differences.",
+                "type": "string"
+              },
+              "requests": {
+                "description": "Permitted requests per window.",
+                "minimum": 0,
+                "type": "integer"
+              },
+              "scope": {
+                "description": "What the limit is counted against.",
+                "enum": [
+                  "per-key",
+                  "per-ip",
+                  "global",
+                  "unknown"
+                ]
+              },
+              "window": {
+                "description": "Window the request budget applies to, e.g. \"60s\", \"1m\", \"1h\", \"1d\".",
+                "minLength": 1,
+                "type": "string"
+              }
+            },
+            "required": [
+              "requests",
+              "window"
+            ],
             "type": "object"
           },
           "rate_limit_notes": {

--- a/schemas/candidate-surface.schema.json
+++ b/schemas/candidate-surface.schema.json
@@ -127,6 +127,37 @@
     "rate_limit_notes": {
       "type": "string"
     },
+    "rate_limit": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["requests", "window"],
+      "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+      "properties": {
+        "requests": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Permitted requests per window."
+        },
+        "window": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Window the request budget applies to, e.g. \"60s\", \"1m\", \"1h\", \"1d\"."
+        },
+        "burst": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Optional short-term burst allowance above the steady rate."
+        },
+        "scope": {
+          "enum": ["per-key", "per-ip", "global", "unknown"],
+          "description": "What the limit is counted against."
+        },
+        "cost_notes": {
+          "type": "string",
+          "description": "Notes on weighted/credit costs or tier differences."
+        }
+      }
+    },
     "review_notes": {
       "type": "string"
     }

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -252,6 +252,37 @@
           "rate_limit_notes": {
             "type": "string"
           },
+          "rate_limit": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["requests", "window"],
+            "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+            "properties": {
+              "requests": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Permitted requests per window."
+              },
+              "window": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Window the request budget applies to, e.g. \"60s\", \"1m\", \"1h\", \"1d\"."
+              },
+              "burst": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Optional short-term burst allowance above the steady rate."
+              },
+              "scope": {
+                "enum": ["per-key", "per-ip", "global", "unknown"],
+                "description": "What the limit is counted against."
+              },
+              "cost_notes": {
+                "type": "string",
+                "description": "Notes on weighted/credit costs or tier differences."
+              }
+            }
+          },
           "notes": {
             "type": "string"
           },
@@ -420,6 +451,37 @@
           },
           "rate_limit_notes": {
             "type": "string"
+          },
+          "rate_limit": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["requests", "window"],
+            "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+            "properties": {
+              "requests": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Permitted requests per window."
+              },
+              "window": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Window the request budget applies to, e.g. \"60s\", \"1m\", \"1h\", \"1d\"."
+              },
+              "burst": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Optional short-term burst allowance above the steady rate."
+              },
+              "scope": {
+                "enum": ["per-key", "per-ip", "global", "unknown"],
+                "description": "What the limit is counted against."
+              },
+              "cost_notes": {
+                "type": "string",
+                "description": "Notes on weighted/credit costs or tier differences."
+              }
+            }
           },
           "review_notes": {
             "type": "string"

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -209,6 +209,37 @@
         "rate_limit_notes": {
           "type": "string"
         },
+        "rate_limit": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["requests", "window"],
+          "description": "Structured, curated rate-limit metadata for a callable surface (#747). Integration-only — metagraphed does not enforce it and it never feeds completeness.",
+          "properties": {
+            "requests": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Permitted requests per window."
+            },
+            "window": {
+              "type": "string",
+              "minLength": 1,
+              "description": "Window the request budget applies to, e.g. \"60s\", \"1m\", \"1h\", \"1d\"."
+            },
+            "burst": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Optional short-term burst allowance above the steady rate."
+            },
+            "scope": {
+              "enum": ["per-key", "per-ip", "global", "unknown"],
+              "description": "What the limit is counted against."
+            },
+            "cost_notes": {
+              "type": "string",
+              "description": "Notes on weighted/credit costs or tier differences."
+            }
+          }
+        },
         "probe": {
           "$ref": "#/$defs/probe"
         },

--- a/tests/contracts.test.mjs
+++ b/tests/contracts.test.mjs
@@ -1,4 +1,6 @@
 import assert from "node:assert/strict";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
 import { describe, test } from "vitest";
 import {
   API_ROUTES,
@@ -192,6 +194,67 @@ describe("public contract registry", () => {
       () => buildOpenApiArtifact("1970-01-01T00:00:00.000Z", null),
       /requires canonical component schemas/,
     );
+  });
+
+  test("#747 Surface accepts a structured rate_limit and rejects malformed ones", async () => {
+    const generatedAt = "1970-01-01T00:00:00.000Z";
+    const openapi = buildOpenApiArtifact(
+      generatedAt,
+      await loadOpenApiComponentSchemas(generatedAt),
+    );
+    const ajv = new Ajv2020({ strict: false, allErrors: true });
+    addFormats(ajv);
+    const validate = ajv.compile({
+      $id: "https://metagraph.sh/test/surface-rate-limit.json",
+      components: openapi.components,
+      $ref: "#/components/schemas/Surface",
+    });
+    const base = {
+      id: "sn-1-test-api",
+      netuid: 1,
+      kind: "subnet-api",
+      url: "https://example.io/api",
+      provider: "tester",
+      auth_required: false,
+      authority: "official",
+      public_safe: true,
+    };
+
+    // A well-formed structured limit (and the optional fields) validates.
+    assert.equal(
+      validate({
+        ...base,
+        rate_limit: {
+          requests: 100,
+          window: "60s",
+          burst: 20,
+          scope: "per-key",
+          cost_notes: "Search calls cost 5 credits each.",
+        },
+      }),
+      true,
+      ajv.errorsText(validate.errors),
+    );
+    // requests + window are the minimum meaningful limit.
+    assert.equal(validate({ ...base, rate_limit: { scope: "per-ip" } }), false);
+    // scope is a closed enum.
+    assert.equal(
+      validate({
+        ...base,
+        rate_limit: { requests: 5, window: "1m", scope: "bogus" },
+      }),
+      false,
+    );
+    // the object is closed — no smuggling unknown keys.
+    assert.equal(
+      validate({
+        ...base,
+        rate_limit: { requests: 5, window: "1m", enforced: true },
+      }),
+      false,
+    );
+    // and it stays optional — a surface without it is still valid.
+    assert.equal(validate(base), true, ajv.errorsText(validate.errors));
   });
 
   test("keeps public API route payloads on typed artifact schemas", async () => {


### PR DESCRIPTION
Closes #747.

Adds an optional, curated `rate_limit` object to surfaces so agents and SDKs can program against documented limits instead of parsing the freeform `rate_limit_notes` string.

## Shape
```jsonc
"rate_limit": {
  "requests": 100,        // required
  "window": "60s",        // required — e.g. "60s", "1m", "1h", "1d"
  "burst": 20,            // optional
  "scope": "per-key",     // optional enum: per-key | per-ip | global | unknown
  "cost_notes": "…"       // optional
}
```

## Wiring (every surface shape)
- **Source** — `subnet-manifest.schema.json` (curated) + `candidate-surface.schema.json` (community input).
- **Served** — `04-surfaces.schema.json` `Surface` + `CandidateSurface`; flows into subnet detail/profile artifacts via the existing `$ref` and through `surfaces.json` via `flattenSurfaces`'s spread (no projection change needed).
- Regenerated contract (`openapi.json`, `types.d.ts`, `metagraphed-api.d.ts`, `api-components`).

## Notes
- **Integration-only.** metagraphed does not enforce limits (we're a registry, not a gateway), and `rate_limit` never feeds completeness.
- Plain integer/string/enum — **no regex patterns**, so no `openapi-sample` `valueForPattern` case is required.
- Kept **optional**; no surface data fabricated (the existing `rate_limit_notes` values are auth/review notes, not real limits). It populates as curation flows in.
- Documented the curated path in `CONTRIBUTING.md` + `docs/submission-gate.md` (with an example).

## Verification
- `validate:schemas` / `validate:api` / `validate:openapi-examples` / `validate:contract-drift` green; full `npm run validate` green.
- `test:coverage`: 1065 passed; gate holds (98.1% / 90.5%).
- New ajv test compiles the served `Surface` schema and asserts a well-formed limit validates, `requests`+`window` are required, `scope` is a closed enum, unknown keys are rejected, and the field stays optional.