### PR TITLE
feat(registry): add SN26 Perturb provider profile (with X)

### DIFF
--- a/registry/providers/community/perturb.json
+++ b/registry/providers/community/perturb.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/0xsigurd/Perturb",
+    "id": "perturb",
+    "kind": "subnet-team",
+    "name": "Perturb",
+    "public_notes": "Subnet 26 (Perturb) team profile — decentralized adversarial robustness network. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/perturbaix"
+    },
+    "website_url": "https://www.perturbai.io/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 26 (Perturb)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #814.

## Provider
- **id:** `perturb` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.perturbai.io/
- **github:** https://github.com/0xsigurd/Perturb
- **social.x:** https://x.com/perturbaix

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
