### PR TITLE
feat(registry): add SN46 Zipcode provider profile (with X)

### DIFF
--- a/registry/providers/community/zipcode.json
+++ b/registry/providers/community/zipcode.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/resi-labs-ai/RESI-models",
+    "id": "zipcode",
+    "kind": "subnet-team",
+    "name": "Zipcode",
+    "public_notes": "Subnet 46 (Zipcode) team profile — the real estate intelligence network. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/resilabsai"
+    },
+    "website_url": "https://zipcode.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 46 (Zipcode)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #831.

## Provider
- **id:** `zipcode` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://zipcode.ai
- **github:** https://github.com/resi-labs-ai/RESI-models
- **social.x:** https://x.com/resilabsai

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
