### PR TITLE
fix(client): isolate ETag cache by request headers

### DIFF
--- a/generated/metagraphed-client.ts
+++ b/generated/metagraphed-client.ts
@@ -455,6 +455,34 @@ function buildRequestUrl(
   return url;
 }
 
+function mergeRequestHeaders(
+  clientHeaders: Record<string, string> | undefined,
+  requestHeaders: HeadersInit | undefined,
+): Record<string, string> {
+  const merged: Record<string, string> = { accept: "application/json" };
+  for (const [key, value] of Object.entries(clientHeaders || {})) {
+    merged[key.toLowerCase()] = value;
+  }
+  if (requestHeaders) {
+    new Headers(requestHeaders).forEach((value, key) => {
+      merged[key.toLowerCase()] = value;
+    });
+  }
+  return merged;
+}
+
+function buildEtagCacheKey(
+  url: URL,
+  requestHeaders: Record<string, string>,
+): string {
+  const headerKey = Object.entries(requestHeaders)
+    .filter(([key]) => key !== "if-none-match")
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => key + ":" + value)
+    .join("\n");
+  return url.toString() + "\n" + headerKey;
+}
+
 /**
  * A typed client with opt-in retries + ETag caching, ergonomic convenience
  * methods for the v1 collections, and fetchAll auto-pagination. Build one with
@@ -551,18 +579,11 @@ export function createMetagraphedClient(
       pathParams as Record<string, string | number> | undefined,
       query as Record<string, unknown> | undefined,
     );
-    // Cache key is the absolute URL. Safe today because every request sends the
-    // same Accept (application/json); if custom headers ever vary the response
-    // representation a header-aware key would be needed to avoid a stale hit.
-    const key = url.toString();
     let attempt = 0;
     let skipConditional = false;
     for (;;) {
-      const requestHeaders: Record<string, string> = {
-        accept: "application/json",
-        ...clientOptions.headers,
-        ...(headers as Record<string, string> | undefined),
-      };
+      const requestHeaders = mergeRequestHeaders(clientOptions.headers, headers);
+      const key = buildEtagCacheKey(url, requestHeaders);
       const cached = !skipConditional && store ? store.get(key) : undefined;
       if (cached) {
         requestHeaders["if-none-match"] = cached.etag;

--- a/scripts/generate-client.mjs
+++ b/scripts/generate-client.mjs
@@ -475,6 +475,34 @@ function buildRequestUrl(
   return url;
 }
 
+function mergeRequestHeaders(
+  clientHeaders: Record<string, string> | undefined,
+  requestHeaders: HeadersInit | undefined,
+): Record<string, string> {
+  const merged: Record<string, string> = { accept: "application/json" };
+  for (const [key, value] of Object.entries(clientHeaders || {})) {
+    merged[key.toLowerCase()] = value;
+  }
+  if (requestHeaders) {
+    new Headers(requestHeaders).forEach((value, key) => {
+      merged[key.toLowerCase()] = value;
+    });
+  }
+  return merged;
+}
+
+function buildEtagCacheKey(
+  url: URL,
+  requestHeaders: Record<string, string>,
+): string {
+  const headerKey = Object.entries(requestHeaders)
+    .filter(([key]) => key !== "if-none-match")
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => key + ":" + value)
+    .join("\\n");
+  return url.toString() + "\\n" + headerKey;
+}
+
 /**
  * A typed client with opt-in retries + ETag caching, ergonomic convenience
  * methods for the v1 collections, and fetchAll auto-pagination. Build one with
@@ -571,18 +599,11 @@ export function createMetagraphedClient(
       pathParams as Record<string, string | number> | undefined,
       query as Record<string, unknown> | undefined,
     );
-    // Cache key is the absolute URL. Safe today because every request sends the
-    // same Accept (application/json); if custom headers ever vary the response
-    // representation a header-aware key would be needed to avoid a stale hit.
-    const key = url.toString();
     let attempt = 0;
     let skipConditional = false;
     for (;;) {
-      const requestHeaders: Record<string, string> = {
-        accept: "application/json",
-        ...clientOptions.headers,
-        ...(headers as Record<string, string> | undefined),
-      };
+      const requestHeaders = mergeRequestHeaders(clientOptions.headers, headers);
+      const key = buildEtagCacheKey(url, requestHeaders);
       const cached = !skipConditional && store ? store.get(key) : undefined;
       if (cached) {
         requestHeaders["if-none-match"] = cached.etag;

--- a/tests/client-sdk.test.ts
+++ b/tests/client-sdk.test.ts
@@ -322,6 +322,35 @@ describe("createMetagraphedClient", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  test("ETag caching isolates entries by headers that can vary representations", async () => {
+    const fetchMock = vi.fn(async (_url: URL, init: RequestInit) => {
+      const headers = init.headers as Record<string, string>;
+      if (headers["x-tenant"] === "tenant-a") {
+        return new Response(
+          JSON.stringify({ ok: true, data: { secret: "tenant-a" }, meta: {} }),
+          { status: 200, headers: { etag: 'W/"tenant-a"' } },
+        );
+      }
+      expect(headers["if-none-match"]).toBeUndefined();
+      return new Response(
+        JSON.stringify({ ok: true, data: { secret: "tenant-b" }, meta: {} }),
+        { status: 200, headers: { etag: 'W/"tenant-b"' } },
+      );
+    });
+    const client = createMetagraphedClient({
+      fetch: fetchMock as unknown as typeof fetch,
+      cache: true,
+    });
+    const first = await client.health({ headers: { "x-tenant": "tenant-a" } });
+    const second = await client.health({ headers: { "x-tenant": "tenant-b" } });
+    expect((first as { data: unknown }).data).toEqual({
+      secret: "tenant-a",
+    });
+    expect((second as { data: unknown }).data).toEqual({
+      secret: "tenant-b",
+    });
+  });
+
   test("fetchAll collects data rows across cursor pages", async () => {
     const pages = [
       {


### PR DESCRIPTION
### Motivation
- The ETag cache previously keyed entries only by the absolute URL which can yield stale/incorrect cached bodies when responses vary by client-level or per-request headers (e.g. tenant or Authorization headers). 
- The goal is to ensure conditional ETag caching honors varying request headers and avoids leaking one principal's cached response to another.

### Description
- Add `mergeRequestHeaders` to normalize and merge client-level and per-request headers into a lowercase map used for requests. 
- Add `buildEtagCacheKey` to derive a cache key from the request `URL` plus the normalized headers while excluding the conditional `if-none-match` header. 
- Apply the header-aware cache key in `generated/metagraphed-client.ts` and mirror the same logic in `scripts/generate-client.mjs` so regenerated clients preserve the fix. 
- Add a regression test in `tests/client-sdk.test.ts` that verifies requests to the same URL with different tenant headers produce distinct cache entries and do not reuse another header context’s cached body.

### Testing
- Ran `npx vitest run tests/client-sdk.test.ts --reporter=verbose` and all tests passed (`24 passed`).
- Ran `npm run validate:generated-client` and it succeeded, confirming the generator and generated client are in sync. 
- Ran `npm run lint` which completed without errors. 
- Ran `npm run format:check` (`prettier`) which reported no formatting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a310b7b6a64832a871fb691cc4f7c54)