### PR TITLE
feat(registry): enrich SN34 BitMind — add detection stats data artifact

### DIFF
--- a/registry/candidates/community/community-sn-34-data-artifact-api-bitmind-ai.json
+++ b/registry/candidates/community/community-sn-34-data-artifact-api-bitmind-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.bitmind.ai/openapi.json",
       "source_urls": ["https://api.bitmind.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.bitmind.ai/health"
+      "url": "https://api.bitmind.ai/api/v1/detections/stats"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.bitmind.ai/api/v1/detections/stats`.

Closes #914.

Made with [Cursor](https://cursor.com)