### PR TITLE
feat(registry): enrich SN34 BitMind — add public API endpoint

### DIFF
--- a/registry/candidates/community/community-sn-34-subnet-api-api-bitmind-ai.json
+++ b/registry/candidates/community/community-sn-34-subnet-api-api-bitmind-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-34-subnet-api-api-bitmind-ai",
+      "kind": "subnet-api",
+      "name": "BitMind community subnet-api",
+      "netuid": 34,
+      "provider": "bitmind",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://bitmind.ai/",
+      "source_urls": ["https://bitmind.ai/"],
+      "state": "schema-valid",
+      "url": "https://api.bitmind.ai/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the public BitMind API health endpoint documented in the OpenAPI schema.

Closes #727.

Made with [Cursor](https://cursor.com)