### PR TITLE
feat(registry): enrich SN56 Gradients — add public data artifact

### DIFF
--- a/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
+++ b/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-56-data-artifact-api-gradients-io",
+      "kind": "data-artifact",
+      "name": "Gradients community data-artifact",
+      "netuid": 56,
+      "provider": "gradients",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.gradients.io/docs",
+      "source_urls": ["https://api.gradients.io/docs"],
+      "state": "schema-valid",
+      "url": "https://api.gradients.io/v1/network/status"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.gradients.io/v1/network/status`, documented in the official gradients API schema/docs.

Closes #677.

Made with [Cursor](https://cursor.com)