### PR TITLE
feat(registry): enrich SN53 EfficientFrontier — add source repository

### DIFF
--- a/registry/candidates/community/community-sn-53-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-53-source-repo-github-com.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-53-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "EfficientFrontier community source-repo",
+      "netuid": 53,
+      "provider": "signalplus",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json",
+      "source_urls": [
+        "https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json"
+      ],
+      "state": "schema-valid",
+      "url": "https://github.com/oxylok/53-EfficientFrontier"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Pick The Right Template

- [x] [Direct subnet/interface candidate](?template=direct-candidate.md): one `registry/candidates/community/*.json` file only.

## Summary

Submit the live `oxylok/53-EfficientFrontier` mirror after `EfficientFrontier-SignalPlus/EfficientFrontier` returned 404. Tensorplex subnet-docs links EfficientFrontier-SignalPlus/EfficientFrontier for SN53 SignalPlus/Efficient Frontier.

Closes #452.

## Template Used

Direct subnet/interface candidate (`direct-candidate.md`)

## Direct Candidate Submission

This PR adds exactly one public subnet/interface candidate.

## Candidate

- Netuid: 53
- Kind: source-repo
- Public URL: https://github.com/oxylok/53-EfficientFrontier
- Source URL: https://github.com/tensorplex-labs/subnet-docs/blob/main/data/53/subnet.json
- Provider/operator: signalplus

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated artifacts.

## Gate Expectations

May route to manual review: GitHub owner (`oxylok`) does not match registered provider `signalplus`.

## Validation

- [x] `npm run validate:candidate -- registry/candidates/community/community-sn-53-source-repo-github-com.json`
