### PR TITLE
feat(registry): add SN105 Beam provider profile (with X)

### DIFF
--- a/registry/providers/community/beam.json
+++ b/registry/providers/community/beam.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/Beam-Network",
+    "id": "beam",
+    "kind": "subnet-team",
+    "name": "Beam",
+    "public_notes": "Subnet 105 (Beam) team profile — decentralized bandwidth network. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/b1m_ai"
+    },
+    "website_url": "https://b1m.ai/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 105 (Beam)** — no provider existed. Includes its **X handle** via the structured `social` field (#745).

Closes #857.

## Provider
- **id:** `beam` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://b1m.ai
- **github:** https://github.com/Beam-Network
- **social.x:** https://x.com/b1m_ai

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
