### PR TITLE
feat(registry): enrich SN93 Bitcast — add stats API data artifact

### DIFF
--- a/registry/candidates/community/community-sn-93-data-artifact-stats-bitcast-network.json
+++ b/registry/candidates/community/community-sn-93-data-artifact-stats-bitcast-network.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-93-data-artifact-stats-bitcast-network",
+      "kind": "data-artifact",
+      "name": "Bitcast community data-artifact",
+      "netuid": 93,
+      "provider": "bitcast-network",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://stats.bitcast.network/docs",
+      "source_urls": ["https://stats.bitcast.network/docs"],
+      "state": "schema-valid",
+      "url": "https://stats.bitcast.network/api/v1/stats"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the live public dashboard at `https://stats.bitcast.network/api/v1/stats`.

Closes #427.

Made with [Cursor](https://cursor.com)