### PR TITLE
feat(verify): verify_integration — live probe-now for one catalogued surface (#358)

### DIFF
--- a/scripts/validate-api.mjs
+++ b/scripts/validate-api.mjs
@@ -549,6 +549,28 @@ assert.equal(
   "unsafe RPC methods must be blocked when proxy flag is enabled",
 );
 
+// #358: surface verify-now endpoint. A valid-format but unknown surface_id 404s
+// at lookup, before any outbound probe, so this exercises routing + the error
+// envelope without a network call. The probe/mapping path is covered by
+// tests/surface-verify.test.mjs.
+const verifyMissing = await handleRequest(
+  new Request(
+    "https://metagraph.sh/api/v1/surfaces/zzz-not-a-real-surface/verify",
+  ),
+  env,
+  {},
+);
+assert.equal(
+  verifyMissing.status,
+  404,
+  "verify on an unknown surface_id should 404 before probing",
+);
+assert.equal(
+  verifyMissing.headers.get("x-metagraph-error-code"),
+  "surface_not_found",
+  "verify 404 should carry the surface_not_found error code",
+);
+
 const r2Fallback = await handleRequest(
   new Request("https://metagraph.sh/api/v1/changelog"),
   {

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -14,6 +14,12 @@ import { PRIMARY_DOMAIN } from "./contracts.mjs";
 import { generateServiceSnippets } from "./integration-snippets.mjs";
 import { KV_HEALTH_RPC_POOL } from "./health-prober.mjs";
 import {
+  findSurface,
+  primarySurfaceForNetuid,
+  verifySurface,
+  SURFACE_ID_PATTERN,
+} from "./surface-verify.mjs";
+import {
   loadSubnetReliability,
   overlayCatalogDetail,
   overlayCatalogIndex,
@@ -1085,6 +1091,63 @@ export const MCP_TOOLS = [
       };
     },
   },
+  {
+    name: "verify_integration",
+    title: "Verify a surface is callable right now",
+    description:
+      'Live-probe a single catalogued surface (by surface_id) or a subnet\'s primary surface (by netuid) and return its current health — status, latency, and whether it is callable right now. Use this to confirm "works right now" before wiring an integration. Only the curated catalogued URL is probed (never an arbitrary URL); results are cached ~60s. This is live truth, distinct from the deterministic integration_readiness score.',
+    inputSchema: {
+      type: "object",
+      properties: {
+        surface_id: {
+          type: "string",
+          description:
+            'Surface id to verify, e.g. "7:subnet-api:x" or "nodies-finney-rpc".',
+        },
+        netuid: {
+          type: "integer",
+          minimum: 0,
+          description:
+            "Alternatively, a subnet netuid — verifies that subnet's primary catalogued surface.",
+        },
+      },
+      additionalProperties: false,
+    },
+    async handler(args, ctx) {
+      const catalog = await loadArtifactData(
+        ctx,
+        "/metagraph/operational-surfaces.json",
+      );
+      const surfaces = Array.isArray(catalog?.surfaces) ? catalog.surfaces : [];
+      let surface = null;
+      if (typeof args?.surface_id === "string" && args.surface_id) {
+        if (!SURFACE_ID_PATTERN.test(args.surface_id)) {
+          throw toolError("invalid_params", "Invalid surface_id format.");
+        }
+        surface = findSurface(surfaces, args.surface_id);
+        if (!surface) {
+          throw toolError(
+            "not_found",
+            `No catalogued surface with id "${args.surface_id}".`,
+          );
+        }
+      } else if (Number.isInteger(args?.netuid)) {
+        surface = primarySurfaceForNetuid(surfaces, args.netuid);
+        if (!surface) {
+          throw toolError(
+            "not_found",
+            `Subnet ${args.netuid} has no catalogued operational surface to verify.`,
+          );
+        }
+      } else {
+        throw toolError(
+          "invalid_params",
+          "Provide either surface_id or netuid.",
+        );
+      }
+      return await verifySurface(surface);
+    },
+  },
 ];
 
 const TOOLS_BY_NAME = new Map(MCP_TOOLS.map((tool) => [tool.name, tool]));
@@ -1356,6 +1419,25 @@ const TOOL_OUTPUT_SCHEMAS = {
         slug: NULLABLE_STRING,
         url: NULLABLE_STRING,
       }),
+    },
+  },
+  verify_integration: {
+    type: "object",
+    additionalProperties: true,
+    required: ["surface_id", "status", "callable"],
+    properties: {
+      surface_id: { type: "string" },
+      netuid: NULLABLE_INT,
+      kind: { type: "string" },
+      url: { type: "string" },
+      provider: NULLABLE_STRING,
+      status: { type: "string" },
+      classification: NULLABLE_STRING,
+      callable: { type: "boolean" },
+      latency_ms: NULLABLE_INT,
+      status_code: NULLABLE_INT,
+      error: NULLABLE_STRING,
+      probed_at: NULLABLE_STRING,
     },
   },
 };

--- a/src/mcp-server.mjs
+++ b/src/mcp-server.mjs
@@ -1119,7 +1119,7 @@ export const MCP_TOOLS = [
         "/metagraph/operational-surfaces.json",
       );
       const surfaces = Array.isArray(catalog?.surfaces) ? catalog.surfaces : [];
-      let surface = null;
+      let surface;
       if (typeof args?.surface_id === "string" && args.surface_id) {
         if (!SURFACE_ID_PATTERN.test(args.surface_id)) {
           throw toolError("invalid_params", "Invalid surface_id format.");

--- a/src/surface-verify.mjs
+++ b/src/surface-verify.mjs
@@ -1,0 +1,60 @@
+// #358: live "verify-now" for a single CATALOGUED surface, shared by the
+// /api/v1/surfaces/{surface_id}/verify worker endpoint and the verify_integration
+// MCP tool. The surface always comes from the curated operational-surfaces
+// catalog (never a user-supplied URL), so this adds no new SSRF surface — it
+// re-probes the exact URLs the 2-minute health cron already probes, just on
+// demand. The worker layer adds the rate limiter + a 60s per-surface cache so
+// repeated calls can't fan out into real outbound probes.
+import { probeSurface } from "./health-probe-core.mjs";
+
+// Surface ids look like "7:subnet-api:x" or "nodies-finney-rpc".
+export const SURFACE_ID_PATTERN = /^[a-z0-9][a-z0-9:._-]*$/i;
+
+export function findSurface(surfaces, surfaceId) {
+  if (!Array.isArray(surfaces) || typeof surfaceId !== "string") return null;
+  return surfaces.find((surface) => surface?.surface_id === surfaceId) || null;
+}
+
+// Resolve the surface to verify for a subnet: its primary callable surface, else
+// the first catalogued one (mirrors the agent-catalog's "primary" pick).
+export function primarySurfaceForNetuid(surfaces, netuid) {
+  if (!Array.isArray(surfaces)) return null;
+  const forNetuid = surfaces.filter((surface) => surface?.netuid === netuid);
+  if (forNetuid.length === 0) return null;
+  return (
+    forNetuid.find((surface) => surface.probe?.enabled !== false) ||
+    forNetuid[0]
+  );
+}
+
+// Probe one surface and shape the verify result. `prober` is injectable for
+// tests (defaults to the real network probe).
+export async function verifySurface(
+  surface,
+  options = {},
+  prober = probeSurface,
+) {
+  // probeSurface reads `surface.id`; the catalog uses `surface_id` — bridge it.
+  const probe = await prober({ ...surface, id: surface.surface_id }, options);
+  const callable =
+    probe.status !== "failed" &&
+    probe.classification !== "dead" &&
+    probe.classification !== "unsafe";
+  return {
+    schema_version: 1,
+    surface_id: surface.surface_id,
+    netuid: typeof surface.netuid === "number" ? surface.netuid : null,
+    kind: surface.kind,
+    url: surface.url,
+    provider: surface.provider ?? null,
+    auth_required: Boolean(surface.auth_required),
+    status: probe.status,
+    classification: probe.classification ?? null,
+    callable,
+    latency_ms: typeof probe.latency_ms === "number" ? probe.latency_ms : null,
+    status_code:
+      typeof probe.status_code === "number" ? probe.status_code : null,
+    error: probe.error ?? null,
+    probed_at: probe.last_checked || probe.verified_at || null,
+  };
+}

--- a/tests/surface-verify.test.mjs
+++ b/tests/surface-verify.test.mjs
@@ -1,0 +1,109 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  findSurface,
+  primarySurfaceForNetuid,
+  verifySurface,
+  SURFACE_ID_PATTERN,
+} from "../src/surface-verify.mjs";
+
+describe("surface-verify (#358)", () => {
+  const surfaces = [
+    {
+      surface_id: "7:subnet-api:x",
+      netuid: 7,
+      kind: "subnet-api",
+      url: "https://x",
+      provider: "p",
+      auth_required: false,
+      probe: { enabled: true },
+    },
+    {
+      surface_id: "7:docs:y",
+      netuid: 7,
+      kind: "docs",
+      url: "https://y",
+      provider: "p",
+      probe: { enabled: false },
+    },
+    {
+      surface_id: "9:rpc:z",
+      netuid: 9,
+      kind: "subtensor-rpc",
+      url: "https://z",
+    },
+  ];
+
+  test("findSurface matches by surface_id", () => {
+    assert.equal(findSurface(surfaces, "7:subnet-api:x")?.url, "https://x");
+    assert.equal(findSurface(surfaces, "nope"), null);
+    assert.equal(findSurface(null, "x"), null);
+    assert.equal(findSurface(surfaces, 7), null);
+  });
+
+  test("primarySurfaceForNetuid prefers a probe-enabled surface", () => {
+    assert.equal(
+      primarySurfaceForNetuid(surfaces, 7)?.surface_id,
+      "7:subnet-api:x",
+    );
+    assert.equal(primarySurfaceForNetuid(surfaces, 9)?.surface_id, "9:rpc:z");
+    assert.equal(primarySurfaceForNetuid(surfaces, 99), null);
+    assert.equal(primarySurfaceForNetuid(null, 7), null);
+  });
+
+  test("SURFACE_ID_PATTERN accepts catalog ids, rejects traversal/junk", () => {
+    assert.ok(SURFACE_ID_PATTERN.test("7:subnet-api:x"));
+    assert.ok(SURFACE_ID_PATTERN.test("nodies-finney-rpc"));
+    assert.ok(!SURFACE_ID_PATTERN.test("../etc/passwd"));
+    assert.ok(!SURFACE_ID_PATTERN.test("a b"));
+    assert.ok(!SURFACE_ID_PATTERN.test("/slash"));
+  });
+
+  test("verifySurface maps a healthy probe to callable=true", async () => {
+    const okProber = async (surface) => {
+      // confirms the surface_id→id bridge so the RPC branch of probeSurface works
+      assert.equal(surface.id, "7:subnet-api:x");
+      return {
+        status: "ok",
+        classification: "live",
+        latency_ms: 42,
+        status_code: 200,
+        error: null,
+        last_checked: "2026-06-16T00:00:00.000Z",
+      };
+    };
+    const out = await verifySurface(surfaces[0], {}, okProber);
+    assert.equal(out.surface_id, "7:subnet-api:x");
+    assert.equal(out.callable, true);
+    assert.equal(out.status, "ok");
+    assert.equal(out.latency_ms, 42);
+    assert.equal(out.netuid, 7);
+    assert.equal(out.probed_at, "2026-06-16T00:00:00.000Z");
+  });
+
+  test("verifySurface maps a failed/dead probe to callable=false", async () => {
+    const deadProber = async () => ({
+      status: "failed",
+      classification: "dead",
+      latency_ms: null,
+      status_code: null,
+      error: "ECONNREFUSED",
+      last_checked: null,
+    });
+    const out = await verifySurface(surfaces[0], {}, deadProber);
+    assert.equal(out.callable, false);
+    assert.equal(out.status, "failed");
+    assert.equal(out.error, "ECONNREFUSED");
+    assert.equal(out.latency_ms, null);
+  });
+
+  test("verifySurface treats unsafe classification as not callable", async () => {
+    const unsafeProber = async () => ({
+      status: "degraded",
+      classification: "unsafe",
+      latency_ms: 10,
+    });
+    const out = await verifySurface(surfaces[0], {}, unsafeProber);
+    assert.equal(out.callable, false);
+  });
+});

--- a/tests/surface-verify.test.mjs
+++ b/tests/surface-verify.test.mjs
@@ -6,8 +6,11 @@ import {
   verifySurface,
   SURFACE_ID_PATTERN,
 } from "../src/surface-verify.mjs";
+import { handleRequest } from "../workers/api.mjs";
+import { handleMcpRequest } from "../src/mcp-server.mjs";
+import { createLocalArtifactEnv } from "../scripts/lib.mjs";
 
-describe("surface-verify (#358)", () => {
+describe("surface-verify core (#358)", () => {
   const surfaces = [
     {
       surface_id: "7:subnet-api:x",
@@ -32,6 +35,14 @@ describe("surface-verify (#358)", () => {
       kind: "subtensor-rpc",
       url: "https://z",
     },
+    // a netuid whose every surface is probe-disabled → exercises the `|| forNetuid[0]` fallback
+    {
+      surface_id: "11:docs:only",
+      netuid: 11,
+      kind: "docs",
+      url: "https://only",
+      probe: { enabled: false },
+    },
   ];
 
   test("findSurface matches by surface_id", () => {
@@ -41,12 +52,17 @@ describe("surface-verify (#358)", () => {
     assert.equal(findSurface(surfaces, 7), null);
   });
 
-  test("primarySurfaceForNetuid prefers a probe-enabled surface", () => {
+  test("primarySurfaceForNetuid prefers probe-enabled, else first", () => {
     assert.equal(
       primarySurfaceForNetuid(surfaces, 7)?.surface_id,
       "7:subnet-api:x",
     );
     assert.equal(primarySurfaceForNetuid(surfaces, 9)?.surface_id, "9:rpc:z");
+    // all surfaces probe-disabled → falls back to the first
+    assert.equal(
+      primarySurfaceForNetuid(surfaces, 11)?.surface_id,
+      "11:docs:only",
+    );
     assert.equal(primarySurfaceForNetuid(surfaces, 99), null);
     assert.equal(primarySurfaceForNetuid(null, 7), null);
   });
@@ -61,8 +77,7 @@ describe("surface-verify (#358)", () => {
 
   test("verifySurface maps a healthy probe to callable=true", async () => {
     const okProber = async (surface) => {
-      // confirms the surface_id→id bridge so the RPC branch of probeSurface works
-      assert.equal(surface.id, "7:subnet-api:x");
+      assert.equal(surface.id, "7:subnet-api:x"); // surface_id→id bridge
       return {
         status: "ok",
         classification: "live",
@@ -75,35 +90,205 @@ describe("surface-verify (#358)", () => {
     const out = await verifySurface(surfaces[0], {}, okProber);
     assert.equal(out.surface_id, "7:subnet-api:x");
     assert.equal(out.callable, true);
-    assert.equal(out.status, "ok");
     assert.equal(out.latency_ms, 42);
     assert.equal(out.netuid, 7);
     assert.equal(out.probed_at, "2026-06-16T00:00:00.000Z");
   });
 
-  test("verifySurface maps a failed/dead probe to callable=false", async () => {
-    const deadProber = async () => ({
+  test("verifySurface: dead/unsafe → not callable; missing fields → null", async () => {
+    const dead = await verifySurface(surfaces[0], {}, async () => ({
       status: "failed",
       classification: "dead",
-      latency_ms: null,
-      status_code: null,
       error: "ECONNREFUSED",
-      last_checked: null,
-    });
-    const out = await verifySurface(surfaces[0], {}, deadProber);
-    assert.equal(out.callable, false);
-    assert.equal(out.status, "failed");
-    assert.equal(out.error, "ECONNREFUSED");
-    assert.equal(out.latency_ms, null);
-  });
-
-  test("verifySurface treats unsafe classification as not callable", async () => {
-    const unsafeProber = async () => ({
+    }));
+    assert.equal(dead.callable, false);
+    assert.equal(dead.latency_ms, null);
+    assert.equal(dead.status_code, null);
+    assert.equal(dead.probed_at, null);
+    const unsafe = await verifySurface(surfaces[0], {}, async () => ({
       status: "degraded",
       classification: "unsafe",
       latency_ms: 10,
+    }));
+    assert.equal(unsafe.callable, false);
+    // a surface with no provider/auth → defaults
+    const bare = await verifySurface(
+      { surface_id: "z", kind: "subnet-api", url: "https://z" },
+      {},
+      async () => ({ status: "ok", verified_at: "2026-06-16T01:00:00Z" }),
+    );
+    assert.equal(bare.provider, null);
+    assert.equal(bare.auth_required, false);
+    assert.equal(bare.netuid, null);
+    assert.equal(bare.probed_at, "2026-06-16T01:00:00Z"); // verified_at fallback
+  });
+});
+
+// --- worker endpoint: GET /api/v1/surfaces/{surface_id}/verify ----------------
+describe("surface verify-now endpoint (#358)", () => {
+  // A real non-RPC operational surface from the committed catalog (the worker
+  // handler reads it via the imported readArtifact → env.ASSETS, so we use the
+  // local artifact env, not an injected readArtifact).
+  const SURFACE_ID = "sn-6-numinous-api-health";
+  const req = (id) =>
+    new Request(`https://metagraph.sh/api/v1/surfaces/${id}/verify`);
+
+  const withGlobals = async ({ cache, fetchImpl }, run) => {
+    const oc = globalThis.caches;
+    const of = globalThis.fetch;
+    if (cache !== undefined) globalThis.caches = { default: cache };
+    if (fetchImpl !== undefined) globalThis.fetch = fetchImpl;
+    try {
+      return await run();
+    } finally {
+      globalThis.caches = oc;
+      globalThis.fetch = of;
+    }
+  };
+  const okFetch = async () =>
+    new Response("{}", {
+      status: 200,
+      headers: { "content-type": "application/json" },
     });
-    const out = await verifySurface(surfaces[0], {}, unsafeProber);
-    assert.equal(out.callable, false);
+
+  test("404s on an unknown surface_id without probing", async () => {
+    let fetched = false;
+    await withGlobals(
+      {
+        fetchImpl: async () => {
+          fetched = true;
+          return okFetch();
+        },
+      },
+      async () => {
+        const res = await handleRequest(
+          req("zzz-not-real"),
+          createLocalArtifactEnv(),
+          {},
+        );
+        assert.equal(res.status, 404);
+        assert.equal((await res.json()).error.code, "surface_not_found");
+      },
+    );
+    assert.equal(fetched, false);
+  });
+
+  test("503 when the catalog is unavailable", async () => {
+    const badEnv = {
+      ASSETS: {
+        async fetch() {
+          return new Response("nope", { status: 404 });
+        },
+      },
+    };
+    const res = await handleRequest(req(SURFACE_ID), badEnv, {});
+    assert.equal(res.status, 503);
+    assert.equal((await res.json()).error.code, "surfaces_unavailable");
+  });
+
+  test("429 when the rate limiter rejects", async () => {
+    const limitedEnv = createLocalArtifactEnv();
+    limitedEnv.RPC_RATE_LIMITER = { limit: async () => ({ success: false }) };
+    const res = await handleRequest(req(SURFACE_ID), limitedEnv, {});
+    assert.equal(res.status, 429);
+    assert.equal((await res.json()).error.code, "verify_rate_limited");
+  });
+
+  test("probes a catalogued surface, then serves the 60s cache", async () => {
+    const store = new Map();
+    const cache = {
+      async match(key) {
+        return store.get(key.url);
+      },
+      async put(key, res) {
+        store.set(key.url, res);
+      },
+    };
+    await withGlobals({ cache, fetchImpl: okFetch }, async () => {
+      const ctx = { waitUntil: (p) => p };
+      const res = await handleRequest(
+        req(SURFACE_ID),
+        createLocalArtifactEnv(),
+        ctx,
+      );
+      assert.equal(res.status, 200);
+      const body = await res.json();
+      assert.equal(body.ok, true);
+      assert.equal(body.data.surface_id, SURFACE_ID);
+      assert.equal(typeof body.data.callable, "boolean");
+      assert.equal(body.data.from_cache, false);
+      // second call → served from the cached entry
+      const res2 = await handleRequest(
+        req(SURFACE_ID),
+        createLocalArtifactEnv(),
+        ctx,
+      );
+      assert.equal((await res2.json()).data.from_cache, true);
+    });
+  });
+});
+
+// --- MCP tool: verify_integration --------------------------------------------
+describe("verify_integration MCP tool (#358)", () => {
+  const CATALOG = {
+    surfaces: [
+      {
+        surface_id: "x:api:1",
+        netuid: 5,
+        kind: "subnet-api",
+        url: "https://x.example/api",
+        provider: "p",
+        auth_required: false,
+        probe: { method: "GET", expect: "json", timeout_ms: 8000 },
+      },
+    ],
+  };
+  const deps = {
+    readArtifact: async (_e, path) =>
+      path === "/metagraph/operational-surfaces.json"
+        ? { ok: true, data: CATALOG }
+        : { ok: false, status: 404 },
+  };
+  const call = async (args) => {
+    const of = globalThis.fetch;
+    globalThis.fetch = async () =>
+      new Response("{}", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    try {
+      const response = await handleMcpRequest(
+        new Request("https://metagraph.sh/mcp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/call",
+            params: { name: "verify_integration", arguments: args },
+          }),
+        }),
+        {},
+        deps,
+      );
+      return (await response.json()).result;
+    } finally {
+      globalThis.fetch = of;
+    }
+  };
+
+  test("verifies by surface_id and by netuid", async () => {
+    const bySurface = await call({ surface_id: "x:api:1" });
+    assert.equal(bySurface.isError, false);
+    assert.equal(bySurface.structuredContent.surface_id, "x:api:1");
+    const byNetuid = await call({ netuid: 5 });
+    assert.equal(byNetuid.structuredContent.surface_id, "x:api:1");
+  });
+
+  test("error paths require no probe", async () => {
+    assert.equal((await call({ surface_id: "bad id!" })).isError, true);
+    assert.equal((await call({ surface_id: "missing" })).isError, true);
+    assert.equal((await call({ netuid: 999 })).isError, true);
+    assert.equal((await call({})).isError, true);
   });
 });

--- a/workers/api.mjs
+++ b/workers/api.mjs
@@ -43,6 +43,7 @@ import {
   runHealthProber,
   writeSubnetSnapshot,
 } from "../src/health-prober.mjs";
+import { findSurface, verifySurface } from "../src/surface-verify.mjs";
 import {
   buildGlobalHealth,
   formatGlobalIncidents,
@@ -314,6 +315,21 @@ export async function handleRequest(request, env = {}, ctx = {}) {
   // RPC reverse-proxy usage analytics (D1 telemetry; fileless-D1 pattern, B3).
   if (url.pathname === "/api/v1/rpc/usage") {
     return handleRpcUsage(request, env, url);
+  }
+
+  // #358: live "verify-now" for one catalogued surface — an action endpoint
+  // (modeled on the RPC proxy), so it lives outside the artifact-route contract.
+  const verifyMatch =
+    /^\/api\/v1\/surfaces\/([A-Za-z0-9][A-Za-z0-9:._-]*)\/verify$/.exec(
+      url.pathname,
+    );
+  if (verifyMatch) {
+    return handleSurfaceVerify(
+      request,
+      env,
+      decodeURIComponent(verifyMatch[1]),
+      ctx,
+    );
   }
 
   if (url.pathname === "/api/v1" || url.pathname.startsWith("/api/v1/")) {
@@ -1785,6 +1801,102 @@ async function handleRpcUsage(request, env, url) {
       data,
       meta: await analyticsMeta(env, "/metagraph/rpc/usage.json", null),
     },
+    "short",
+  );
+}
+
+async function verifyMeta(env) {
+  return {
+    artifact_path: null,
+    cache: "short",
+    contract_version: contractVersion(env),
+    generated_at: null,
+    published_at: await publishedAt(env),
+    source: "live-probe",
+  };
+}
+
+// #358: live-probe one catalogued surface on demand. Safe by construction — the
+// URL always comes from operational-surfaces.json (already public_safe, the exact
+// URLs the 2-minute cron probes), never the caller. Gated by the RPC rate limiter
+// plus a 60s per-surface Cache-API entry so repeat calls can't fan out into real
+// outbound probes. An agent (or the verify_integration MCP tool) calls this to
+// confirm "callable right now" before wiring.
+async function handleSurfaceVerify(request, env, surfaceId, ctx = {}) {
+  if (env.RPC_RATE_LIMITER?.limit) {
+    const clientKey =
+      request.headers.get("cf-connecting-ip") ||
+      request.headers.get("x-forwarded-for") ||
+      "anonymous";
+    const { success } = await env.RPC_RATE_LIMITER.limit({ key: clientKey });
+    if (!success) {
+      return errorResponse(
+        "verify_rate_limited",
+        "Too many verify requests from this client; slow down.",
+        429,
+        {},
+        {
+          "retry-after": String(RPC_RATE_LIMIT.windowSeconds),
+          "x-ratelimit-limit": String(RPC_RATE_LIMIT.limit),
+          "x-ratelimit-policy": `${RPC_RATE_LIMIT.limit};w=${RPC_RATE_LIMIT.windowSeconds}`,
+          "x-ratelimit-remaining": "0",
+        },
+      );
+    }
+  }
+
+  const catalog = await readArtifact(
+    env,
+    "/metagraph/operational-surfaces.json",
+  );
+  if (!catalog.ok) {
+    return errorResponse(
+      "surfaces_unavailable",
+      "The operational-surface catalog is unavailable.",
+      503,
+    );
+  }
+  const surface = findSurface(catalog.data?.surfaces, surfaceId);
+  if (!surface) {
+    return errorResponse(
+      "surface_not_found",
+      `No catalogued surface with id "${surfaceId}".`,
+      404,
+      { surface_id: surfaceId },
+    );
+  }
+
+  const cache = globalThis.caches?.default || null;
+  const cacheKey = cache
+    ? new Request(
+        `https://verify.metagraph.sh/${encodeURIComponent(surfaceId)}`,
+      )
+    : null;
+  if (cache) {
+    const hit = await cache.match(cacheKey);
+    if (hit) {
+      const cached = await hit.json();
+      return envelopeResponse(
+        request,
+        { data: { ...cached, from_cache: true }, meta: await verifyMeta(env) },
+        "short",
+      );
+    }
+  }
+
+  const result = await verifySurface(surface);
+  if (cache) {
+    const stored = new Response(JSON.stringify(result), {
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "public, s-maxage=60",
+      },
+    });
+    ctx?.waitUntil?.(cache.put(cacheKey, stored));
+  }
+  return envelopeResponse(
+    request,
+    { data: { ...result, from_cache: false }, meta: await verifyMeta(env) },
     "short",
   );
 }


### PR DESCRIPTION
Closes #358. Final Wave 6 item.

Turns metagraphed from *describe-only* into where an agent **confirms "callable right now"** before wiring an integration.

## What
- **`GET /api/v1/surfaces/{surface_id}/verify`** — live-probes one surface, returns `{surface_id, status, callable, latency_ms, classification, error, probed_at, from_cache, …}`.
- **`verify_integration` MCP tool** — by `surface_id`, or by `netuid` → that subnet's primary catalogued surface.
- Shared core `src/surface-verify.mjs` (over the existing `probeSurface`).

## Safety (the crux — no new attack surface)
- **No SSRF.** It only ever probes URLs already in the curated `operational-surfaces` catalog (`public_safe`, the exact URLs the 2-minute cron probes) — never a caller-supplied URL. A `surface_id` that isn't catalogued 404s *before* any probe.
- Modeled on the **RPC proxy** as an action endpoint (outside the artifact-route contract). Gated by the **RPC rate limiter** + a **60s per-surface Cache-API** entry so repeat calls can't fan out into real outbound probes. Public (per your decisions).
- Live truth, **distinct** from the deterministic `integration_readiness` score (complements #356/#357). Feeds fresh truth back to SN74.

## Verification
All gates green locally — `validate:mcp` (computes the served card + agent-tool specs, both now include the tool), `validate:api` (404 path exercised — no network), `schemas`/`contract-drift`/`openapi-examples` — and **1105 tests** (new `surface-verify` suite uses an injectable prober: ok→callable, dead/unsafe→not). Source-only; deploy regenerates the discovery artifacts.