### PR TITLE
feat(registry): enrich SN14 Cacheon — add OpenAPI schema

### DIFF
--- a/registry/candidates/community/community-sn-14-openapi-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-openapi-api-cacheon-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-14-openapi-api-cacheon-ai",
+      "kind": "openapi",
+      "name": "Cacheon community openapi",
+      "netuid": 14,
+      "provider": "cacheon",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://cacheon.ai/docs/miners/api-contract",
+      "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
+      "state": "schema-valid",
+      "url": "https://api.cacheon.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the live Cacheon monitoring OpenAPI 3.1 schema at `api.cacheon.ai/openapi.json`, documented alongside the miner API contract docs.

Closes #718.

Made with [Cursor](https://cursor.com)