### PR TITLE
feat(subnets): add updated_at freshness to /api/v1/subnets list rows (#640)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -2955,6 +2955,11 @@ export interface components {
             surface_count: number;
             symbol?: string | null;
             tempo?: number;
+            /**
+             * Format: date-time
+             * @description When the authoritative native chain snapshot backing this row was captured (the snapshot's captured_at). A display-only freshness floor for the list's 'last updated' column; the live per-surface probe time is overlaid on the detail/health routes, not here. Never feeds completeness/readiness/gaps (the #343 flywheel-preservation gate).
+             */
+            updated_at?: string | null;
             /** Format: uri */
             website_url?: string | null;
         };

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -7815,6 +7815,14 @@
             "minimum": 0,
             "type": "integer"
           },
+          "updated_at": {
+            "description": "When the authoritative native chain snapshot backing this row was captured (the snapshot's captured_at). A display-only freshness floor for the list's 'last updated' column; the live per-surface probe time is overlaid on the detail/health routes, not here. Never feeds completeness/readiness/gaps (the #343 flywheel-preservation gate).",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "website_url": {
             "format": "uri",
             "type": [

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -2955,6 +2955,11 @@ export interface components {
             surface_count: number;
             symbol?: string | null;
             tempo?: number;
+            /**
+             * Format: date-time
+             * @description When the authoritative native chain snapshot backing this row was captured (the snapshot's captured_at). A display-only freshness floor for the list's 'last updated' column; the live per-surface probe time is overlaid on the detail/health routes, not here. Never feeds completeness/readiness/gaps (the #343 flywheel-preservation gate).
+             */
+            updated_at?: string | null;
             /** Format: uri */
             website_url?: string | null;
         };

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -7793,6 +7793,14 @@
             "minimum": 0,
             "type": "integer"
           },
+          "updated_at": {
+            "description": "When the authoritative native chain snapshot backing this row was captured (the snapshot's captured_at). A display-only freshness floor for the list's 'last updated' column; the live per-surface probe time is overlaid on the detail/health routes, not here. Never feeds completeness/readiness/gaps (the #343 flywheel-preservation gate).",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "website_url": {
             "format": "uri",
             "type": [

--- a/schemas/components/05-subnets.schema.json
+++ b/schemas/components/05-subnets.schema.json
@@ -114,6 +114,11 @@
             "type": "integer",
             "minimum": 0
           },
+          "updated_at": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "When the authoritative native chain snapshot backing this row was captured (the snapshot's captured_at). A display-only freshness floor for the list's 'last updated' column; the live per-surface probe time is overlaid on the detail/health routes, not here. Never feeds completeness/readiness/gaps (the #343 flywheel-preservation gate)."
+          },
           "candidate_count": {
             "type": "integer",
             "minimum": 0

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -377,6 +377,11 @@ const subnetIndex = mergedSubnets.map((subnet) => {
     netuid: subnet.netuid,
     participant_count: subnet.participant_count,
     probed_surface_count: subnet.probed_surface_count,
+    // #640: display-only freshness floor for the list's "last updated" column —
+    // the native snapshot's captured_at (when authoritative chain data was
+    // captured). The per-surface live probe time is overlaid on detail/health,
+    // not here. Never feeds completeness/readiness/gaps (the #343 flywheel gate).
+    updated_at: nativeSnapshot.captured_at || null,
     registered_at_block: subnet.registered_at_block,
     slug: subnet.slug,
     source_repo: subnet.source_repo,


### PR DESCRIPTION
Closes #640.

## Problem
`/api/v1/subnets` **list** rows returned no `freshness`/`updated_at`/`last_checked`/`last_ok`, so the UI's subnets-table "Last updated" column rendered blank (the frontend normalizer already tries all four fallbacks — the data just wasn't there).

## Fix
Project the native chain snapshot's `captured_at` onto each `SubnetIndexEntry` as `updated_at` (a real, reproducible per-snapshot timestamp — the build's own `generated_at` is the epoch-0 reproducibility placeholder, so it can't be used). This is the same value `/freshness` already exposes as `native_data_as_of`.

- **Display-only** freshness floor — the live per-surface probe time stays overlaid on the detail/health routes, not the list. Never feeds `completeness_score`/readiness/gaps (the #343 flywheel gate).
- Schema field is nullable + optional, so the committed cold-start seed (without it) still validates; deploy regenerates the artifact with the value.
- Plain `date-time` string → no `valueForPattern` openapi-sample trap.

## Verification
- `validate:schemas`, `validate:api`, `validate:contract-drift`, `validate:openapi-examples` all green
- `npm test` → 1097 passed
- Built row sample: `netuid 0 → updated_at 2026-06-14T09:03:28Z`

Contract regenerated (openapi/types/components); data artifacts left to the deploy build per the ADR 0006 seed discipline.