### PR TITLE
feat(registry): enrich SN74 Gittensor — add miners API endpoint

### DIFF
--- a/registry/candidates/community/community-sn-74-subnet-api-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-subnet-api-api-gittensor-io.json
@@ -14,15 +14,15 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://api.gittensor.io/swagger",
-      "source_urls": ["https://api.gittensor.io/swagger"],
+      "source_url": "https://api.gittensor.io/swagger-json",
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
       "state": "schema-valid",
-      "url": "https://api.gittensor.io/dash/repos"
+      "url": "https://api.gittensor.io/dash/miners"
     }
   ],
   "schema_version": 1,
   "submission": {
-    "submitted_by": "jaso0n0818",
-    "submitted_by_url": "https://github.com/jaso0n0818"
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
   }
 }


### PR DESCRIPTION
## Summary
Submit the live public subnet-api at `https://api.gittensor.io/dash/miners`.

Closes #723.