### PR TITLE
feat(registry): add SN60 Bitsec.ai provider profile

### DIFF
--- a/registry/providers/community/bitsec-ai.json
+++ b/registry/providers/community/bitsec-ai.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/Bitsec-AI/sandbox",
+    "id": "bitsec-ai",
+    "kind": "subnet-team",
+    "name": "Bitsec.ai",
+    "public_notes": "Subnet 60 (Bitsec.ai) team profile — find and fix exploits in codebases. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://bitsec.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 60 (Bitsec.ai)** — no provider existed.

Closes #839.

## Provider
- **id:** `bitsec-ai` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://bitsec.ai
- **github:** https://github.com/Bitsec-AI/sandbox


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
