### PR TITLE
Fix unsafe provider social URL sanitization

### DIFF
--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -768,8 +768,10 @@ const enrichedProviders = providers.map((provider) => {
     socialAccounts(null, provider.social) ||
     (netuids.length === 1 ? mergedByNetuid.get(netuids[0])?.social : null) ||
     null;
+  const safeProvider = { ...provider };
+  delete safeProvider.social;
   return {
-    ...provider,
+    ...safeProvider,
     ...(logoUrl ? { logo_url: logoUrl } : {}),
     ...(social ? { social } : {}),
     netuids,

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -1245,6 +1245,12 @@ export function validateProviderForSubmission({
   const teamUrl = normalizePublicUrl(provider?.team_url);
   const contactUrl = normalizePublicUrl(provider?.contact_url);
   const logoUrl = normalizePublicHttpUrl(provider?.logo_url);
+  const socialEntries =
+    provider?.social &&
+    typeof provider.social === "object" &&
+    !Array.isArray(provider.social)
+      ? Object.entries(provider.social)
+      : [];
 
   if (!provider || typeof provider !== "object") {
     return {
@@ -1303,6 +1309,19 @@ export function validateProviderForSubmission({
       });
     } else if (provider[field] && provider[field] !== normalized) {
       warnings.push(`provider ${field} will be normalized by registry tooling`);
+    }
+  }
+  for (const [key, value] of socialEntries) {
+    const normalized = normalizePublicHttpUrl(value);
+    if (!normalized) {
+      errors.push({
+        category: "private-or-unsafe-url",
+        message: `provider social.${key} is invalid or unsafe`,
+      });
+    } else if (value !== normalized) {
+      warnings.push(
+        `provider social.${key} will be normalized by registry tooling`,
+      );
     }
   }
   if (!["community", "provider-claimed"].includes(provider.authority)) {

--- a/tests/coverage-fill.test.mjs
+++ b/tests/coverage-fill.test.mjs
@@ -132,6 +132,7 @@ describe("submission-policy provider extraction and validation", () => {
         github_url: "http://169.254.169.254",
         team_url: "http://192.168.0.1",
         contact_url: "ftp://example.com",
+        social: { x: "http://169.254.169.254/latest/meta-data" },
         authority: "official",
         notes: "legacy notes",
       },
@@ -165,6 +166,10 @@ describe("submission-policy provider extraction and validation", () => {
     );
     assert.equal(
       messages.includes("provider contact_url is invalid or unsafe"),
+      true,
+    );
+    assert.equal(
+      messages.includes("provider social.x is invalid or unsafe"),
       true,
     );
     assert.equal(

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -936,6 +936,10 @@ describe("socialAccounts (#745)", () => {
     );
     assert.equal(socialAccounts(null, { x: "not a url" }), null);
     assert.equal(socialAccounts(null, { x: "" }), null);
+    assert.equal(
+      socialAccounts(null, { x: "http://169.254.169.254/latest/meta-data" }),
+      null,
+    );
   });
 
   test("returns null for empty / non-string input", () => {


### PR DESCRIPTION
### Motivation

- Prevent raw `provider.social` from being emitted when sanitization produces `null`, which allowed unsafe/private HTTP URLs (e.g. metadata service addresses) to survive into generated artifacts and become a downstream SSRF/phishing primitive.
- Ensure submission validation enforces the same public-safe HTTP URL boundaries for curated `social` entries as other URL fields.
- Add regression checks so future changes do not reintroduce the raw-field retention or validation gap.

### Description

- In `scripts/build-artifacts.mjs` drop the raw `social` key before returning enriched provider objects by creating a shallow copy and `delete`ing `social`, so only sanitized curated `social` or a safe single-subnet borrow are emitted (remove raw-field retention bug).
- In `scripts/submission-policy.mjs` validate each `provider.social` entry with `normalizePublicHttpUrl`, pushing `private-or-unsafe-url` errors for unsafe values and warnings when a value will be normalized, mirroring other URL checks.
- Add regression tests: update `tests/lib-helpers.test.mjs` to assert `socialAccounts` returns `null` for a metadata-service URL, and update `tests/coverage-fill.test.mjs` to include a provider `social` with a private URL and assert `validateProviderForSubmission` flags `provider social.x` as invalid.

### Testing

- Ran lint with `npm run lint` and it completed successfully.
- Ran unit tests with `npm test -- --run tests/lib-helpers.test.mjs tests/coverage-fill.test.mjs` and all tests passed (`92` tests passed in the run used here).
- Built artifacts with `npm run build:artifacts`, which completed and produced the expected artifacts.
- Ran the public-safety scan with `npm run scan:public-safety` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30ea3e0548832aa48306afd1c00e26)