### PR TITLE
feat(registry): enrich SN106 Nodexo — add source repository

### DIFF
--- a/registry/candidates/community/community-sn-106-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-106-source-repo-github-com.json
@@ -1,0 +1,30 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-106-source-repo-github-com",
+      "kind": "source-repo",
+      "name": "Nodexo community source-repo",
+      "netuid": 106,
+      "provider": "nodexo",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://github.com/oxylok/106-voidai/blob/main/README.md",
+      "source_urls": [
+        "https://github.com/oxylok/106-voidai/blob/main/README.md"
+      ],
+      "state": "schema-valid",
+      "url": "https://github.com/oxylok/106-voidai"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Pick The Right Template

- [x] [Direct subnet/interface candidate](?template=direct-candidate.md): one `registry/candidates/community/*.json` file only.

## Summary

Submit the live `oxylok/106-voidai` repo for SN106 (on-chain identity: Nodexo). README documents SN106 concentrated-liquidity mining on Solana for wAlpha/wTAO pairs.

Closes #435.

## Template Used

Direct subnet/interface candidate (`direct-candidate.md`)

## Direct Candidate Submission

This PR adds exactly one public subnet/interface candidate.

## Candidate

- Netuid: 106
- Kind: source-repo
- Public URL: https://github.com/oxylok/106-voidai
- Source URL: https://github.com/oxylok/106-voidai/blob/main/README.md
- Provider/operator: nodexo

## Checklist

- [x] This PR changes exactly one `registry/candidates/community/*.json` file.
- [x] I generated the file with `npm run candidate:new`.
- [x] The submitted URL is public and safe for read-only probes.
- [x] The source URL publicly supports the interface claim.
- [x] This does not require authentication.
- [x] This does not duplicate an existing Metagraphed surface or candidate.
- [x] This does not include secrets, wallet/PAT data, private URLs, private dashboards, validator internals, or generated artifacts.

## Gate Expectations

May route to manual review: GitHub owner (`oxylok`) does not match registered provider `nodexo`.

## Validation

- [x] `npm run validate:candidate -- registry/candidates/community/community-sn-106-source-repo-github-com.json`
