### PR TITLE
feat(registry): enrich SN6 Numinous — add benchmarks baseline data artifact

### DIFF
--- a/registry/candidates/community/community-sn-6-data-artifact-api-numinouslabs-io.json
+++ b/registry/candidates/community/community-sn-6-data-artifact-api-numinouslabs-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.numinouslabs.io/api/openapi.json",
       "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.numinouslabs.io/api/v1/leaderboard"
+      "url": "https://api.numinouslabs.io/api/v1/benchmarks/baseline"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.numinouslabs.io/api/v1/benchmarks/baseline`, documented in the official numinous API schema/docs.

Closes #908.

Made with [Cursor](https://cursor.com)