### PR TITLE
feat(registry): enrich SN14 Cacheon — add metrics API endpoint

### DIFF
--- a/registry/candidates/community/community-sn-14-subnet-api-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-subnet-api-api-cacheon-ai.json
@@ -14,15 +14,15 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://cacheon.ai/docs/miners/api-contract",
-      "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
+      "source_url": "https://api.cacheon.ai/openapi.json",
+      "source_urls": ["https://api.cacheon.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.cacheon.ai/api/status"
+      "url": "https://api.cacheon.ai/api/metrics"
     }
   ],
   "schema_version": 1,
   "submission": {
-    "submitted_by": "jsonbored",
-    "submitted_by_url": "https://github.com/jsonbored"
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
   }
 }


### PR DESCRIPTION
## Summary
Submit the live public subnet-api at `https://api.cacheon.ai/api/metrics`.

Closes #913.

Made with [Cursor](https://cursor.com)