### PR TITLE
feat(registry): add SN97 Albedo provider profile

### DIFF
--- a/registry/providers/community/albedo.json
+++ b/registry/providers/community/albedo.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/unarbos/albedo",
+    "id": "albedo",
+    "kind": "subnet-team",
+    "name": "Albedo",
+    "public_notes": "Subnet 97 (Albedo) team profile — alchemical intelligence. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://us-east-1.hippius.com/albedo/index.html"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 97 (Albedo)** — no provider existed.

Closes #853.

## Provider
- **id:** `albedo` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://us-east-1.hippius.com/albedo/index.html
- **github:** https://github.com/unarbos/albedo


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
