### PR TITLE
feat(registry): add SN65 TAO Private Network provider profile (with X)

### DIFF
--- a/registry/providers/community/tao-private-network.json
+++ b/registry/providers/community/tao-private-network.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/taofu-labs/tpn-subnet",
+    "id": "tao-private-network",
+    "kind": "subnet-team",
+    "name": "TAO Private Network",
+    "public_notes": "Subnet 65 (TAO Private Network) team profile — developer-friendly decentralised VPN infrastructure. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/tpn_labs"
+    },
+    "website_url": "https://tpn.taofu.xyz/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 65 (TAO Private Network)** — no provider existed — including its **X handle** via the structured `social` field (#745).

Closes #833.

## Provider
- **id:** `tao-private-network` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://tpn.taofu.xyz/
- **github:** https://github.com/taofu-labs/tpn-subnet
- **social.x:** https://x.com/tpn_labs

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
