### PR TITLE
feat(registry): enrich SN34 BitMind — add OpenAPI schema

### DIFF
--- a/registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
+++ b/registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-34-openapi-api-bitmind-ai",
+      "kind": "openapi",
+      "name": "BitMind community openapi",
+      "netuid": 34,
+      "provider": "bitmind",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://bitmind.ai/",
+      "source_urls": ["https://bitmind.ai/"],
+      "state": "schema-valid",
+      "url": "https://api.bitmind.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the live BitMind Detection API OpenAPI 3.1 schema.

Closes #727.

Made with [Cursor](https://cursor.com)