### PR TITLE
feat(registry): add SN37 Aurelius provider profile (with X)

### DIFF
--- a/registry/providers/community/aurelius.json
+++ b/registry/providers/community/aurelius.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/Aurelius-Protocol/Aurelius-Protocol",
+    "id": "aurelius",
+    "kind": "subnet-team",
+    "name": "Aurelius",
+    "public_notes": "Subnet 37 (Aurelius) team profile — decentralized alignment of artificial intelligence. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/aureliusaligned"
+    },
+    "website_url": "https://aureliusaligned.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 37 (Aurelius)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #829.

## Provider
- **id:** `aurelius` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://aureliusaligned.ai
- **github:** https://github.com/Aurelius-Protocol/Aurelius-Protocol
- **social.x:** https://x.com/aureliusaligned

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
