### PR TITLE
feat(data): structured per-API auth detail + snippet rewiring (#746)

### DIFF
--- a/docs/submission-gate.md
+++ b/docs/submission-gate.md
@@ -92,6 +92,8 @@ and it does not feed completeness — it's a machine-readable hint so agents and
 SDKs can pace their calls. Leave it off when you only have prose, and use
 `rate_limit_notes` for that.
 
+`auth` is the same idea for credentials — `{ scheme, location?, name?, value_format?, token_url?, scopes_note? }` (only `scheme` is required: `none` / `bearer` / `api-key` / `basic` / `oauth2` / `custom`). It is auto-derived from a captured OpenAPI's `securitySchemes`, so curate it only to override or when no spec is captured. It drives the copy-paste auth header/param in the generated snippets. **Placeholders only — never a real key or token.**
+
 Provider profile review files must contain exactly one provider profile:
 
 ```json

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1214,6 +1214,30 @@ export interface components {
         /** @enum {unknown} */
         CandidateState: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
         CandidateSurface: {
+            /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
+            auth?: {
+                /**
+                 * @description Where the credential is sent.
+                 * @enum {unknown}
+                 */
+                location?: "header" | "query" | "cookie";
+                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". */
+                name?: string;
+                /**
+                 * @description Credential scheme.
+                 * @enum {unknown}
+                 */
+                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "custom";
+                /** @description Note on required scopes or how to obtain a credential. */
+                scopes_note?: string;
+                /**
+                 * Format: uri
+                 * @description OAuth2/OIDC token or authorize endpoint, when the spec declares one.
+                 */
+                token_url?: string;
+                /** @description Placeholder showing the value shape, e.g. "Bearer <token>". Never a real secret. */
+                value_format?: string;
+            } | null;
             auth_required: boolean;
             /** @enum {unknown} */
             confidence?: "low" | "medium" | "high";
@@ -3189,6 +3213,30 @@ export interface components {
             schema_version: 1;
         };
         Surface: {
+            /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
+            auth?: {
+                /**
+                 * @description Where the credential is sent.
+                 * @enum {unknown}
+                 */
+                location?: "header" | "query" | "cookie";
+                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". */
+                name?: string;
+                /**
+                 * @description Credential scheme.
+                 * @enum {unknown}
+                 */
+                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "custom";
+                /** @description Note on required scopes or how to obtain a credential. */
+                scopes_note?: string;
+                /**
+                 * Format: uri
+                 * @description OAuth2/OIDC token or authorize endpoint, when the spec declares one.
+                 */
+                token_url?: string;
+                /** @description Placeholder showing the value shape, e.g. "Bearer <token>". Never a real secret. */
+                value_format?: string;
+            } | null;
             auth_required: boolean;
             authority: components["schemas"]["Authority"];
             classification?: components["schemas"]["Classification"];

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -806,6 +806,56 @@
       "CandidateSurface": {
         "additionalProperties": false,
         "properties": {
+          "auth": {
+            "additionalProperties": false,
+            "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+            "properties": {
+              "location": {
+                "description": "Where the credential is sent.",
+                "enum": [
+                  "header",
+                  "query",
+                  "cookie"
+                ]
+              },
+              "name": {
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\".",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Credential scheme.",
+                "enum": [
+                  "none",
+                  "bearer",
+                  "api-key",
+                  "basic",
+                  "oauth2",
+                  "custom"
+                ]
+              },
+              "scopes_note": {
+                "description": "Note on required scopes or how to obtain a credential.",
+                "type": "string"
+              },
+              "token_url": {
+                "description": "OAuth2/OIDC token or authorize endpoint, when the spec declares one.",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "value_format": {
+                "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "auth_required": {
             "type": "boolean"
           },
@@ -8855,6 +8905,56 @@
       "Surface": {
         "additionalProperties": false,
         "properties": {
+          "auth": {
+            "additionalProperties": false,
+            "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+            "properties": {
+              "location": {
+                "description": "Where the credential is sent.",
+                "enum": [
+                  "header",
+                  "query",
+                  "cookie"
+                ]
+              },
+              "name": {
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\".",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Credential scheme.",
+                "enum": [
+                  "none",
+                  "bearer",
+                  "api-key",
+                  "basic",
+                  "oauth2",
+                  "custom"
+                ]
+              },
+              "scopes_note": {
+                "description": "Note on required scopes or how to obtain a credential.",
+                "type": "string"
+              },
+              "token_url": {
+                "description": "OAuth2/OIDC token or authorize endpoint, when the spec declares one.",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "value_format": {
+                "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "auth_required": {
             "type": "boolean"
           },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1214,6 +1214,30 @@ export interface components {
         /** @enum {unknown} */
         CandidateState: "schema-invalid" | "schema-valid" | "maintainer-review" | "verified" | "stale" | "rejected";
         CandidateSurface: {
+            /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
+            auth?: {
+                /**
+                 * @description Where the credential is sent.
+                 * @enum {unknown}
+                 */
+                location?: "header" | "query" | "cookie";
+                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". */
+                name?: string;
+                /**
+                 * @description Credential scheme.
+                 * @enum {unknown}
+                 */
+                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "custom";
+                /** @description Note on required scopes or how to obtain a credential. */
+                scopes_note?: string;
+                /**
+                 * Format: uri
+                 * @description OAuth2/OIDC token or authorize endpoint, when the spec declares one.
+                 */
+                token_url?: string;
+                /** @description Placeholder showing the value shape, e.g. "Bearer <token>". Never a real secret. */
+                value_format?: string;
+            } | null;
             auth_required: boolean;
             /** @enum {unknown} */
             confidence?: "low" | "medium" | "high";
@@ -3189,6 +3213,30 @@ export interface components {
             schema_version: 1;
         };
         Surface: {
+            /** @description Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness. */
+            auth?: {
+                /**
+                 * @description Where the credential is sent.
+                 * @enum {unknown}
+                 */
+                location?: "header" | "query" | "cookie";
+                /** @description Header or query-parameter name, e.g. "Authorization" or "X-API-Key". */
+                name?: string;
+                /**
+                 * @description Credential scheme.
+                 * @enum {unknown}
+                 */
+                scheme: "none" | "bearer" | "api-key" | "basic" | "oauth2" | "custom";
+                /** @description Note on required scopes or how to obtain a credential. */
+                scopes_note?: string;
+                /**
+                 * Format: uri
+                 * @description OAuth2/OIDC token or authorize endpoint, when the spec declares one.
+                 */
+                token_url?: string;
+                /** @description Placeholder showing the value shape, e.g. "Bearer <token>". Never a real secret. */
+                value_format?: string;
+            } | null;
             auth_required: boolean;
             authority: components["schemas"]["Authority"];
             classification?: components["schemas"]["Classification"];

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -792,6 +792,56 @@
       "CandidateSurface": {
         "additionalProperties": false,
         "properties": {
+          "auth": {
+            "additionalProperties": false,
+            "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+            "properties": {
+              "location": {
+                "description": "Where the credential is sent.",
+                "enum": [
+                  "header",
+                  "query",
+                  "cookie"
+                ]
+              },
+              "name": {
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\".",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Credential scheme.",
+                "enum": [
+                  "none",
+                  "bearer",
+                  "api-key",
+                  "basic",
+                  "oauth2",
+                  "custom"
+                ]
+              },
+              "scopes_note": {
+                "description": "Note on required scopes or how to obtain a credential.",
+                "type": "string"
+              },
+              "token_url": {
+                "description": "OAuth2/OIDC token or authorize endpoint, when the spec declares one.",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "value_format": {
+                "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "auth_required": {
             "type": "boolean"
           },
@@ -8833,6 +8883,56 @@
       "Surface": {
         "additionalProperties": false,
         "properties": {
+          "auth": {
+            "additionalProperties": false,
+            "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+            "properties": {
+              "location": {
+                "description": "Where the credential is sent.",
+                "enum": [
+                  "header",
+                  "query",
+                  "cookie"
+                ]
+              },
+              "name": {
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\".",
+                "type": "string"
+              },
+              "scheme": {
+                "description": "Credential scheme.",
+                "enum": [
+                  "none",
+                  "bearer",
+                  "api-key",
+                  "basic",
+                  "oauth2",
+                  "custom"
+                ]
+              },
+              "scopes_note": {
+                "description": "Note on required scopes or how to obtain a credential.",
+                "type": "string"
+              },
+              "token_url": {
+                "description": "OAuth2/OIDC token or authorize endpoint, when the spec declares one.",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "type": "string"
+              },
+              "value_format": {
+                "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ],
+            "type": [
+              "object",
+              "null"
+            ]
+          },
           "auth_required": {
             "type": "boolean"
           },

--- a/schemas/candidate-surface.schema.json
+++ b/schemas/candidate-surface.schema.json
@@ -158,6 +158,40 @@
         }
       }
     },
+    "auth": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "required": ["scheme"],
+      "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+      "properties": {
+        "scheme": {
+          "enum": ["none", "bearer", "api-key", "basic", "oauth2", "custom"],
+          "description": "Credential scheme."
+        },
+        "location": {
+          "enum": ["header", "query", "cookie"],
+          "description": "Where the credential is sent."
+        },
+        "name": {
+          "type": "string",
+          "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\"."
+        },
+        "value_format": {
+          "type": "string",
+          "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret."
+        },
+        "token_url": {
+          "type": "string",
+          "format": "uri",
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+          "description": "OAuth2/OIDC token or authorize endpoint, when the spec declares one."
+        },
+        "scopes_note": {
+          "type": "string",
+          "description": "Note on required scopes or how to obtain a credential."
+        }
+      }
+    },
     "review_notes": {
       "type": "string"
     }

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -283,6 +283,47 @@
               }
             }
           },
+          "auth": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["scheme"],
+            "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+            "properties": {
+              "scheme": {
+                "enum": [
+                  "none",
+                  "bearer",
+                  "api-key",
+                  "basic",
+                  "oauth2",
+                  "custom"
+                ],
+                "description": "Credential scheme."
+              },
+              "location": {
+                "enum": ["header", "query", "cookie"],
+                "description": "Where the credential is sent."
+              },
+              "name": {
+                "type": "string",
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\"."
+              },
+              "value_format": {
+                "type": "string",
+                "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret."
+              },
+              "token_url": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "description": "OAuth2/OIDC token or authorize endpoint, when the spec declares one."
+              },
+              "scopes_note": {
+                "type": "string",
+                "description": "Note on required scopes or how to obtain a credential."
+              }
+            }
+          },
           "notes": {
             "type": "string"
           },
@@ -480,6 +521,47 @@
               "cost_notes": {
                 "type": "string",
                 "description": "Notes on weighted/credit costs or tier differences."
+              }
+            }
+          },
+          "auth": {
+            "type": ["object", "null"],
+            "additionalProperties": false,
+            "required": ["scheme"],
+            "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+            "properties": {
+              "scheme": {
+                "enum": [
+                  "none",
+                  "bearer",
+                  "api-key",
+                  "basic",
+                  "oauth2",
+                  "custom"
+                ],
+                "description": "Credential scheme."
+              },
+              "location": {
+                "enum": ["header", "query", "cookie"],
+                "description": "Where the credential is sent."
+              },
+              "name": {
+                "type": "string",
+                "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\"."
+              },
+              "value_format": {
+                "type": "string",
+                "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret."
+              },
+              "token_url": {
+                "type": "string",
+                "format": "uri",
+                "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+                "description": "OAuth2/OIDC token or authorize endpoint, when the spec declares one."
+              },
+              "scopes_note": {
+                "type": "string",
+                "description": "Note on required scopes or how to obtain a credential."
               }
             }
           },

--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -240,6 +240,47 @@
             }
           }
         },
+        "auth": {
+          "type": ["object", "null"],
+          "additionalProperties": false,
+          "required": ["scheme"],
+          "description": "Structured, caller-actionable auth detail (#746): how to pass a credential. Derived from the OpenAPI securitySchemes when present, else curated. Placeholders only — never a real secret; integration-only, never feeds completeness.",
+          "properties": {
+            "scheme": {
+              "enum": [
+                "none",
+                "bearer",
+                "api-key",
+                "basic",
+                "oauth2",
+                "custom"
+              ],
+              "description": "Credential scheme."
+            },
+            "location": {
+              "enum": ["header", "query", "cookie"],
+              "description": "Where the credential is sent."
+            },
+            "name": {
+              "type": "string",
+              "description": "Header or query-parameter name, e.g. \"Authorization\" or \"X-API-Key\"."
+            },
+            "value_format": {
+              "type": "string",
+              "description": "Placeholder showing the value shape, e.g. \"Bearer <token>\". Never a real secret."
+            },
+            "token_url": {
+              "type": "string",
+              "format": "uri",
+              "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://",
+              "description": "OAuth2/OIDC token or authorize endpoint, when the spec declares one."
+            },
+            "scopes_note": {
+              "type": "string",
+              "description": "Note on required scopes or how to obtain a credential."
+            }
+          }
+        },
         "probe": {
           "$ref": "#/$defs/probe"
         },

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -1119,6 +1119,10 @@ function buildSubnetServices(netuid) {
         surface.auth_required || schema?.snapshot?.auth_required,
       );
       const authSchemes = schema?.snapshot?.auth_schemes || [];
+      // Structured per-surface auth detail (#746): a curated override on the
+      // surface wins; otherwise the value derived from the captured spec's
+      // securitySchemes. null when neither is present. Placeholders only.
+      const authDetail = surface.auth || schema?.snapshot?.auth_detail || null;
       return {
         surface_id: surface.id,
         kind: surface.kind,
@@ -1132,12 +1136,14 @@ function buildSubnetServices(netuid) {
         // credential (fixes Chutes etc. that declared apiKey yet showed false).
         auth_required: authRequired,
         auth_schemes: authSchemes,
-        // Copy-paste curl/Python/TS that GETs this surface, auth header
-        // pre-filled from the declared scheme (issue #351). Reporting-only.
+        auth: authDetail,
+        // Copy-paste curl/Python/TS that GETs this surface, auth header/param
+        // filled from the structured auth detail (issue #746, was #351 guess).
         snippets: generateServiceSnippets({
           base_url: surface.url,
           auth_required: authRequired,
           auth_schemes: authSchemes,
+          auth: authDetail,
         }),
         schema_url: surface.schema_url || null,
         schema_status: surface.schema_status || null,

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -1377,6 +1377,90 @@ export function deriveDescriptionFromNotes(notes, { maxLength = 280 } = {}) {
     .trimEnd()}…`;
 }
 
+// Pull a usable OAuth2/OIDC token (or authorize) endpoint out of a security
+// scheme, tolerating OpenAPI 3 `flows.*` and Swagger 2 top-level shapes.
+function oauthTokenUrl(scheme) {
+  if (typeof scheme.openIdConnectUrl === "string") {
+    return scheme.openIdConnectUrl;
+  }
+  const flows =
+    scheme.flows && typeof scheme.flows === "object" ? scheme.flows : {};
+  for (const flow of Object.values(flows)) {
+    if (flow && typeof flow.tokenUrl === "string") {
+      return flow.tokenUrl;
+    }
+    if (flow && typeof flow.authorizationUrl === "string") {
+      return flow.authorizationUrl;
+    }
+  }
+  if (typeof scheme.tokenUrl === "string") {
+    return scheme.tokenUrl;
+  }
+  if (typeof scheme.authorizationUrl === "string") {
+    return scheme.authorizationUrl;
+  }
+  return null;
+}
+
+// Map a captured OpenAPI/Swagger securitySchemes object to a single structured
+// auth hint a caller can act on (#746): the scheme + concrete header/param name
+// and a value PLACEHOLDER (never a real secret). Prefers a concrete api-key/http
+// scheme over oauth2 when several are declared. token_url is junk/SSRF-guarded.
+export function deriveAuthDetail(schemes) {
+  const entries = Object.values(schemes || {}).filter(
+    (scheme) => scheme && typeof scheme === "object",
+  );
+  if (!entries.length) {
+    return null;
+  }
+  const pick =
+    entries.find((scheme) => String(scheme.type).toLowerCase() === "apikey") ||
+    entries.find((scheme) => String(scheme.type).toLowerCase() === "http") ||
+    entries[0];
+  const type = String(pick.type || "").toLowerCase();
+  if (type === "apikey" && typeof pick.name === "string" && pick.name) {
+    const location = ["header", "query", "cookie"].includes(pick.in)
+      ? pick.in
+      : "header";
+    return {
+      scheme: "api-key",
+      location,
+      name: pick.name,
+      value_format: "<api-key>",
+    };
+  }
+  if (type === "http") {
+    if (String(pick.scheme || "").toLowerCase() === "basic") {
+      return {
+        scheme: "basic",
+        location: "header",
+        name: "Authorization",
+        value_format: "Basic <base64(user:pass)>",
+      };
+    }
+    return {
+      scheme: "bearer",
+      location: "header",
+      name: "Authorization",
+      value_format: "Bearer <token>",
+    };
+  }
+  if (type === "oauth2" || type === "openidconnect") {
+    const detail = {
+      scheme: "oauth2",
+      location: "header",
+      name: "Authorization",
+      value_format: "Bearer <token>",
+    };
+    const tokenUrl = normalizePublicHttpUrl(oauthTokenUrl(pick));
+    if (tokenUrl) {
+      detail.token_url = tokenUrl;
+    }
+    return detail;
+  }
+  return null;
+}
+
 // Derive auth metadata from a captured OpenAPI/Swagger spec: OpenAPI 3
 // components.securitySchemes or Swagger 2 securityDefinitions. A spec that
 // declares any security scheme is treated as requiring auth — the fix for
@@ -1393,7 +1477,13 @@ export function extractAuth(spec) {
         .filter((type) => typeof type === "string"),
     ),
   ].sort();
-  return { auth_required: authSchemes.length > 0, auth_schemes: authSchemes };
+  return {
+    auth_required: authSchemes.length > 0,
+    auth_schemes: authSchemes,
+    // Structured, caller-actionable detail (#746): exact header/param + value
+    // placeholder. null when no scheme is declared.
+    auth_detail: deriveAuthDetail(schemes),
+  };
 }
 
 // Declared lifecycle, derived from canonical on-chain identity names (teams set

--- a/src/integration-snippets.mjs
+++ b/src/integration-snippets.mjs
@@ -6,9 +6,37 @@
 //
 // We snippet a GET of the surface URL itself (always a valid, documented entry
 // point regardless of surface kind); for subnet-api surfaces with a captured
-// schema the agent then reads it (get_api_schema) for specific endpoints. The
-// auth header is a best-effort placeholder from the declared scheme types — the
-// captured spec carries scheme TYPES, not header names, so we use conventions.
+// schema the agent then reads it (get_api_schema) for specific endpoints. Auth
+// uses the structured `auth` detail (#746) — the exact header/param name + a
+// value PLACEHOLDER derived from the spec's securitySchemes or curated — and
+// only falls back to a scheme-type guess when no structured detail is present.
+
+// Resolve the structured per-surface auth (#746) into a snippet-ready credential:
+// { location: "header"|"query", name, value-placeholder }. Returns null for no
+// auth or an unsafe placeholder (a placeholder must never break snippet quoting,
+// and is never a real secret).
+function authFromDetail(auth) {
+  if (!auth || typeof auth !== "object") return null;
+  const scheme = String(auth.scheme || "").toLowerCase();
+  if (scheme === "none") return null;
+  const location = auth.location === "query" ? "query" : "header";
+  const name =
+    typeof auth.name === "string" && auth.name
+      ? auth.name
+      : location === "query"
+        ? "api_key"
+        : "Authorization";
+  const value =
+    typeof auth.value_format === "string" && auth.value_format
+      ? auth.value_format
+      : scheme === "api-key"
+        ? "YOUR_API_KEY"
+        : scheme === "basic"
+          ? "Basic <base64(user:pass)>"
+          : "Bearer YOUR_API_KEY";
+  if (/['"`\\\n]/.test(name) || /['"`\\\n]/.test(value)) return null;
+  return { location, name, value };
+}
 
 function authHeaderForSchemes(schemes) {
   const types = new Set(
@@ -51,36 +79,52 @@ function isCredentialSafeUrl(url) {
 export function generateServiceSnippets(service) {
   const url = service?.base_url;
   if (!isSnippetSafeUrl(url)) return null;
-  const authHeader =
-    service?.auth_required && isCredentialSafeUrl(url)
-      ? authHeaderForSchemes(service?.auth_schemes)
-      : null;
+  // Prefer the structured auth detail; fall back to the scheme-type guess only
+  // when no structured detail is present at all. A structured detail is
+  // authoritative — including an explicit scheme:"none" (→ no credential). Auth
+  // is only ever attached over a credential-safe (https/wss) transport.
+  const hasStructuredAuth = service?.auth && typeof service.auth === "object";
+  const auth = !isCredentialSafeUrl(url)
+    ? null
+    : hasStructuredAuth
+      ? authFromDetail(service.auth)
+      : service?.auth_required
+        ? { location: "header", ...authHeaderForSchemes(service?.auth_schemes) }
+        : null;
 
-  const curl = authHeader
-    ? `curl -sS '${url}' \\\n  -H '${authHeader.name}: ${authHeader.value}'`
-    : `curl -sS '${url}'`;
+  // Header credentials go in the request headers; query credentials go on the URL.
+  const requestUrl =
+    auth?.location === "query"
+      ? `${url}${url.includes("?") ? "&" : "?"}${auth.name}=${auth.value}`
+      : url;
+  if (!isSnippetSafeUrl(requestUrl)) return null;
+  const header = auth?.location === "header" ? auth : null;
 
-  const pythonHeaders = authHeader
-    ? `, headers={"${authHeader.name}": "${authHeader.value}"}`
+  const curl = header
+    ? `curl -sS '${requestUrl}' \\\n  -H '${header.name}: ${header.value}'`
+    : `curl -sS '${requestUrl}'`;
+
+  const pythonHeaders = header
+    ? `, headers={"${header.name}": "${header.value}"}`
     : "";
   const python = [
     "import requests",
     "",
-    `resp = requests.get("${url}"${pythonHeaders})`,
+    `resp = requests.get("${requestUrl}"${pythonHeaders})`,
     "resp.raise_for_status()",
     "print(resp.json())",
   ].join("\n");
 
-  const typescript = authHeader
+  const typescript = header
     ? [
-        `const resp = await fetch("${url}", {`,
-        `  headers: { "${authHeader.name}": "${authHeader.value}" },`,
+        `const resp = await fetch("${requestUrl}", {`,
+        `  headers: { "${header.name}": "${header.value}" },`,
         "});",
         "if (!resp.ok) throw new Error(`HTTP ${resp.status}`);",
         "const data = await resp.json();",
       ].join("\n")
     : [
-        `const resp = await fetch("${url}");`,
+        `const resp = await fetch("${requestUrl}");`,
         "if (!resp.ok) throw new Error(`HTTP ${resp.status}`);",
         "const data = await resp.json();",
       ].join("\n");

--- a/tests/integration-snippets.test.mjs
+++ b/tests/integration-snippets.test.mjs
@@ -100,3 +100,102 @@ describe("generateServiceSnippets (#351)", () => {
     );
   });
 });
+
+describe("generateServiceSnippets structured auth (#746)", () => {
+  const base = { base_url: "https://api.example.com/v1", auth_required: true };
+
+  test("structured header auth uses the exact header name + placeholder", () => {
+    const out = generateServiceSnippets({
+      ...base,
+      auth: {
+        scheme: "api-key",
+        location: "header",
+        name: "X-API-Key",
+        value_format: "<api-key>",
+      },
+    });
+    assert.match(out.curl, /-H 'X-API-Key: <api-key>'/);
+    assert.match(out.python, /"X-API-Key": "<api-key>"/);
+    assert.match(out.typescript, /"X-API-Key": "<api-key>"/);
+  });
+
+  test("structured query auth puts the credential on the URL, not a header", () => {
+    const out = generateServiceSnippets({
+      ...base,
+      auth: {
+        scheme: "api-key",
+        location: "query",
+        name: "api_key",
+        value_format: "YOUR_API_KEY",
+      },
+    });
+    assert.match(out.curl, /\?api_key=YOUR_API_KEY/);
+    assert.doesNotMatch(out.curl, /-H /);
+    assert.match(out.python, /\?api_key=YOUR_API_KEY/);
+  });
+
+  test("appends with & when the base URL already has a query string", () => {
+    const out = generateServiceSnippets({
+      ...base,
+      base_url: "https://api.example.com/v1?v=2",
+      auth: { scheme: "api-key", location: "query", name: "key" },
+    });
+    assert.match(out.curl, /\?v=2&key=YOUR_API_KEY/);
+  });
+
+  test("structured auth wins over the scheme-type guess", () => {
+    const out = generateServiceSnippets({
+      ...base,
+      auth_schemes: ["http"], // would guess Authorization: Bearer
+      auth: {
+        scheme: "api-key",
+        location: "header",
+        name: "X-Custom-Key",
+        value_format: "<key>",
+      },
+    });
+    assert.match(out.curl, /X-Custom-Key/);
+    assert.doesNotMatch(out.curl, /Authorization/);
+  });
+
+  test("scheme:none yields a plain GET even when auth_required is set", () => {
+    const out = generateServiceSnippets({
+      ...base,
+      auth: { scheme: "none" },
+    });
+    assert.doesNotMatch(out.curl, /-H /);
+  });
+
+  test("rejects a placeholder that could break snippet quoting", () => {
+    const out = generateServiceSnippets({
+      ...base,
+      auth: {
+        scheme: "api-key",
+        location: "header",
+        name: "X-API-Key",
+        value_format: "x'; rm -rf /",
+      },
+    });
+    // unsafe placeholder is dropped → falls back to a plain GET, never injected
+    assert.doesNotMatch(out.curl, /rm -rf/);
+  });
+
+  test("fills scheme-appropriate placeholders when value_format is omitted", () => {
+    const bearer = generateServiceSnippets({
+      ...base,
+      auth: { scheme: "bearer" },
+    });
+    assert.match(bearer.curl, /-H 'Authorization: Bearer YOUR_API_KEY'/);
+    const basic = generateServiceSnippets({
+      ...base,
+      auth: { scheme: "basic" },
+    });
+    assert.match(basic.curl, /Authorization: Basic <base64/);
+    // query api-key with no name defaults the param to api_key
+    const key = generateServiceSnippets({
+      ...base,
+      auth: { scheme: "api-key", location: "query" },
+    });
+    assert.match(key.curl, /\?api_key=YOUR_API_KEY/);
+  });
+});

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -22,6 +22,7 @@ import {
   isPlaceholderIdentityUrl,
   backfilledIdentityUrl,
   socialAccounts,
+  deriveAuthDetail,
   nativeContactHandle,
   nativeDisplayName,
   nativeContactUrl,
@@ -246,15 +247,37 @@ describe("extractAuth", () => {
   test("flags auth from OpenAPI 3 securitySchemes", () => {
     assert.deepEqual(
       extractAuth({
-        components: { securitySchemes: { ApiKeyHeader: { type: "apiKey" } } },
+        components: {
+          securitySchemes: {
+            ApiKeyHeader: { type: "apiKey", in: "header", name: "X-API-Key" },
+          },
+        },
       }),
-      { auth_required: true, auth_schemes: ["apiKey"] },
+      {
+        auth_required: true,
+        auth_schemes: ["apiKey"],
+        auth_detail: {
+          scheme: "api-key",
+          location: "header",
+          name: "X-API-Key",
+          value_format: "<api-key>",
+        },
+      },
     );
   });
   test("flags auth from Swagger 2 securityDefinitions", () => {
     assert.deepEqual(
       extractAuth({ securityDefinitions: { oauth: { type: "oauth2" } } }),
-      { auth_required: true, auth_schemes: ["oauth2"] },
+      {
+        auth_required: true,
+        auth_schemes: ["oauth2"],
+        auth_detail: {
+          scheme: "oauth2",
+          location: "header",
+          name: "Authorization",
+          value_format: "Bearer <token>",
+        },
+      },
     );
   });
   test("dedupes + sorts scheme types", () => {
@@ -273,10 +296,12 @@ describe("extractAuth", () => {
     assert.deepEqual(extractAuth({ paths: {} }), {
       auth_required: false,
       auth_schemes: [],
+      auth_detail: null,
     });
     assert.deepEqual(extractAuth(null), {
       auth_required: false,
       auth_schemes: [],
+      auth_detail: null,
     });
   });
 });
@@ -933,5 +958,119 @@ describe("socialAccounts (#745)", () => {
       "x",
       "youtube",
     ]);
+  });
+});
+
+describe("deriveAuthDetail (#746)", () => {
+  test("apiKey scheme maps to the exact header/param name", () => {
+    assert.deepEqual(
+      deriveAuthDetail({
+        k: { type: "apiKey", in: "header", name: "X-API-Key" },
+      }),
+      {
+        scheme: "api-key",
+        location: "header",
+        name: "X-API-Key",
+        value_format: "<api-key>",
+      },
+    );
+    // query-located key keeps its location
+    assert.equal(
+      deriveAuthDetail({ k: { type: "apiKey", in: "query", name: "api_key" } })
+        .location,
+      "query",
+    );
+  });
+
+  test("http bearer and basic map to Authorization", () => {
+    assert.deepEqual(
+      deriveAuthDetail({ b: { type: "http", scheme: "bearer" } }),
+      {
+        scheme: "bearer",
+        location: "header",
+        name: "Authorization",
+        value_format: "Bearer <token>",
+      },
+    );
+    assert.equal(
+      deriveAuthDetail({ b: { type: "http", scheme: "basic" } }).value_format,
+      "Basic <base64(user:pass)>",
+    );
+  });
+
+  test("oauth2 pulls a junk-guarded token_url from flows", () => {
+    const out = deriveAuthDetail({
+      o: {
+        type: "oauth2",
+        flows: {
+          clientCredentials: { tokenUrl: "https://auth.example.com/token" },
+        },
+      },
+    });
+    assert.equal(out.scheme, "oauth2");
+    assert.equal(out.token_url, "https://auth.example.com/token");
+  });
+
+  test("drops an unsafe/placeholder token_url rather than surfacing it", () => {
+    const out = deriveAuthDetail({
+      o: {
+        type: "oauth2",
+        flows: { password: { tokenUrl: "http://127.0.0.1/token" } },
+      },
+    });
+    assert.equal(out.scheme, "oauth2");
+    assert.equal("token_url" in out, false);
+  });
+
+  test("prefers a concrete api-key/http scheme over oauth2", () => {
+    const out = deriveAuthDetail({
+      oauth: { type: "oauth2", flows: {} },
+      key: { type: "apiKey", in: "header", name: "X-Key" },
+    });
+    assert.equal(out.scheme, "api-key");
+    assert.equal(out.name, "X-Key");
+  });
+
+  test("returns null when no security scheme is declared", () => {
+    assert.equal(deriveAuthDetail({}), null);
+    assert.equal(deriveAuthDetail(null), null);
+    assert.equal(deriveAuthDetail(undefined), null);
+  });
+
+  test("resolves token_url from openIdConnect, authorizationUrl, and Swagger-2 shapes", () => {
+    assert.equal(
+      deriveAuthDetail({
+        o: {
+          type: "openIdConnect",
+          openIdConnectUrl:
+            "https://idp.example.com/.well-known/openid-configuration",
+        },
+      }).token_url,
+      "https://idp.example.com/.well-known/openid-configuration",
+    );
+    assert.equal(
+      deriveAuthDetail({
+        o: {
+          type: "oauth2",
+          flows: {
+            implicit: {
+              authorizationUrl: "https://auth.example.com/authorize",
+            },
+          },
+        },
+      }).token_url,
+      "https://auth.example.com/authorize",
+    );
+    assert.equal(
+      deriveAuthDetail({
+        o: { type: "oauth2", tokenUrl: "https://auth.example.com/token" },
+      }).token_url,
+      "https://auth.example.com/token",
+    );
+  });
+
+  test("ignores non-object scheme entries and unknown scheme types", () => {
+    assert.equal(deriveAuthDetail({ a: null, b: "nope" }), null);
+    assert.equal(deriveAuthDetail({ a: { type: "mutualTLS" } }), null);
   });
 });


### PR DESCRIPTION
Closes #746. Sibling to #747 (rate-limit) — same surface-schema home.

The #1 blocker to one-shot integration was that we captured `auth_required` + scheme *types* but not the concrete header/credential mapping, so the snippet generator **guessed** header names. This adds the real mapping.

## Structured `auth`
`{ scheme, location?, name?, value_format?, token_url?, scopes_note? }` (only `scheme` required: `none`/`bearer`/`api-key`/`basic`/`oauth2`/`custom`).

- **Auto-derived** — `deriveAuthDetail()` maps a captured OpenAPI/Swagger `securitySchemes` object to the exact header/param + a value **placeholder**:
  - `apiKey` → `{location, name, value_format: "<api-key>"}`
  - `http`/`bearer` → `Authorization: Bearer <token>`; `http`/`basic` → `Authorization: Basic <base64(user:pass)>`
  - `oauth2`/`openIdConnect` → `Bearer <token>` + junk/SSRF-guarded `token_url` (from `flows.*.tokenUrl`/`authorizationUrl`, `openIdConnectUrl`, or Swagger-2 top-level)
  - `extractAuth()` returns it, so it flows through the existing snapshot spread.
- **Curated override** — `surface.auth` wins over the derived value (e.g. an undocumented `X-API-Key`).

## Snippet rewiring (`src/integration-snippets.mjs`)
Consumes the structured auth — exact header **or query-param** credential — instead of guessing. A structured detail is authoritative (incl. `scheme:"none"` → plain GET); the scheme-type guess remains only as the fallback when no detail is present. Placeholders are snippet-quote-safe; auth is only ever attached over https/wss.

## Schema homes
`subnet-manifest` (curated source) + `candidate-surface` (community input) + served `Surface`/`CandidateSurface`; the derived value also rides the `services` array (loose schema). Regenerated contract.

## Verification
- Build + `validate:schemas`/`api`/`openapi-examples`/`contract-drift` green; full `npm run validate` green.
- `test:coverage`: 1080 passed; gate holds (98.06% / 90.51%). `public-safety` test green — **placeholders only, no secrets**.
- No regex traps: `token_url` reuses the existing `^https` `valueForPattern` case.

Data seed unchanged (ADR 0006 drift); structured auth lands live on the next publish + as specs are re-captured.