### PR TITLE
feat(registry): add SN34 BitMind Detection API OpenAPI schema

### DIFF
--- a/registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
+++ b/registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-34-openapi-api-bitmind-ai",
+      "kind": "openapi",
+      "name": "BitMind community openapi",
+      "netuid": 34,
+      "provider": "bitmind",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/BitMind-AI/docs/blob/main/api-specs/subnet-api/subnet-api-openapi.yaml",
+      "source_urls": [
+        "https://github.com/BitMind-AI/docs/blob/main/api-specs/subnet-api/subnet-api-openapi.yaml"
+      ],
+      "state": "schema-valid",
+      "url": "https://api.bitmind.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds community candidate for SN34 BitMind machine-readable OpenAPI schema at `https://api.bitmind.ai/openapi.json`.
- Source: official BitMind docs repo OpenAPI spec (`api-specs/subnet-api/subnet-api-openapi.yaml`).

Addresses #727 (OpenAPI surface).

## Validation
```bash
npm run validate:candidate -- registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
```

## Test plan
- [x] `api.bitmind.ai/openapi.json` returns OpenAPI 3.1 JSON (200)
- [x] Source URL resolves on GitHub
- [x] One candidate file only
