### PR TITLE
feat(registry): enrich SN34 BitMind — add subnet SDK

### DIFF
--- a/registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
+++ b/registry/candidates/community/community-sn-34-openapi-api-bitmind-ai.json
@@ -14,8 +14,8 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://bitmind.ai/",
-      "source_urls": ["https://bitmind.ai/"],
+      "source_url": "https://api.bitmind.ai/openapi.json",
+      "source_urls": ["https://api.bitmind.ai/openapi.json"],
       "state": "schema-valid",
       "url": "https://api.bitmind.ai/openapi.json"
     }


### PR DESCRIPTION
## Summary
Submit the live public sdk at `https://github.com/BitMind-AI/bitmind-subnet`.

Closes #914.

Made with [Cursor](https://cursor.com)