### PR TITLE
feat(registry): add SN34 BitMind public health subnet-api endpoint

### DIFF
--- a/registry/candidates/community/community-sn-34-subnet-api-api-bitmind-ai.json
+++ b/registry/candidates/community/community-sn-34-subnet-api-api-bitmind-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-34-subnet-api-api-bitmind-ai",
+      "kind": "subnet-api",
+      "name": "BitMind community subnet-api",
+      "netuid": 34,
+      "provider": "bitmind",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://docs.bitmind.ai/api-reference",
+      "source_urls": ["https://docs.bitmind.ai/api-reference"],
+      "state": "schema-valid",
+      "url": "https://api.bitmind.ai/"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "jaso0n0818",
+    "submitted_by_url": "https://github.com/jaso0n0818"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds community candidate for SN34 BitMind unauthenticated public API health endpoint at `https://api.bitmind.ai/health`.
- Source: official BitMind API reference docs.

Addresses #727 (public API endpoint).

## Validation
```bash
npm run validate:candidate -- registry/candidates/community/community-sn-34-subnet-api-api-bitmind-ai.json
```

## Test plan
- [x] `GET /health` returns JSON `{"status":"healthy",...}` without auth (200)
- [x] Documented in https://docs.bitmind.ai/api-reference
- [x] One candidate file only
