### PR TITLE
feat(readiness): readiness_verified — live-probe gate on the readiness score (#357)

### DIFF
--- a/docs/integration-readiness.md
+++ b/docs/integration-readiness.md
@@ -60,6 +60,18 @@ score:
 | `identity-only` | neither of the above, but `has_source_repo` or `active_lifecycle` |
 | `dormant`       | none — no interface, no candidate, no docs, no repo, not active   |
 
+## Live verification (`readiness.readiness_verified`)
+
+The numeric `score` is deliberately build-time and deterministic, so
+`has_callable_api` fires on a _catalogued_ surface — a subnet can score 100 with
+a dead API. `readiness_verified` (#357) closes that gap **at serve time only**:
+it is `true` when ≥1 catalogued surface was probed healthy (status `"ok"`) by the
+live 2-minute cron. It is **absent** on the static build artifact (there is no
+live truth there) and overlaid onto live agent-catalog detail responses. Treat it
+as the "proven callable right now" gate on top of the deterministic score — an
+agent that needs ground truth before wiring should require
+`readiness_verified === true`, not just a high score.
+
 ## Re-weighting
 
 The composite is one reasonable default. Because every component boolean ships

--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1923,6 +1923,8 @@ export interface components {
              * @enum {string}
              */
             readiness_tier: "buildable" | "emerging" | "identity-only" | "dormant";
+            /** @description Serve-time only (#357): true when ≥1 catalogued surface was probed healthy (status "ok") by the live cron — so an agent never treats a catalogued-but-dead API as ready. Absent on the static build artifact (no live truth there); overlaid on live agent-catalog detail responses. The numeric score stays a deterministic build value; this is the live verification gate on top of it. */
+            readiness_verified?: boolean;
             readiness_version: number;
             score: number;
         };
@@ -3812,6 +3814,7 @@ export interface operations {
                      *         "readiness": {
                      *           "components": {},
                      *           "readiness_tier": "buildable",
+                     *           "readiness_verified": false,
                      *           "readiness_version": 1,
                      *           "score": 100
                      *         },

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -3572,6 +3572,10 @@
             ],
             "type": "string"
           },
+          "readiness_verified": {
+            "description": "Serve-time only (#357): true when ≥1 catalogued surface was probed healthy (status \"ok\") by the live cron — so an agent never treats a catalogued-but-dead API as ready. Absent on the static build artifact (no live truth there); overlaid on live agent-catalog detail responses. The numeric score stays a deterministic build value; this is the live verification gate on top of it.",
+            "type": "boolean"
+          },
           "readiness_version": {
             "minimum": 1,
             "type": "integer"
@@ -10050,6 +10054,7 @@
                     "readiness": {
                       "components": {},
                       "readiness_tier": "buildable",
+                      "readiness_verified": false,
                       "readiness_version": 1,
                       "score": 100
                     },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1923,6 +1923,8 @@ export interface components {
              * @enum {string}
              */
             readiness_tier: "buildable" | "emerging" | "identity-only" | "dormant";
+            /** @description Serve-time only (#357): true when ≥1 catalogued surface was probed healthy (status "ok") by the live cron — so an agent never treats a catalogued-but-dead API as ready. Absent on the static build artifact (no live truth there); overlaid on live agent-catalog detail responses. The numeric score stays a deterministic build value; this is the live verification gate on top of it. */
+            readiness_verified?: boolean;
             readiness_version: number;
             score: number;
         };
@@ -3812,6 +3814,7 @@ export interface operations {
                      *         "readiness": {
                      *           "components": {},
                      *           "readiness_tier": "buildable",
+                     *           "readiness_verified": false,
                      *           "readiness_version": 1,
                      *           "score": 100
                      *         },

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -3550,6 +3550,10 @@
             ],
             "type": "string"
           },
+          "readiness_verified": {
+            "description": "Serve-time only (#357): true when ≥1 catalogued surface was probed healthy (status \"ok\") by the live cron — so an agent never treats a catalogued-but-dead API as ready. Absent on the static build artifact (no live truth there); overlaid on live agent-catalog detail responses. The numeric score stays a deterministic build value; this is the live verification gate on top of it.",
+            "type": "boolean"
+          },
           "readiness_version": {
             "minimum": 1,
             "type": "integer"

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -700,6 +700,10 @@
             "description": "Categorical readiness gradient (#356): buildable = verified callable API; emerging = candidate API or public docs but not yet verified; identity-only = source repo / active presence but no interface; dormant = none. Ranks the large API-less tail that otherwise cliffs at one score."
           },
           "readiness_version": { "type": "integer", "minimum": 1 },
+          "readiness_verified": {
+            "type": "boolean",
+            "description": "Serve-time only (#357): true when ≥1 catalogued surface was probed healthy (status \"ok\") by the live cron — so an agent never treats a catalogued-but-dead API as ready. Absent on the static build artifact (no live truth there); overlaid on live agent-catalog detail responses. The numeric score stays a deterministic build value; this is the live verification gate on top of it."
+          },
           "components": {
             "type": "object",
             "additionalProperties": false,

--- a/src/health-serving.mjs
+++ b/src/health-serving.mjs
@@ -974,9 +974,19 @@ export function overlayCatalogDetail(staticDetail, live, netuid) {
       },
     };
   });
+  // #357: readiness_verified — only true when a catalogued surface was actually
+  // probed healthy ("ok") by the live cron, so an agent never treats a
+  // catalogued-but-dead API as ready. Computed from the same rows that drive
+  // per-service health; absent on the static artifact (no live truth there).
+  const readinessVerified = services.some(
+    (service) => service.health?.status === "ok",
+  );
   return {
     ...staticDetail,
     services,
+    readiness: staticDetail?.readiness
+      ? { ...staticDetail.readiness, readiness_verified: readinessVerified }
+      : staticDetail?.readiness,
     operational_observed_at: live.last_run_at || null,
     health_source: live.health_source || "live-cron-prober",
   };

--- a/tests/health-serving.test.mjs
+++ b/tests/health-serving.test.mjs
@@ -968,6 +968,46 @@ describe("composed-artifact health overlays", () => {
     assert.equal(out.services[0].eligibility.callable, false);
   });
 
+  test("overlayCatalogDetail gates readiness_verified on a live ok probe (#357)", () => {
+    const readiness = {
+      score: 100,
+      readiness_tier: "buildable",
+      readiness_version: 2,
+      components: { has_callable_api: true },
+    };
+    const detail = {
+      netuid: 7,
+      readiness,
+      services: [
+        {
+          surface_id: "7:subnet-api:x",
+          base_url: "https://x",
+          health: { status: "ok", stale: true },
+          eligibility: { callable: true },
+        },
+      ],
+    };
+    // live `x` probed "failed" → catalogued but NOT verified; score untouched.
+    const dead = overlayCatalogDetail(detail, live, 7);
+    assert.equal(dead.readiness.readiness_verified, false);
+    assert.equal(dead.readiness.score, 100);
+    assert.equal(dead.readiness.readiness_tier, "buildable");
+    // same surface probed "ok" → verified.
+    const okLive = {
+      ...live,
+      surfaces: [{ ...live.surfaces[0], status: "ok" }],
+    };
+    const verified = overlayCatalogDetail(detail, okLive, 7);
+    assert.equal(verified.readiness.readiness_verified, true);
+    // a detail with no readiness object → field simply absent (no crash).
+    const bare = overlayCatalogDetail(
+      { netuid: 7, services: detail.services },
+      okLive,
+      7,
+    );
+    assert.equal(bare.readiness, undefined);
+  });
+
   test("overlayCatalogIndex returns null without a live snapshot", () => {
     assert.equal(overlayCatalogIndex({ subnets: [] }, null), null);
   });


### PR DESCRIPTION
Closes #357.

## Problem
`integration_readiness`'s `score` is **build-time and deterministic**, so `has_callable_api` fires on a *catalogued* surface — **a subnet can score 100 with a dead API**. The issue's guardrail: fix this *before* `/ask` or the UI makes readiness the headline answer.

## Fix
`readiness_verified` — computed at **serve time** in `overlayCatalogDetail` from the same live 2-minute-cron rows that drive per-service health: `true` only when ≥1 catalogued surface was probed healthy (`status === "ok"`).

- **Optional** field on `IntegrationReadiness` — **absent** on the static build artifact (no live truth there), overlaid onto live agent-catalog detail responses. The numeric `score` stays deterministic + reproducible; this is the live gate layered on top, not a change to the score.
- An agent that needs ground truth before wiring requires `readiness_verified === true`, not just a high score.

## Scope + verification
Agent-catalog detail (what `/ask` + MCP consume) is the surface; the static profile keeps the deterministic score. Schema + rubric doc (`docs/integration-readiness.md`) updated; contract regenerated.

`validate:schemas/api/contract-drift/openapi-examples` ✓ · `npm test` 1099 (new overlay test covers ok→verified / failed→not / no-readiness-object) ✓. Builds on #356.