### PR TITLE
feat(client): retries, ETag caching, convenience methods + fetchAll on the TS SDK

### DIFF
--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -281,3 +281,432 @@ function interpolatePath(
     return encodeURIComponent(String(value));
   });
 }
+
+// ---------------------------------------------------------------------------
+// DX layer (issue #750): an opt-in client wrapper over the typed surface above
+// adding retries/backoff, ETag conditional caching, convenience methods, and a
+// fetchAll auto-pagination helper. The typed core (metagraphedFetch etc.) is
+// unchanged and stays the zero-config entrypoint. Everything here is additive
+// and tree-shakeable: import createMetagraphedClient only if you want it.
+// ---------------------------------------------------------------------------
+
+/** Opt-in retry/backoff configuration. Retries are OFF unless enabled. */
+export interface RetryOptions {
+  /** Max retry attempts after the first try (default 2). 0 disables retries. */
+  retries?: number;
+  /** Base backoff in ms before exponential growth + jitter (default 200). */
+  minDelayMs?: number;
+  /** Backoff ceiling in ms (default 10000). */
+  maxDelayMs?: number;
+  /** Retryable HTTP statuses (default 429, 500, 502, 503, 504). */
+  statuses?: number[];
+}
+
+/** Pluggable ETag store. Defaults to a bounded in-memory LRU when caching is on. */
+export interface EtagCache {
+  get(key: string): { etag: string; body: unknown } | undefined;
+  set(key: string, entry: { etag: string; body: unknown }): void;
+}
+
+const DEFAULT_CACHE_MAX_ENTRIES = 256;
+
+/**
+ * A bounded in-memory LRU ETag store — the default when caching is enabled. Evicts
+ * the least-recently-used entry once it exceeds maxEntries, so a long-lived client
+ * over high-cardinality URLs (per-subnet detail, paginated cursor pages) can't grow
+ * the cache without bound. Pass a custom { get, set } store for different eviction
+ * or persistence, or call createLruEtagCache(n) directly to size it.
+ */
+export function createLruEtagCache(
+  maxEntries: number = DEFAULT_CACHE_MAX_ENTRIES,
+): EtagCache {
+  const entries = new Map<string, { etag: string; body: unknown }>();
+  return {
+    get(key) {
+      const entry = entries.get(key);
+      if (entry !== undefined) {
+        entries.delete(key);
+        entries.set(key, entry);
+      }
+      return entry;
+    },
+    set(key, entry) {
+      entries.delete(key);
+      entries.set(key, entry);
+      while (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value;
+        if (oldest === undefined) {
+          break;
+        }
+        entries.delete(oldest);
+      }
+    },
+  };
+}
+
+export interface MetagraphedClientOptions {
+  /** API origin (default https://api.metagraph.sh). */
+  baseUrl?: string;
+  /** Per-request timeout in ms (default 30000; 0 disables). */
+  timeoutMs?: number;
+  /** Extra headers merged into every request. */
+  headers?: Record<string, string>;
+  /** Fetch implementation (default globalThis.fetch); useful for tests. */
+  fetch?: typeof fetch;
+  /** Opt-in retries: true (defaults), a retry count, or full RetryOptions. */
+  retry?: RetryOptions | number | boolean;
+  /** Opt-in ETag conditional caching: true (a bounded in-memory LRU) or a custom { get, set } store. */
+  cache?: boolean | EtagCache;
+}
+
+const RETRYABLE_STATUSES = [429, 500, 502, 503, 504];
+
+function resolveRetry(
+  retry: RetryOptions | number | boolean | undefined,
+): Required<RetryOptions> | null {
+  if (!retry) {
+    return null;
+  }
+  const opts: RetryOptions =
+    typeof retry === "number"
+      ? { retries: retry }
+      : retry === true
+        ? {}
+        : retry;
+  const retries = opts.retries ?? 2;
+  if (retries <= 0) {
+    return null;
+  }
+  return {
+    retries,
+    minDelayMs: opts.minDelayMs ?? 200,
+    maxDelayMs: opts.maxDelayMs ?? 10000,
+    statuses: opts.statuses ?? RETRYABLE_STATUSES,
+  };
+}
+
+/**
+ * Backoff before the next attempt: honor a Retry-After header (delta-seconds or
+ * an HTTP date) when present, otherwise exponential backoff with equal jitter
+ * (50-100% of the computed backoff), both capped at maxDelayMs.
+ */
+function retryDelayMs(
+  response: Response | undefined,
+  attempt: number,
+  retry: Required<RetryOptions>,
+): number {
+  const header = response ? response.headers.get("retry-after") : null;
+  if (header) {
+    const seconds = Number(header);
+    if (Number.isFinite(seconds)) {
+      return Math.min(Math.max(0, seconds) * 1000, retry.maxDelayMs);
+    }
+    const dateMs = Date.parse(header);
+    if (Number.isFinite(dateMs)) {
+      return Math.min(Math.max(0, dateMs - Date.now()), retry.maxDelayMs);
+    }
+  }
+  const expo = Math.min(retry.minDelayMs * 2 ** attempt, retry.maxDelayMs);
+  return Math.round(expo * (0.5 + Math.random() / 2));
+}
+
+function sleep(
+  ms: number,
+  signal: AbortSignal | null | undefined,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ms <= 0) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new MetagraphedError("Request aborted during retry backoff", 0));
+    };
+    const timer = setTimeout(() => {
+      if (signal) {
+        signal.removeEventListener("abort", onAbort);
+      }
+      resolve();
+    }, ms);
+    if (signal) {
+      if (signal.aborted) {
+        clearTimeout(timer);
+        reject(new MetagraphedError("Request aborted during retry backoff", 0));
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+function buildRequestUrl(
+  path: string,
+  baseUrl: string,
+  pathParams: Record<string, string | number> | undefined,
+  query: Record<string, unknown> | undefined,
+): URL {
+  const url = new URL(interpolatePath(path, pathParams), baseUrl);
+  for (const [key, value] of Object.entries(query || {})) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url;
+}
+
+/**
+ * A typed client with opt-in retries + ETag caching, ergonomic convenience
+ * methods for the v1 collections, and fetchAll auto-pagination. Build one with
+ * createMetagraphedClient.
+ */
+export interface MetagraphedClient {
+  request<Path extends ApiPath>(
+    path: Path,
+    options?: MetagraphedFetchOptions<Path>,
+  ): Promise<JsonResponse<Path>>;
+  paginate<Path extends ApiPath>(
+    path: Path,
+    options?: MetagraphedFetchOptions<Path>,
+  ): AsyncGenerator<JsonResponse<Path>, void, unknown>;
+  fetchAll<Item = unknown, Path extends ApiPath = ApiPath>(
+    path: Path,
+    options?: MetagraphedFetchOptions<Path>,
+  ): Promise<Item[]>;
+  rpc<Result = unknown>(
+    network: string,
+    request: JsonRpcRequest,
+    options?: MetagraphedRpcOptions,
+  ): Promise<Result>;
+  subnets(
+    query?: QueryParams<"/api/v1/subnets">,
+    options?: MetagraphedFetchOptions<"/api/v1/subnets">,
+  ): Promise<JsonResponse<"/api/v1/subnets">>;
+  getSubnet(
+    netuid: number,
+    options?: MetagraphedFetchOptions<"/api/v1/subnets/{netuid}">,
+  ): Promise<JsonResponse<"/api/v1/subnets/{netuid}">>;
+  providers(
+    query?: QueryParams<"/api/v1/providers">,
+    options?: MetagraphedFetchOptions<"/api/v1/providers">,
+  ): Promise<JsonResponse<"/api/v1/providers">>;
+  getProvider(
+    slug: string,
+    options?: MetagraphedFetchOptions<"/api/v1/providers/{slug}">,
+  ): Promise<JsonResponse<"/api/v1/providers/{slug}">>;
+  surfaces(
+    query?: QueryParams<"/api/v1/surfaces">,
+    options?: MetagraphedFetchOptions<"/api/v1/surfaces">,
+  ): Promise<JsonResponse<"/api/v1/surfaces">>;
+  endpoints(
+    query?: QueryParams<"/api/v1/endpoints">,
+    options?: MetagraphedFetchOptions<"/api/v1/endpoints">,
+  ): Promise<JsonResponse<"/api/v1/endpoints">>;
+  candidates(
+    query?: QueryParams<"/api/v1/candidates">,
+    options?: MetagraphedFetchOptions<"/api/v1/candidates">,
+  ): Promise<JsonResponse<"/api/v1/candidates">>;
+  profiles(
+    query?: QueryParams<"/api/v1/profiles">,
+    options?: MetagraphedFetchOptions<"/api/v1/profiles">,
+  ): Promise<JsonResponse<"/api/v1/profiles">>;
+  health(
+    options?: MetagraphedFetchOptions<"/api/v1/health">,
+  ): Promise<JsonResponse<"/api/v1/health">>;
+}
+
+/**
+ * Build a configured client. All enhancements are opt-in: with no options it
+ * behaves like metagraphedFetch (no retries, no caching). Enable retries with
+ * { retry: true } and ETag caching with { cache: true }.
+ */
+export function createMetagraphedClient(
+  clientOptions: MetagraphedClientOptions = {},
+): MetagraphedClient {
+  const baseUrl = clientOptions.baseUrl ?? "https://api.metagraph.sh";
+  const fetchImpl = clientOptions.fetch ?? globalThis.fetch;
+  const retry = resolveRetry(clientOptions.retry);
+  const store: EtagCache | null = clientOptions.cache
+    ? clientOptions.cache === true
+      ? createLruEtagCache()
+      : clientOptions.cache
+    : null;
+
+  async function request<Path extends ApiPath>(
+    path: Path,
+    options: MetagraphedFetchOptions<Path> = {},
+  ): Promise<JsonResponse<Path>> {
+    const {
+      baseUrl: requestBaseUrl,
+      pathParams,
+      query,
+      timeoutMs = clientOptions.timeoutMs ?? 30000,
+      signal,
+      headers,
+      ...init
+    } = options;
+    const url = buildRequestUrl(
+      String(path),
+      requestBaseUrl ?? baseUrl,
+      pathParams as Record<string, string | number> | undefined,
+      query as Record<string, unknown> | undefined,
+    );
+    // Cache key is the absolute URL. Safe today because every request sends the
+    // same Accept (application/json); if custom headers ever vary the response
+    // representation a header-aware key would be needed to avoid a stale hit.
+    const key = url.toString();
+    let attempt = 0;
+    let skipConditional = false;
+    for (;;) {
+      const requestHeaders: Record<string, string> = {
+        accept: "application/json",
+        ...clientOptions.headers,
+        ...(headers as Record<string, string> | undefined),
+      };
+      const cached = !skipConditional && store ? store.get(key) : undefined;
+      if (cached) {
+        requestHeaders["if-none-match"] = cached.etag;
+      }
+      let response: Response;
+      try {
+        response = await fetchImpl(url, {
+          ...init,
+          method: "GET",
+          headers: requestHeaders,
+          signal: resolveSignal(signal, timeoutMs),
+        });
+      } catch (error) {
+        // A caller-initiated abort is intentional — never retry it. Transient
+        // transport failures (DNS, connection reset, or the per-attempt timeout
+        // firing) are retried within the retry budget, then rethrown.
+        if (signal && signal.aborted) {
+          throw error;
+        }
+        if (retry && attempt < retry.retries) {
+          await sleep(retryDelayMs(undefined, attempt, retry), signal);
+          attempt += 1;
+          continue;
+        }
+        throw error;
+      }
+      if (response.status === 304) {
+        if (cached) {
+          return cached.body as JsonResponse<Path>;
+        }
+        // Not Modified, but the store no longer has the entry (a shared/evicting
+        // store can drop it between send and receipt). Re-issue once without the
+        // conditional header to get a full body instead of throwing on the 304.
+        skipConditional = true;
+        continue;
+      }
+      if (
+        retry &&
+        retry.statuses.includes(response.status) &&
+        attempt < retry.retries
+      ) {
+        await sleep(retryDelayMs(response, attempt, retry), signal);
+        attempt += 1;
+        continue;
+      }
+      const body = await readJsonBody(response);
+      if (!response.ok) {
+        const envelope = isErrorEnvelope(body) ? body : undefined;
+        throw new MetagraphedError(
+          envelope?.error?.message ??
+            "GET " + url.pathname + " failed with status " + response.status,
+          response.status,
+          envelope?.error?.code,
+          envelope,
+        );
+      }
+      if (store) {
+        const etag = response.headers.get("etag");
+        if (etag) {
+          store.set(key, { etag, body });
+        }
+      }
+      return body as JsonResponse<Path>;
+    }
+  }
+
+  async function* paginate<Path extends ApiPath>(
+    path: Path,
+    options: MetagraphedFetchOptions<Path> = {},
+  ): AsyncGenerator<JsonResponse<Path>, void, unknown> {
+    const baseQuery: Record<string, unknown> = {
+      ...(options.query as Record<string, unknown> | undefined),
+    };
+    let cursor: unknown = baseQuery.cursor;
+    for (;;) {
+      if (cursor !== undefined && cursor !== null) {
+        baseQuery.cursor = cursor;
+      }
+      const page = await request(path, {
+        ...options,
+        query: baseQuery as unknown as QueryParams<Path>,
+      });
+      yield page;
+      const next = (
+        page as { meta?: { pagination?: { next_cursor?: unknown } } }
+      )?.meta?.pagination?.next_cursor;
+      if (next === undefined || next === null) {
+        return;
+      }
+      cursor = next;
+    }
+  }
+
+  async function fetchAll<Item = unknown, Path extends ApiPath = ApiPath>(
+    path: Path,
+    options: MetagraphedFetchOptions<Path> = {},
+  ): Promise<Item[]> {
+    const items: Item[] = [];
+    for await (const page of paginate(path, options)) {
+      const data = (page as { data?: unknown }).data;
+      if (Array.isArray(data)) {
+        items.push(...(data as Item[]));
+      } else if (data !== undefined && data !== null) {
+        items.push(data as Item);
+      }
+    }
+    return items;
+  }
+
+  function rpc<Result = unknown>(
+    network: string,
+    rpcRequest: JsonRpcRequest,
+    options: MetagraphedRpcOptions = {},
+  ): Promise<Result> {
+    return metagraphedRpc<Result>(network, rpcRequest, { baseUrl, ...options });
+  }
+
+  return {
+    request,
+    paginate,
+    fetchAll,
+    rpc,
+    subnets: (query, options) =>
+      request("/api/v1/subnets", { ...options, query }),
+    getSubnet: (netuid, options) =>
+      request("/api/v1/subnets/{netuid}", {
+        ...options,
+        pathParams: { netuid } as PathParams<"/api/v1/subnets/{netuid}">,
+      }),
+    providers: (query, options) =>
+      request("/api/v1/providers", { ...options, query }),
+    getProvider: (slug, options) =>
+      request("/api/v1/providers/{slug}", {
+        ...options,
+        pathParams: { slug } as PathParams<"/api/v1/providers/{slug}">,
+      }),
+    surfaces: (query, options) =>
+      request("/api/v1/surfaces", { ...options, query }),
+    endpoints: (query, options) =>
+      request("/api/v1/endpoints", { ...options, query }),
+    candidates: (query, options) =>
+      request("/api/v1/candidates", { ...options, query }),
+    profiles: (query, options) =>
+      request("/api/v1/profiles", { ...options, query }),
+    health: (options) => request("/api/v1/health", { ...options }),
+  };
+}

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -85,6 +85,38 @@ import { metagraphedRpc } from "@jsonbored/metagraphed";
 const healthInfo = await metagraphedRpc("finney", { method: "system_health" });
 ```
 
+### Configured client: retries, ETag caching, convenience methods
+
+`createMetagraphedClient` wraps the typed surface with opt-in retries/backoff,
+opt-in ETag conditional caching, ergonomic per-collection methods, and a
+`fetchAll` auto-pagination helper. Everything is opt-in and tree-shakeable — with
+no options it behaves exactly like `metagraphedFetch`.
+
+```ts
+import { createMetagraphedClient } from "@jsonbored/metagraphed";
+
+const client = createMetagraphedClient({
+  // Opt-in retries on 429/5xx + transport errors (network / timeout) — exponential
+  // backoff + jitter, honors Retry-After. Caller-initiated aborts are never retried.
+  retry: { retries: 3 }, // or `retry: true` for defaults
+  // Opt-in ETag conditional caching: revalidates with If-None-Match, serves the
+  // cached body on a 304. `true` uses a bounded in-memory LRU (size it with
+  // `createLruEtagCache(n)`); or pass your own `{ get, set }` store.
+  cache: true,
+});
+
+// Typed convenience methods for the v1 collections + single resources.
+const subnets = await client.subnets({ limit: 10 });
+const subnet7 = await client.getSubnet(7);
+const provider = await client.getProvider("allways");
+
+// fetchAll walks every page and returns the flattened rows.
+const all = await client.fetchAll("/api/v1/subnets", { query: { limit: 100 } });
+
+// request() / paginate() / rpc() share the same retry + cache config.
+const health = await client.request("/api/v1/health");
+```
+
 Every REST response is the standard envelope `{ ok, schema_version, data, meta }`
 (`meta.pagination` on list routes, `meta.published_at` for freshness). See the
 [API stability guide](https://github.com/JSONbored/metagraphed/blob/main/docs/api-stability.md)

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -301,5 +301,434 @@ function interpolatePath(
     return encodeURIComponent(String(value));
   });
 }
+
+// ---------------------------------------------------------------------------
+// DX layer (issue #750): an opt-in client wrapper over the typed surface above
+// adding retries/backoff, ETag conditional caching, convenience methods, and a
+// fetchAll auto-pagination helper. The typed core (metagraphedFetch etc.) is
+// unchanged and stays the zero-config entrypoint. Everything here is additive
+// and tree-shakeable: import createMetagraphedClient only if you want it.
+// ---------------------------------------------------------------------------
+
+/** Opt-in retry/backoff configuration. Retries are OFF unless enabled. */
+export interface RetryOptions {
+  /** Max retry attempts after the first try (default 2). 0 disables retries. */
+  retries?: number;
+  /** Base backoff in ms before exponential growth + jitter (default 200). */
+  minDelayMs?: number;
+  /** Backoff ceiling in ms (default 10000). */
+  maxDelayMs?: number;
+  /** Retryable HTTP statuses (default 429, 500, 502, 503, 504). */
+  statuses?: number[];
+}
+
+/** Pluggable ETag store. Defaults to a bounded in-memory LRU when caching is on. */
+export interface EtagCache {
+  get(key: string): { etag: string; body: unknown } | undefined;
+  set(key: string, entry: { etag: string; body: unknown }): void;
+}
+
+const DEFAULT_CACHE_MAX_ENTRIES = 256;
+
+/**
+ * A bounded in-memory LRU ETag store — the default when caching is enabled. Evicts
+ * the least-recently-used entry once it exceeds maxEntries, so a long-lived client
+ * over high-cardinality URLs (per-subnet detail, paginated cursor pages) can't grow
+ * the cache without bound. Pass a custom { get, set } store for different eviction
+ * or persistence, or call createLruEtagCache(n) directly to size it.
+ */
+export function createLruEtagCache(
+  maxEntries: number = DEFAULT_CACHE_MAX_ENTRIES,
+): EtagCache {
+  const entries = new Map<string, { etag: string; body: unknown }>();
+  return {
+    get(key) {
+      const entry = entries.get(key);
+      if (entry !== undefined) {
+        entries.delete(key);
+        entries.set(key, entry);
+      }
+      return entry;
+    },
+    set(key, entry) {
+      entries.delete(key);
+      entries.set(key, entry);
+      while (entries.size > maxEntries) {
+        const oldest = entries.keys().next().value;
+        if (oldest === undefined) {
+          break;
+        }
+        entries.delete(oldest);
+      }
+    },
+  };
+}
+
+export interface MetagraphedClientOptions {
+  /** API origin (default https://api.metagraph.sh). */
+  baseUrl?: string;
+  /** Per-request timeout in ms (default 30000; 0 disables). */
+  timeoutMs?: number;
+  /** Extra headers merged into every request. */
+  headers?: Record<string, string>;
+  /** Fetch implementation (default globalThis.fetch); useful for tests. */
+  fetch?: typeof fetch;
+  /** Opt-in retries: true (defaults), a retry count, or full RetryOptions. */
+  retry?: RetryOptions | number | boolean;
+  /** Opt-in ETag conditional caching: true (a bounded in-memory LRU) or a custom { get, set } store. */
+  cache?: boolean | EtagCache;
+}
+
+const RETRYABLE_STATUSES = [429, 500, 502, 503, 504];
+
+function resolveRetry(
+  retry: RetryOptions | number | boolean | undefined,
+): Required<RetryOptions> | null {
+  if (!retry) {
+    return null;
+  }
+  const opts: RetryOptions =
+    typeof retry === "number"
+      ? { retries: retry }
+      : retry === true
+        ? {}
+        : retry;
+  const retries = opts.retries ?? 2;
+  if (retries <= 0) {
+    return null;
+  }
+  return {
+    retries,
+    minDelayMs: opts.minDelayMs ?? 200,
+    maxDelayMs: opts.maxDelayMs ?? 10000,
+    statuses: opts.statuses ?? RETRYABLE_STATUSES,
+  };
+}
+
+/**
+ * Backoff before the next attempt: honor a Retry-After header (delta-seconds or
+ * an HTTP date) when present, otherwise exponential backoff with equal jitter
+ * (50-100% of the computed backoff), both capped at maxDelayMs.
+ */
+function retryDelayMs(
+  response: Response | undefined,
+  attempt: number,
+  retry: Required<RetryOptions>,
+): number {
+  const header = response ? response.headers.get("retry-after") : null;
+  if (header) {
+    const seconds = Number(header);
+    if (Number.isFinite(seconds)) {
+      return Math.min(Math.max(0, seconds) * 1000, retry.maxDelayMs);
+    }
+    const dateMs = Date.parse(header);
+    if (Number.isFinite(dateMs)) {
+      return Math.min(Math.max(0, dateMs - Date.now()), retry.maxDelayMs);
+    }
+  }
+  const expo = Math.min(retry.minDelayMs * 2 ** attempt, retry.maxDelayMs);
+  return Math.round(expo * (0.5 + Math.random() / 2));
+}
+
+function sleep(
+  ms: number,
+  signal: AbortSignal | null | undefined,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (ms <= 0) {
+      resolve();
+      return;
+    }
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new MetagraphedError("Request aborted during retry backoff", 0));
+    };
+    const timer = setTimeout(() => {
+      if (signal) {
+        signal.removeEventListener("abort", onAbort);
+      }
+      resolve();
+    }, ms);
+    if (signal) {
+      if (signal.aborted) {
+        clearTimeout(timer);
+        reject(new MetagraphedError("Request aborted during retry backoff", 0));
+        return;
+      }
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+}
+
+function buildRequestUrl(
+  path: string,
+  baseUrl: string,
+  pathParams: Record<string, string | number> | undefined,
+  query: Record<string, unknown> | undefined,
+): URL {
+  const url = new URL(interpolatePath(path, pathParams), baseUrl);
+  for (const [key, value] of Object.entries(query || {})) {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  }
+  return url;
+}
+
+/**
+ * A typed client with opt-in retries + ETag caching, ergonomic convenience
+ * methods for the v1 collections, and fetchAll auto-pagination. Build one with
+ * createMetagraphedClient.
+ */
+export interface MetagraphedClient {
+  request<Path extends ApiPath>(
+    path: Path,
+    options?: MetagraphedFetchOptions<Path>,
+  ): Promise<JsonResponse<Path>>;
+  paginate<Path extends ApiPath>(
+    path: Path,
+    options?: MetagraphedFetchOptions<Path>,
+  ): AsyncGenerator<JsonResponse<Path>, void, unknown>;
+  fetchAll<Item = unknown, Path extends ApiPath = ApiPath>(
+    path: Path,
+    options?: MetagraphedFetchOptions<Path>,
+  ): Promise<Item[]>;
+  rpc<Result = unknown>(
+    network: string,
+    request: JsonRpcRequest,
+    options?: MetagraphedRpcOptions,
+  ): Promise<Result>;
+  subnets(
+    query?: QueryParams<"/api/v1/subnets">,
+    options?: MetagraphedFetchOptions<"/api/v1/subnets">,
+  ): Promise<JsonResponse<"/api/v1/subnets">>;
+  getSubnet(
+    netuid: number,
+    options?: MetagraphedFetchOptions<"/api/v1/subnets/{netuid}">,
+  ): Promise<JsonResponse<"/api/v1/subnets/{netuid}">>;
+  providers(
+    query?: QueryParams<"/api/v1/providers">,
+    options?: MetagraphedFetchOptions<"/api/v1/providers">,
+  ): Promise<JsonResponse<"/api/v1/providers">>;
+  getProvider(
+    slug: string,
+    options?: MetagraphedFetchOptions<"/api/v1/providers/{slug}">,
+  ): Promise<JsonResponse<"/api/v1/providers/{slug}">>;
+  surfaces(
+    query?: QueryParams<"/api/v1/surfaces">,
+    options?: MetagraphedFetchOptions<"/api/v1/surfaces">,
+  ): Promise<JsonResponse<"/api/v1/surfaces">>;
+  endpoints(
+    query?: QueryParams<"/api/v1/endpoints">,
+    options?: MetagraphedFetchOptions<"/api/v1/endpoints">,
+  ): Promise<JsonResponse<"/api/v1/endpoints">>;
+  candidates(
+    query?: QueryParams<"/api/v1/candidates">,
+    options?: MetagraphedFetchOptions<"/api/v1/candidates">,
+  ): Promise<JsonResponse<"/api/v1/candidates">>;
+  profiles(
+    query?: QueryParams<"/api/v1/profiles">,
+    options?: MetagraphedFetchOptions<"/api/v1/profiles">,
+  ): Promise<JsonResponse<"/api/v1/profiles">>;
+  health(
+    options?: MetagraphedFetchOptions<"/api/v1/health">,
+  ): Promise<JsonResponse<"/api/v1/health">>;
+}
+
+/**
+ * Build a configured client. All enhancements are opt-in: with no options it
+ * behaves like metagraphedFetch (no retries, no caching). Enable retries with
+ * { retry: true } and ETag caching with { cache: true }.
+ */
+export function createMetagraphedClient(
+  clientOptions: MetagraphedClientOptions = {},
+): MetagraphedClient {
+  const baseUrl = clientOptions.baseUrl ?? "https://api.metagraph.sh";
+  const fetchImpl = clientOptions.fetch ?? globalThis.fetch;
+  const retry = resolveRetry(clientOptions.retry);
+  const store: EtagCache | null = clientOptions.cache
+    ? clientOptions.cache === true
+      ? createLruEtagCache()
+      : clientOptions.cache
+    : null;
+
+  async function request<Path extends ApiPath>(
+    path: Path,
+    options: MetagraphedFetchOptions<Path> = {},
+  ): Promise<JsonResponse<Path>> {
+    const {
+      baseUrl: requestBaseUrl,
+      pathParams,
+      query,
+      timeoutMs = clientOptions.timeoutMs ?? 30000,
+      signal,
+      headers,
+      ...init
+    } = options;
+    const url = buildRequestUrl(
+      String(path),
+      requestBaseUrl ?? baseUrl,
+      pathParams as Record<string, string | number> | undefined,
+      query as Record<string, unknown> | undefined,
+    );
+    // Cache key is the absolute URL. Safe today because every request sends the
+    // same Accept (application/json); if custom headers ever vary the response
+    // representation a header-aware key would be needed to avoid a stale hit.
+    const key = url.toString();
+    let attempt = 0;
+    let skipConditional = false;
+    for (;;) {
+      const requestHeaders: Record<string, string> = {
+        accept: "application/json",
+        ...clientOptions.headers,
+        ...(headers as Record<string, string> | undefined),
+      };
+      const cached = !skipConditional && store ? store.get(key) : undefined;
+      if (cached) {
+        requestHeaders["if-none-match"] = cached.etag;
+      }
+      let response: Response;
+      try {
+        response = await fetchImpl(url, {
+          ...init,
+          method: "GET",
+          headers: requestHeaders,
+          signal: resolveSignal(signal, timeoutMs),
+        });
+      } catch (error) {
+        // A caller-initiated abort is intentional — never retry it. Transient
+        // transport failures (DNS, connection reset, or the per-attempt timeout
+        // firing) are retried within the retry budget, then rethrown.
+        if (signal && signal.aborted) {
+          throw error;
+        }
+        if (retry && attempt < retry.retries) {
+          await sleep(retryDelayMs(undefined, attempt, retry), signal);
+          attempt += 1;
+          continue;
+        }
+        throw error;
+      }
+      if (response.status === 304) {
+        if (cached) {
+          return cached.body as JsonResponse<Path>;
+        }
+        // Not Modified, but the store no longer has the entry (a shared/evicting
+        // store can drop it between send and receipt). Re-issue once without the
+        // conditional header to get a full body instead of throwing on the 304.
+        skipConditional = true;
+        continue;
+      }
+      if (
+        retry &&
+        retry.statuses.includes(response.status) &&
+        attempt < retry.retries
+      ) {
+        await sleep(retryDelayMs(response, attempt, retry), signal);
+        attempt += 1;
+        continue;
+      }
+      const body = await readJsonBody(response);
+      if (!response.ok) {
+        const envelope = isErrorEnvelope(body) ? body : undefined;
+        throw new MetagraphedError(
+          envelope?.error?.message ??
+            "GET " + url.pathname + " failed with status " + response.status,
+          response.status,
+          envelope?.error?.code,
+          envelope,
+        );
+      }
+      if (store) {
+        const etag = response.headers.get("etag");
+        if (etag) {
+          store.set(key, { etag, body });
+        }
+      }
+      return body as JsonResponse<Path>;
+    }
+  }
+
+  async function* paginate<Path extends ApiPath>(
+    path: Path,
+    options: MetagraphedFetchOptions<Path> = {},
+  ): AsyncGenerator<JsonResponse<Path>, void, unknown> {
+    const baseQuery: Record<string, unknown> = {
+      ...(options.query as Record<string, unknown> | undefined),
+    };
+    let cursor: unknown = baseQuery.cursor;
+    for (;;) {
+      if (cursor !== undefined && cursor !== null) {
+        baseQuery.cursor = cursor;
+      }
+      const page = await request(path, {
+        ...options,
+        query: baseQuery as unknown as QueryParams<Path>,
+      });
+      yield page;
+      const next = (
+        page as { meta?: { pagination?: { next_cursor?: unknown } } }
+      )?.meta?.pagination?.next_cursor;
+      if (next === undefined || next === null) {
+        return;
+      }
+      cursor = next;
+    }
+  }
+
+  async function fetchAll<Item = unknown, Path extends ApiPath = ApiPath>(
+    path: Path,
+    options: MetagraphedFetchOptions<Path> = {},
+  ): Promise<Item[]> {
+    const items: Item[] = [];
+    for await (const page of paginate(path, options)) {
+      const data = (page as { data?: unknown }).data;
+      if (Array.isArray(data)) {
+        items.push(...(data as Item[]));
+      } else if (data !== undefined && data !== null) {
+        items.push(data as Item);
+      }
+    }
+    return items;
+  }
+
+  function rpc<Result = unknown>(
+    network: string,
+    rpcRequest: JsonRpcRequest,
+    options: MetagraphedRpcOptions = {},
+  ): Promise<Result> {
+    return metagraphedRpc<Result>(network, rpcRequest, { baseUrl, ...options });
+  }
+
+  return {
+    request,
+    paginate,
+    fetchAll,
+    rpc,
+    subnets: (query, options) =>
+      request("/api/v1/subnets", { ...options, query }),
+    getSubnet: (netuid, options) =>
+      request("/api/v1/subnets/{netuid}", {
+        ...options,
+        pathParams: { netuid } as PathParams<"/api/v1/subnets/{netuid}">,
+      }),
+    providers: (query, options) =>
+      request("/api/v1/providers", { ...options, query }),
+    getProvider: (slug, options) =>
+      request("/api/v1/providers/{slug}", {
+        ...options,
+        pathParams: { slug } as PathParams<"/api/v1/providers/{slug}">,
+      }),
+    surfaces: (query, options) =>
+      request("/api/v1/surfaces", { ...options, query }),
+    endpoints: (query, options) =>
+      request("/api/v1/endpoints", { ...options, query }),
+    candidates: (query, options) =>
+      request("/api/v1/candidates", { ...options, query }),
+    profiles: (query, options) =>
+      request("/api/v1/profiles", { ...options, query }),
+    health: (options) => request("/api/v1/health", { ...options }),
+  };
+}
 `;
 }

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -3,6 +3,8 @@
 // throw-on-error contract, timeout signal, RPC helper, and cursor pagination.
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
+  createLruEtagCache,
+  createMetagraphedClient,
   MetagraphedError,
   metagraphedFetch,
   metagraphedPaginate,
@@ -200,5 +202,225 @@ describe("metagraphedRpc", () => {
     await expect(
       metagraphedRpc("finney", { method: "author_submitExtrinsic" }),
     ).rejects.toMatchObject({ status: 403, code: "rpc_method_blocked" });
+  });
+});
+
+describe("createMetagraphedClient", () => {
+  test("convenience methods build typed paths + queries", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ ok: true, data: { netuid: 7 }, meta: {} }),
+    );
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await client.getSubnet(7);
+    expect((fetchMock.mock.calls[0][0] as URL).toString()).toBe(
+      "https://api.metagraph.sh/api/v1/subnets/7",
+    );
+    await client.subnets({ limit: 5 } as never);
+    expect((fetchMock.mock.calls[1][0] as URL).searchParams.get("limit")).toBe(
+      "5",
+    );
+  });
+
+  test("does not retry by default — throws on the first 503", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse({ ok: false, error: { code: "x", message: "down" } }, 503),
+    );
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    await expect(client.health()).rejects.toMatchObject({ status: 503 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("retries opt-in on 429/5xx then resolves the success", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async () =>
+      ++call === 1
+        ? jsonResponse({ ok: false, error: { code: "x", message: "" } }, 429)
+        : jsonResponse({ ok: true, data: { netuid: 7 }, meta: {} }),
+    );
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      retry: { retries: 2, minDelayMs: 0 },
+    });
+    const out = await client.getSubnet(7);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect((out as { data: unknown }).data).toEqual({ netuid: 7 });
+  });
+
+  test("retries exhaust then throw the final error envelope", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(
+        { ok: false, error: { code: "unavailable", message: "down" } },
+        503,
+      ),
+    );
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      retry: { retries: 2, minDelayMs: 0 },
+    });
+    await expect(client.health()).rejects.toMatchObject({
+      status: 503,
+      code: "unavailable",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(3); // initial + 2 retries
+  });
+
+  test("backoff honors a Retry-After header", async () => {
+    vi.useFakeTimers();
+    try {
+      const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
+      let call = 0;
+      const fetchMock = vi.fn(async () =>
+        ++call === 1
+          ? new Response("{}", {
+              status: 503,
+              headers: { "retry-after": "2" },
+            })
+          : jsonResponse({ ok: true, data: { up: true }, meta: {} }),
+      );
+      const client = createMetagraphedClient({
+        fetch: fetchMock as unknown as typeof fetch,
+        timeoutMs: 0,
+        retry: { retries: 1 },
+      });
+      const pending = client.health();
+      await vi.advanceTimersByTimeAsync(2000);
+      await pending;
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 2000);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  test("ETag caching sends If-None-Match and returns the cached body on 304", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async (_url: URL, init: RequestInit) => {
+      call += 1;
+      if (call === 1) {
+        return new Response(
+          JSON.stringify({ ok: true, data: { v: 1 }, meta: {} }),
+          { status: 200, headers: { etag: 'W/"abc"' } },
+        );
+      }
+      expect((init.headers as Record<string, string>)["if-none-match"]).toBe(
+        'W/"abc"',
+      );
+      return new Response(null, { status: 304 });
+    });
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      cache: true,
+    });
+    const first = await client.health();
+    const second = await client.health();
+    expect((first as { data: unknown }).data).toEqual({ v: 1 });
+    expect((second as { data: unknown }).data).toEqual({ v: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("fetchAll collects data rows across cursor pages", async () => {
+    const pages = [
+      {
+        ok: true,
+        data: [{ netuid: 1 }, { netuid: 2 }],
+        meta: { pagination: { next_cursor: "c2" } },
+      },
+      {
+        ok: true,
+        data: [{ netuid: 3 }],
+        meta: { pagination: { next_cursor: null } },
+      },
+    ];
+    let index = 0;
+    const fetchMock = vi.fn(async () => jsonResponse(pages[index++]));
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+    });
+    const all = await client.fetchAll("/api/v1/subnets" as never);
+    expect(all).toEqual([{ netuid: 1 }, { netuid: 2 }, { netuid: 3 }]);
+    expect((fetchMock.mock.calls[1][0] as URL).searchParams.get("cursor")).toBe(
+      "c2",
+    );
+  });
+
+  test("retries transport errors (network/timeout) then resolves", async () => {
+    let call = 0;
+    const fetchMock = vi.fn(async () => {
+      call += 1;
+      if (call === 1) throw new TypeError("network down");
+      return jsonResponse({ ok: true, data: { up: true }, meta: {} });
+    });
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      retry: { retries: 2, minDelayMs: 0 },
+    });
+    const out = await client.health();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect((out as { data: unknown }).data).toEqual({ up: true });
+  });
+
+  test("rethrows a transport error after exhausting retries", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new TypeError("ECONNRESET");
+    });
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      retry: { retries: 1, minDelayMs: 0 },
+    });
+    await expect(client.health()).rejects.toThrow("ECONNRESET");
+    expect(fetchMock).toHaveBeenCalledTimes(2); // initial + 1 retry
+  });
+
+  test("does not retry a caller-initiated abort", async () => {
+    const controller = new AbortController();
+    const fetchMock = vi.fn(async () => {
+      controller.abort();
+      throw new DOMException("aborted", "AbortError");
+    });
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      retry: { retries: 3, minDelayMs: 0 },
+    });
+    await expect(
+      client.health({ signal: controller.signal }),
+    ).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("re-issues unconditionally when a 304 has no cache entry", async () => {
+    const evicting = { get: () => undefined, set: () => {} };
+    let call = 0;
+    const fetchMock = vi.fn(async (_url: URL, init: RequestInit) => {
+      call += 1;
+      if (call === 1) return new Response(null, { status: 304 });
+      expect(
+        (init.headers as Record<string, string>)["if-none-match"],
+      ).toBeUndefined();
+      return jsonResponse({ ok: true, data: { fresh: true }, meta: {} });
+    });
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      cache: evicting,
+    });
+    const out = await client.health();
+    expect((out as { data: unknown }).data).toEqual({ fresh: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createLruEtagCache", () => {
+  test("evicts the least-recently-used entry beyond maxEntries", () => {
+    const cache = createLruEtagCache(2);
+    cache.set("a", { etag: "1", body: "A" });
+    cache.set("b", { etag: "2", body: "B" });
+    cache.get("a"); // touch -> "b" becomes least-recently-used
+    cache.set("c", { etag: "3", body: "C" }); // exceeds cap -> evict "b"
+    expect(cache.get("a")?.body).toBe("A");
+    expect(cache.get("b")).toBeUndefined();
+    expect(cache.get("c")?.body).toBe("C");
   });
 });


### PR DESCRIPTION
## Summary
Adds an opt-in `createMetagraphedClient` DX layer to the TypeScript SDK (`@jsonbored/metagraphed`) over the existing generated typed surface.

**Closes #750.**

- **Retries/backoff** (opt-in) on 429/5xx with exponential backoff + full jitter, honoring `Retry-After` (delta-seconds or HTTP-date).
- **ETag conditional caching** (opt-in): sends `If-None-Match`, serves the cached body on `304`; in-memory by default or a pluggable `{ get, set }` store.
- **Convenience methods** (`getSubnet`, `subnets`, `providers`, `getProvider`, `surfaces`, `endpoints`, `candidates`, `profiles`, `health`) + **`fetchAll`** auto-pagination, plus `request` / `paginate` / `rpc`.

Backward compatible and tree-shakeable — the zero-config `metagraphedFetch` path is unchanged; you only pull in the wrapper if you import `createMetagraphedClient`.

## Implementation notes
- The typed surface stays **generated from OpenAPI**: the layer is added to the client generator (`scripts/generate-client.mjs`) and emitted into `generated/metagraphed-client.ts`, so `validate:generated-client` stays green and the published package picks it up via its existing sync. No generated *types* were hand-edited.
- Re-exported automatically through `packages/client/src/index.ts` (`export *`); confirmed `createMetagraphedClient` + the new types land in the built `dist/index.d.ts`.
- No new runtime dependencies; native `fetch` (injectable via `options.fetch` for tests).

## Completion checklist (closes #750)
- [x] Retries/backoff (opt-in) honoring Retry-After; tested
- [x] ETag conditional-request caching (opt-in); tested
- [x] Convenience methods + auto-pagination helper; types preserved
- [x] Backward compatible + tree-shakeable; typecheck (`tsup --dts`) passes
- [x] README/examples updated
- [x] Version bump + changelog — handled by release-please from this `feat(client)` commit (component `client`)

## Validation
- `npm run validate:generated-client` (drift) ✓
- `npm run format:check` ✓ · `npm run lint` ✓
- `npm --prefix packages/client run build` (tsup `--dts` typecheck + esm/cjs bundle) ✓
- `npm run test:coverage` — all suites pass, including 8 new SDK tests (retries on 429/5xx, Retry-After honoring, ETag→304 caching, convenience methods, `fetchAll`) ✓
