### PR TITLE
feat(registry): add SN58 Handshake58 directory providers API

### DIFF
--- a/registry/candidates/community/community-sn-58-subnet-api-handshake58-com.json
+++ b/registry/candidates/community/community-sn-58-subnet-api-handshake58-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-58-subnet-api-handshake58-com",
+      "kind": "subnet-api",
+      "name": "Handshake58 Bittensor provider directory API",
+      "netuid": 58,
+      "provider": "handshake58",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://handshake58.com/openapi.json",
+      "source_urls": ["https://handshake58.com/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://handshake58.com/api/directory/providers"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Community submission for **Subnet 58 (Handshake58)** — public `subnet-api` surface.

Adds exactly one candidate file for the unauthenticated provider-directory JSON at `/api/directory/providers`, listed in the Handshake58 OpenAPI schema (distinct from the merged `/api/validator/registry` data-artifact, #768).

## Candidate
- **Kind:** `subnet-api`
- **URL:** https://handshake58.com/api/directory/providers
- **Source:** https://handshake58.com/openapi.json (the OpenAPI schema documents `/api/directory/providers`)
- **Context:** subnet surface enrichment epic #427

## Validation
Verified the endpoint returns public JSON (HTTP 200, `application/json`, no auth) and that `/api/directory/providers` is documented in the live OpenAPI schema. Regenerated with `npm run candidate:new` so the file matches the repository JSON style, and passed the UGC preflight locally — `submission:pr` → `submit_pr` (non-blocking), plus `validate:candidate`, `validate:intake`, `scan:public-safety`, `validate:private-boundary`, and Prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
