### PR TITLE
chore(enrich): taostats identity gap-fills

### DIFF
--- a/registry/subnets/bitrecs.json
+++ b/registry/subnets/bitrecs.json
@@ -40,7 +40,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://www.bitrecs.ai/"],
+      "source_urls": [
+        "https://www.bitrecs.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,7 +60,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://www.bitrecs.ai/"],
+      "source_urls": [
+        "https://www.bitrecs.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -88,5 +92,8 @@
       },
       "notes": "Official Bitrecs source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/cookingtao_"
+  }
 }

--- a/registry/subnets/bitrecs.json
+++ b/registry/subnets/bitrecs.json
@@ -40,9 +40,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://www.bitrecs.ai/"
-      ],
+      "source_urls": ["https://www.bitrecs.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -60,9 +58,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://www.bitrecs.ai/"
-      ],
+      "source_urls": ["https://www.bitrecs.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/bitstarter.json
+++ b/registry/subnets/bitstarter.json
@@ -56,7 +56,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://bitstarter.ai/"],
+      "source_urls": [
+        "https://bitstarter.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -95,7 +97,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://app.bitstarter.ai/"],
+      "source_urls": [
+        "https://app.bitstarter.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -146,5 +150,8 @@
       },
       "notes": "Public Bitstarter app workflow for incubator project submissions."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/bitstarterai"
+  }
 }

--- a/registry/subnets/bitstarter.json
+++ b/registry/subnets/bitstarter.json
@@ -56,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://bitstarter.ai/"
-      ],
+      "source_urls": ["https://bitstarter.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -97,9 +95,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://app.bitstarter.ai/"
-      ],
+      "source_urls": ["https://app.bitstarter.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -57,9 +57,7 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": [
-        "https://chutes.ai/"
-      ],
+      "source_urls": ["https://chutes.ai/"],
       "url": "https://chutes.ai/"
     },
     {
@@ -77,9 +75,7 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": [
-        "https://chutes.ai/docs"
-      ],
+      "source_urls": ["https://chutes.ai/docs"],
       "url": "https://chutes.ai/docs"
     },
     {
@@ -160,9 +156,7 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": [
-        "https://chutes.ai/"
-      ],
+      "source_urls": ["https://chutes.ai/"],
       "url": "https://chutes.ai/app?type=llm"
     },
     {
@@ -180,9 +174,7 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": [
-        "https://chutes.ai/"
-      ],
+      "source_urls": ["https://chutes.ai/"],
       "url": "https://chutes.ai/app?type=diffusion"
     },
     {
@@ -284,9 +276,7 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": [
-        "https://api.taomarketcap.com/public/v1/subnets/64"
-      ],
+      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/64"],
       "url": "https://taomarketcap.com/subnets/64"
     }
   ],

--- a/registry/subnets/chutes.json
+++ b/registry/subnets/chutes.json
@@ -57,7 +57,9 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": ["https://chutes.ai/"],
+      "source_urls": [
+        "https://chutes.ai/"
+      ],
       "url": "https://chutes.ai/"
     },
     {
@@ -75,7 +77,9 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": ["https://chutes.ai/docs"],
+      "source_urls": [
+        "https://chutes.ai/docs"
+      ],
       "url": "https://chutes.ai/docs"
     },
     {
@@ -156,7 +160,9 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": ["https://chutes.ai/"],
+      "source_urls": [
+        "https://chutes.ai/"
+      ],
       "url": "https://chutes.ai/app?type=llm"
     },
     {
@@ -174,7 +180,9 @@
       },
       "provider": "chutes",
       "public_safe": true,
-      "source_urls": ["https://chutes.ai/"],
+      "source_urls": [
+        "https://chutes.ai/"
+      ],
       "url": "https://chutes.ai/app?type=diffusion"
     },
     {
@@ -276,9 +284,14 @@
       },
       "provider": "taomarketcap",
       "public_safe": true,
-      "source_urls": ["https://api.taomarketcap.com/public/v1/subnets/64"],
+      "source_urls": [
+        "https://api.taomarketcap.com/public/v1/subnets/64"
+      ],
       "url": "https://taomarketcap.com/subnets/64"
     }
   ],
-  "website_url": "https://chutes.ai/"
+  "website_url": "https://chutes.ai/",
+  "social": {
+    "x": "https://x.com/chutes_ai"
+  }
 }

--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -51,9 +51,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://heyditto.ai/"
-      ],
+      "source_urls": ["https://heyditto.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -71,10 +69,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://heyditto.ai/docs/",
-        "https://heyditto.ai/"
-      ],
+      "source_urls": ["https://heyditto.ai/docs/", "https://heyditto.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -155,10 +150,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://assistant.heyditto.ai/",
-        "https://heyditto.ai/"
-      ],
+      "source_urls": ["https://assistant.heyditto.ai/", "https://heyditto.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/ditto.json
+++ b/registry/subnets/ditto.json
@@ -51,7 +51,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://heyditto.ai/"],
+      "source_urls": [
+        "https://heyditto.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -69,7 +71,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://heyditto.ai/docs/", "https://heyditto.ai/"],
+      "source_urls": [
+        "https://heyditto.ai/docs/",
+        "https://heyditto.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -150,7 +155,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://assistant.heyditto.ai/", "https://heyditto.ai/"],
+      "source_urls": [
+        "https://assistant.heyditto.ai/",
+        "https://heyditto.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -180,5 +188,8 @@
       },
       "notes": "Public Ditto GitHub organization repository listing. Tracked separately from source-repo until a canonical repository is verified."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/heydittoai"
+  }
 }

--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Djinn-Inc/djinn"
-      ],
+      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/Djinn-Inc/djinn"
-      ],
+      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/djinn.json
+++ b/registry/subnets/djinn.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/Djinn-Inc/djinn"],
+      "source_urls": [
+        "https://github.com/Djinn-Inc/djinn"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -65,5 +69,8 @@
       },
       "notes": "Official Djinn source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/djinn_gg"
+  }
 }

--- a/registry/subnets/enigma.json
+++ b/registry/subnets/enigma.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/qbittensor-labs/enigma"
-      ],
+      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,9 +57,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/qbittensor-labs/enigma"
-      ],
+      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/enigma.json
+++ b/registry/subnets/enigma.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
+      "source_urls": [
+        "https://github.com/qbittensor-labs/enigma"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -57,7 +59,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/qbittensor-labs/enigma"],
+      "source_urls": [
+        "https://github.com/qbittensor-labs/enigma"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -66,5 +70,8 @@
       },
       "notes": "Official Enigma source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/qbittensorlabs"
+  }
 }

--- a/registry/subnets/forevermoney.json
+++ b/registry/subnets/forevermoney.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/SN98-ForeverMoney/forever-money"
-      ],
+      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,9 +57,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/SN98-ForeverMoney/forever-money"
-      ],
+      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/forevermoney.json
+++ b/registry/subnets/forevermoney.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
+      "source_urls": [
+        "https://github.com/SN98-ForeverMoney/forever-money"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -57,7 +59,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/SN98-ForeverMoney/forever-money"],
+      "source_urls": [
+        "https://github.com/SN98-ForeverMoney/forever-money"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -66,5 +70,8 @@
       },
       "notes": "Official ForeverMoney source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/forevermoney_ai"
+  }
 }

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -1,9 +1,5 @@
 {
-  "categories": [
-    "developer-tools",
-    "repositories",
-    "pilot"
-  ],
+  "categories": ["developer-tools", "repositories", "pilot"],
   "curation": {
     "gap_notes": [
       "No verified dashboard surface yet.",
@@ -135,9 +131,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
-      "source_urls": [
-        "https://docs.gittensor.io/register-repository.html"
-      ],
+      "source_urls": ["https://docs.gittensor.io/register-repository.html"],
       "url": "https://gittensor.io/repositories"
     },
     {
@@ -154,9 +148,7 @@
       },
       "provider": "gittensor",
       "public_safe": true,
-      "source_urls": [
-        "https://docs.gittensor.io/repository-hyperparameters"
-      ],
+      "source_urls": ["https://docs.gittensor.io/repository-hyperparameters"],
       "url": "https://raw.githubusercontent.com/entrius/gittensor/main/gittensor/validator/weights/master_repositories.json"
     },
     {
@@ -173,9 +165,7 @@
       },
       "provider": "gittensory",
       "public_safe": true,
-      "source_urls": [
-        "https://gittensory.aethereal.dev/"
-      ],
+      "source_urls": ["https://gittensory.aethereal.dev/"],
       "url": "https://gittensory-api.aethereal.dev/v1/public/subnet-interface"
     },
     {

--- a/registry/subnets/gittensor.json
+++ b/registry/subnets/gittensor.json
@@ -1,5 +1,9 @@
 {
-  "categories": ["developer-tools", "repositories", "pilot"],
+  "categories": [
+    "developer-tools",
+    "repositories",
+    "pilot"
+  ],
   "curation": {
     "gap_notes": [
       "No verified dashboard surface yet.",
@@ -131,7 +135,9 @@
       },
       "provider": "gittensor",
       "public_safe": true,
-      "source_urls": ["https://docs.gittensor.io/register-repository.html"],
+      "source_urls": [
+        "https://docs.gittensor.io/register-repository.html"
+      ],
       "url": "https://gittensor.io/repositories"
     },
     {
@@ -148,7 +154,9 @@
       },
       "provider": "gittensor",
       "public_safe": true,
-      "source_urls": ["https://docs.gittensor.io/repository-hyperparameters"],
+      "source_urls": [
+        "https://docs.gittensor.io/repository-hyperparameters"
+      ],
       "url": "https://raw.githubusercontent.com/entrius/gittensor/main/gittensor/validator/weights/master_repositories.json"
     },
     {
@@ -165,7 +173,9 @@
       },
       "provider": "gittensory",
       "public_safe": true,
-      "source_urls": ["https://gittensory.aethereal.dev/"],
+      "source_urls": [
+        "https://gittensory.aethereal.dev/"
+      ],
       "url": "https://gittensory-api.aethereal.dev/v1/public/subnet-interface"
     },
     {
@@ -203,5 +213,8 @@
       "url": "https://gittensory.aethereal.dev/"
     }
   ],
-  "website_url": "https://gittensor.io/"
+  "website_url": "https://gittensor.io/",
+  "social": {
+    "x": "https://x.com/gittensor_io"
+  }
 }

--- a/registry/subnets/hippius.json
+++ b/registry/subnets/hippius.json
@@ -41,9 +41,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://hippius.com/"
-      ],
+      "source_urls": ["https://hippius.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -61,9 +59,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://docs.hippius.com/"
-      ],
+      "source_urls": ["https://docs.hippius.com/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -81,9 +77,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://docs.hippius.com/blockchain/api"
-      ],
+      "source_urls": ["https://docs.hippius.com/blockchain/api"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -101,9 +95,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/thenervelab/hippius-validator"
-      ],
+      "source_urls": ["https://github.com/thenervelab/hippius-validator"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -121,9 +113,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/thenervelab/hippius-storage-miner"
-      ],
+      "source_urls": ["https://github.com/thenervelab/hippius-storage-miner"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/hippius.json
+++ b/registry/subnets/hippius.json
@@ -41,7 +41,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://hippius.com/"],
+      "source_urls": [
+        "https://hippius.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -59,7 +61,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://docs.hippius.com/"],
+      "source_urls": [
+        "https://docs.hippius.com/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -77,7 +81,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://docs.hippius.com/blockchain/api"],
+      "source_urls": [
+        "https://docs.hippius.com/blockchain/api"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -95,7 +101,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/thenervelab/hippius-validator"],
+      "source_urls": [
+        "https://github.com/thenervelab/hippius-validator"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -113,7 +121,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/thenervelab/hippius-storage-miner"],
+      "source_urls": [
+        "https://github.com/thenervelab/hippius-storage-miner"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -122,5 +132,8 @@
       },
       "notes": "Official Hippius storage miner repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/hippius_subnet"
+  }
 }

--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -39,7 +39,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/mobiusfund/investing"],
+      "source_urls": [
+        "https://github.com/mobiusfund/investing"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -97,7 +99,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/mobiusfund/investing"],
+      "source_urls": [
+        "https://github.com/mobiusfund/investing"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -106,5 +110,8 @@
       },
       "notes": "Official Investing source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/Investing88ai"
+  }
 }

--- a/registry/subnets/investing.json
+++ b/registry/subnets/investing.json
@@ -39,9 +39,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/mobiusfund/investing"
-      ],
+      "source_urls": ["https://github.com/mobiusfund/investing"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -99,9 +97,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/mobiusfund/investing"
-      ],
+      "source_urls": ["https://github.com/mobiusfund/investing"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taos-im/sn-79"
-      ],
+      "source_urls": ["https://github.com/taos-im/sn-79"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taos-im/sn-79/blob/main/README.md"
-      ],
+      "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -78,9 +74,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/taos-im/sn-79"
-      ],
+      "source_urls": ["https://github.com/taos-im/sn-79"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/mvtrx.json
+++ b/registry/subnets/mvtrx.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taos-im/sn-79"],
+      "source_urls": [
+        "https://github.com/taos-im/sn-79"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taos-im/sn-79/blob/main/README.md"],
+      "source_urls": [
+        "https://github.com/taos-im/sn-79/blob/main/README.md"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -74,7 +78,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/taos-im/sn-79"],
+      "source_urls": [
+        "https://github.com/taos-im/sn-79"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -83,5 +89,8 @@
       },
       "notes": "Official MVTRX source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/taos_im"
+  }
 }

--- a/registry/subnets/platform.json
+++ b/registry/subnets/platform.json
@@ -93,9 +93,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/PlatformNetwork/platform"
-      ],
+      "source_urls": ["https://github.com/PlatformNetwork/platform"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/platform.json
+++ b/registry/subnets/platform.json
@@ -93,7 +93,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/PlatformNetwork/platform"],
+      "source_urls": [
+        "https://github.com/PlatformNetwork/platform"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -102,5 +104,8 @@
       },
       "notes": "Official Platform Network source repository. The repository describes Platform as a Bittensor subnet for decentralized collaborative AI research."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/platformnet"
+  }
 }

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -67,10 +67,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/dashboard",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/dashboard", "https://thesoma.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -88,10 +85,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/mcp",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/mcp", "https://thesoma.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -109,10 +103,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://thesoma.ai/soma-access",
-        "https://thesoma.ai/"
-      ],
+      "source_urls": ["https://thesoma.ai/soma-access", "https://thesoma.ai/"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/soma.json
+++ b/registry/subnets/soma.json
@@ -67,7 +67,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/dashboard", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/dashboard",
+        "https://thesoma.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -85,7 +88,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/mcp", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/mcp",
+        "https://thesoma.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -103,7 +109,10 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://thesoma.ai/soma-access", "https://thesoma.ai/"],
+      "source_urls": [
+        "https://thesoma.ai/soma-access",
+        "https://thesoma.ai/"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -154,5 +163,8 @@
       },
       "notes": "Live alternate repository discovered through Tensorplex subnet docs. Kept as secondary evidence; DendriteHQ/SOMA remains the primary source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/somasubnet"
+  }
 }

--- a/registry/subnets/streetvision-natix.json
+++ b/registry/subnets/streetvision-natix.json
@@ -61,7 +61,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/natixnetwork/streetvision-subnet"],
+      "source_urls": [
+        "https://github.com/natixnetwork/streetvision-subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -79,7 +81,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/natixnetwork/streetvision-subnet"],
+      "source_urls": [
+        "https://github.com/natixnetwork/streetvision-subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -151,5 +155,8 @@
       },
       "notes": "Public NATIX Hugging Face organization linked from the StreetVision README."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/natixnetwork"
+  }
 }

--- a/registry/subnets/streetvision-natix.json
+++ b/registry/subnets/streetvision-natix.json
@@ -61,9 +61,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/natixnetwork/streetvision-subnet"
-      ],
+      "source_urls": ["https://github.com/natixnetwork/streetvision-subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -81,9 +79,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/natixnetwork/streetvision-subnet"
-      ],
+      "source_urls": ["https://github.com/natixnetwork/streetvision-subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -38,7 +38,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
+      "source_urls": [
+        "https://github.com/sundae-bar/bittensor-subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -56,7 +58,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
+      "source_urls": [
+        "https://github.com/sundae-bar/bittensor-subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -65,5 +69,8 @@
       },
       "notes": "Official Sundae Bar source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/sundae_bar_"
+  }
 }

--- a/registry/subnets/sundae-bar.json
+++ b/registry/subnets/sundae-bar.json
@@ -38,9 +38,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/sundae-bar/bittensor-subnet"
-      ],
+      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -58,9 +56,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/sundae-bar/bittensor-subnet"
-      ],
+      "source_urls": ["https://github.com/sundae-bar/bittensor-subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -40,9 +40,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/TensorUSD/subnet"
-      ],
+      "source_urls": ["https://github.com/TensorUSD/subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -80,9 +78,7 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": [
-        "https://github.com/TensorUSD/subnet"
-      ],
+      "source_urls": ["https://github.com/TensorUSD/subnet"],
       "probe": {
         "enabled": true,
         "method": "HEAD",

--- a/registry/subnets/tensorusd.json
+++ b/registry/subnets/tensorusd.json
@@ -40,7 +40,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/TensorUSD/subnet"],
+      "source_urls": [
+        "https://github.com/TensorUSD/subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -78,7 +80,9 @@
       "auth_required": false,
       "authority": "official",
       "public_safe": true,
-      "source_urls": ["https://github.com/TensorUSD/subnet"],
+      "source_urls": [
+        "https://github.com/TensorUSD/subnet"
+      ],
       "probe": {
         "enabled": true,
         "method": "HEAD",
@@ -87,5 +91,8 @@
       },
       "notes": "Official TensorUSD source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/tensorusd"
+  }
 }

--- a/registry/subnets/vidaio.json
+++ b/registry/subnets/vidaio.json
@@ -74,5 +74,8 @@
       },
       "notes": "Public Vidaio source repository."
     }
-  ]
+  ],
+  "social": {
+    "x": "https://x.com/vidaio_"
+  }
 }


### PR DESCRIPTION
## Summary

Gap-fills sourced from **taostats** `/api/subnet/identity/v1` — third-party source, provenance-tagged for human review. All fills are **additive only** (never overwrites existing data), sanitized via `socialAccounts()`.

**This batch (2):** 17 subnets get `social.x` (curated X/Twitter URL).

| Field | Count |
|-------|-------|
| `social.x` | 17 |

### Subnets touched

SN63 (enigma), SN64 (chutes), SN72 (streetvision-natix), SN74 (gittensor), SN75 (hippius), SN79 (mvtrx), SN85 (vidaio), SN88 (investing), SN91 (bitstarter), SN98 (forevermoney), SN100 (platform), SN103 (djinn), SN113 (tensorusd), SN114 (soma), SN118 (ditto), SN121 (sundae-bar), SN122 (bitrecs)

## Provenance

Values sourced from **taostats** `/api/subnet/identity/v1` (third-party). These are Twitter/X handles as listed in the taostats subnet identity registry. Please verify each handle maps to the correct project before merging.

24 more subnets with twitter gaps remain but have no overlay file yet — those require a separate review to create minimal manifests.

> ⚠️ Third-party fills — verify handle → subnet mapping before merging.