### PR TITLE
feat(registry): add SN127 Astrid provider profile

### DIFF
--- a/registry/providers/community/astrid.json
+++ b/registry/providers/community/astrid.json
@@ -1,0 +1,17 @@
+{
+  "provider": {
+    "authority": "community",
+    "github_url": "https://github.com/astridintelligence/sn-127",
+    "id": "astrid",
+    "kind": "subnet-team",
+    "name": "Astrid",
+    "public_notes": "Subnet 127 (Astrid) team profile — the capital axis for Bittensor. Identity from on-chain SubnetIdentitiesV3 (name, website, source repo). Review input only (authority: community).",
+    "schema_version": 1,
+    "website_url": "https://www.astrid.global/"
+  },
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "oktofeesh1",
+    "submitted_by_url": "https://github.com/oktofeesh1"
+  }
+}


### PR DESCRIPTION
## Summary
Adds a verified subnet-team provider profile for **Subnet 127 (Astrid)** — no provider existed.

Closes #863.

## Provider
- **id:** `astrid` · **kind:** `subnet-team` · **authority:** `community`
- **website:** https://www.astrid.global/
- **github:** https://github.com/astridintelligence/sn-127


Identity from the subnet's on-chain SubnetIdentitiesV3. Review inputs only; routes to human review.

## Validation
One file. submission:pr → manual_review, blocking false, no errors; intake / public-safety / private-boundary pass.
