### PR TITLE
feat(registry): enrich SN118 Ditto — add Hermes SDK

### DIFF
--- a/registry/candidates/community/community-sn-118-sdk-github-com.json
+++ b/registry/candidates/community/community-sn-118-sdk-github-com.json
@@ -14,10 +14,10 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://heyditto.ai/docs/mcp-server",
-      "source_urls": ["https://heyditto.ai/docs/mcp-server"],
+      "source_url": "https://heyditto.ai/docs",
+      "source_urls": ["https://heyditto.ai/docs"],
       "state": "schema-valid",
-      "url": "https://github.com/ditto-assistant/ditto-mcp"
+      "url": "https://github.com/ditto-assistant/ditto-hermes"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public sdk at `https://github.com/ditto-assistant/ditto-hermes`.

Closes #906.