### PR TITLE
feat(registry): add SN36 Eirel provider profile (with X)

### DIFF
--- a/registry/providers/community/eirel.json
+++ b/registry/providers/community/eirel.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/RendixNetwork/eirel-ai",
+    "id": "eirel",
+    "kind": "subnet-team",
+    "name": "Eirel",
+    "public_notes": "Subnet 36 (Eirel) team profile — the execution layer for multimodal AI workloads. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/rendix_network"
+    },
+    "website_url": "https://eirel.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 36 (Eirel)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #827.

## Provider
- **id:** `eirel` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://eirel.ai/
- **github:** https://github.com/RendixNetwork/eirel-ai
- **social.x:** https://x.com/rendix_network

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
