### PR TITLE
feat(registry): add SN108 TalkHead provider profile (with X)

### DIFF
--- a/registry/providers/community/talkhead.json
+++ b/registry/providers/community/talkhead.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/talkheadai/talkhead-subnet",
+    "id": "talkhead",
+    "kind": "subnet-team",
+    "name": "TalkHead",
+    "public_notes": "Subnet 108 (TalkHead) team profile — talking-head generation. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/talkheadai"
+    },
+    "website_url": "https://www.talkhead.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 108 (TalkHead)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #820.

## Provider
- **id:** `talkhead` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.talkhead.ai
- **github:** https://github.com/talkheadai/talkhead-subnet
- **social.x:** https://x.com/talkheadai

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
