### PR TITLE
feat(registry): add SN112 minotaur provider profile (with X)

### DIFF
--- a/registry/providers/community/minotaur.json
+++ b/registry/providers/community/minotaur.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/subnet112/minotaur_subnet",
+    "id": "minotaur",
+    "kind": "subnet-team",
+    "name": "minotaur",
+    "public_notes": "Subnet 112 (minotaur) team profile — distributed DEX aggregator and swap-intent network. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/minotaursubnet"
+    },
+    "website_url": "https://minotaursubnet.com/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 112 (minotaur)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #822.

## Provider
- **id:** `minotaur` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://minotaursubnet.com
- **github:** https://github.com/subnet112/minotaur_subnet
- **social.x:** https://x.com/minotaursubnet

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
