### PR TITLE
feat(registry): add SN55 NIOME provider profile

### DIFF
--- a/registry/providers/community/niome.json
+++ b/registry/providers/community/niome.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/genomesio/subnet-niome",
+    "id": "niome",
+    "kind": "subnet-team",
+    "name": "NIOME",
+    "public_notes": "Subnet 55 (NIOME) team profile — a decentralized AI subnet on genomes.io. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://niome.genomes.io/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 55 (NIOME)** — no provider existed.

Closes #837.

## Provider
- **id:** `niome` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://niome.genomes.io
- **github:** https://github.com/genomesio/subnet-niome


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
