### PR TITLE
feat(registry): add SN120 Affine provider profile (with X)

### DIFF
--- a/registry/providers/community/affine.json
+++ b/registry/providers/community/affine.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/AffineFoundation/affine",
+    "id": "affine",
+    "kind": "subnet-team",
+    "name": "Affine",
+    "public_notes": "Subnet 120 (Affine) team profile — reason mining. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/affine_io"
+    },
+    "website_url": "https://www.affine.io/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 120 (Affine)** — no provider existed. Includes its **X handle** via the structured `social` field (#745).

Closes #859.

## Provider
- **id:** `affine` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.affine.io
- **github:** https://github.com/AffineFoundation/affine
- **social.x:** https://x.com/affine_io

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
