### PR TITLE
feat(registry): add SN83 CliqueAI provider profile

### DIFF
--- a/registry/providers/community/cliqueai.json
+++ b/registry/providers/community/cliqueai.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/toptensor/CliqueAI",
+    "id": "cliqueai",
+    "kind": "subnet-team",
+    "name": "CliqueAI",
+    "public_notes": "Subnet 83 (CliqueAI) team profile — AI-powered maximum clique solver. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://cliqueai.toptensor.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 83 (CliqueAI)** — no provider existed.

Closes #849.

## Provider
- **id:** `cliqueai` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://cliqueai.toptensor.ai/
- **github:** https://github.com/toptensor/CliqueAI


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
