### PR TITLE
feat(registry): enrich SN56 Gradients — add tournament weights data artifact

### DIFF
--- a/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
+++ b/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.gradients.io/docs",
       "source_urls": ["https://api.gradients.io/docs"],
       "state": "schema-valid",
-      "url": "https://api.gradients.io/v1/network/status"
+      "url": "https://api.gradients.io/v1/performance/latest-tournament-weights"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.gradients.io/v1/performance/latest-tournament-weights`, documented in the official gradients API schema/docs.

Closes #905.

Made with [Cursor](https://cursor.com)