### PR TITLE
feat(registry): enrich SN7 Allways — add crown data artifact

### DIFF
--- a/registry/candidates/community/community-sn-7-data-artifact-api-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-data-artifact-api-all-ways-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.all-ways.io/swagger-json",
       "source_urls": ["https://api.all-ways.io/swagger-json"],
       "state": "schema-valid",
-      "url": "https://api.all-ways.io/miners/leaderboard"
+      "url": "https://api.all-ways.io/crown"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.all-ways.io/crown`, documented in the official allways API schema/docs.

Closes #903.

Made with [Cursor](https://cursor.com)