### PR TITLE
docs(readme): resource-links row near the top

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Bittensor subnet integration registry. For every subnet it answers: **what d
 [![PyPI](https://img.shields.io/pypi/v/metagraphed?logo=pypi&logoColor=white&label=PyPI)](https://pypi.org/project/metagraphed/)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-blue)](./LICENSE)
 
+**[Website](https://metagraph.sh)** &nbsp;·&nbsp; [API](https://api.metagraph.sh) &nbsp;·&nbsp; [OpenAPI](https://api.metagraph.sh/metagraph/openapi.json) &nbsp;·&nbsp; [MCP](https://api.metagraph.sh/mcp) &nbsp;·&nbsp; [Agent docs](https://api.metagraph.sh/llms.txt) &nbsp;·&nbsp; [Feeds](https://api.metagraph.sh/api/v1/feeds/registry) &nbsp;·&nbsp; [npm](https://www.npmjs.com/package/@jsonbored/metagraphed) &nbsp;·&nbsp; [PyPI](https://pypi.org/project/metagraphed/)
+
 </div>
 
 ---


### PR DESCRIPTION
Adds a one-click resource row under the badges so every entry point is reachable from the top of the README:

> **Website** · API · OpenAPI · MCP · Agent docs (llms.txt) · Feeds · npm · PyPI

Docs-only, 2-line change. (Banner/logo dropped from this PR — being handled separately.)