### PR TITLE
feat(registry): enrich SN6 Numinous — add health data artifact

### DIFF
--- a/registry/candidates/community/community-sn-6-data-artifact-api-numinouslabs-io.json
+++ b/registry/candidates/community/community-sn-6-data-artifact-api-numinouslabs-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.numinouslabs.io/api/openapi.json",
       "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.numinouslabs.io/api/v1/leaderboard"
+      "url": "https://api.numinouslabs.io/api/health"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.numinouslabs.io/api/health`, verified with curl (HTTP 200 + JSON).

Closes #908.

## Checklist
- [x] Exactly one `registry/candidates/community/*.json` file changed
- [x] Generated with `npm run candidate:new`
- [x] `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (errors: [], manual_reasons: [])
- [x] URL returns 200 + JSON without authentication

Made with [Cursor](https://cursor.com)