### PR TITLE
chore(enrich): taostats enrichment tooling (for the local routine)

### DIFF
--- a/scripts/enrich-taostats.mjs
+++ b/scripts/enrich-taostats.mjs
@@ -1,0 +1,183 @@
+#!/usr/bin/env node
+// taostats enrichment engine — STEP 1: gap analysis (read-only, no writes).
+// Fetches subnet identity from taostats and compares it to metagraphed's current
+// served state, reporting where taostats can FILL A GAP (a field metagraphed is
+// missing that taostats has). It never proposes overwriting a value metagraphed
+// already has — taostats is a third-party source that sits BELOW native chain +
+// curated overlays in the trust model. Every proposed fill is provenance-tagged
+// `source: taostats`.
+//
+//   export TAOSTATS_API_KEY=...        (.env* is gitignored)
+//   node scripts/enrich-taostats.mjs            # gap summary
+//   node scripts/enrich-taostats.mjs --details  # per-subnet gaps too
+//
+// Next steps (not in this file yet): --write to stage overlay gap-fills on a
+// branch + open a rolling PR for review; a separate live-metrics artifact.
+
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const API_KEY = process.env.TAOSTATS_API_KEY;
+const BASE = process.env.TAOSTATS_API_BASE || "https://api.taostats.io";
+const AUTH_HEADER = process.env.TAOSTATS_AUTH_HEADER || "Authorization";
+const DETAILS = process.argv.includes("--details");
+const JSON_OUT = process.argv.includes("--json");
+
+if (!API_KEY) {
+  console.error(
+    "✗ TAOSTATS_API_KEY is not set (see scripts/taostats-probe.mjs).",
+  );
+  process.exit(1);
+}
+
+// taostats identity field -> the metagraphed field it can gap-fill. `nested`
+// targets live under social.{key}. Curated overlay always wins; this only fills
+// when metagraphed's served value is empty.
+const FIELD_MAP = [
+  { mg: "source_repo", ts: "github_repo", kind: "url" },
+  { mg: "website_url", ts: "subnet_url", kind: "url" },
+  { mg: "logo_url", ts: "logo_url", kind: "url" },
+  { mg: "discord", ts: "discord", kind: "string" },
+  { mg: "description", ts: "description", kind: "string" },
+  { mg: "social.x", ts: "twitter", kind: "social", nested: "x" },
+  { mg: "categories", ts: "tags", kind: "array" },
+];
+
+async function fetchAllIdentities() {
+  const out = new Map(); // netuid -> identity record
+  let page = 1;
+  for (;;) {
+    const url = `${BASE}/api/subnet/identity/v1?limit=200&page=${page}`;
+    const res = await fetch(url, {
+      headers: { [AUTH_HEADER]: API_KEY, accept: "application/json" },
+      signal: AbortSignal.timeout(30000),
+    });
+    if (!res.ok) {
+      throw new Error(`taostats identity page ${page} -> HTTP ${res.status}`);
+    }
+    const body = await res.json();
+    const rows = Array.isArray(body?.data) ? body.data : [];
+    for (const row of rows) {
+      if (Number.isInteger(row?.netuid)) out.set(row.netuid, row);
+    }
+    const pg = body?.pagination || {};
+    const next = pg.next_page ?? (rows.length === 200 ? page + 1 : null);
+    if (!next || rows.length === 0) break;
+    page = Number(next);
+    if (page > 50) break; // safety
+  }
+  return out;
+}
+
+const isEmpty = (v) =>
+  v === null ||
+  v === undefined ||
+  (typeof v === "string" && v.trim() === "") ||
+  (Array.isArray(v) && v.length === 0);
+
+function mgValue(subnet, field) {
+  if (field.nested) return subnet.social?.[field.nested];
+  return subnet[field.mg];
+}
+
+function tsValue(identity, field) {
+  const raw = identity[field.ts];
+  if (isEmpty(raw)) return null;
+  if (
+    field.kind === "url" &&
+    typeof raw === "string" &&
+    !/^https?:\/\//i.test(raw)
+  ) {
+    // taostats sometimes returns bare handles/paths; the real engine will run
+    // these through normalizePublicHttpUrl. For analysis, keep as-is.
+    return raw;
+  }
+  return raw;
+}
+
+function main() {
+  const subnetsArtifact = JSON.parse(
+    readFileSync(path.join(repoRoot, "public/metagraph/subnets.json"), "utf8"),
+  );
+  const subnets = subnetsArtifact.subnets || [];
+  return fetchAllIdentities().then((identities) => {
+    const gapsByField = Object.fromEntries(FIELD_MAP.map((f) => [f.mg, 0]));
+    const perSubnet = [];
+    let taostatsKnown = 0;
+
+    for (const subnet of subnets) {
+      const identity = identities.get(subnet.netuid);
+      if (!identity) continue;
+      taostatsKnown += 1;
+      const gaps = [];
+      for (const field of FIELD_MAP) {
+        const have = mgValue(subnet, field);
+        const ts = tsValue(identity, field);
+        if (isEmpty(have) && !isEmpty(ts)) {
+          gaps.push({ field: field.mg, fill: ts });
+          gapsByField[field.mg] += 1;
+        }
+      }
+      if (gaps.length)
+        perSubnet.push({
+          netuid: subnet.netuid,
+          slug: subnet.slug,
+          name: subnet.name,
+          gaps,
+        });
+    }
+
+    // Machine-readable output for the Claude enrichment routine to consume.
+    if (JSON_OUT) {
+      process.stdout.write(
+        JSON.stringify(
+          { matched: taostatsKnown, summary: gapsByField, subnets: perSubnet },
+          null,
+          2,
+        ) + "\n",
+      );
+      return;
+    }
+
+    console.log(
+      `taostats gap analysis — ${subnets.length} metagraphed subnets, ` +
+        `${taostatsKnown} matched in taostats identity.\n`,
+    );
+    console.log(
+      "Gap-fills taostats could contribute (metagraphed empty + taostats has):",
+    );
+    for (const f of FIELD_MAP) {
+      console.log(`  ${f.mg.padEnd(14)} ${gapsByField[f.mg]} subnet(s)`);
+    }
+    const totalFills = Object.values(gapsByField).reduce((a, b) => a + b, 0);
+    console.log(
+      `\n  → ${totalFills} total gap-fills across ${perSubnet.length} subnet(s).` +
+        " All would be provenance-tagged source:taostats, gap-fill only.\n",
+    );
+
+    if (DETAILS) {
+      for (const s of perSubnet.slice(0, 40)) {
+        console.log(
+          `  SN${s.netuid} ${s.name}: ` +
+            s.gaps
+              .map((g) => `${g.field}=${String(g.fill).slice(0, 48)}`)
+              .join("  |  "),
+        );
+      }
+      if (perSubnet.length > 40)
+        console.log(`  …and ${perSubnet.length - 40} more.`);
+    } else {
+      console.log("Run with --details to see per-subnet gap-fills.");
+    }
+  });
+}
+
+main().catch((error) => {
+  console.error(`✗ ${error.message}`);
+  process.exit(1);
+});

--- a/scripts/taostats-probe.mjs
+++ b/scripts/taostats-probe.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+// taostats API probe (read-only) — the FIRST step of the taostats enrichment
+// engine (the deterministic fetcher that will gap-fill registry identity,
+// discover providers/owners, and detect new subnets, opening provenance-tagged
+// PRs for review). The taostats docs obscure the exact endpoint paths + response
+// field names, so before writing the engine we confirm them against the live API
+// with YOUR key. This script makes ONLY GET requests, writes nothing, and never
+// prints the key.
+//
+// Usage:
+//   export TAOSTATS_API_KEY=...        # never commit this; .env* is gitignored
+//   node scripts/taostats-probe.mjs            # probe all capabilities, 1 sample each
+//   node scripts/taostats-probe.mjs --netuid 1 # probe against a specific subnet
+//   node scripts/taostats-probe.mjs --full     # print full first-item JSON, not just keys
+//
+// Output per capability: the first candidate path that returns 2xx, the HTTP
+// status, any rate-limit headers, the response's top-level keys, and the field
+// names of the first item (so we can map taostats → registry fields precisely).
+
+const API_KEY = process.env.TAOSTATS_API_KEY;
+const BASE = process.env.TAOSTATS_API_BASE || "https://api.taostats.io";
+// taostats authenticates with the raw key in the Authorization header (no
+// "Bearer "). Override if your account differs.
+const AUTH_HEADER = process.env.TAOSTATS_AUTH_HEADER || "Authorization";
+
+const args = process.argv.slice(2);
+const FULL = args.includes("--full");
+const netuidArg = args.indexOf("--netuid");
+const NETUID = netuidArg >= 0 ? Number(args[netuidArg + 1]) : 1;
+
+if (!API_KEY) {
+  console.error(
+    "✗ TAOSTATS_API_KEY is not set.\n" +
+      "  Get one at https://taostats.io/pro then:  export TAOSTATS_API_KEY=...\n" +
+      "  (Do not paste it in chat or commit it — .env* is gitignored.)",
+  );
+  process.exit(1);
+}
+
+// Candidate paths per capability. taostats versions paths (…/v1) and split some
+// under /api/dtao/. We try each in order and report the first that works, so the
+// probe DISCOVERS the live paths rather than assuming them.
+const CAPABILITIES = [
+  {
+    name: "subnets-list (identity + metadata for all subnets)",
+    paths: [
+      "/api/subnet/latest/v1",
+      "/api/dtao/subnet/latest/v1",
+      "/api/subnet/v1?limit=5",
+      "/api/dtao/subnet/identity/latest/v1?limit=5",
+    ],
+  },
+  {
+    name: "subnet-identity (name / github / url / description)",
+    paths: [
+      `/api/subnet/identity/v1?netuid=${NETUID}`,
+      `/api/dtao/subnet_identity/v1?netuid=${NETUID}`,
+      `/api/dtao/subnet/identity/latest/v1?netuid=${NETUID}`,
+    ],
+  },
+  {
+    name: "subnet-owner",
+    paths: [
+      `/api/subnet/owner/v1?netuid=${NETUID}`,
+      `/api/dtao/subnet/owner/v1?netuid=${NETUID}`,
+    ],
+  },
+  {
+    name: "validators-in-subnet",
+    paths: [
+      `/api/validator/latest/v1?netuid=${NETUID}&limit=3`,
+      `/api/dtao/validator/latest/v1?netuid=${NETUID}&limit=3`,
+      `/api/metagraph/latest/v1?netuid=${NETUID}&limit=3`,
+    ],
+  },
+  {
+    name: "subnet-emission / metrics",
+    paths: [
+      `/api/subnet/emission/v1?netuid=${NETUID}`,
+      `/api/dtao/subnet_emission/v1?netuid=${NETUID}`,
+      `/api/dtao/pool/latest/v1?netuid=${NETUID}`,
+    ],
+  },
+  {
+    name: "subnet-registrations (new-subnet detection)",
+    paths: [
+      "/api/subnet/registration/v1?limit=5",
+      "/api/dtao/subnet_registration/v1?limit=5",
+    ],
+  },
+];
+
+function fieldNames(value) {
+  if (Array.isArray(value)) {
+    return value.length
+      ? `array[${value.length}] of { ${fieldNames(value[0])} }`
+      : "array[0]";
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value).join(", ");
+  }
+  return typeof value;
+}
+
+// taostats list responses are usually { data: [...], pagination: {...} }. Pull
+// the first record whatever the envelope.
+function firstRecord(body) {
+  if (Array.isArray(body)) return body[0];
+  if (body && Array.isArray(body.data)) return body.data[0];
+  if (body && typeof body === "object") {
+    for (const v of Object.values(body)) {
+      if (Array.isArray(v) && v.length) return v[0];
+    }
+  }
+  return body;
+}
+
+async function probe(path) {
+  const url = `${BASE}${path}`;
+  let res;
+  try {
+    res = await fetch(url, {
+      headers: { [AUTH_HEADER]: API_KEY, accept: "application/json" },
+      signal: AbortSignal.timeout(20000),
+    });
+  } catch (error) {
+    return { ok: false, status: 0, error: String(error?.message || error) };
+  }
+  const rl = {
+    limit:
+      res.headers.get("x-ratelimit-limit") ||
+      res.headers.get("ratelimit-limit"),
+    remaining:
+      res.headers.get("x-ratelimit-remaining") ||
+      res.headers.get("ratelimit-remaining"),
+  };
+  let body;
+  const text = await res.text();
+  try {
+    body = text ? JSON.parse(text) : undefined;
+  } catch {
+    body = { _nonJson: text.slice(0, 200) };
+  }
+  return { ok: res.ok, status: res.status, rl, body };
+}
+
+console.log(
+  `taostats probe → ${BASE}  (netuid ${NETUID}, auth via ${AUTH_HEADER})\n`,
+);
+
+let firstOk = false;
+for (const cap of CAPABILITIES) {
+  console.log(`## ${cap.name}`);
+  let hit = false;
+  for (const path of cap.paths) {
+    const r = await probe(path);
+    if (r.status === 0) {
+      console.log(`   ✗ ${path} — request failed: ${r.error}`);
+      continue;
+    }
+    const rlNote = r.rl?.limit
+      ? `  [ratelimit ${r.rl.remaining}/${r.rl.limit}]`
+      : "";
+    if (r.ok) {
+      firstOk = true;
+      hit = true;
+      const rec = firstRecord(r.body);
+      console.log(`   ✓ ${r.status} ${path}${rlNote}`);
+      console.log(`     envelope keys: ${fieldNames(r.body)}`);
+      console.log(`     first record:  ${fieldNames(rec)}`);
+      if (FULL)
+        console.log(
+          `     sample: ${JSON.stringify(rec, null, 2).slice(0, 1200)}`,
+        );
+      break; // first working path per capability is enough
+    }
+    // 401/403 → auth/plan problem; 404 → wrong path (try next). Report either way.
+    console.log(`   · ${r.status} ${path}${rlNote}`);
+  }
+  if (!hit)
+    console.log(
+      "   (no candidate path returned 2xx — share this so I can adjust)",
+    );
+  console.log("");
+}
+
+if (!firstOk) {
+  console.error(
+    "No endpoint returned 2xx. If everything was 401/403 the key/plan or the auth\n" +
+      "header is the issue (try TAOSTATS_AUTH_HEADER=Authorization or your account's\n" +
+      "documented header). If 404, the paths differ — paste the output and I'll fix them.",
+  );
+  process.exit(2);
+}
+console.log(
+  "Done. Paste this output back and I'll finalize scripts/enrich-taostats.mjs\n" +
+    "against the real field names (gap-fill only, provenance-tagged, PRs for review).",
+);


### PR DESCRIPTION
Read-only taostats tooling the local Claude enrichment routine calls: `taostats-probe.mjs` (confirms endpoints) and `enrich-taostats.mjs` (`--json` gap-fills: fields metagraphed is missing that taostats has — gap-fill only, sanitized + provenance-noted by the routine). No writes here; the routine does the sanitize→overlay→review-PR. Key stays in gitignored `.env`; `.claude/loop.md` (the routine prompt) is local/gitignored.