### PR TITLE
feat(registry): add SN77 Liquidity provider profile

### DIFF
--- a/registry/providers/community/liquidity.json
+++ b/registry/providers/community/liquidity.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/creativebuilds/sn77",
+    "id": "liquidity",
+    "kind": "subnet-team",
+    "name": "Liquidity",
+    "public_notes": "Subnet 77 (Liquidity) team profile — supply liquidity on external chains via unified routing. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://sn77.xyz/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 77 (Liquidity)** — no provider existed.

Closes #843.

## Provider
- **id:** `liquidity` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://sn77.xyz
- **github:** https://github.com/creativebuilds/sn77


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
