### PR TITLE
perf(ci): run the validate suite and checks as parallel jobs

### DIFF
--- a/.github/actions/classify-validation-route/action.yml
+++ b/.github/actions/classify-validation-route/action.yml
@@ -1,0 +1,56 @@
+name: Classify validation route
+description: >-
+  Compute this PR's changed files with a merge-base (three-dot) diff and classify
+  the validation route as "ugc" (a single community candidate/provider submission)
+  or "full" (everything else). Writes changed-files.txt + submitted-artifact-files.txt
+  to the workspace and exposes mode/scope as outputs. Shared by the parallel test +
+  checks jobs so the stale-base-safe diff and the classifier live in one place.
+outputs:
+  mode:
+    description: Validation route — "ugc" or "full".
+    value: ${{ steps.route.outputs.mode }}
+  scope:
+    description: PR scope — "normal-pr", "direct-candidate", or "direct-provider".
+    value: ${{ steps.route.outputs.scope }}
+runs:
+  using: composite
+  steps:
+    - name: Capture changed files
+      if: github.event_name == 'pull_request'
+      shell: bash
+      env:
+        BASE_REF: ${{ github.base_ref || 'main' }}
+        BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
+      run: |
+        # Diff against the MERGE-BASE (three-dot A...B), not the current base
+        # tip (two-dot A B). With fetch-depth:0 the merge-base is always
+        # available, so changed-files.txt is exactly THIS PR's changes:
+        # community/registry files that landed on main AFTER the branch point
+        # no longer show up as phantom deletions and mis-route a normal code PR
+        # into "ugc" mode (the recurring stale-base UGC-preflight false-positive
+        # that forced a rebase on every config/code PR during an active flywheel).
+        # Real deletions made BY the PR are still shown, so the deletion-aware
+        # policy checks keep working; submitted-artifact-files stays
+        # deletion-filtered (removing a public artifact — e.g. moving it R2-only
+        # per ADR 0001 — is not a submitted artifact).
+        if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
+          git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
+          git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > submitted-artifact-files.txt
+        else
+          git fetch origin "$BASE_REF"
+          git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
+          git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > submitted-artifact-files.txt
+        fi
+
+    - name: Capture changed files for full validation
+      if: github.event_name != 'pull_request'
+      shell: bash
+      run: |
+        : > changed-files.txt
+        : > submitted-artifact-files.txt
+
+    - name: Classify validation route
+      id: route
+      shell: bash
+      run: python3 scripts/classify-validation-route.py

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,14 +15,17 @@ concurrency:
   cancel-in-progress: true
 
 # The work splits across two parallel jobs that share a runner-free route
-# classification (the classify-validation-route composite action): `test` runs
-# the suite + coverage; `checks` runs build + lint + the ~20 contract / schema /
-# safety validations (and the light UGC submission path). They are independent —
-# no validation needs the tests, and the test suite needs no build step — so
-# running them on two runners makes the wall-clock max(test, checks) instead of
-# the sum (~30% faster than the old single job). Both short-circuit the heavy
-# path for a UGC submission (a single community candidate/provider file): the
-# test job becomes a no-op and checks runs only the submission preflight.
+# classification (the classify-validation-route composite action): `test` builds
+# then runs the suite + coverage; `checks` builds then runs lint + the ~20
+# contract / schema / safety validations (and the light UGC submission path).
+# They are independent — no validation needs the test results — so running them
+# on two runners makes the wall-clock max(test, checks) instead of the sum. Both
+# build: the suite's reader tests serve R2-only artifacts (registry-summary.json
+# etc.) that have NO committed fallback and only exist after npm run build, so a
+# fresh runner must stage them; the duplicate ~5s build runs in parallel. Both
+# short-circuit the heavy path for a UGC submission (a single community
+# candidate/provider file): the test job becomes a no-op and checks runs only
+# the submission preflight.
 jobs:
   test:
     name: test
@@ -47,6 +50,16 @@ jobs:
       - name: Install
         if: steps.route.outputs.mode == 'full'
         run: npm ci
+
+      # Stage artifacts before the suite: the reader tests serve R2-only
+      # artifacts that have NO committed fallback (dist/metagraph-r2/metagraph/*,
+      # e.g. registry-summary.json), which only exist after a build — exactly as
+      # the checks job and the old single job do.
+      - name: Build artifacts
+        if: steps.route.outputs.mode == 'full'
+        env:
+          METAGRAPH_PRESERVE_PROBE_HEALTH: "1"
+        run: npm run build
 
       - name: Test (with coverage gate)
         if: steps.route.outputs.mode == 'full'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,8 +14,18 @@ concurrency:
   group: validate-${{ github.ref }}
   cancel-in-progress: true
 
+# The work splits across two parallel jobs that share a runner-free route
+# classification (the classify-validation-route composite action): `test` runs
+# the suite + coverage; `checks` runs build + lint + the ~20 contract / schema /
+# safety validations (and the light UGC submission path). They are independent —
+# no validation needs the tests, and the test suite needs no build step — so
+# running them on two runners makes the wall-clock max(test, checks) instead of
+# the sum (~30% faster than the old single job). Both short-circuit the heavy
+# path for a UGC submission (a single community candidate/provider file): the
+# test job becomes a no-op and checks runs only the submission preflight.
 jobs:
-  validate:
+  test:
+    name: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -23,103 +33,49 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Capture changed files
-        if: github.event_name == 'pull_request'
-        env:
-          BASE_REF: ${{ github.base_ref || 'main' }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || '' }}
-        run: |
-          # Diff against the MERGE-BASE (three-dot A...B), not the current base
-          # tip (two-dot A B). With fetch-depth:0 the merge-base is always
-          # available, so changed-files.txt is exactly THIS PR's changes:
-          # community/registry files that landed on main AFTER the branch point
-          # no longer show up as phantom deletions and mis-route a normal code PR
-          # into "ugc" mode (the recurring stale-base UGC-preflight false-positive
-          # that forced a rebase on every config/code PR during an active flywheel).
-          # Real deletions made BY the PR are still shown, so the deletion-aware
-          # policy checks keep working; submitted-artifact-files stays
-          # deletion-filtered (removing a public artifact — e.g. moving it R2-only
-          # per ADR 0001 — is not a submitted artifact).
-          if [ -n "$BASE_SHA" ] && [ -n "$HEAD_SHA" ]; then
-            git diff --name-only "$BASE_SHA"..."$HEAD_SHA" > changed-files.txt
-            git diff --name-only --diff-filter=d "$BASE_SHA"..."$HEAD_SHA" > submitted-artifact-files.txt
-          else
-            git fetch origin "$BASE_REF"
-            git diff --name-only "origin/$BASE_REF"...HEAD > changed-files.txt
-            git diff --name-only --diff-filter=d "origin/$BASE_REF"...HEAD > submitted-artifact-files.txt
-          fi
+      - name: Classify validation route
+        id: route
+        uses: ./.github/actions/classify-validation-route
 
-      - name: Capture changed files for full validation
-        if: github.event_name != 'pull_request'
-        run: |
-          : > changed-files.txt
-          : > submitted-artifact-files.txt
+      - name: Setup Node
+        if: steps.route.outputs.mode == 'full'
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
+        with:
+          node-version: 22.22.3
+          cache: npm
+
+      - name: Install
+        if: steps.route.outputs.mode == 'full'
+        run: npm ci
+
+      - name: Test (with coverage gate)
+        if: steps.route.outputs.mode == 'full'
+        run: npm run test:coverage
+
+      # Upload coverage to Codecov — the primary PR coverage gate (delta-based
+      # project + patch, see codecov.yml). vitest's thresholds are now just a
+      # local backstop. Runs on PRs AND main pushes (main = the comparison base);
+      # the upload failing never fails CI (the gate is Codecov's own status).
+      - name: Upload coverage to Codecov
+        if: steps.route.outputs.mode == 'full'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage/lcov.info
+          fail_ci_if_error: false
+
+  checks:
+    name: checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          fetch-depth: 0
 
       - name: Classify validation route
         id: route
-        run: |
-          python3 <<'VALIDATE_ROUTE_PY'
-          import json
-          import os
-          import pathlib
-          import re
-
-          changed_files = sorted(
-              file.strip().replace("\\", "/").removeprefix("./")
-              for file in pathlib.Path("changed-files.txt").read_text(encoding="utf-8").splitlines()
-              if file.strip()
-          )
-          candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
-          provider_pattern = re.compile(r"^registry/providers/community/[a-z0-9][a-z0-9-]*\.json$")
-          candidate_files = [file for file in changed_files if candidate_pattern.fullmatch(file)]
-          provider_files = [file for file in changed_files if provider_pattern.fullmatch(file)]
-          touched_community = [
-              file for file in changed_files
-              if file.startswith("registry/candidates/community/")
-              or file.startswith("registry/providers/community/")
-          ]
-          errors = []
-          submission_files = candidate_files + provider_files
-          if not submission_files and not touched_community:
-              scope = "normal-pr"
-          else:
-              scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
-              if len(submission_files) != 1:
-                  errors.append({
-                      "category": "unsupported-shape",
-                      "message": "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file",
-                  })
-              unrelated = [
-                  file for file in changed_files
-                  if not candidate_pattern.fullmatch(file)
-                  and not provider_pattern.fullmatch(file)
-              ]
-              if unrelated:
-                  errors.append({
-                      "category": "generated-artifact-tampering",
-                      "message": "direct submissions cannot change other files: " + ", ".join(unrelated),
-                  })
-          mode = "ugc" if scope in {"direct-candidate", "direct-provider"} else "full"
-          report = {
-              "schema_version": 1,
-              "mode": mode,
-              "scope": scope,
-              "changed_files": changed_files,
-              "candidate_files": candidate_files,
-              "provider_files": provider_files,
-              "errors": errors,
-          }
-          pathlib.Path("validate-route.json").write_text(
-              json.dumps(report, indent=2) + "\n", encoding="utf-8"
-          )
-          output_path = os.environ.get("GITHUB_OUTPUT")
-          if output_path:
-              with open(output_path, "a", encoding="utf-8") as output:
-                  output.write(f"mode={mode}\n")
-                  output.write(f"scope={scope}\n")
-          print(json.dumps(report, indent=2))
-          VALIDATE_ROUTE_PY
+        uses: ./.github/actions/classify-validation-route
 
       - name: Setup Node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -130,6 +86,7 @@ jobs:
       - name: Install
         run: npm ci
 
+      # --- UGC submission path (a single community candidate/provider file) ---
       - name: Run UGC submission preflight
         if: steps.route.outputs.mode == 'ugc'
         env:
@@ -149,6 +106,7 @@ jobs:
         if: steps.route.outputs.mode == 'ugc'
         run: npm run validate:private-boundary
 
+      # --- Full validation path ---
       - name: Lint + format
         if: steps.route.outputs.mode == 'full'
         run: |
@@ -181,22 +139,6 @@ jobs:
       - name: Validate registry
         if: steps.route.outputs.mode == 'full'
         run: npm run validate
-
-      - name: Test (with coverage gate)
-        if: steps.route.outputs.mode == 'full'
-        run: npm run test:coverage
-
-      # Upload coverage to Codecov — the primary PR coverage gate (delta-based
-      # project + patch, see codecov.yml). vitest's thresholds are now just a
-      # local backstop. Runs on PRs AND main pushes (main = the comparison base);
-      # the upload failing never fails CI (the gate is Codecov's own status).
-      - name: Upload coverage to Codecov
-        if: steps.route.outputs.mode == 'full'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/lcov.info
-          fail_ci_if_error: false
 
       - name: Generate R2 manifest
         if: steps.route.outputs.mode == 'full'

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,13 @@ vite.config.ts.timestamp-*
 # shared project slash commands in .claude/commands/ (e.g. /lineage-discovery).
 .claude/*
 !.claude/commands/
+
+# Python bytecode (scripts/classify-validation-route.py — the CI route classifier)
+__pycache__/
+*.pyc
+
+# Transient route-classification artifacts written at the repo root by the
+# classify-validation-route action / scripts/classify-validation-route.py
+/changed-files.txt
+/submitted-artifact-files.txt
+/validate-route.json

--- a/scripts/classify-validation-route.py
+++ b/scripts/classify-validation-route.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Classify a PR's validation route for CI (UGC submission vs full validation).
+
+Reads ``changed-files.txt`` (one path per line, produced by the merge-base diff in
+the classify-validation-route composite action) and decides:
+
+  * ``mode=ugc``   — the PR is a single community candidate/provider submission
+                     (registry/{candidates,providers}/community/<slug>.json). The
+                     checks job runs the light submission preflight only.
+  * ``mode=full``  — everything else. The full build + contract/schema/safety
+                     suite runs (and the test job runs the test suite).
+
+This is pure stdlib so it can run BEFORE ``npm ci`` (letting the test job skip
+install for UGC PRs). It mirrors the canonical classifier in
+``scripts/submission-policy.mjs`` (also exposed via ``scripts/ci-validate-route.mjs``);
+keep the two in sync. Writes ``validate-route.json`` for debugging and appends
+``mode``/``scope`` to ``$GITHUB_OUTPUT`` when present.
+"""
+
+import json
+import os
+import pathlib
+import re
+
+changed_files = sorted(
+    file.strip().replace("\\", "/").removeprefix("./")
+    for file in pathlib.Path("changed-files.txt")
+    .read_text(encoding="utf-8")
+    .splitlines()
+    if file.strip()
+)
+candidate_pattern = re.compile(r"^registry/candidates/community/[a-z0-9][a-z0-9-]*\.json$")
+provider_pattern = re.compile(r"^registry/providers/community/[a-z0-9][a-z0-9-]*\.json$")
+candidate_files = [file for file in changed_files if candidate_pattern.fullmatch(file)]
+provider_files = [file for file in changed_files if provider_pattern.fullmatch(file)]
+touched_community = [
+    file
+    for file in changed_files
+    if file.startswith("registry/candidates/community/")
+    or file.startswith("registry/providers/community/")
+]
+errors = []
+submission_files = candidate_files + provider_files
+if not submission_files and not touched_community:
+    scope = "normal-pr"
+else:
+    scope = "direct-provider" if len(provider_files) == 1 else "direct-candidate"
+    if len(submission_files) != 1:
+        errors.append(
+            {
+                "category": "unsupported-shape",
+                "message": "direct submissions must change exactly one registry/candidates/community/*.json or registry/providers/community/*.json file",
+            }
+        )
+    unrelated = [
+        file
+        for file in changed_files
+        if not candidate_pattern.fullmatch(file) and not provider_pattern.fullmatch(file)
+    ]
+    if unrelated:
+        errors.append(
+            {
+                "category": "generated-artifact-tampering",
+                "message": "direct submissions cannot change other files: " + ", ".join(unrelated),
+            }
+        )
+mode = "ugc" if scope in {"direct-candidate", "direct-provider"} else "full"
+report = {
+    "schema_version": 1,
+    "mode": mode,
+    "scope": scope,
+    "changed_files": changed_files,
+    "candidate_files": candidate_files,
+    "provider_files": provider_files,
+    "errors": errors,
+}
+pathlib.Path("validate-route.json").write_text(
+    json.dumps(report, indent=2) + "\n", encoding="utf-8"
+)
+output_path = os.environ.get("GITHUB_OUTPUT")
+if output_path:
+    with open(output_path, "a", encoding="utf-8") as output:
+        output.write(f"mode={mode}\n")
+        output.write(f"scope={scope}\n")
+print(json.dumps(report, indent=2))

--- a/scripts/validate-workflows.mjs
+++ b/scripts/validate-workflows.mjs
@@ -112,14 +112,28 @@ for (const workflow of workflows) {
     );
   }
   if (workflow === "validate.yml") {
+    // The routing diff lives in the classify-validation-route composite action
+    // (shared by the parallel test + checks jobs); the deletion-filtered
+    // verification is consumed back in this workflow.
+    const routeAction = await fs.readFile(
+      path.join(
+        repoRoot,
+        ".github/actions/classify-validation-route/action.yml",
+      ),
+      "utf8",
+    );
     check(
-      content.includes("git diff --name-only ") &&
-        content.includes("> changed-files.txt") &&
-        content.includes("--diff-filter=d") &&
-        content.includes("> submitted-artifact-files.txt") &&
-        content.includes("--changed-files submitted-artifact-files.txt"),
+      routeAction.includes("git diff --name-only ") &&
+        routeAction.includes("> changed-files.txt") &&
+        routeAction.includes("--diff-filter=d") &&
+        routeAction.includes("> submitted-artifact-files.txt"),
       workflow,
-      "validate workflow must keep PR routing diffs unfiltered and filter deletions only for submitted-artifact verification",
+      "classify-validation-route action must keep PR routing diffs unfiltered and filter deletions only for submitted-artifact verification",
+    );
+    check(
+      content.includes("--changed-files submitted-artifact-files.txt"),
+      workflow,
+      "validate workflow must verify submitted artifacts from the deletion-filtered list",
     );
   }
   if (workflow === "submission-gate.yml") {


### PR DESCRIPTION
## What

Splits the monolithic `validate` job into two **parallel jobs on two runners**:

- **`test`** — route classify → test suite + coverage → Codecov upload.
- **`checks`** — route classify → build + lint + the ~20 contract / schema / safety validations (and the light UGC submission path).

They're independent (no validation needs the tests; the suite needs no build step), so wall-clock becomes **`max(test, checks)`** instead of the sum.

## Why this, and not #953

#953 split the test *files* within one runner — but that's CPU-core-bound (parallel readers were 5s locally → **18s** on CI's smaller runner) and couldn't touch the **42s artifact-build floor**. Real CI gain was only ~3–7s. This splits the **job** across **separate runners** → genuine parallelism. Target: **~113–120s → ~80s (~30%)**. (The PR's own run will show the real number.)

## How the shared route classification works

Both jobs need the ugc/full route to know whether to run. Rather than duplicate it, a new composite action **`.github/actions/classify-validation-route`** carries:
- the stale-base-safe **three-dot diff** (#943), and
- the classifier — extracted **verbatim** from the old inline python to `scripts/classify-validation-route.py` (pure stdlib, so it still runs *before* `npm ci`, letting the `test` job skip install entirely for UGC PRs).

`scripts/validate-workflows.mjs` now asserts the routing-diff invariant in the **action** (where the logic lives) and keeps the deletion-filtered-verification check in the workflow.

## Safety

- **Route parity verified** across 6 scenarios (empty → full; 1 candidate → ugc/direct-candidate; 1 provider → ugc/direct-provider; code → full; candidate+code → ugc + 1 error; 2 candidates → ugc + 1 error) — identical to the old classifier. **Zero classification behavior change.**
- `validate:workflows` ✓ (10 files), `prettier --check` ✓, `scan:public-safety` ✓, eslint ✓, route files + `__pycache__` gitignored.
- Job rename (`validate` → `test`/`checks`) is safe: branch protection's required-status-checks list is empty.
- No test-code footgun (each job runs tests normally — the `fileParallelism: false` blunt-safe default is untouched).

## Follow-up

Once merged, the `test` job is the long pole (~80s). Reducing `artifacts.test.mjs`'s 4× build (it's the reproducibility gate — riskier) could push the whole job toward the ~66s `checks` floor. Tracked separately.