### PR TITLE
feat(registry): enrich SN14 Cacheon — add leader history data artifact

### DIFF
--- a/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://cacheon.ai/docs/miners/api-contract",
       "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
       "state": "schema-valid",
-      "url": "https://api.cacheon.ai/api/health"
+      "url": "https://api.cacheon.ai/api/leader/history"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public data-artifact at `https://api.cacheon.ai/api/leader/history`, verified with curl (HTTP 200 + JSON).

Closes #904.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + validate + submission:pr passed
- [x] URL not a duplicate subnet-api surface (status was 404; leader/history returns JSON)

Made with [Cursor](https://cursor.com)