### PR TITLE
feat(registry): add SN93 Bitcast provider profile

### DIFF
--- a/registry/providers/community/bitcast.json
+++ b/registry/providers/community/bitcast.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/bitcast-network/bitcast",
+    "id": "bitcast",
+    "kind": "subnet-team",
+    "name": "Bitcast",
+    "public_notes": "Subnet 93 (Bitcast) team profile — the decentralized creators economy. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://stats.bitcast.network/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 93 (Bitcast)** — no provider existed.

Closes #851.

## Provider
- **id:** `bitcast` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://stats.bitcast.network/
- **github:** https://github.com/bitcast-network/bitcast


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
