### PR TITLE
feat(registry): enrich SN58 Handshake58 — add MCP providers data artifact

### DIFF
--- a/registry/candidates/community/community-sn-58-data-artifact-handshake58-com.json
+++ b/registry/candidates/community/community-sn-58-data-artifact-handshake58-com.json
@@ -5,7 +5,7 @@
       "confidence": "medium",
       "id": "community-sn-58-data-artifact-handshake58-com",
       "kind": "data-artifact",
-      "name": "Handshake58 validator provider registry",
+      "name": "Pending community data-artifact",
       "netuid": 58,
       "provider": "handshake58",
       "public_safe": true,
@@ -14,15 +14,15 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://handshake58.com/.well-known/ai-plugin.json",
-      "source_urls": ["https://handshake58.com/.well-known/ai-plugin.json"],
+      "source_url": "https://handshake58.com/openapi.json",
+      "source_urls": ["https://handshake58.com/openapi.json"],
       "state": "schema-valid",
-      "url": "https://handshake58.com/api/validator/registry"
+      "url": "https://handshake58.com/api/mcp/providers"
     }
   ],
   "schema_version": 1,
   "submission": {
-    "submitted_by": "jaso0n0818",
-    "submitted_by_url": "https://github.com/jaso0n0818"
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
   }
 }


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://handshake58.com/api/mcp/providers`.

Closes #721.