### PR TITLE
feat(registry): add SN68 NOVA provider profile (with X)

### DIFF
--- a/registry/providers/community/nova.json
+++ b/registry/providers/community/nova.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/metanova-labs/nova",
+    "id": "nova",
+    "kind": "subnet-team",
+    "name": "NOVA",
+    "public_notes": "Subnet 68 (NOVA) team profile — accelerating drug discovery. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/metanova_labs"
+    },
+    "website_url": "https://www.metanova-labs.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 68 (NOVA)** — no provider existed — including its **X handle** via the structured `social` field (#745, empty registry-wide until now).

Closes #808.

## Provider
- **id:** `nova` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.metanova-labs.ai
- **github:** https://github.com/metanova-labs/nova
- **social.x:** https://x.com/metanova_labs

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only (no official authority, can't set endpoint health); routes to human review.

## Validation
One file. Local preflight: submission:pr → manual_review (expected), blocking false, no errors; validate:intake, scan:public-safety, validate:private-boundary all pass.
