### PR TITLE
fix(ci): pass delete-only candidate/provider PRs through the UGC preflight

### DIFF
--- a/scripts/submission-pr.mjs
+++ b/scripts/submission-pr.mjs
@@ -46,7 +46,9 @@ const isRemovedDirectFile = (file) =>
   file.endsWith(".json") &&
   !existsSync(path.join(inputRoot, file));
 const removedDirectFiles = changedFiles.filter(isRemovedDirectFile);
-const effectiveChangedFiles = changedFiles.filter((file) => !isRemovedDirectFile(file));
+const effectiveChangedFiles = changedFiles.filter(
+  (file) => !isRemovedDirectFile(file),
+);
 if (removedDirectFiles.length > 0) {
   console.log(
     `Submission preflight: ${removedDirectFiles.length} removed direct file(s) treated as registry deletion(s): ${removedDirectFiles.join(", ")}`,

--- a/scripts/submission-pr.mjs
+++ b/scripts/submission-pr.mjs
@@ -1,4 +1,4 @@
-import { promises as fs } from "node:fs";
+import { existsSync, promises as fs } from "node:fs";
 import path from "node:path";
 import {
   loadCandidates,
@@ -33,10 +33,29 @@ if (!changedFilesPath) {
 const changedFiles = normalizeChangedFiles(
   await fs.readFile(changedFilesPath, "utf8"),
 );
-const directCandidateFile = changedFiles.find((file) =>
+// A delete-only direct submission REMOVES the candidate/provider file — it's absent from the working
+// tree. A removal is a registry DELETION, not a content submission to validate; reading the missing file
+// ENOENT-ed the whole preflight and false-failed maintainer cleanup #944. Drop removed direct files so a
+// pure removal routes as a normal/non-submission PR (and passes); the review gate + maintainer authorize
+// the deletion separately. (#candidate-deletion)
+// Use the broad community-dir prefix (matching classifyPrScope's touchedCommunity* check), not just the
+// strict DIRECT_*_PATTERN, so ANY removed candidate/provider file is recognized as a deletion.
+const isRemovedDirectFile = (file) =>
+  (file.startsWith("registry/candidates/community/") ||
+    file.startsWith("registry/providers/community/")) &&
+  file.endsWith(".json") &&
+  !existsSync(path.join(inputRoot, file));
+const removedDirectFiles = changedFiles.filter(isRemovedDirectFile);
+const effectiveChangedFiles = changedFiles.filter((file) => !isRemovedDirectFile(file));
+if (removedDirectFiles.length > 0) {
+  console.log(
+    `Submission preflight: ${removedDirectFiles.length} removed direct file(s) treated as registry deletion(s): ${removedDirectFiles.join(", ")}`,
+  );
+}
+const directCandidateFile = effectiveChangedFiles.find((file) =>
   DIRECT_CANDIDATE_PATTERN.test(file),
 );
-const directProviderFile = changedFiles.find((file) =>
+const directProviderFile = effectiveChangedFiles.find((file) =>
   DIRECT_PROVIDER_PATTERN.test(file),
 );
 const candidateDocument = directCandidateFile
@@ -72,7 +91,7 @@ const existingProviders = directProviderFile
   : await loadProviders();
 
 const report = buildPrSubmissionReport({
-  changedFiles,
+  changedFiles: effectiveChangedFiles,
   candidateDocument,
   providerDocument,
   submitter,

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -163,6 +163,30 @@ describe("Metagraphed submission gate policy", () => {
     }
   });
 
+  test("passes a delete-only candidate PR (removed file) instead of ENOENT-failing the preflight (#candidate-deletion)", () => {
+    const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-del-"));
+    try {
+      const changedFilesPath = path.join(tmp, "changed-files.txt");
+      const outputPath = path.join(tmp, "report.json");
+      // A candidate path absent from the working tree = a deletion. Before the fix the preflight ENOENT-ed
+      // reading the missing file (exit 1); now it treats the removal as a non-submission and passes.
+      writeFileSync(
+        changedFilesPath,
+        "registry/candidates/community/__removed-candidate__.json\n",
+      );
+      execFileSync(
+        process.execPath,
+        ["scripts/submission-pr.mjs", "--changed-files", changedFilesPath, "--out", outputPath, "--submitter", "JSONbored"],
+        { stdio: "pipe" },
+      ); // must NOT throw — exit 0
+      const report = JSON.parse(readFileSync(outputPath, "utf8"));
+      assert.equal(report.blocking, false);
+      assert.equal(report.state, "not-routed");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   test("routes mixed direct candidate PRs through the UGC gate", () => {
     const tmp = mkdtempSync(path.join(tmpdir(), "metagraphed-route-"));
     try {

--- a/tests/submission-gate.test.mjs
+++ b/tests/submission-gate.test.mjs
@@ -176,7 +176,15 @@ describe("Metagraphed submission gate policy", () => {
       );
       execFileSync(
         process.execPath,
-        ["scripts/submission-pr.mjs", "--changed-files", changedFilesPath, "--out", outputPath, "--submitter", "JSONbored"],
+        [
+          "scripts/submission-pr.mjs",
+          "--changed-files",
+          changedFilesPath,
+          "--out",
+          outputPath,
+          "--submitter",
+          "JSONbored",
+        ],
         { stdio: "pipe" },
       ); // must NOT throw — exit 0
       const report = JSON.parse(readFileSync(outputPath, "utf8"));


### PR DESCRIPTION
## Problem (found reverting #898 via #944)

The UGC submission preflight (`scripts/submission-pr.mjs`) reads the changed candidate/provider file. A **delete-only** PR removes that file, so the read ENOENT-ed and failed the required `validate` check — false-failing maintainer cleanup #944, which needed an `--admin` bypass. Same class as the reviewbot gate fix (which closed the same PR).

## Fix

Drop **removed** community candidate/provider files (absent from the working tree) before validation: a pure removal then routes as a normal/non-submission PR and passes the preflight. The review gate + maintainer authorize the deletion separately. Uses the broad `registry/{candidates,providers}/community/` prefix (matching `classifyPrScope`'s own check), so any removed registry file is recognized.

## Tests

Added a subprocess test: a removed candidate path → `submission-pr.mjs` exits 0, report `not-routed`/non-blocking (was ENOENT exit 1). All 47 submission-gate tests pass; prettier-clean.

Pairs with reviewbot's gate fix so an affiliated-maintainer candidate deletion merges cleanly end-to-end.