### PR TITLE
feat(registry): add SN71 Leadpoet provider profile

### DIFF
--- a/registry/providers/community/leadpoet.json
+++ b/registry/providers/community/leadpoet.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/leadpoet/leadpoet",
+    "id": "leadpoet",
+    "kind": "subnet-team",
+    "name": "Leadpoet",
+    "public_notes": "Subnet 71 (Leadpoet) team profile — intent-driven AI for modern sales teams. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://leadpoet.com/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 71 (Leadpoet)** — no provider existed.

Closes #841.

## Provider
- **id:** `leadpoet` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://leadpoet.com
- **github:** https://github.com/leadpoet/leadpoet


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
