### PR TITLE
feat(registry): enrich SN14 Cacheon — add public data artifact

### DIFF
--- a/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-14-data-artifact-api-cacheon-ai",
+      "kind": "data-artifact",
+      "name": "Cacheon community data-artifact",
+      "netuid": 14,
+      "provider": "cacheon",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://cacheon.ai/docs/miners/api-contract",
+      "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
+      "state": "schema-valid",
+      "url": "https://api.cacheon.ai/api/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the read-only Cacheon `/api/health` JSON endpoint as a public data artifact for SN14.

Closes #718.

Made with [Cursor](https://cursor.com)