### PR TITLE
feat(registry): enrich SN6 Numinous — add benchmarks baseline data artifact

### DIFF
--- a/registry/candidates/community/community-sn-6-data-artifact-api-numinouslabs-io.json
+++ b/registry/candidates/community/community-sn-6-data-artifact-api-numinouslabs-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.numinouslabs.io/api/openapi.json",
       "source_urls": ["https://api.numinouslabs.io/api/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.numinouslabs.io/api/v1/leaderboard"
+      "url": "https://api.numinouslabs.io/api/v1/benchmarks/baseline"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public endpoint at `https://api.numinouslabs.io/api/v1/benchmarks/baseline`, verified with curl (HTTP 200 + JSON).

Closes #908.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (errors: [], manual_reasons: [])
- [x] URL not a duplicate subnet-api surface (checked against surfaces.csv)

Made with [Cursor](https://cursor.com)