### PR TITLE
feat(registry): add SN50 Synth provider profile

### DIFF
--- a/registry/providers/community/synth.json
+++ b/registry/providers/community/synth.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/mode-network/synth-subnet",
+    "id": "synth",
+    "kind": "subnet-team",
+    "name": "Synth",
+    "public_notes": "Subnet 50 (Synth) team profile — predictive intelligence for financial markets, operated by Mode Network. Public-safe identity from the subnet's on-chain SubnetIdentitiesV3 (name, website, source repo).",
+    "schema_version": 1,
+    "website_url": "https://synthdata.co/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
Re-opens contributor @oktofeesh1's submission from #795, which was auto-closed by a gate bug (the provider validator didn't unwrap the canonical { provider: {...} } envelope, so a valid profile was wrongly rejected as 'must include a non-empty id and name'). Fixed + deployed in reviewbot#192, so this re-submission reviews correctly. Profile: Subnet 50 (Synth) team — Mode Network; public-safe on-chain identity. Original author: @oktofeesh1 (preserved in the file's submission block).