### PR TITLE
feat(registry): enrich SN6 Numinous — add public data artifact

### DIFF
--- a/registry/candidates/community/community-sn-6-data-artifact-api-numinouslabs-io.json
+++ b/registry/candidates/community/community-sn-6-data-artifact-api-numinouslabs-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-6-data-artifact-api-numinouslabs-io",
+      "kind": "data-artifact",
+      "name": "Numinous community data-artifact",
+      "netuid": 6,
+      "provider": "numinous",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.numinouslabs.io/api/openapi.json",
+      "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.numinouslabs.io/api/v1/leaderboard"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the read-only Numinous leaderboard JSON endpoint as a public data artifact.

Closes #698.

Made with [Cursor](https://cursor.com)