### PR TITLE
feat(registry): add SN78 Vocence provider profile

### DIFF
--- a/registry/providers/community/vocence.json
+++ b/registry/providers/community/vocence.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/vocence-78/vocence",
+    "id": "vocence",
+    "kind": "subnet-team",
+    "name": "Vocence",
+    "public_notes": "Subnet 78 (Vocence) team profile — the voice layer for decentralized intelligence. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://www.vocence.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 78 (Vocence)** — no provider existed.

Closes #845.

## Provider
- **id:** `vocence` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.vocence.ai
- **github:** https://github.com/vocence-78/vocence


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
