### PR TITLE
fix(feeds): add Vary: Accept to content-negotiated feed responses

### DIFF
--- a/src/feeds.mjs
+++ b/src/feeds.mjs
@@ -382,6 +382,7 @@ export async function handleFeedRequest(request, env, url, deps = {}) {
     headers: {
       "content-type": FEED_CONTENT_TYPES[format],
       "cache-control": `public, max-age=${FEED_CACHE_SECONDS}`,
+      vary: "Accept",
       "x-content-type-options": "nosniff",
     },
   });

--- a/tests/feeds.test.mjs
+++ b/tests/feeds.test.mjs
@@ -257,6 +257,7 @@ describe("feeds — handleFeedRequest", () => {
       accept: "text/html, application/rss+xml",
     });
     assert.match(res.headers.get("content-type"), /application\/rss\+xml/);
+    assert.equal(res.headers.get("vary"), "Accept");
   });
 
   test("per-subnet feed merges registry + incident items for that netuid", async () => {


### PR DESCRIPTION
### Motivation
- Unsuffixed feed endpoints negotiate RSS/Atom/JSON via the `Accept` header but were returned with `Cache-Control: public, max-age=...` and no `Vary`, allowing shared caches to serve the wrong format to later clients.

### Description
- Add `Vary: Accept` to successful responses in `handleFeedRequest` so caches key content-negotiated representations by the `Accept` header.
- Extend `tests/feeds.test.mjs` to assert the presence of the `Vary: Accept` header for an Accept-negotiated response.

### Testing
- Ran the feed unit tests with `npx vitest run tests/feeds.test.mjs` and got all tests passing (`20 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d715f2f8832aab20bbda167dd6f0)