### PR TITLE
feat(registry): enrich SN49 Nepher Robotics — add ready data artifact

### DIFF
--- a/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
+++ b/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/list"
+      "url": "https://tournament-api.nepher.ai/ready"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://tournament-api.nepher.ai/ready`.

Closes #916.