### PR TITLE
feat(registry): enrich SN7 Allways — add OpenAPI schema

### DIFF
--- a/registry/candidates/community/community-sn-7-openapi-api-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-openapi-api-all-ways-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-openapi-api-all-ways-io",
+      "kind": "openapi",
+      "name": "Allways community openapi",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://api.all-ways.io/swagger",
+      "source_urls": ["https://api.all-ways.io/swagger"],
+      "state": "schema-valid",
+      "url": "https://api.all-ways.io/swagger-json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit the live public endpoint at `https://api.all-ways.io/swagger-json`, verified with curl (HTTP 200 + JSON).

Closes #903.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (errors: [], manual_reasons: [])
- [x] URL not a duplicate subnet-api surface (checked against surfaces.csv)

Made with [Cursor](https://cursor.com)