### PR TITLE
feat(registry): add SN50 Synth provider profile

### DIFF
--- a/registry/providers/community/synth.json
+++ b/registry/providers/community/synth.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/mode-network/synth-subnet",
+    "id": "synth",
+    "kind": "subnet-team",
+    "name": "Synth",
+    "public_notes": "Subnet 50 (Synth) team profile — predictive intelligence for financial markets, operated by Mode Network. Public-safe identity from the subnet's on-chain SubnetIdentitiesV3 (name, website, source repo).",
+    "schema_version": 1,
+    "website_url": "https://synthdata.co/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified **`subnet-team` provider profile for Subnet 50 (Synth)** — the registry had no provider for this subnet.

Closes #794.

## Provider
- **id:** `synth` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://synthdata.co/ (live, 200)
- **github:** https://github.com/mode-network/synth-subnet (live)
- **operator:** Mode Network

Identity is from the subnet's on-chain `SubnetIdentitiesV3` (name, website, source repo), re-verified live. Provider profiles are review inputs only (no official authority, can't set endpoint health) and route to human review per the submission gate.

## Validation
One file (`registry/providers/community/synth.json`). Local preflight: `submission:pr` → `manual_review` (expected for providers), `blocking: false`, no errors; `validate:intake`, `scan:public-safety`, `validate:private-boundary` all pass.
