### PR TITLE
feat(registry): enrich SN118 Ditto — add source repository

### DIFF
--- a/registry/candidates/community/community-sn-118-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-118-source-repo-github-com.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-118-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "Ditto community source-repo",
+      "netuid": 118,
+      "provider": "ditto-assistant",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/ditto-assistant/ditto-cli/blob/main/README.md",
+      "source_urls": [
+        "https://github.com/ditto-assistant/ditto-cli/blob/main/README.md"
+      ],
+      "state": "schema-valid",
+      "url": "https://github.com/ditto-assistant/ditto-cli"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Pick The Right Template

- [x] [Direct subnet/interface candidate](?template=direct-candidate.md): one `registry/candidates/community/*.json` file only.

## Summary

Submit the official `ditto-assistant/ditto-cli` repository linked from the Ditto docs and npm package homepage. README references https://heyditto.ai as the Ditto product site.

Closes #448.

## Template Used

Direct subnet/interface candidate (`direct-candidate.md`)

## Direct Candidate Submission

This PR adds exactly one public subnet/interface candidate.

## Candidate

- Netuid: 118
- Kind: source-repo
- Public URL: https://github.com/ditto-assistant/ditto-cli
- Source URL: https://github.com/ditto-assistant/ditto-cli/blob/main/README.md
- Provider/operator: ditto-assistant

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated artifacts.

## Gate Expectations

This submission should pass automated checks; the repo is under the registered Ditto GitHub org.

## Validation

- [x] `npm run validate:candidate -- registry/candidates/community/community-sn-118-source-repo-github-com.json`
