### PR TITLE
feat(registry): enrich SN49 Nepher Robotics — add active leaderboard data artifact

### DIFF
--- a/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
+++ b/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/list"
+      "url": "https://tournament-api.nepher.ai/api/v1/scores/leaderboard/active"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://tournament-api.nepher.ai/api/v1/scores/leaderboard/active`, verified with curl (HTTP 200 + JSON). Replaces the closed #924 ready endpoint (health-check JSON, wrong kind).

Closes #916.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + validate + submission:pr passed
- [x] URL not registered as duplicate subnet-api surface

Made with [Cursor](https://cursor.com)