### PR TITLE
feat(registry): enrich SN22 Desearch — add public data artifact

### DIFF
--- a/registry/candidates/community/community-sn-22-data-artifact-api-desearch-ai.json
+++ b/registry/candidates/community/community-sn-22-data-artifact-api-desearch-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-22-data-artifact-api-desearch-ai",
+      "kind": "data-artifact",
+      "name": "Desearch community data-artifact",
+      "netuid": 22,
+      "provider": "desearch",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://www.desearch.ai/docs",
+      "source_urls": ["https://www.desearch.ai/docs"],
+      "state": "schema-valid",
+      "url": "https://api.desearch.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.desearch.ai/openapi.json`, documented in the official desearch API schema/docs.

Closes #705.

Made with [Cursor](https://cursor.com)