### PR TITLE
feat(registry): enrich SN56 Gradients — add latest tournament details data artifact

### DIFF
--- a/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
+++ b/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.gradients.io/docs",
       "source_urls": ["https://api.gradients.io/docs"],
       "state": "schema-valid",
-      "url": "https://api.gradients.io/v1/network/status"
+      "url": "https://api.gradients.io/tournament/latest/details"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public endpoint at `https://api.gradients.io/tournament/latest/details`, verified with curl (HTTP 200 + JSON).

Closes #905.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (errors: [], manual_reasons: [])
- [x] URL not a duplicate subnet-api surface (checked against surfaces.csv)

Made with [Cursor](https://cursor.com)