### PR TITLE
feat(registry): enrich SN56 Gradients — add latest tournament weights data artifact

### DIFF
--- a/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
+++ b/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
@@ -14,10 +14,10 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://api.gradients.io/docs",
-      "source_urls": ["https://api.gradients.io/docs"],
+      "source_url": "https://api.gradients.io/openapi.json",
+      "source_urls": ["https://api.gradients.io/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.gradients.io/v1/network/status"
+      "url": "https://api.gradients.io/v1/performance/latest-tournament-weights"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.gradients.io/v1/performance/latest-tournament-weights`, verified with curl (HTTP 200 + JSON).

Closes #905.

## Checklist
- [x] Exactly one `registry/candidates/community/*.json` file changed
- [x] Generated with `npm run candidate:new`
- [x] `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (errors: [], manual_reasons: [])
- [x] URL returns 200 + JSON without authentication

Made with [Cursor](https://cursor.com)