### PR TITLE
feat(registry): enrich SN14 Cacheon — add status data artifact

### DIFF
--- a/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
@@ -14,10 +14,10 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://cacheon.ai/docs/miners/api-contract",
-      "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
+      "source_url": "https://api.cacheon.ai/openapi.json",
+      "source_urls": ["https://api.cacheon.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.cacheon.ai/api/health"
+      "url": "https://api.cacheon.ai/api/status"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.cacheon.ai/api/status`.

Closes #913.

Made with [Cursor](https://cursor.com)