### PR TITLE
feat(registry): enrich SN116 TaoLend — add source repository

### DIFF
--- a/registry/candidates/community/community-sn-116-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-116-source-repo-github-com.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-116-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "TaoLend source repository",
+      "netuid": 116,
+      "provider": "taolend",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/oxylok/116-taolend/blob/main/README.md",
+      "source_urls": [
+        "https://github.com/oxylok/116-taolend/blob/main/README.md"
+      ],
+      "state": "schema-valid",
+      "url": "https://github.com/oxylok/116-taolend"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Pick The Right Template

Use the matching PR template so the submission gate can classify your PR
correctly:

- [x] [Direct subnet/interface candidate](?template=direct-candidate.md): one
  `registry/candidates/community/*.json` file only.
- [ ] [Provider/operator profile](?template=provider-profile.md): one
  `registry/providers/community/*.json` file only.
- [ ] [Backend/code change](?template=backend-code.md): scripts, schemas,
  contracts, workflows, or registry generator logic.
- [ ] [Docs-only change](?template=docs-only.md): README or docs edits only.

For direct UGC submissions, do not edit generated `public/metagraph/**`
artifacts, native snapshots, scripts, workflows, package files, or multiple
candidate/provider files.

## Summary

Submit the live public `oxylok/116-taolend` repo after `xpenlab/taolend` returned 404. Adds one verified `source-repo` surface for SN116 TaoLend. The repository README documents SN116 registration/validator setup and links to https://taolend.io; commits are signed by `elsieyy@taolend.io`.

Closes #455.

## Template Used

Direct subnet/interface candidate (`direct-candidate.md`)

## Direct Candidate Submission

This PR adds or updates exactly one public subnet/interface candidate.

## Candidate

- Netuid: 116
- Kind: source-repo
- Public URL: https://github.com/oxylok/116-taolend
- Source URL: https://github.com/oxylok/116-taolend/blob/main/README.md
- Provider/operator: taolend

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new` or matched
      `docs/examples/submissions/direct-candidate.json`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private
      dashboards, validator internals, or generated artifacts.

## Gate Expectations

Safe app-layer submissions can be AI-reviewed by the private Metagraphed gate
and may be merged automatically by the GitHub App after public checks pass.

Base-layer RPC/WSS/archive endpoints, authenticated surfaces, unknown
providers, identity disputes, and adapter requests route to manual review.

This submission may route to manual review because the GitHub repo owner (`oxylok`) does not match the registered `taolend` provider slug.

## Validation

- [x] `npm run validate:candidate -- registry/candidates/community/community-sn-116-source-repo-github-com.json`