### PR TITLE
feat(registry): add SN35 OxMarkets provider profile (with X)

### DIFF
--- a/registry/providers/community/oxmarkets.json
+++ b/registry/providers/community/oxmarkets.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/General-Tao-Ventures/cartha-validator",
+    "id": "oxmarkets",
+    "kind": "subnet-team",
+    "name": "OxMarkets",
+    "public_notes": "Subnet 35 (OxMarkets) team profile — liquidity-as-a-service powering 0xMarkets. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/0x_Markets"
+    },
+    "website_url": "https://www.0xmarkets.io/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 35 (OxMarkets)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #825.

## Provider
- **id:** `oxmarkets` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.0xmarkets.io/
- **github:** https://github.com/General-Tao-Ventures/cartha-validator
- **social.x:** https://x.com/0x_Markets

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
