### PR TITLE
Accept and propagate structured `rate_limit` in candidate submissions

### DIFF
--- a/scripts/generated-overlays.mjs
+++ b/scripts/generated-overlays.mjs
@@ -426,6 +426,7 @@ function promoteCandidate(candidate, verification) {
     public_safe: true,
     source_urls: candidate.source_urls || [candidate.source_url],
     quality_signals: verification.quality_signals,
+    rate_limit: candidate.rate_limit,
     rate_limit_notes: candidate.rate_limit_notes,
     probe: probeForKind(candidate.kind),
     notes: candidate.review_notes,

--- a/scripts/submission-policy.mjs
+++ b/scripts/submission-policy.mjs
@@ -90,6 +90,7 @@ const CANDIDATE_SCHEMA_FIELDS = new Set([
   "public_safe",
   "verification",
   "rate_limit_notes",
+  "rate_limit",
   "review_notes",
 ]);
 
@@ -832,6 +833,85 @@ function validateCandidateSchemaShape(candidate) {
       message: "candidate source_type must be a string",
     });
   }
+  if (candidate.rate_limit !== undefined) {
+    if (
+      !candidate.rate_limit ||
+      typeof candidate.rate_limit !== "object" ||
+      Array.isArray(candidate.rate_limit)
+    ) {
+      errors.push({
+        category: "unsupported-shape",
+        message: "candidate rate_limit must be an object",
+      });
+    } else {
+      const allowedRateLimitFields = new Set([
+        "requests",
+        "window",
+        "burst",
+        "scope",
+        "cost_notes",
+      ]);
+      for (const field of ["requests", "window"]) {
+        if (candidate.rate_limit[field] === undefined) {
+          errors.push({
+            category: "unsupported-shape",
+            message: `candidate rate_limit.${field} is required`,
+          });
+        }
+      }
+      for (const field of Object.keys(candidate.rate_limit)) {
+        if (!allowedRateLimitFields.has(field)) {
+          errors.push({
+            category: "unsupported-shape",
+            message: `candidate rate_limit.${field} is not allowed`,
+          });
+        }
+      }
+      for (const field of ["requests", "burst"]) {
+        if (
+          candidate.rate_limit[field] !== undefined &&
+          (!Number.isInteger(candidate.rate_limit[field]) ||
+            candidate.rate_limit[field] < 0)
+        ) {
+          errors.push({
+            category: "unsupported-shape",
+            message: `candidate rate_limit.${field} must be a non-negative integer`,
+          });
+        }
+      }
+      if (
+        candidate.rate_limit.window !== undefined &&
+        (typeof candidate.rate_limit.window !== "string" ||
+          candidate.rate_limit.window.length === 0)
+      ) {
+        errors.push({
+          category: "unsupported-shape",
+          message: "candidate rate_limit.window is required",
+        });
+      }
+      if (
+        candidate.rate_limit.scope !== undefined &&
+        !["per-key", "per-ip", "global", "unknown"].includes(
+          candidate.rate_limit.scope,
+        )
+      ) {
+        errors.push({
+          category: "unsupported-shape",
+          message: "candidate rate_limit.scope is unsupported",
+        });
+      }
+      if (
+        candidate.rate_limit.cost_notes !== undefined &&
+        typeof candidate.rate_limit.cost_notes !== "string"
+      ) {
+        errors.push({
+          category: "unsupported-shape",
+          message: "candidate rate_limit.cost_notes must be a string",
+        });
+      }
+    }
+  }
+
   for (const field of ["rate_limit_notes", "review_notes"]) {
     if (
       candidate[field] !== undefined &&

--- a/tests/coverage-fill.test.mjs
+++ b/tests/coverage-fill.test.mjs
@@ -251,6 +251,71 @@ describe("submission-policy candidate schema shape branches", () => {
     );
   });
 
+  test("flags a non-object structured rate_limit (#788)", () => {
+    const result = validateCandidateForSubmission({
+      candidate: { ...baseCandidate, rate_limit: 42 },
+      document: validSubmissionDocument,
+      submitter: "jsonbored",
+      native,
+      providers,
+    });
+    assert.equal(
+      result.errors.some(
+        (error) => error.message === "candidate rate_limit must be an object",
+      ),
+      true,
+    );
+  });
+
+  test("flags every malformed field inside a structured rate_limit (#788)", () => {
+    const messagesFor = (rateLimit) =>
+      validateCandidateForSubmission({
+        candidate: { ...baseCandidate, rate_limit: rateLimit },
+        document: validSubmissionDocument,
+        submitter: "jsonbored",
+        native,
+        providers,
+      }).errors.map((error) => error.message);
+
+    // missing requests + window, unknown field, negative burst, bad scope,
+    // non-string cost_notes.
+    const a = messagesFor({
+      burst: -1,
+      scope: "sometimes",
+      cost_notes: 9,
+      nope: 1,
+    });
+    assert.ok(a.includes("candidate rate_limit.requests is required"));
+    assert.ok(a.includes("candidate rate_limit.window is required"));
+    assert.ok(a.includes("candidate rate_limit.nope is not allowed"));
+    assert.ok(
+      a.includes("candidate rate_limit.burst must be a non-negative integer"),
+    );
+    assert.ok(a.includes("candidate rate_limit.scope is unsupported"));
+    assert.ok(a.includes("candidate rate_limit.cost_notes must be a string"));
+
+    // negative requests + non-string window.
+    const b = messagesFor({ requests: -5, window: 7 });
+    assert.ok(
+      b.includes(
+        "candidate rate_limit.requests must be a non-negative integer",
+      ),
+    );
+    assert.ok(b.includes("candidate rate_limit.window is required"));
+
+    // a well-formed structured limit passes the rate_limit checks.
+    const c = messagesFor({
+      requests: 100,
+      window: "60s",
+      burst: 10,
+      scope: "per-key",
+      cost_notes: "5 credits per call",
+    });
+    assert.ok(
+      !c.some((message) => message.startsWith("candidate rate_limit.")),
+    );
+  });
+
   test("flags malformed verification metadata inside a verification object", () => {
     const result = validateCandidateForSubmission({
       candidate: {

--- a/tests/script-utils.test.mjs
+++ b/tests/script-utils.test.mjs
@@ -898,6 +898,66 @@ describe("script utility contracts", () => {
     assert.equal(manualOverlays[0].surfaces.length, 1);
   });
 
+  test("promotes structured candidate rate limits into generated surfaces", async () => {
+    const nativeSnapshot = {
+      captured_at: "2026-06-08T00:00:00.000Z",
+      subnets: [{ netuid: 88, name: "Limiter", status: "active" }],
+    };
+    const rateLimit = {
+      requests: 120,
+      window: "1m",
+      burst: 20,
+      scope: "per-ip",
+      cost_notes: "Shared anonymous budget.",
+    };
+    const candidates = [
+      {
+        id: "sn-88-limiter-api",
+        netuid: 88,
+        name: "Limiter API",
+        kind: "subnet-api",
+        url: "https://limiter.example.com/api",
+        provider: "limiter",
+        source_type: "project-website-common-path",
+        source_tier: "provider-claimed",
+        source_url: "https://limiter.example.com/docs",
+        source_urls: ["https://limiter.example.com/docs"],
+        rate_limit: rateLimit,
+        rate_limit_notes: "See docs for tier details.",
+      },
+    ];
+    const verification = {
+      schema_version: 1,
+      results: [
+        {
+          candidate_id: "sn-88-limiter-api",
+          classification: "live",
+          content_type: "application/json",
+          quality_signals: {
+            content_type_matches_kind: true,
+            public_safe: true,
+            rate_limited: false,
+            redirected: false,
+            source_tier: "provider-claimed",
+            transient_failure: false,
+          },
+        },
+      ],
+    };
+
+    const overlaySet = await generateBaselineOverlaySet({
+      candidates,
+      existingGeneratedOverlays: [],
+      manualOverlays: [],
+      nativeSnapshot,
+      verification,
+    });
+
+    const [surface] = overlaySet.generatedOverlays[0].surfaces;
+    assert.deepEqual(surface.rate_limit, rateLimit);
+    assert.equal(surface.rate_limit_notes, "See docs for tier details.");
+  });
+
   test("does not promote HTML-only Swagger pages as OpenAPI surfaces", async () => {
     const nativeSnapshot = {
       captured_at: "2026-06-08T00:00:00.000Z",

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -62,9 +62,18 @@ describe("Metagraphed submission gate policy", () => {
   });
 
   test("accepts a one-file direct candidate for private review", () => {
+    const document = structuredClone(validCandidateDocument);
+    document.candidates[0].rate_limit = {
+      requests: 60,
+      window: "1m",
+      burst: 10,
+      scope: "per-key",
+      cost_notes: "Free tier limit.",
+    };
+
     const report = buildPrSubmissionReport({
       changedFiles: ["registry/candidates/community/allways-docs-example.json"],
-      candidateDocument: validCandidateDocument,
+      candidateDocument: document,
       native,
       providers,
       existingSubnets: subnets,
@@ -76,6 +85,10 @@ describe("Metagraphed submission gate policy", () => {
     assert.equal(report.private_review_required, true);
     assert.equal(report.blocking, false);
     assert.equal(report.candidate.id, "community-sn-7-docs-example");
+    assert.deepEqual(
+      report.candidate.rate_limit,
+      document.candidates[0].rate_limit,
+    );
   });
 
   test("blocks direct candidates with malformed schema metadata", () => {


### PR DESCRIPTION
### Motivation
- The candidate schema and docs introduced a structured `rate_limit` object but the deterministic direct-submission gate still rejected unknown fields, causing valid candidate PRs to be marked `schema-invalid`.
- Promoted/generated overlays previously only copied `rate_limit_notes` and dropped the structured `rate_limit`, causing accepted candidates to lose that metadata when surfaced.
- The change makes the submission policy accept the documented `rate_limit` shape and ensures promotion preserves it, while adding regression tests to prevent regressions.

### Description
- Added `"rate_limit"` to the `CANDIDATE_SCHEMA_FIELDS` allowlist in `scripts/submission-policy.mjs` so direct candidates may include the field.
- Implemented deterministic validation for `candidate.rate_limit` inside `validateCandidateSchemaShape` (required `requests` + `window`, allowed nested keys `requests|window|burst|scope|cost_notes`, and type/enum checks) in `scripts/submission-policy.mjs`.
- Preserved structured `rate_limit` when promoting candidates by copying `candidate.rate_limit` into the generated surface in `scripts/generated-overlays.mjs`.
- Added regression tests: updated `tests/submission-gate.test.mjs` to cover accepting a direct candidate with `rate_limit`, and added `tests/script-utils.test.mjs` coverage ensuring `rate_limit` is promoted into generated surfaces.

### Testing
- Ran the targeted unit tests with `npm test -- --run tests/submission-gate.test.mjs tests/script-utils.test.mjs`, and all tests passed (`2 files, 80 tests passed`).
- Ran formatting and style checks with `npx prettier --write` followed by `npm run format:check` and `npm run lint`, and they completed successfully with no issues.
- Changes were committed (branch head `c5fccb2`) including the code edits and test additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30f2f180bc832a8a6b5b19df41ef95)