### PR TITLE
ci(validate): classify PRs from the merge-base (three-dot) to kill the stale-base UGC false-positive

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,14 +30,20 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
         run: |
-          # Keep the global changed-files list unfiltered so PR routing and
-          # policy checks still see deletions. Only the submitted-artifact
-          # verifier receives a deletion-filtered list, because removing a
-          # public artifact (for example moving it to R2-only, ADR 0001) is not
-          # a submitted artifact.
+          # Diff against the MERGE-BASE (three-dot A...B), not the current base
+          # tip (two-dot A B). With fetch-depth:0 the merge-base is always
+          # available, so changed-files.txt is exactly THIS PR's changes:
+          # community/registry files that landed on main AFTER the branch point
+          # no longer show up as phantom deletions and mis-route a normal code PR
+          # into "ugc" mode (the recurring stale-base UGC-preflight false-positive
+          # that forced a rebase on every config/code PR during an active flywheel).
+          # Real deletions made BY the PR are still shown, so the deletion-aware
+          # policy checks keep working; submitted-artifact-files stays
+          # deletion-filtered (removing a public artifact — e.g. moving it R2-only
+          # per ADR 0001 — is not a submitted artifact).
           if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-            git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
-            git diff --name-only --diff-filter=d "$BASE_SHA" "$HEAD_SHA" > submitted-artifact-files.txt
+            git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
+            git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > submitted-artifact-files.txt
           else
             git fetch origin "$BASE_REF"
             git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt


### PR DESCRIPTION
## What

The `validate` job's "Capture changed files" step now diffs the PR against its **merge-base** (three-dot `BASE_SHA...HEAD_SHA`) instead of the **current base tip** (two-dot `BASE_SHA HEAD_SHA`). `changed-files.txt` becomes exactly *this PR's* changes. The non-PR (push) path already used three-dot — this brings the PR path in line.

## Why

The UGC-submission preflight classifies a PR by `changed-files.txt`. With the two-dot diff, any `registry/.../community/*.json` that lands on `main` **after** the branch point shows up as a phantom *deletion* in the PR's diff. The preflight then mis-routes a normal config/code PR into `ugc` mode and fails it with *"direct submissions cannot change other files…"* — a ~14s false fail that has nothing to do with the PR's code.

During an active contributor flywheel `main` moves constantly, so this bit **every** config/code PR (including the Codecov PR #917 this session) and the only workaround was `git rebase origin/main && git push --force-with-lease` on each one. Three-dot fixes it permanently.

## Proof (synthetic stale-branch replay)

Replayed this one-file change onto `origin/main~25` (simulating a branch made 25 commits ago) and compared:

| diff method | community files flagged | result |
|---|---|---|
| **two-dot** `git diff main HEAD` (old) | **19** phantom deletions | → mis-routes to `ugc`, false fail |
| **three-dot** `git diff main...HEAD` (new) | **0** | → correct |

## Safety

- **`fetch-depth: 0`** is already set on the checkout, so the merge-base is always available — no fetch-depth/shallow-clone risk.
- **Real deletions made by the PR are still shown** (three-dot includes the PR's own deletions), so the deletion-aware policy checks keep working.
- **`submitted-artifact-files.txt` stays deletion-filtered** (`--diff-filter=d`) — unchanged semantics.
- Standard GitHub-Actions "PR changed files" pattern.

Follow-up to #917 (Codecov), which surfaced this for the 3rd time this session.