### PR TITLE
feat(readiness): readiness_tier + non-API low-weight components (#356)

### DIFF
--- a/docs/integration-readiness.md
+++ b/docs/integration-readiness.md
@@ -24,22 +24,41 @@ breakdown ships alongside the score so you can re-weight it for your own needs.
   (emissions, TAO price, miner quality) is a different question — that's chain
   data, not metagraphed's lane.
 
-## Rubric (`readiness_version: 1`)
+## Rubric (`readiness_version: 2`)
 
 Score = sum of the component weights below, clamped to 100. Each component is an
 objective boolean published under `readiness.components`.
 
-| Component          | Weight | True when                                                                                                                                         |
-| ------------------ | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `has_callable_api` | 30     | the subnet exposes ≥1 catalogued service surface                                                                                                  |
-| `documented`       | 25     | ≥1 service has a captured OpenAPI/Swagger schema                                                                                                  |
-| `auth_clarity`     | 15     | every callable service has clear auth — either no auth, or auth required _with_ known schemes (so an agent knows whether and how to authenticate) |
-| `callable_now`     | 15     | ≥1 service is structurally callable (public-safe, not dead/unsafe)                                                                                |
-| `active_lifecycle` | 10     | `lifecycle === "active"` (not deprecated/parked/pending)                                                                                          |
-| `profile_complete` | 5      | the subnet's `completeness_score` ≥ 70                                                                                                            |
+| Component           | Weight | True when                                                                                                                                         |
+| ------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `has_callable_api`  | 30     | the subnet exposes ≥1 catalogued service surface                                                                                                  |
+| `documented`        | 25     | ≥1 service has a captured OpenAPI/Swagger schema                                                                                                  |
+| `auth_clarity`      | 15     | every callable service has clear auth — either no auth, or auth required _with_ known schemes (so an agent knows whether and how to authenticate) |
+| `callable_now`      | 15     | ≥1 service is structurally callable (public-safe, not dead/unsafe)                                                                                |
+| `active_lifecycle`  | 10     | `lifecycle === "active"` (not deprecated/parked/pending)                                                                                          |
+| `profile_complete`  | 5      | the subnet's `completeness_score` ≥ 70                                                                                                            |
+| `has_source_repo`   | 4      | a source repository is recorded (curated or chain identity)                                                                                       |
+| `has_candidate_api` | 4      | a community-flagged candidate surface of an operational kind exists (unverified — does not imply callable)                                        |
+| `has_public_docs`   | 3      | a documentation link is recorded, even without a captured schema (distinct from `documented`)                                                     |
 
 `auth_clarity` intentionally treats "auth required, schemes known" as **clear** —
-it does not penalize an honestly auth-gated API.
+it does not penalize an honestly auth-gated API. The three low-weight components
+added in `readiness_version: 2` (#356) carry **no** dependency on a callable API,
+so the large API-less tail stops cliffing at one score and becomes a ranked
+curation pipeline; they cannot, combined, lift an API-less subnet above ~21.
+
+## Readiness tier (`readiness.readiness_tier`)
+
+A categorical gradient derived purely from the components (so it stays stable if
+weights are re-tuned), for filtering/sorting the tail without thresholding the
+score:
+
+| Tier            | When                                                              |
+| --------------- | ----------------------------------------------------------------- |
+| `buildable`     | `has_callable_api` — a verified callable surface exists           |
+| `emerging`      | no callable API, but `has_candidate_api` or `has_public_docs`     |
+| `identity-only` | neither of the above, but `has_source_repo` or `active_lifecycle` |
+| `dormant`       | none — no interface, no candidate, no docs, no repo, not active   |
 
 ## Re-weighting
 

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1913,8 +1913,16 @@ export interface components {
                 callable_now?: boolean;
                 documented?: boolean;
                 has_callable_api?: boolean;
+                has_candidate_api?: boolean;
+                has_public_docs?: boolean;
+                has_source_repo?: boolean;
                 profile_complete?: boolean;
             };
+            /**
+             * @description Categorical readiness gradient (#356): buildable = verified callable API; emerging = candidate API or public docs but not yet verified; identity-only = source repo / active presence but no interface; dormant = none. Ranks the large API-less tail that otherwise cliffs at one score.
+             * @enum {string}
+             */
+            readiness_tier: "buildable" | "emerging" | "identity-only" | "dormant";
             readiness_version: number;
             score: number;
         };
@@ -3803,6 +3811,7 @@ export interface operations {
                      *         "notes": "Example description.",
                      *         "readiness": {
                      *           "components": {},
+                     *           "readiness_tier": "buildable",
                      *           "readiness_version": 1,
                      *           "score": 100
                      *         },
@@ -10702,6 +10711,7 @@ export interface operations {
                      *           },
                      *           "readiness": {
                      *             "components": {},
+                     *             "readiness_tier": "buildable",
                      *             "readiness_version": 1,
                      *             "score": 100
                      *           },
@@ -11001,6 +11011,7 @@ export interface operations {
                      *           },
                      *           "readiness": {
                      *             "components": {},
+                     *             "readiness_tier": "buildable",
                      *             "readiness_version": 1,
                      *             "score": 100
                      *           },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3547,11 +3547,30 @@
               "has_callable_api": {
                 "type": "boolean"
               },
+              "has_candidate_api": {
+                "type": "boolean"
+              },
+              "has_public_docs": {
+                "type": "boolean"
+              },
+              "has_source_repo": {
+                "type": "boolean"
+              },
               "profile_complete": {
                 "type": "boolean"
               }
             },
             "type": "object"
+          },
+          "readiness_tier": {
+            "description": "Categorical readiness gradient (#356): buildable = verified callable API; emerging = candidate API or public docs but not yet verified; identity-only = source repo / active presence but no interface; dormant = none. Ranks the large API-less tail that otherwise cliffs at one score.",
+            "enum": [
+              "buildable",
+              "emerging",
+              "identity-only",
+              "dormant"
+            ],
+            "type": "string"
           },
           "readiness_version": {
             "minimum": 1,
@@ -3565,6 +3584,7 @@
         },
         "required": [
           "score",
+          "readiness_tier",
           "readiness_version",
           "components"
         ],
@@ -10029,6 +10049,7 @@
                     "notes": "Example description.",
                     "readiness": {
                       "components": {},
+                      "readiness_tier": "buildable",
                       "readiness_version": 1,
                       "score": 100
                     },
@@ -20821,6 +20842,7 @@
                       },
                       "readiness": {
                         "components": {},
+                        "readiness_tier": "buildable",
                         "readiness_version": 1,
                         "score": 100
                       },
@@ -21148,6 +21170,7 @@
                       },
                       "readiness": {
                         "components": {},
+                        "readiness_tier": "buildable",
                         "readiness_version": 1,
                         "score": 100
                       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1913,8 +1913,16 @@ export interface components {
                 callable_now?: boolean;
                 documented?: boolean;
                 has_callable_api?: boolean;
+                has_candidate_api?: boolean;
+                has_public_docs?: boolean;
+                has_source_repo?: boolean;
                 profile_complete?: boolean;
             };
+            /**
+             * @description Categorical readiness gradient (#356): buildable = verified callable API; emerging = candidate API or public docs but not yet verified; identity-only = source repo / active presence but no interface; dormant = none. Ranks the large API-less tail that otherwise cliffs at one score.
+             * @enum {string}
+             */
+            readiness_tier: "buildable" | "emerging" | "identity-only" | "dormant";
             readiness_version: number;
             score: number;
         };
@@ -3803,6 +3811,7 @@ export interface operations {
                      *         "notes": "Example description.",
                      *         "readiness": {
                      *           "components": {},
+                     *           "readiness_tier": "buildable",
                      *           "readiness_version": 1,
                      *           "score": 100
                      *         },
@@ -10702,6 +10711,7 @@ export interface operations {
                      *           },
                      *           "readiness": {
                      *             "components": {},
+                     *             "readiness_tier": "buildable",
                      *             "readiness_version": 1,
                      *             "score": 100
                      *           },
@@ -11001,6 +11011,7 @@ export interface operations {
                      *           },
                      *           "readiness": {
                      *             "components": {},
+                     *             "readiness_tier": "buildable",
                      *             "readiness_version": 1,
                      *             "score": 100
                      *           },

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3525,11 +3525,30 @@
               "has_callable_api": {
                 "type": "boolean"
               },
+              "has_candidate_api": {
+                "type": "boolean"
+              },
+              "has_public_docs": {
+                "type": "boolean"
+              },
+              "has_source_repo": {
+                "type": "boolean"
+              },
               "profile_complete": {
                 "type": "boolean"
               }
             },
             "type": "object"
+          },
+          "readiness_tier": {
+            "description": "Categorical readiness gradient (#356): buildable = verified callable API; emerging = candidate API or public docs but not yet verified; identity-only = source repo / active presence but no interface; dormant = none. Ranks the large API-less tail that otherwise cliffs at one score.",
+            "enum": [
+              "buildable",
+              "emerging",
+              "identity-only",
+              "dormant"
+            ],
+            "type": "string"
           },
           "readiness_version": {
             "minimum": 1,
@@ -3543,6 +3562,7 @@
         },
         "required": [
           "score",
+          "readiness_tier",
           "readiness_version",
           "components"
         ],

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -685,10 +685,20 @@
       "IntegrationReadiness": {
         "type": "object",
         "description": "Codified, objective build-time readiness for building on a subnet (0-100). Deterministic; live up/down status is separate (get_subnet_health). See docs/integration-readiness.md.",
-        "required": ["score", "readiness_version", "components"],
+        "required": [
+          "score",
+          "readiness_tier",
+          "readiness_version",
+          "components"
+        ],
         "additionalProperties": false,
         "properties": {
           "score": { "type": "integer", "minimum": 0, "maximum": 100 },
+          "readiness_tier": {
+            "type": "string",
+            "enum": ["buildable", "emerging", "identity-only", "dormant"],
+            "description": "Categorical readiness gradient (#356): buildable = verified callable API; emerging = candidate API or public docs but not yet verified; identity-only = source repo / active presence but no interface; dormant = none. Ranks the large API-less tail that otherwise cliffs at one score."
+          },
           "readiness_version": { "type": "integer", "minimum": 1 },
           "components": {
             "type": "object",
@@ -699,7 +709,10 @@
               "auth_clarity": { "type": "boolean" },
               "callable_now": { "type": "boolean" },
               "active_lifecycle": { "type": "boolean" },
-              "profile_complete": { "type": "boolean" }
+              "profile_complete": { "type": "boolean" },
+              "has_source_repo": { "type": "boolean" },
+              "has_public_docs": { "type": "boolean" },
+              "has_candidate_api": { "type": "boolean" }
             }
           }
         }

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -649,7 +649,9 @@ const serviceKindsByNetuid = new Map(
     ].sort(),
   ]),
 );
-const READINESS_VERSION = 1;
+// v2 (#356): added readiness_tier + non-API low-weight components
+// (has_source_repo / has_public_docs / has_candidate_api).
+const READINESS_VERSION = 2;
 const readinessByNetuid = new Map(
   mergedSubnets.map((subnet) => [
     subnet.netuid,
@@ -658,6 +660,9 @@ const readinessByNetuid = new Map(
       lifecycle: subnet.lifecycle,
       completenessScore: profileArtifacts.byNetuid.get(subnet.netuid)
         ?.completeness_score,
+      sourceRepo: subnet.source_repo,
+      docsUrl: subnet.docs_url,
+      candidates: candidatesByNetuid.get(subnet.netuid),
     }),
   ]),
 );
@@ -1194,10 +1199,25 @@ function buildSubnetServices(netuid) {
 // up right now" dimension is intentionally separate (get_subnet_health / the
 // health overlay). Components are published so agents can re-weight to their own
 // needs. Rubric: docs/integration-readiness.md.
+// #356: a categorical readiness gradient that turns the API-less long tail into
+// a ranked curation pipeline instead of a single 0-15 cliff. Derived purely from
+// components (not the numeric score) so the tier stays stable if weights move.
+function readinessTier(components) {
+  if (components.has_callable_api) return "buildable";
+  if (components.has_candidate_api || components.has_public_docs)
+    return "emerging";
+  if (components.has_source_repo || components.active_lifecycle)
+    return "identity-only";
+  return "dormant";
+}
+
 function subnetIntegrationReadiness({
   services,
   lifecycle,
   completenessScore,
+  sourceRepo,
+  docsUrl,
+  candidates,
 }) {
   const callable = services.filter((service) => service.eligibility.callable);
   const components = {
@@ -1211,6 +1231,15 @@ function subnetIntegrationReadiness({
     callable_now: callable.length > 0,
     active_lifecycle: lifecycle === "active",
     profile_complete: (completenessScore ?? 0) >= 70,
+    // #356: low-weight, NON-API signals so the ~99 API-less subnets stop
+    // cliffing at one score and rank as a curation pipeline. has_public_docs is
+    // any docs link (distinct from `documented`, which needs a verified schema);
+    // has_candidate_api is an unverified community-flagged operational surface.
+    has_source_repo: Boolean(sourceRepo),
+    has_public_docs: Boolean(docsUrl),
+    has_candidate_api: (candidates ?? []).some((candidate) =>
+      OPERATIONAL_SURFACE_KINDS.includes(candidate.kind),
+    ),
   };
   const score = Math.min(
     100,
@@ -1219,9 +1248,19 @@ function subnetIntegrationReadiness({
       (components.auth_clarity ? 15 : 0) +
       (components.callable_now ? 15 : 0) +
       (components.active_lifecycle ? 10 : 0) +
-      (components.profile_complete ? 5 : 0),
+      (components.profile_complete ? 5 : 0) +
+      // Low-weight curation-pipeline signals (#356) — they spread the API-less
+      // tail without disturbing the API-led top (the sum still caps at 100).
+      (components.has_source_repo ? 4 : 0) +
+      (components.has_candidate_api ? 4 : 0) +
+      (components.has_public_docs ? 3 : 0),
   );
-  return { score, readiness_version: READINESS_VERSION, components };
+  return {
+    score,
+    readiness_tier: readinessTier(components),
+    readiness_version: READINESS_VERSION,
+    components,
+  };
 }
 
 await fs.rm(r2ArtifactDir("agent-catalog"), { recursive: true, force: true });


### PR DESCRIPTION
Closes #356.

## Problem
`integration_readiness` was effectively **binary**: `has_callable_api` (30 pts) and the other API-gated components dominate, so the **~99 subnets without a catalogued API all cliffed at 0–15** — useless as a ranking for the curation pipeline.

## Fix (`readiness_version` → 2)
- **`readiness_tier`** — a categorical gradient (`buildable` / `emerging` / `identity-only` / `dormant`), derived from the component booleans (not the numeric score, so it survives weight re-tuning).
- **Three low-weight, NON-API components** — `has_source_repo` (4), `has_candidate_api` (4), `has_public_docs` (3) — so the API-less tail spreads into a ranked pipeline **without** disturbing the API-led top (sum still caps at 100).

Verified the tail is now ranked — index `integration_readiness` spreads across **0, 4, 7, 10, 13, 14, 17, 18, 21** (was a single 0–15 cliff); API-having subnets stay 74–100.

## Scope
Schema gains `readiness_tier` (required) + the new component booleans; rubric doc (`docs/integration-readiness.md`) updated to v2; contract regenerated. The tier ships on the profile + agent-catalog `readiness` block; display-only, never feeds completeness.

Verified: `validate:schemas/api/contract-drift/openapi-examples` ✓ · `npm test` (1098) ✓ · build-artifacts.mjs is outside coverage scope (build-script). Foundation for #357 (probe-gated `readiness_verified`).