### PR TITLE
feat(registry): add SN124 Swarm provider profile (with X)

### DIFF
--- a/registry/providers/community/swarm.json
+++ b/registry/providers/community/swarm.json
@@ -1,0 +1,20 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/swarm-subnet/swarm",
+    "id": "swarm",
+    "kind": "subnet-team",
+    "name": "Swarm",
+    "public_notes": "Subnet 124 (Swarm) team profile — decentralized swarm intelligence. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo); X handle from taostats. Review input only (authority: community).",
+    "schema_version": 1,
+    "social": {
+      "x": "https://x.com/swarmsubnet"
+    },
+    "website_url": "https://www.swarm124.com/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 124 (Swarm)** — no provider existed. Includes its **X handle** via the structured `social` field (#745).

Closes #861.

## Provider
- **id:** `swarm` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.swarm124.com
- **github:** https://github.com/swarm-subnet/swarm
- **social.x:** https://x.com/swarmsubnet

Identity from the subnet's on-chain SubnetIdentitiesV3; X handle from taostats. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
