### PR TITLE
feat(registry): add SN17 404-GEN provider profile (with X)

### DIFF
--- a/registry/providers/community/404-gen.json
+++ b/registry/providers/community/404-gen.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/404-Repo/404-gen-subnet",
+    "id": "404-gen",
+    "kind": "subnet-team",
+    "name": "404-GEN",
+    "public_notes": "Subnet 17 (404-GEN) team profile — decentralized 3D content generation. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/404gen_"
+    },
+    "website_url": "https://www.404.xyz/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 17 (404-GEN)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #812.

## Provider
- **id:** `404-gen` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.404.xyz
- **github:** https://github.com/404-Repo/404-gen-subnet
- **social.x:** https://x.com/404gen_

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
