### PR TITLE
feat(registry): add SN44 Score provider profile (with X)

### DIFF
--- a/registry/providers/community/score.json
+++ b/registry/providers/community/score.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/score-technologies/turbovision",
+    "id": "score",
+    "kind": "subnet-team",
+    "name": "Score",
+    "public_notes": "Subnet 44 (Score) team profile — making every camera intelligent. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/webuildscore"
+    },
+    "website_url": "https://www.wearescore.com/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 44 (Score)** — no provider existed. Includes its **X handle** via the structured `social` field (#745).

Closes #835.

## Provider
- **id:** `score` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.wearescore.com/
- **github:** https://github.com/score-technologies/turbovision
- **social.x:** https://x.com/webuildscore

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
