### PR TITLE
fix: restrict curated social overlay hosts

### DIFF
--- a/schemas/subnet-manifest.schema.json
+++ b/schemas/subnet-manifest.schema.json
@@ -75,22 +75,22 @@
         "x": {
           "type": "string",
           "format": "uri",
-          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://([^/?#@]+\\.)?([Xx]\\.com|[Tt]witter\\.com)([:/?#]|$)"
         },
         "telegram": {
           "type": "string",
           "format": "uri",
-          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://([^/?#@]+\\.)?([Tt]\\.me|[Tt]elegram\\.me|[Tt]elegram\\.org)([:/?#]|$)"
         },
         "reddit": {
           "type": "string",
           "format": "uri",
-          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://([^/?#@]+\\.)?[Rr]eddit\\.com([:/?#]|$)"
         },
         "youtube": {
           "type": "string",
           "format": "uri",
-          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://"
+          "pattern": "^[Hh][Tt][Tt][Pp][Ss]?://([^/?#@]+\\.)?([Yy]outube\\.com|[Yy]outu\\.be)([:/?#]|$)"
         }
       }
     },

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -949,6 +949,14 @@ function socialHostKey(host) {
   return null;
 }
 
+function socialHostMatchesKey(url, key) {
+  try {
+    return socialHostKey(new URL(url).hostname) === key;
+  } catch {
+    return false;
+  }
+}
+
 // Resolve a subnet/provider's structured social links: a curated overlay
 // `social` object wins per platform; otherwise extract from the free-text
 // on-chain `additional` content (sanitized + junk-guarded via
@@ -985,7 +993,7 @@ export function socialAccounts(additionalText, overlaySocial = null) {
   ) {
     for (const key of SOCIAL_KEYS) {
       const curated = normalizePublicHttpUrl(overlaySocial[key]);
-      if (curated) {
+      if (curated && socialHostMatchesKey(curated, key)) {
         out[key] = curated;
       }
     }

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -942,6 +942,24 @@ describe("socialAccounts (#745)", () => {
     );
   });
 
+  test("ignores curated overlays whose host does not match the platform key", () => {
+    assert.equal(
+      socialAccounts(null, { x: "https://attacker.example/phish" }),
+      null,
+    );
+    assert.deepEqual(
+      socialAccounts("https://x.com/from_chain", {
+        x: "https://attacker.example/phish",
+        telegram: "https://t.me/curated",
+      }),
+      { x: "https://x.com/from_chain", telegram: "https://t.me/curated" },
+    );
+    assert.equal(
+      socialAccounts(null, { telegram: "https://x.com/not_telegram" }),
+      null,
+    );
+  });
+
   test("returns null for empty / non-string input", () => {
     assert.equal(socialAccounts(""), null);
     assert.equal(socialAccounts("just words, no links"), null);


### PR DESCRIPTION
### Motivation
- Curated `social` overlay fields could accept any public HTTP(S) URL, allowing arbitrary hosts (e.g. `https://attacker.example/...`) to be published as platform-specific links and weakening registry metadata integrity.
- Chain-extracted social links were already classified by host via `SOCIAL_HOSTS` and `socialHostKey()`, but overlay values bypassed that host check and could override chain values.
- The change aims to prevent overlays from mislabeling arbitrary hosts as `x`, `telegram`, `reddit`, or `youtube` while preserving legitimate curated links.

### Description
- Added `socialHostMatchesKey(url, key)` and require it before accepting a curated overlay value in `socialAccounts()` located in `scripts/lib.mjs` so overlays must match the platform allowlist to win.
- Tightened `schemas/subnet-manifest.schema.json` `social` property `pattern` values so `social.x`, `social.telegram`, `social.reddit`, and `social.youtube` only validate URLs whose hosts match the corresponding platform domains.
- Added a regression test in `tests/lib-helpers.test.mjs` that verifies arbitrary-host overlays are ignored and valid platform overlays still override chain-extracted values.
- Preserved existing normalization (`normalizePublicHttpUrl()`) and placeholder/junk guards so prior sanitization behavior remains unchanged.

### Testing
- Ran the unit tests for `tests/lib-helpers.test.mjs` with `npm test -- tests/lib-helpers.test.mjs` and observed all tests passed (`84 passed`).
- Performed an AJV schema validation smoke test using Node/Ajv that confirms a manifest with `social.x = https://attacker.example/phish` is rejected while valid platform URLs validate successfully.
- `npm run validate:schemas` did not complete in this checkout due to a missing artifact (`public/metagraph/candidates.json`) and therefore could not be run to completion in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30f19904dc832a8816dc420971a4a6)