### PR TITLE
feat(registry): add SN99 Leoma provider profile

### DIFF
--- a/registry/providers/community/leoma.json
+++ b/registry/providers/community/leoma.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/RendixNetwork/leoma",
+    "id": "leoma",
+    "kind": "subnet-team",
+    "name": "Leoma",
+    "public_notes": "Subnet 99 (Leoma) team profile — decentralized video generation platform. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://leoma.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 99 (Leoma)** — no provider existed.

Closes #855.

## Provider
- **id:** `leoma` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://leoma.ai/
- **github:** https://github.com/RendixNetwork/leoma


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
