### PR TITLE
feat(api): most-enriched registry leaderboard board (#753)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -470,7 +470,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards. */
+        /** Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards. */
         get: operations["registryLeaderboards"];
         put?: never;
         post?: never;
@@ -6918,7 +6918,7 @@ export interface operations {
     registryLeaderboards: {
         parameters: {
             query?: {
-                board?: "healthiest" | "fastest-rpc" | "most-complete" | "fastest-growing";
+                board?: "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing";
                 limit?: number;
             };
             header?: never;

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -14733,6 +14733,7 @@
                 "healthiest",
                 "fastest-rpc",
                 "most-complete",
+                "most-enriched",
                 "fastest-growing"
               ],
               "type": "string"
@@ -14860,7 +14861,7 @@
             "description": "Unexpected backend error."
           }
         },
-        "summary": "Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards.",
+        "summary": "Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards.",
         "tags": [
           "registry",
           "analytics"

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -470,7 +470,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /** Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards. */
+        /** Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards. */
         get: operations["registryLeaderboards"];
         put?: never;
         post?: never;
@@ -6918,7 +6918,7 @@ export interface operations {
     registryLeaderboards: {
         parameters: {
             query?: {
-                board?: "healthiest" | "fastest-rpc" | "most-complete" | "fastest-growing";
+                board?: "healthiest" | "fastest-rpc" | "most-complete" | "most-enriched" | "fastest-growing";
                 limit?: number;
             };
             header?: never;

--- a/src/contracts.mjs
+++ b/src/contracts.mjs
@@ -819,7 +819,7 @@ export const PUBLIC_ARTIFACTS = [
   artifact(
     "registry-leaderboards",
     "/metagraph/registry/leaderboards.json",
-    "Registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing), computed live from D1 + registry projections at /api/v1/registry/leaderboards (no static file).",
+    "Registry leaderboards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing), computed live from D1 + registry projections at /api/v1/registry/leaderboards (no static file).",
     "RegistryLeaderboardsArtifact",
   ),
   artifact(
@@ -1373,7 +1373,7 @@ export const API_ROUTES = [
     "GET",
     "/api/v1/registry/leaderboards",
     "/metagraph/registry/leaderboards.json",
-    "Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards.",
+    "Fetch registry leaderboards (healthiest, fastest-rpc, most-complete, most-enriched, fastest-growing) computed live from D1 + registry projections. Omit `board` for all boards.",
     "standard",
     ["registry", "analytics"],
     [
@@ -1385,6 +1385,7 @@ export const API_ROUTES = [
             "healthiest",
             "fastest-rpc",
             "most-complete",
+            "most-enriched",
             "fastest-growing",
           ],
         },

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -557,14 +557,15 @@ export const LEADERBOARD_BOARDS = [
   "healthiest",
   "fastest-rpc",
   "most-complete",
+  "most-enriched",
   "fastest-growing",
 ];
 
 // Assemble registry leaderboards from already-query-shaped inputs:
 // healthRows [{netuid, total, ok_count, avg_latency_ms}], rpcRows
 // [{netuid, min_latency_ms}], mostComplete [{netuid, slug, name,
-// completeness_score}], growthRows [{netuid, delta}]. `subnetMeta` is a
-// Map(netuid -> {slug, name}).
+// completeness_score, surface_count, operational_interface_count}], growthRows
+// [{netuid, delta}]. `subnetMeta` is a Map(netuid -> {slug, name}).
 export function formatLeaderboards({
   board,
   limit,
@@ -619,6 +620,26 @@ export function formatLeaderboards({
     .sort((a, b) => (b.completeness_score ?? -1) - (a.completeness_score ?? -1))
     .slice(0, cap);
 
+  // Enrichment depth: how much curation/discovery has fleshed out a subnet's
+  // surface area (the flywheel output), ranked by total surfaces then callable
+  // (operational) interface depth. Distinct from completeness (which weights
+  // identity + required kinds) and readiness (which weights live callability).
+  const enrichedBoard = (mostComplete || [])
+    .map((row) => ({
+      netuid: row.netuid,
+      slug: row.slug ?? null,
+      name: row.name ?? null,
+      surface_count: Number(row.surface_count) || 0,
+      operational_interface_count: Number(row.operational_interface_count) || 0,
+    }))
+    .filter((entry) => entry.surface_count > 0)
+    .sort(
+      (a, b) =>
+        b.surface_count - a.surface_count ||
+        b.operational_interface_count - a.operational_interface_count,
+    )
+    .slice(0, cap);
+
   const fastestGrowing = (growthRows || [])
     .map((row) => ({
       netuid: row.netuid,
@@ -636,6 +657,7 @@ export function formatLeaderboards({
     healthiest,
     "fastest-rpc": fastestRpc,
     "most-complete": completeBoard,
+    "most-enriched": enrichedBoard,
     "fastest-growing": fastestGrowing,
   };
   const boards = board ? { [board]: allBoards[board] || [] } : allBoards;

--- a/tests/analytics.test.mjs
+++ b/tests/analytics.test.mjs
@@ -145,8 +145,22 @@ describe("formatLeaderboards", () => {
       { netuid: 2, min_latency_ms: 120 },
     ],
     mostComplete: [
-      { netuid: 1, slug: "one", name: "One", completeness_score: 80 },
-      { netuid: 2, slug: "two", name: "Two", completeness_score: 95 },
+      {
+        netuid: 1,
+        slug: "one",
+        name: "One",
+        completeness_score: 80,
+        surface_count: 12,
+        operational_interface_count: 4,
+      },
+      {
+        netuid: 2,
+        slug: "two",
+        name: "Two",
+        completeness_score: 95,
+        surface_count: 6,
+        operational_interface_count: 1,
+      },
     ],
     growthRows: [
       { netuid: 1, delta: 5 },
@@ -165,8 +179,22 @@ describe("formatLeaderboards", () => {
     assert.equal(out.boards.healthiest[0].name, "One");
     assert.equal(out.boards["fastest-rpc"][0].netuid, 2); // lowest latency
     assert.equal(out.boards["most-complete"][0].netuid, 2); // 95
+    assert.equal(out.boards["most-enriched"][0].netuid, 1); // 12 surfaces > 6
+    assert.equal(out.boards["most-enriched"][0].surface_count, 12);
     assert.equal(out.boards["fastest-growing"][0].netuid, 1); // +5 only positive
     assert.equal(out.boards["fastest-growing"].length, 1);
+  });
+  test("most-enriched excludes zero-surface subnets", () => {
+    const out = formatLeaderboards({
+      ...inputs,
+      mostComplete: [
+        { netuid: 1, slug: "one", name: "One", surface_count: 3 },
+        { netuid: 9, slug: "nine", name: "Nine", surface_count: 0 },
+      ],
+      board: "most-enriched",
+    });
+    assert.equal(out.boards["most-enriched"].length, 1);
+    assert.equal(out.boards["most-enriched"][0].netuid, 1);
   });
   test("filters to a single board and respects limit cap", () => {
     const out = formatLeaderboards({

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -1555,6 +1555,9 @@ async function leaderboardProfilesProjection(env, now = Date.now()) {
       slug: profile.slug ?? null,
       name: profile.name ?? null,
       completeness_score: profile.completeness_score ?? null,
+      // Enrichment-depth signals for the most-enriched board (#753).
+      surface_count: profile.surface_count ?? 0,
+      operational_interface_count: profile.operational_interface_count ?? 0,
     });
   }
   const projection = { subnetMeta, mostComplete, builtAt: now };


### PR DESCRIPTION
Advances #753. The backend leaderboard API (`/api/v1/registry/leaderboards`) already serves **healthiest** (reliability/uptime), **fastest-rpc** (latency), **most-complete** (completeness), and **fastest-growing** (trajectory). This adds the missing **most-enriched** board from #753's wishlist.

## most-enriched
Ranks subnets by curation/discovery **depth** — `surface_count` (total curated/discovered surfaces — the contributor-flywheel output), tie-broken by `operational_interface_count` (callable interfaces). It's deliberately distinct from:
- **most-complete** — weights identity + required surface kinds, and
- **healthiest** — weights live uptime/latency.

So it answers "which subnets has the flywheel fleshed out the most?", a different lens than "most callable" or "most reliable".

## Implementation (no new artifact/query)
- Reuses `leaderboardProfilesProjection` (reads the served `profiles.json`); adds `surface_count` + `operational_interface_count` to the projected rows.
- `formatLeaderboards` builds the new board (filters zero-surface subnets, sorts depth-desc).
- Extends `LEADERBOARD_BOARDS`, the route `board` enum, and the two route/artifact descriptions; regenerated `openapi.json` + `types.d.ts` + the generated client surface. The `RegistryLeaderboardsArtifact` schema needs no change (boards use `additionalProperties`).

## Verification
- `validate:api` / `validate:openapi` / `validate:contract-drift` / `validate:generated-client` all green (58 routes).
- `test:coverage`: 1081 passed; gate holds (98.06% / 90.5%). New `formatLeaderboards` tests cover ranking + zero-surface exclusion.
- `api-index.json` is a build-only drifting seed (regenerated on the next publish), consistent with prior contract PRs.

Frontend leaderboard views are a linked **metagraphed-ui** follow-up (separate repo); this lands the backend board so the UI has data to render.