### PR TITLE
feat(registry): add SN18 Zeus provider profile (with X)

### DIFF
--- a/registry/providers/community/zeus.json
+++ b/registry/providers/community/zeus.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/Orpheus-AI/Zeus",
+    "id": "zeus",
+    "kind": "subnet-team",
+    "name": "Zeus",
+    "public_notes": "Subnet 18 (Zeus) team profile — pushing weather forecasts beyond state-of-the-art. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/zeussubnet"
+    },
+    "website_url": "https://www.zeussubnet.com/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 18 (Zeus)** — no provider existed — including its **X handle** via the structured `social` field (#745, empty registry-wide until now).

Closes #806.

## Provider
- **id:** `zeus` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.zeussubnet.com/
- **github:** https://github.com/Orpheus-AI/Zeus
- **social.x:** https://x.com/zeussubnet

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only (no official authority, can't set endpoint health); routes to human review.

## Validation
One file. Local preflight: submission:pr → manual_review (expected), blocking false, no errors; validate:intake, scan:public-safety, validate:private-boundary all pass.
