### PR TITLE
fix(ci): validate must check submitted_by against the PR author, not GITHUB_ACTOR

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -128,7 +128,8 @@ jobs:
         if: steps.route.outputs.mode == 'ugc'
         env:
           GITHUB_ACTOR: ${{ github.actor }}
-        run: npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+        run: npm run submission:pr -- --changed-files changed-files.txt --out submission-report.json --submitter "$PR_AUTHOR"
 
       - name: Validate UGC intake templates
         if: steps.route.outputs.mode == 'ugc'


### PR DESCRIPTION
## Problem

`validate` fails intermittently with **`submission.submitted_by must match the PR author`** — and it correlates exactly with reviewbot reviewing / many submissions open at once.

**Root cause:** `scripts/submission-pr.mjs` resolves the submitter as `--submitter || process.env.GITHUB_ACTOR`, but `validate.yml` never passed `--submitter`. So it falls back to `GITHUB_ACTOR` — *whoever triggered the run*, not the PR author. Under `strict` branch protection a behind PR must be brought up to date, so reviewbot pushes a catch-up commit as `reviewwed[bot]`; that push re-triggers `validate` with `GITHUB_ACTOR = reviewwed[bot]`, which no longer matches the JSON's `submitted_by` (the human) → spurious failure. The same happens on any maintainer re-run or Actions retry. "Tons of submissions at once" amplifies it: each merge pushes others behind → more bot catch-up pushes → more failures.

Concrete: PR #804 (`oktofeesh1`, `submitted_by: oktofeesh1`) — validate run triggered by `reviewwed[bot]` → failed `submitted_by must match the PR author`.

## Fix

Pass the **actual PR author** from the `pull_request` event to the preflight, so the `submitted_by` check is correct regardless of who *triggered* the run. `submission-pr.mjs` already prefers `--submitter`, so this is a one-line workflow change; the step is UGC-mode + PR-only, so the value is always present. `strict` protection stays (artifact consistency on merge is preserved).

Diagnosed from the reviewbot side — this is a metagraphed CI bug, not a reviewbot one.
