### PR TITLE
feat(registry): add SN80 dogelayer provider profile (with X)

### DIFF
--- a/registry/providers/community/dogelayer.json
+++ b/registry/providers/community/dogelayer.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/dogelayer-ai/dogelayer",
+    "id": "dogelayer",
+    "kind": "subnet-team",
+    "name": "dogelayer",
+    "public_notes": "Subnet 80 (dogelayer) team profile — decentralized mining pool infrastructure. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/layer_doge"
+    },
+    "website_url": "https://dogelayer.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 80 (dogelayer)** — no provider existed. Includes its **X handle** via the structured `social` field (#745).

Closes #847.

## Provider
- **id:** `dogelayer` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://dogelayer.ai
- **github:** https://github.com/dogelayer-ai/dogelayer
- **social.x:** https://x.com/layer_doge

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
