### PR TITLE
feat(registry): enrich SN49 Nepher Robotics — add public data artifact

### DIFF
--- a/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
+++ b/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-49-data-artifact-tournament-api-nepher-ai",
+      "kind": "data-artifact",
+      "name": "Nepher Robotics community data-artifact",
+      "netuid": 49,
+      "provider": "nepher-robotics",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://tournament-api.nepher.ai/openapi.json",
+      "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://tournament-api.nepher.ai/health"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the live tournament health JSON at `https://tournament-api.nepher.ai/health`, documented in the official Nepher tournament OpenAPI schema.

Closes #737.

Made with [Cursor](https://cursor.com)