### PR TITLE
feat(registry): enrich SN40 Chunking — add source repository

### DIFF
--- a/registry/candidates/community/community-sn-40-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-40-source-repo-github-com.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-40-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "Chunking community source-repo",
+      "netuid": 40,
+      "provider": "vectorchat",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json",
+      "source_urls": [
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json"
+      ],
+      "state": "schema-valid",
+      "url": "https://github.com/salahawk/chunking_subnet"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Pick The Right Template

- [x] [Direct subnet/interface candidate](?template=direct-candidate.md): one `registry/candidates/community/*.json` file only.

## Summary

Submit a live Chunking subnet implementation after `VectorChat/chunking_subnet` returned 404. Tensorplex subnet-docs still lists VectorChat/chunking_subnet for SN40; the fork README documents the Chunking Subnet on Bittensor.

Closes #451.

## Template Used

Direct subnet/interface candidate (`direct-candidate.md`)

## Direct Candidate Submission

This PR adds exactly one public subnet/interface candidate.

## Candidate

- Netuid: 40
- Kind: source-repo
- Public URL: https://github.com/salahawk/chunking_subnet
- Source URL: https://github.com/tensorplex-labs/subnet-docs/blob/main/data/40/subnet.json
- Provider/operator: vectorchat

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated artifacts.

## Gate Expectations

May route to manual review: repo owner is not VectorChat and canonical VectorChat/chunking_subnet is 404.

## Validation

- [x] `npm run validate:candidate -- registry/candidates/community/community-sn-40-source-repo-github-com.json`
