### PR TITLE
feat(registry): add SN59 Babelbit provider profile (with X)

### DIFF
--- a/registry/providers/community/babelbit.json
+++ b/registry/providers/community/babelbit.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/babelbit/babelbit_subnet",
+    "id": "babelbit",
+    "kind": "subnet-team",
+    "name": "Babelbit",
+    "public_notes": "Subnet 59 (Babelbit) team profile — harnessing the predictive power of language. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/babelbit"
+    },
+    "website_url": "https://babelbit.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 59 (Babelbit)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #816.

## Provider
- **id:** `babelbit` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://babelbit.ai
- **github:** https://github.com/babelbit/babelbit_subnet
- **social.x:** https://x.com/babelbit

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
