### PR TITLE
ci(coverage): adopt Codecov as the PR coverage gate (delta-based, no churn)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -180,6 +180,18 @@ jobs:
         if: steps.route.outputs.mode == 'full'
         run: npm run test:coverage
 
+      # Upload coverage to Codecov — the primary PR coverage gate (delta-based
+      # project + patch, see codecov.yml). vitest's thresholds are now just a
+      # local backstop. Runs on PRs AND main pushes (main = the comparison base);
+      # the upload failing never fails CI (the gate is Codecov's own status).
+      - name: Upload coverage to Codecov
+        if: steps.route.outputs.mode == 'full'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+
       - name: Generate R2 manifest
         if: steps.route.outputs.mode == 'full'
         run: npm run r2:manifest

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,32 @@
+# Codecov — the primary PR coverage gate (replaces the fixed absolute-% pin that
+# vitest.config.mjs used to enforce; those thresholds are now just a backstop
+# floor). This is DELTA-based, so it never causes the "every PR must match a
+# near-peak absolute number and one merge pushes the others below it" churn:
+#   - `project` compares total coverage to the PR base, tolerating a small drop.
+#   - `patch` checks only the lines THIS PR changed (the real "test your new
+#     code" signal — PR-local, independent of global fluctuation).
+# The uploaded lcov is already scoped to runtime code (src/** + workers/** + 5
+# named scripts) by vitest's coverage.include, so Codecov reports only those.
+coverage:
+  status:
+    project:
+      default:
+        target: auto # compare against the PR base, not a fixed number
+        threshold: 1% # tolerate up to a 1% total drop before failing
+        informational: false
+    patch:
+      default:
+        target: 80% # 80% of the lines a PR changes must be covered
+        threshold: 0%
+        informational: false
+
+comment:
+  layout: "condensed_header, diff, files"
+  behavior: default
+  require_changes: false
+
+# Codecov's own status checks are only merge-blocking if added to branch
+# protection's required checks (metagraphed's are intentionally empty — the owner
+# admin-merges). Until then these are informative PR annotations + the dashboard.
+github_checks:
+  annotations: true

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -3,7 +3,9 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     environment: "node",
-    exclude: ["node_modules/**", "private/**"],
+    // `.claude/**` keeps gitignored agent worktrees (.claude/worktrees/*, each a
+    // full repo copy with its own tests) from doubling the run + skewing coverage.
+    exclude: ["node_modules/**", "private/**", ".claude/**"],
     // Run test FILES sequentially (each still in its own isolated fork). The
     // artifact-build tests (tests/artifacts.test.mjs) execFileSync the real
     // scripts/build-artifacts.mjs, which mutates the shared on-disk artifact
@@ -22,20 +24,26 @@ export default defineConfig({
     fileParallelism: false,
     coverage: {
       provider: "v8",
-      reporter: ["text", "json-summary"],
+      // lcov for the Codecov upload (codecov/codecov-action reads
+      // coverage/lcov.info); json-summary/text for local + CI readouts.
+      reporter: ["text", "json-summary", "lcov"],
       include: [
         "src/**/*.mjs",
         "workers/**/*.mjs",
         "scripts/{artifact-budgets,lib,openapi-components,submission-notifications,submission-policy}.mjs",
       ],
-      // Locked in after the coverage push (global ~98.7% stmts/lines, 92.7%
-      // branches). Gates below the achieved level so coverage can't silently
-      // regress past the 97%+ bar.
+      // BACKSTOP floors only — NOT the primary gate. The real PR coverage gate is
+      // Codecov (delta-based project + patch coverage, see codecov.yml). That
+      // avoids the fixed-pin churn where every PR must match a near-peak absolute
+      // number and a single merge can push other open PRs below it. These floors
+      // sit well under the achieved ~98% lines/stmts / ~90% branches, so a normal
+      // PR never trips them; they only catch a catastrophic local regression
+      // before push (and keep `npm run test:coverage` meaningful offline).
       thresholds: {
-        branches: 90,
-        functions: 97,
-        lines: 98,
-        statements: 98,
+        branches: 85,
+        functions: 90,
+        lines: 92,
+        statements: 92,
       },
     },
   },


### PR DESCRIPTION
Implements the Codecov integration you set up (token's in repo secrets).

## Why
The coverage gate was a **fixed absolute-% pin** in vitest (`lines/stmts 98, fns 97, branches 90`, ~0.7% under the achieved ~98.7%). That's the setup that churns in your other repos: any PR adding under-tested code drops below the pin, and a merge shifting the baseline can push other open PRs red. (It bit once today — #358's new worker handler dipped below 98%.)

## What
Replace the fixed pin with Codecov's **delta-based** gate:
- **vitest** now emits `lcov` and keeps only a **backstop floor** (92/92/90/85) — well under the achieved ~98%, so a normal PR never trips it locally; Codecov is the real gate.
- **`codecov.yml`**: `project` (target `auto`, 1% tolerance — base-relative, no fixed number to chase) + `patch` (80% of the *lines a PR changes*). The lcov is already scoped to runtime code (`src/**` + `workers/**` + 5 scripts) by vitest's `coverage.include`.
- **`validate.yml`** uploads to Codecov (**codecov-action v7**, SHA-pinned) on the `full`-mode path (PRs + main = the comparison base); upload failure never fails CI.
- **Bonus fix:** vitest `exclude` now skips `.claude/**` — a gitignored agent worktree was doubling the local run (92 files/2217 tests) and skewing/breaking `npm run test:coverage`. CI was unaffected (fresh checkout), but local runs need this.

## Verified
`npm run test:coverage` green — **1112 tests, 98.06% lines / 90.62% branches**, `coverage/lcov.info` emitted (27 source files). YAML validated.

## Note
Codecov's checks post as **informational** PR annotations until added to branch protection's required checks (yours is intentionally empty — you admin-merge). Tighten `patch.target` later if you want a harder new-code bar.

Separately: the **CI job-split** (fast-fail lint job parallel to the heavy job) I flagged is a riskier refactor of the every-PR validate workflow — I'd do that as its own PR with careful testing rather than bundle it here. Say the word.