### PR TITLE
feat(registry): add SN107 Minos provider profile (with X)

### DIFF
--- a/registry/providers/community/minos.json
+++ b/registry/providers/community/minos.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/minos-protocol/minos_subnet",
+    "id": "minos",
+    "kind": "subnet-team",
+    "name": "Minos",
+    "public_notes": "Subnet 107 (Minos) team profile — the foundational layer of genomics. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/theminos_ai"
+    },
+    "website_url": "https://theminos.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 107 (Minos)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #818.

## Provider
- **id:** `minos` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://theminos.ai
- **github:** https://github.com/minos-protocol/minos_subnet
- **social.x:** https://x.com/theminos_ai

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
