### PR TITLE
fix(provider): constrain fallback logo URLs

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -757,10 +757,13 @@ const enrichedProviders = providers.map((provider) => {
   // provider operates (display-only, never feeds completeness). Multi-subnet
   // providers stay logo-less — the UI resolves a favicon from website_url.
   const curatedLogoUrl = normalizePublicHttpUrl(provider.logo_url);
-  const logoUrl =
-    curatedLogoUrl ||
-    (netuids.length === 1 ? mergedByNetuid.get(netuids[0])?.logo_url : null) ||
-    null;
+  // #785: normalize the single-subnet fallback logo so a non-HTTP(S) subnet
+  // logo (e.g. ws://) never lands in the provider artifact and blocks publish.
+  const fallbackLogoUrl =
+    netuids.length === 1
+      ? normalizePublicHttpUrl(mergedByNetuid.get(netuids[0])?.logo_url)
+      : null;
+  const logoUrl = curatedLogoUrl || fallbackLogoUrl || null;
   // Structured social links (#745): a curated provider `social` override wins;
   // else a single-subnet provider borrows that subnet's social (mirrors the
   // logo_url borrow above). Display-only — never feeds completeness.
@@ -768,6 +771,8 @@ const enrichedProviders = providers.map((provider) => {
     socialAccounts(null, provider.social) ||
     (netuids.length === 1 ? mergedByNetuid.get(netuids[0])?.social : null) ||
     null;
+  // #786: drop the raw curated `social` before spreading so an unsanitized
+  // (possibly unsafe/private) value can never survive into the artifact.
   const safeProvider = { ...provider };
   delete safeProvider.social;
   return {


### PR DESCRIPTION
### Motivation
- The Provider schema now requires `logo_url` to be an HTTP(S) URI, but the provider artifact builder could copy a subnet `logo_url` that allowed `ws://`/`wss://`, causing schema validation failures for valid subnet artifacts to block publish.
- The change ensures provider artifacts never emit a fallback logo with a non-HTTP(S) scheme while preserving existing curated-logo precedence.

### Description
- Normalize the single-subnet fallback logo through `normalizePublicHttpUrl()` before emitting provider artifacts to enforce HTTP(S)-only semantics. (change in `scripts/build-artifacts.mjs`)
- Preserve curated provider `logo_url` precedence and keep multi-subnet providers logo-less when no curated logo exists.

### Testing
- Ran `npm run -s build:artifacts` and `npm run -s validate:schemas`, both of which succeeded. 
- Ran `npm run -s lint` and `npm run -s format:check`, both of which succeeded. 
- Ran `npm test`, which produced two failing tests: one timeout in `tests/artifacts.test.mjs` and one DNS/host-resolution assertion failure in `tests/public-safety.test.mjs`, which appear to be environment-related and unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30abec8d94832a8056875b63be88e9)