### PR TITLE
feat(registry): add SN126 Poker44 provider profile (with X)

### DIFF
--- a/registry/providers/community/poker44.json
+++ b/registry/providers/community/poker44.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/Poker44/Poker44-subnet",
+    "id": "poker44",
+    "kind": "subnet-team",
+    "name": "Poker44",
+    "public_notes": "Subnet 126 (Poker44) team profile — decentralized poker platform. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/poker44subnet"
+    },
+    "website_url": "https://poker44.net/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 126 (Poker44)** — no provider existed — including its **X handle** via the structured `social` field (#745, empty registry-wide until now).

Closes #810.

## Provider
- **id:** `poker44` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://poker44.net
- **github:** https://github.com/Poker44/Poker44-subnet
- **social.x:** https://x.com/poker44subnet

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only (no official authority, can't set endpoint health); routes to human review.

## Validation
One file. Local preflight: submission:pr → manual_review (expected), blocking false, no errors; validate:intake, scan:public-safety, validate:private-boundary all pass.
