### PR TITLE
feat(registry): enrich SN49 Nepher Robotics — add tournament list data artifact

### DIFF
--- a/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
+++ b/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://tournament-api.nepher.ai/health"
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/list"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://tournament-api.nepher.ai/api/v1/tournaments/active/list`, documented in the official nepher-robotics API schema/docs.

Closes #916.

Made with [Cursor](https://cursor.com)