### PR TITLE
feat(registry): enrich SN27 Nodexo — add source repository

### DIFF
--- a/registry/candidates/community/community-sn-27-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-27-source-repo-github-com.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-27-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "Team TBC community source-repo",
+      "netuid": 27,
+      "provider": "nodexo",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/neuralinternet/SN27-opencompute/blob/main/server.py",
+      "source_urls": [
+        "https://github.com/neuralinternet/SN27-opencompute/blob/main/server.py"
+      ],
+      "state": "schema-valid",
+      "url": "https://github.com/neuralinternet/SN27-opencompute"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Pick The Right Template

- [x] [Direct subnet/interface candidate](?template=direct-candidate.md): one `registry/candidates/community/*.json` file only.

## Summary

Submit the live `neuralinternet/SN27-opencompute` repo after `neuralinternet/compute-subnet` returned 404. Repo description and `server.py` reference SN27/Nodexo compute monitoring.

Closes #450.

## Template Used

Direct subnet/interface candidate (`direct-candidate.md`)

## Direct Candidate Submission

This PR adds exactly one public subnet/interface candidate.

## Candidate

- Netuid: 27
- Kind: source-repo
- Public URL: https://github.com/neuralinternet/SN27-opencompute
- Source URL: https://github.com/neuralinternet/SN27-opencompute/blob/main/server.py
- Provider/operator: nodexo

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated artifacts.

## Gate Expectations

Canonical `neuralinternet/compute-subnet` is still 404; this uses the live Neural Internet SN27 tooling repo.

## Validation

- [x] `npm run validate:candidate -- registry/candidates/community/community-sn-27-source-repo-github-com.json`
