### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/ippcteam/SN21-adtao"],
+      "source_urls": [
+        "https://github.com/ippcteam/SN21-adtao"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -57,7 +59,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/ippcteam/SN21-adtao"],
+      "source_urls": [
+        "https://github.com/ippcteam/SN21-adtao"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -66,5 +70,8 @@
       },
       "notes": "Official AdTAO source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/ppcrebel"
+  }
 }

--- a/registry/subnets/adtao.json
+++ b/registry/subnets/adtao.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/ippcteam/SN21-adtao"
-      ],
+      "source_urls": ["https://github.com/ippcteam/SN21-adtao"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,9 +57,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/ippcteam/SN21-adtao"
-      ],
+      "source_urls": ["https://github.com/ippcteam/SN21-adtao"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/apex.json
+++ b/registry/subnets/apex.json
@@ -41,9 +41,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/macrocosm-os/apex"
-      ],
+      "source_urls": ["https://github.com/macrocosm-os/apex"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -81,9 +79,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/macrocosm-os/apex"
-      ],
+      "source_urls": ["https://github.com/macrocosm-os/apex"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/apex.json
+++ b/registry/subnets/apex.json
@@ -41,7 +41,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/macrocosm-os/apex"],
+      "source_urls": [
+        "https://github.com/macrocosm-os/apex"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -79,7 +81,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/macrocosm-os/apex"],
+      "source_urls": [
+        "https://github.com/macrocosm-os/apex"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -88,5 +92,8 @@
       },
       "notes": "Official Apex source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/macrocosmosai"
+  }
 }

--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -72,7 +72,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://bitads.ai/docs"],
+      "source_urls": [
+        "https://bitads.ai/docs"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -90,7 +92,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/FirstTensorLabs/BitAds"],
+      "source_urls": [
+        "https://github.com/FirstTensorLabs/BitAds"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -99,5 +103,8 @@
       },
       "notes": "Official BitAds source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/bitkoop"
+  }
 }

--- a/registry/subnets/bitads.json
+++ b/registry/subnets/bitads.json
@@ -72,9 +72,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://bitads.ai/docs"
-      ],
+      "source_urls": ["https://bitads.ai/docs"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -92,9 +90,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/FirstTensorLabs/BitAds"
-      ],
+      "source_urls": ["https://github.com/FirstTensorLabs/BitAds"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/blockmachine.json
+++ b/registry/subnets/blockmachine.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taostat/blockmachine"
-      ],
+      "source_urls": ["https://github.com/taostat/blockmachine"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,9 +57,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://blockmachine.io/whitepaper"
-      ],
+      "source_urls": ["https://blockmachine.io/whitepaper"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -79,9 +75,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taostat/blockmachine"
-      ],
+      "source_urls": ["https://github.com/taostat/blockmachine"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/blockmachine.json
+++ b/registry/subnets/blockmachine.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taostat/blockmachine"],
+      "source_urls": [
+        "https://github.com/taostat/blockmachine"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -57,7 +59,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://blockmachine.io/whitepaper"],
+      "source_urls": [
+        "https://blockmachine.io/whitepaper"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -75,7 +79,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taostat/blockmachine"],
+      "source_urls": [
+        "https://github.com/taostat/blockmachine"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -84,5 +90,8 @@
       },
       "notes": "Official BlockMachine source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/blockmachine_io"
+  }
 }

--- a/registry/subnets/cacheon.json
+++ b/registry/subnets/cacheon.json
@@ -116,5 +116,8 @@
       },
       "notes": "Official miner API contract documentation for Cacheon. This is documentation for miner-hosted OpenAI-compatible endpoints, not a promoted shared public API endpoint."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/cacheon_ai"
+  }
 }

--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -61,7 +61,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/macrocosm-os/data-universe"],
+      "source_urls": [
+        "https://github.com/macrocosm-os/data-universe"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -182,7 +184,9 @@
       "auth_required": false,
       "authority": "registry-observed",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/13"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/13"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -191,5 +195,8 @@
       },
       "notes": "Universal TaoMarketCap subnet dashboard candidate. Third-party enrichment, not protocol authority."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/macrocosmosai"
+  }
 }

--- a/registry/subnets/data-universe.json
+++ b/registry/subnets/data-universe.json
@@ -61,9 +61,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/macrocosm-os/data-universe"
-      ],
+      "source_urls": ["https://github.com/macrocosm-os/data-universe"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -184,9 +182,7 @@
       "auth_required": false,
       "authority": "registry-observed",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/13"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/13"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -53,7 +53,9 @@
       },
       "provider": "desearch",
       "public_safe": true,
-      "source_urls": ["https://www.desearch.ai/"],
+      "source_urls": [
+        "https://www.desearch.ai/"
+      ],
       "url": "https://www.desearch.ai/"
     },
     {
@@ -71,7 +73,9 @@
       },
       "provider": "desearch",
       "public_safe": true,
-      "source_urls": ["https://www.desearch.ai/docs"],
+      "source_urls": [
+        "https://www.desearch.ai/docs"
+      ],
       "url": "https://www.desearch.ai/docs"
     },
     {
@@ -211,9 +215,14 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/22"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/22"
+      ],
       "url": "https://taomarketcap.com/subnets/22"
     }
   ],
-  "website_url": "https://www.desearch.ai/"
+  "website_url": "https://www.desearch.ai/",
+  "social": {
+    "x": "https://x.com/desearch_ai"
+  }
 }

--- a/registry/subnets/desearch.json
+++ b/registry/subnets/desearch.json
@@ -53,9 +53,7 @@
       },
       "provider": "desearch",
       "public_safe": true,
-      "source_urls": [
-        "https://www.desearch.ai/"
-      ],
+      "source_urls": ["https://www.desearch.ai/"],
       "url": "https://www.desearch.ai/"
     },
     {
@@ -73,9 +71,7 @@
       },
       "provider": "desearch",
       "public_safe": true,
-      "source_urls": [
-        "https://www.desearch.ai/docs"
-      ],
+      "source_urls": ["https://www.desearch.ai/docs"],
       "url": "https://www.desearch.ai/docs"
     },
     {
@@ -215,9 +211,7 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/22"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/22"],
       "url": "https://taomarketcap.com/subnets/22"
     }
   ],

--- a/registry/subnets/dsperse.json
+++ b/registry/subnets/dsperse.json
@@ -101,5 +101,8 @@
       },
       "notes": "Public source repository for DSperse / SN2."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/inference_labs"
+  }
 }

--- a/registry/subnets/endure.json
+++ b/registry/subnets/endure.json
@@ -54,7 +54,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://endure.network/"],
+      "source_urls": [
+        "https://endure.network/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -72,7 +74,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://endure.network/"],
+      "source_urls": [
+        "https://endure.network/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -81,5 +85,8 @@
       },
       "notes": "Official Endure documentation linked from the project website."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/endurenet"
+  }
 }

--- a/registry/subnets/endure.json
+++ b/registry/subnets/endure.json
@@ -54,9 +54,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://endure.network/"
-      ],
+      "source_urls": ["https://endure.network/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -74,9 +72,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://endure.network/"
-      ],
+      "source_urls": ["https://endure.network/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/gm.json
+++ b/registry/subnets/gm.json
@@ -33,5 +33,8 @@
       "SubnetRadar published Discord-derived news about a TEE-enabled model routing marketplace, but that is not treated as an official operational interface."
     ]
   },
-  "surfaces": []
+  "surfaces": [],
+  "social": {
+    "x": "https://x.com/say_gm_"
+  }
 }

--- a/registry/subnets/graphite.json
+++ b/registry/subnets/graphite.json
@@ -73,5 +73,8 @@
       },
       "notes": "Official Graphite source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/graphitesubnet"
+  }
 }

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -4,7 +4,11 @@
   "name": "GroundLayer",
   "slug": "sn-20",
   "status": "active",
-  "categories": ["baseline-curated", "capital-markets", "identity-reviewed"],
+  "categories": [
+    "baseline-curated",
+    "capital-markets",
+    "identity-reviewed"
+  ],
   "source_repo": null,
   "dashboard_url": "https://taomarketcap.com/subnets/20",
   "website_url": "https://www.groundlayer.xyz/",
@@ -103,5 +107,8 @@
       },
       "notes": "Official GroundLayer roadmap page."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/groundlayerhq"
+  }
 }

--- a/registry/subnets/groundlayer.json
+++ b/registry/subnets/groundlayer.json
@@ -4,11 +4,7 @@
   "name": "GroundLayer",
   "slug": "sn-20",
   "status": "active",
-  "categories": [
-    "baseline-curated",
-    "capital-markets",
-    "identity-reviewed"
-  ],
+  "categories": ["baseline-curated", "capital-markets", "identity-reviewed"],
   "source_repo": null,
   "dashboard_url": "https://taomarketcap.com/subnets/20",
   "website_url": "https://www.groundlayer.xyz/",

--- a/registry/subnets/itsai.json
+++ b/registry/subnets/itsai.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/It-s-AI/llm-detection"
-      ],
+      "source_urls": ["https://github.com/It-s-AI/llm-detection"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/It-s-AI/llm-detection"
-      ],
+      "source_urls": ["https://github.com/It-s-AI/llm-detection"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/itsai.json
+++ b/registry/subnets/itsai.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/It-s-AI/llm-detection"],
+      "source_urls": [
+        "https://github.com/It-s-AI/llm-detection"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/It-s-AI/llm-detection"],
+      "source_urls": [
+        "https://github.com/It-s-AI/llm-detection"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -65,5 +69,8 @@
       },
       "notes": "Official ItsAI source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/ai_detection"
+  }
 }

--- a/registry/subnets/mainframe.json
+++ b/registry/subnets/mainframe.json
@@ -41,7 +41,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/macrocosm-os/mainframe"],
+      "source_urls": [
+        "https://github.com/macrocosm-os/mainframe"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -50,5 +52,8 @@
       },
       "notes": "Official Mainframe source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/macrocosmosai"
+  }
 }

--- a/registry/subnets/mainframe.json
+++ b/registry/subnets/mainframe.json
@@ -41,9 +41,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/macrocosm-os/mainframe"
-      ],
+      "source_urls": ["https://github.com/macrocosm-os/mainframe"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -100,9 +100,7 @@
       },
       "provider": "nepher-robotics",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/nepher-ai/nepher-subnet"
-      ],
+      "source_urls": ["https://github.com/nepher-ai/nepher-subnet"],
       "url": "https://github.com/nepher-ai/nepher-subnet"
     },
     {
@@ -120,9 +118,7 @@
       },
       "provider": "nepher-robotics",
       "public_safe": true,
-      "source_urls": [
-        "https://nepher.ai"
-      ],
+      "source_urls": ["https://nepher.ai"],
       "url": "https://tournament.nepher.ai"
     },
     {
@@ -220,9 +216,7 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/49"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/49"],
       "url": "https://taomarketcap.com/subnets/49"
     }
   ],

--- a/registry/subnets/nepher-robotics.json
+++ b/registry/subnets/nepher-robotics.json
@@ -100,7 +100,9 @@
       },
       "provider": "nepher-robotics",
       "public_safe": true,
-      "source_urls": ["https://github.com/nepher-ai/nepher-subnet"],
+      "source_urls": [
+        "https://github.com/nepher-ai/nepher-subnet"
+      ],
       "url": "https://github.com/nepher-ai/nepher-subnet"
     },
     {
@@ -118,7 +120,9 @@
       },
       "provider": "nepher-robotics",
       "public_safe": true,
-      "source_urls": ["https://nepher.ai"],
+      "source_urls": [
+        "https://nepher.ai"
+      ],
       "url": "https://tournament.nepher.ai"
     },
     {
@@ -216,9 +220,14 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/49"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/49"
+      ],
       "url": "https://taomarketcap.com/subnets/49"
     }
   ],
-  "website_url": "https://nepher.ai"
+  "website_url": "https://nepher.ai",
+  "social": {
+    "x": "https://x.com/nepher_robotics"
+  }
 }

--- a/registry/subnets/numinous.json
+++ b/registry/subnets/numinous.json
@@ -161,5 +161,8 @@
       },
       "notes": "Read-only leaderboard endpoint documented by the Numinous OpenAPI schema."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/numinous_ai"
+  }
 }

--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/ORO-AI/oro"],
+      "source_urls": [
+        "https://github.com/ORO-AI/oro"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -57,7 +59,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/ORO-AI/oro/blob/main/README.md"],
+      "source_urls": [
+        "https://github.com/ORO-AI/oro/blob/main/README.md"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -75,7 +79,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/ORO-AI/oro"],
+      "source_urls": [
+        "https://github.com/ORO-AI/oro"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -84,5 +90,8 @@
       },
       "notes": "Official ORO source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/oroagents"
+  }
 }

--- a/registry/subnets/oro.json
+++ b/registry/subnets/oro.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/ORO-AI/oro"
-      ],
+      "source_urls": ["https://github.com/ORO-AI/oro"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,9 +57,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/ORO-AI/oro/blob/main/README.md"
-      ],
+      "source_urls": ["https://github.com/ORO-AI/oro/blob/main/README.md"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -79,9 +75,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/ORO-AI/oro"
-      ],
+      "source_urls": ["https://github.com/ORO-AI/oro"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -40,9 +40,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/qbittensor-labs/quantum-compute"
-      ],
+      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -60,9 +58,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/qbittensor-labs/quantum-compute"
-      ],
+      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/quantum-compute.json
+++ b/registry/subnets/quantum-compute.json
@@ -40,7 +40,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
+      "source_urls": [
+        "https://github.com/qbittensor-labs/quantum-compute"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,7 +60,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/quantum-compute"],
+      "source_urls": [
+        "https://github.com/qbittensor-labs/quantum-compute"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -67,5 +71,8 @@
       },
       "notes": "Official Quantum Compute source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/qbittensorlabs"
+  }
 }

--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -57,9 +57,7 @@
       },
       "provider": "silx-labs",
       "public_safe": true,
-      "source_urls": [
-        "https://silxinc.com/"
-      ],
+      "source_urls": ["https://silxinc.com/"],
       "url": "https://silxinc.com/"
     },
     {
@@ -199,9 +197,7 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/24"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/24"],
       "url": "https://taomarketcap.com/subnets/24"
     }
   ],

--- a/registry/subnets/quasar.json
+++ b/registry/subnets/quasar.json
@@ -57,7 +57,9 @@
       },
       "provider": "silx-labs",
       "public_safe": true,
-      "source_urls": ["https://silxinc.com/"],
+      "source_urls": [
+        "https://silxinc.com/"
+      ],
       "url": "https://silxinc.com/"
     },
     {
@@ -197,9 +199,14 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/24"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/24"
+      ],
       "url": "https://taomarketcap.com/subnets/24"
     }
   ],
-  "website_url": "https://silxinc.com/"
+  "website_url": "https://silxinc.com/",
+  "social": {
+    "x": "https://x.com/quasarmodels"
+  }
 }

--- a/registry/subnets/talisman-ai.json
+++ b/registry/subnets/talisman-ai.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Team-Rizzo/talisman-ai"
-      ],
+      "source_urls": ["https://github.com/Team-Rizzo/talisman-ai"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Team-Rizzo/talisman-ai"
-      ],
+      "source_urls": ["https://github.com/Team-Rizzo/talisman-ai"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/talisman-ai.json
+++ b/registry/subnets/talisman-ai.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/Team-Rizzo/talisman-ai"],
+      "source_urls": [
+        "https://github.com/Team-Rizzo/talisman-ai"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/Team-Rizzo/talisman-ai"],
+      "source_urls": [
+        "https://github.com/Team-Rizzo/talisman-ai"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -65,5 +69,8 @@
       },
       "notes": "Official Talisman AI source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/wearetalisman"
+  }
 }

--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -40,7 +40,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/manifold-inc/targon"],
+      "source_urls": [
+        "https://github.com/manifold-inc/targon"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,7 +60,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://targon.com/", "https://docs.targon.com/"],
+      "source_urls": [
+        "https://targon.com/",
+        "https://docs.targon.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -97,7 +102,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/manifold-inc/targon"],
+      "source_urls": [
+        "https://github.com/manifold-inc/targon"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -106,5 +113,8 @@
       },
       "notes": "Official Targon source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/targoncompute"
+  }
 }

--- a/registry/subnets/targon.json
+++ b/registry/subnets/targon.json
@@ -40,9 +40,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/manifold-inc/targon"
-      ],
+      "source_urls": ["https://github.com/manifold-inc/targon"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -60,10 +58,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://targon.com/",
-        "https://docs.targon.com/"
-      ],
+      "source_urls": ["https://targon.com/", "https://docs.targon.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -102,9 +97,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/manifold-inc/targon"
-      ],
+      "source_urls": ["https://github.com/manifold-inc/targon"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -61,9 +61,7 @@
       "auth_required": false,
       "authority": "provider-claimed",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/one-covenant/templar"
-      ],
+      "source_urls": ["https://github.com/one-covenant/templar"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -102,9 +100,7 @@
       "auth_required": false,
       "authority": "provider-claimed",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/one-covenant/templar"
-      ],
+      "source_urls": ["https://github.com/one-covenant/templar"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -122,9 +118,7 @@
       "auth_required": false,
       "authority": "provider-claimed",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/one-covenant/templar"
-      ],
+      "source_urls": ["https://github.com/one-covenant/templar"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/templar.json
+++ b/registry/subnets/templar.json
@@ -61,7 +61,9 @@
       "auth_required": false,
       "authority": "provider-claimed",
       "public_safe": true,
-      "source_urls": ["https://github.com/one-covenant/templar"],
+      "source_urls": [
+        "https://github.com/one-covenant/templar"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -100,7 +102,9 @@
       "auth_required": false,
       "authority": "provider-claimed",
       "public_safe": true,
-      "source_urls": ["https://github.com/one-covenant/templar"],
+      "source_urls": [
+        "https://github.com/one-covenant/templar"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -118,7 +122,9 @@
       "auth_required": false,
       "authority": "provider-claimed",
       "public_safe": true,
-      "source_urls": ["https://github.com/one-covenant/templar"],
+      "source_urls": [
+        "https://github.com/one-covenant/templar"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -127,5 +133,8 @@
       },
       "notes": "Public Grafana evaluation dashboard linked from the Templar repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/tplr_ai"
+  }
 }

--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -76,9 +76,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://trajrl.com/docs"
-      ],
+      "source_urls": ["https://trajrl.com/docs"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -96,9 +94,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://trajrl.com/"
-      ],
+      "source_urls": ["https://trajrl.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -116,9 +112,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://trajrl.com/"
-      ],
+      "source_urls": ["https://trajrl.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -136,9 +130,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://trajrl.com/"
-      ],
+      "source_urls": ["https://trajrl.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -156,9 +148,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://trajrl.com/"
-      ],
+      "source_urls": ["https://trajrl.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -176,9 +166,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/trajectoryRL/trajectoryRL"
-      ],
+      "source_urls": ["https://github.com/trajectoryRL/trajectoryRL"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/trajectoryrl.json
+++ b/registry/subnets/trajectoryrl.json
@@ -76,7 +76,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://trajrl.com/docs"],
+      "source_urls": [
+        "https://trajrl.com/docs"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -94,7 +96,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "source_urls": [
+        "https://trajrl.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -112,7 +116,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "source_urls": [
+        "https://trajrl.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -130,7 +136,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "source_urls": [
+        "https://trajrl.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -148,7 +156,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://trajrl.com/"],
+      "source_urls": [
+        "https://trajrl.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -166,7 +176,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/trajectoryRL/trajectoryRL"],
+      "source_urls": [
+        "https://github.com/trajectoryRL/trajectoryRL"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -175,5 +187,8 @@
       },
       "notes": "Official TrajectoryRL source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/trajectoryrl"
+  }
 }

--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -78,7 +78,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/TrishoolAI/trishool-phase2"],
+      "source_urls": [
+        "https://github.com/TrishoolAI/trishool-phase2"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -87,5 +89,8 @@
       },
       "notes": "Official Trishool phase two source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/trishoolai"
+  }
 }

--- a/registry/subnets/trishool.json
+++ b/registry/subnets/trishool.json
@@ -78,9 +78,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/TrishoolAI/trishool-phase2"
-      ],
+      "source_urls": ["https://github.com/TrishoolAI/trishool-phase2"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/vanta.json
+++ b/registry/subnets/vanta.json
@@ -74,9 +74,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://www.vantanetwork.io/"
-      ],
+      "source_urls": ["https://www.vantanetwork.io/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -94,9 +92,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://www.vantanetwork.io/"
-      ],
+      "source_urls": ["https://www.vantanetwork.io/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -114,9 +110,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://www.vantanetwork.io/"
-      ],
+      "source_urls": ["https://www.vantanetwork.io/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -134,9 +128,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taoshidev/vanta-network"
-      ],
+      "source_urls": ["https://github.com/taoshidev/vanta-network"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/vanta.json
+++ b/registry/subnets/vanta.json
@@ -74,7 +74,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://www.vantanetwork.io/"],
+      "source_urls": [
+        "https://www.vantanetwork.io/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -92,7 +94,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://www.vantanetwork.io/"],
+      "source_urls": [
+        "https://www.vantanetwork.io/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -110,7 +114,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://www.vantanetwork.io/"],
+      "source_urls": [
+        "https://www.vantanetwork.io/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -128,7 +134,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taoshidev/vanta-network"],
+      "source_urls": [
+        "https://github.com/taoshidev/vanta-network"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -137,5 +145,8 @@
       },
       "notes": "Official Vanta Network source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/taoshiio"
+  }
 }


### PR DESCRIPTION
## Summary

Gap-fills sourced from **taostats** `/api/subnet/identity/v1` — a third-party source. All fills are **additive only** (never overwrites existing data) and sanitized through the repo's own `socialAccounts()` helper before writing.

**This batch:** 25 subnets get `social.x` (curated X/Twitter URL) where metagraphed previously had no value.

| Field | Count | Notes |
|-------|-------|-------|
| `social.x` | 25 | Handles converted to `https://x.com/<handle>` via `socialAccounts()` |

### Subnets touched

SN1 (apex), SN2 (dsperse), SN3 (templar), SN4 (targon), SN6 (numinous), SN8 (vanta), SN11 (trajectoryrl), SN13 (data-universe), SN14 (cacheon), SN15 (oro), SN16 (bitads), SN19 (blockmachine), SN20 (groundlayer), SN21 (adtao), SN22 (desearch), SN23 (trishool), SN24 (quasar), SN25 (mainframe), SN28 (gm), SN30 (endure), SN32 (itsai), SN43 (graphite), SN45 (talisman-ai), SN48 (quantum-compute), SN49 (nepher-robotics)

## Provenance

Values sourced from **taostats** (third-party). These are the Twitter/X handles as listed in the taostats subnet identity registry. Please verify handles are correct for your subnet before merging — this is a best-effort gap-fill, not a verified source.

41 more subnets with taostats twitter gaps remain for a future batch (capped at 25 per run for reviewability).

> ⚠️ Do not merge without reviewing the handle → subnet mapping. These are third-party fills.