### PR TITLE
feat(api): reference captured request/response fixtures on callable services (#748)

### DIFF
--- a/generated/metagraphed-api.d.ts
+++ b/generated/metagraphed-api.d.ts
@@ -1051,6 +1051,7 @@ export interface components {
                 eligibility?: {
                     [key: string]: unknown;
                 };
+                fixture?: components["schemas"]["SurfaceFixtureReference"];
                 health?: {
                     [key: string]: unknown;
                 };
@@ -3323,6 +3324,24 @@ export interface components {
                 status_code?: number | null;
                 topics?: string[];
                 verified_at?: string;
+            };
+        };
+        /** @description Bounded reference to a captured, sanitized live request/response sample for one surface (#748). The request + response shape are inline; fetch the full sanitized body at artifact_path (GET /metagraph/fixtures/{surface_id}.json, or the get_fixture MCP tool). */
+        SurfaceFixtureReference: {
+            /** @description Public artifact path of the full sanitized fixture. */
+            artifact_path: string;
+            /**
+             * Format: date-time
+             * @description When the sample was captured.
+             */
+            captured_at?: string | null;
+            request: {
+                method: string;
+                url: string | null;
+            };
+            response: {
+                content_type?: string | null;
+                status: number | null;
             };
         };
         /** @enum {unknown} */

--- a/public/metagraph/openapi.json
+++ b/public/metagraph/openapi.json
@@ -231,6 +231,9 @@
                       "additionalProperties": true,
                       "type": "object"
                     },
+                    "fixture": {
+                      "$ref": "#/components/schemas/SurfaceFixtureReference"
+                    },
                     "health": {
                       "additionalProperties": true,
                       "type": "object"
@@ -9234,6 +9237,70 @@
           "auth_required",
           "authority",
           "public_safe"
+        ],
+        "type": "object"
+      },
+      "SurfaceFixtureReference": {
+        "additionalProperties": false,
+        "description": "Bounded reference to a captured, sanitized live request/response sample for one surface (#748). The request + response shape are inline; fetch the full sanitized body at artifact_path (GET /metagraph/fixtures/{surface_id}.json, or the get_fixture MCP tool).",
+        "properties": {
+          "artifact_path": {
+            "description": "Public artifact path of the full sanitized fixture.",
+            "type": "string"
+          },
+          "captured_at": {
+            "description": "When the sample was captured.",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "request": {
+            "additionalProperties": false,
+            "properties": {
+              "method": {
+                "type": "string"
+              },
+              "url": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "method",
+              "url"
+            ],
+            "type": "object"
+          },
+          "response": {
+            "additionalProperties": false,
+            "properties": {
+              "content_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "request",
+          "response",
+          "artifact_path"
         ],
         "type": "object"
       },

--- a/public/metagraph/types.d.ts
+++ b/public/metagraph/types.d.ts
@@ -1051,6 +1051,7 @@ export interface components {
                 eligibility?: {
                     [key: string]: unknown;
                 };
+                fixture?: components["schemas"]["SurfaceFixtureReference"];
                 health?: {
                     [key: string]: unknown;
                 };
@@ -3323,6 +3324,24 @@ export interface components {
                 status_code?: number | null;
                 topics?: string[];
                 verified_at?: string;
+            };
+        };
+        /** @description Bounded reference to a captured, sanitized live request/response sample for one surface (#748). The request + response shape are inline; fetch the full sanitized body at artifact_path (GET /metagraph/fixtures/{surface_id}.json, or the get_fixture MCP tool). */
+        SurfaceFixtureReference: {
+            /** @description Public artifact path of the full sanitized fixture. */
+            artifact_path: string;
+            /**
+             * Format: date-time
+             * @description When the sample was captured.
+             */
+            captured_at?: string | null;
+            request: {
+                method: string;
+                url: string | null;
+            };
+            response: {
+                content_type?: string | null;
+                status: number | null;
             };
         };
         /** @enum {unknown} */

--- a/schemas/api-components.schema.json
+++ b/schemas/api-components.schema.json
@@ -217,6 +217,9 @@
                       "additionalProperties": true,
                       "type": "object"
                     },
+                    "fixture": {
+                      "$ref": "#/components/schemas/SurfaceFixtureReference"
+                    },
                     "health": {
                       "additionalProperties": true,
                       "type": "object"
@@ -9212,6 +9215,70 @@
           "auth_required",
           "authority",
           "public_safe"
+        ],
+        "type": "object"
+      },
+      "SurfaceFixtureReference": {
+        "additionalProperties": false,
+        "description": "Bounded reference to a captured, sanitized live request/response sample for one surface (#748). The request + response shape are inline; fetch the full sanitized body at artifact_path (GET /metagraph/fixtures/{surface_id}.json, or the get_fixture MCP tool).",
+        "properties": {
+          "artifact_path": {
+            "description": "Public artifact path of the full sanitized fixture.",
+            "type": "string"
+          },
+          "captured_at": {
+            "description": "When the sample was captured.",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "request": {
+            "additionalProperties": false,
+            "properties": {
+              "method": {
+                "type": "string"
+              },
+              "url": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "method",
+              "url"
+            ],
+            "type": "object"
+          },
+          "response": {
+            "additionalProperties": false,
+            "properties": {
+              "content_type": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "status": {
+                "type": [
+                  "integer",
+                  "null"
+                ]
+              }
+            },
+            "required": [
+              "status"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "request",
+          "response",
+          "artifact_path"
         ],
         "type": "object"
       },

--- a/schemas/components/04-surfaces.schema.json
+++ b/schemas/components/04-surfaces.schema.json
@@ -771,6 +771,41 @@
           }
         ]
       },
+      "SurfaceFixtureReference": {
+        "type": "object",
+        "description": "Bounded reference to a captured, sanitized live request/response sample for one surface (#748). The request + response shape are inline; fetch the full sanitized body at artifact_path (GET /metagraph/fixtures/{surface_id}.json, or the get_fixture MCP tool).",
+        "required": ["request", "response", "artifact_path"],
+        "properties": {
+          "captured_at": {
+            "type": ["string", "null"],
+            "format": "date-time",
+            "description": "When the sample was captured."
+          },
+          "request": {
+            "type": "object",
+            "required": ["method", "url"],
+            "properties": {
+              "method": { "type": "string" },
+              "url": { "type": ["string", "null"] }
+            },
+            "additionalProperties": false
+          },
+          "response": {
+            "type": "object",
+            "required": ["status"],
+            "properties": {
+              "status": { "type": ["integer", "null"] },
+              "content_type": { "type": ["string", "null"] }
+            },
+            "additionalProperties": false
+          },
+          "artifact_path": {
+            "type": "string",
+            "description": "Public artifact path of the full sanitized fixture."
+          }
+        },
+        "additionalProperties": false
+      },
       "AgentCatalogSubnetArtifact": {
         "allOf": [
           { "$ref": "#/components/schemas/ArtifactBase" },
@@ -820,6 +855,9 @@
                     "eligibility": {
                       "type": "object",
                       "additionalProperties": true
+                    },
+                    "fixture": {
+                      "$ref": "#/components/schemas/SurfaceFixtureReference"
                     }
                   },
                   "additionalProperties": true

--- a/scripts/build-artifacts.mjs
+++ b/scripts/build-artifacts.mjs
@@ -47,6 +47,7 @@ import {
   slugify,
   staleOperationalKinds,
   subnetLifecycle,
+  surfaceFixtureReference,
   writeJson,
 } from "./lib.mjs";
 import {
@@ -1142,6 +1143,13 @@ function buildSubnetServices(netuid) {
       // surface wins; otherwise the value derived from the captured spec's
       // securitySchemes. null when neither is present. Placeholders only.
       const authDetail = surface.auth || schema?.snapshot?.auth_detail || null;
+      // Captured live request/response sample for this surface (#748): a bounded
+      // reference (request + response shape + link to the full sanitized body),
+      // the natural companion to the call snippet. Present only when captured.
+      const fixtureRef = surfaceFixtureReference(
+        surface.id,
+        capturedFixtures.get(surface.id),
+      );
       return {
         surface_id: surface.id,
         kind: surface.kind,
@@ -1164,6 +1172,7 @@ function buildSubnetServices(netuid) {
           auth_schemes: authSchemes,
           auth: authDetail,
         }),
+        ...(fixtureRef ? { fixture: fixtureRef } : {}),
         schema_url: surface.schema_url || null,
         schema_status: surface.schema_status || null,
         schema_artifact: schema?.path || null,

--- a/scripts/lib.mjs
+++ b/scripts/lib.mjs
@@ -853,6 +853,37 @@ export function sanitizeFixtureBody(
   return walk(value, 0);
 }
 
+// Bounded reference to a captured live request/response fixture (#748). Gives an
+// agent reading a subnet's callable services enough to see the example REQUEST
+// (method + url) and the response shape (status + content_type) inline, plus
+// artifact_path to fetch the full sanitized body (GET
+// /metagraph/fixtures/{surface_id}.json, also the get_fixture MCP tool). The
+// body itself is NOT inlined — captured bodies can be ~1 MB — so service detail
+// stays lean and the one already-sanitized copy is served from a single place.
+// Returns null when there is no fixture, so callers omit the field entirely.
+export function surfaceFixtureReference(surfaceId, fixture) {
+  if (!surfaceId || !fixture || typeof fixture !== "object") {
+    return null;
+  }
+  const request = fixture.request || {};
+  const response = fixture.response || {};
+  return {
+    captured_at: fixture.captured_at || null,
+    request: {
+      method: typeof request.method === "string" ? request.method : "GET",
+      url: typeof request.url === "string" ? request.url : null,
+    },
+    response: {
+      status: Number.isInteger(response.status) ? response.status : null,
+      content_type:
+        typeof response.content_type === "string"
+          ? response.content_type
+          : null,
+    },
+    artifact_path: `/metagraph/fixtures/${surfaceId}.json`,
+  };
+}
+
 export function normalizePublicUrl(value) {
   if (typeof value !== "string") {
     return null;

--- a/tests/lib-helpers.test.mjs
+++ b/tests/lib-helpers.test.mjs
@@ -33,6 +33,7 @@ import {
   clusterDomainFromUrl,
   buildSubnetLineageLinks,
   sanitizeFixtureBody,
+  surfaceFixtureReference,
   writeJson,
 } from "../scripts/lib.mjs";
 
@@ -1116,5 +1117,57 @@ describe("subnetContact", () => {
     assert.equal(subnetContact(""), null);
     assert.equal(subnetContact(null), null);
     assert.equal(subnetContact(42), null);
+  });
+});
+
+describe("surfaceFixtureReference (#748)", () => {
+  const fixture = {
+    schema_version: 1,
+    surface_id: "allways-api-health",
+    netuid: 7,
+    kind: "subnet-api",
+    captured_at: "2026-06-16T12:00:00.000Z",
+    request: { method: "GET", url: "https://api.all-ways.io/health" },
+    response: {
+      status: 200,
+      content_type: "application/json",
+      body: { ok: true },
+    },
+  };
+
+  test("projects a bounded reference and links the full fixture artifact", () => {
+    const ref = surfaceFixtureReference("allways-api-health", fixture);
+    assert.deepEqual(ref, {
+      captured_at: "2026-06-16T12:00:00.000Z",
+      request: { method: "GET", url: "https://api.all-ways.io/health" },
+      response: { status: 200, content_type: "application/json" },
+      artifact_path: "/metagraph/fixtures/allways-api-health.json",
+    });
+  });
+
+  test("never inlines the response body (kept lean; body stays at artifact_path)", () => {
+    const ref = surfaceFixtureReference("allways-api-health", fixture);
+    assert.equal("body" in ref.response, false);
+    assert.equal(JSON.stringify(ref).includes('"ok"'), false);
+  });
+
+  test("defaults method to GET and tolerates missing optional fields", () => {
+    const ref = surfaceFixtureReference("sn-9-x", {
+      request: { url: "https://x.example/api" },
+      response: { status: 204 },
+    });
+    assert.equal(ref.request.method, "GET");
+    assert.equal(ref.captured_at, null);
+    assert.equal(ref.response.content_type, null);
+    assert.equal(ref.response.status, 204);
+    assert.equal(ref.artifact_path, "/metagraph/fixtures/sn-9-x.json");
+  });
+
+  test("returns null when there is no fixture or no surface id", () => {
+    assert.equal(surfaceFixtureReference("sn-9-x", null), null);
+    assert.equal(surfaceFixtureReference("sn-9-x", undefined), null);
+    assert.equal(surfaceFixtureReference("sn-9-x", "nope"), null);
+    assert.equal(surfaceFixtureReference("", fixture), null);
+    assert.equal(surfaceFixtureReference(null, fixture), null);
   });
 });


### PR DESCRIPTION
Closes #748 (backend; frontend block is a follow-on metagraphed-ui PR).

## What
The `capture-fixtures` pipeline already records one sanitized live request/response sample per no-auth GET surface (#352) at `/metagraph/fixtures/{surface_id}.json`, but it was reachable **only** via the `get_fixture` MCP tool — invisible to a caller reading a subnet's services over the REST API.

Each callable service in the **agent-catalog** detail (`/api/v1/agent-catalog/{netuid}`) now carries a bounded `fixture` reference, right next to the existing call `snippets`:

```json
"fixture": {
  "captured_at": "2026-06-16T…",
  "request":  { "method": "GET", "url": "https://api.example/health" },
  "response": { "status": 200, "content_type": "application/json" },
  "artifact_path": "/metagraph/fixtures/sn-7-allways-health.json"
}
```

The snippet says *how to call it*; the fixture says *what comes back* + links the full sanitized body. The body is **never inlined** (captured bodies can be ~1 MB) — service detail stays lean and the single already-sanitized copy is served from one place (REST artifact path or `get_fixture`).

## Completion requirements (#748)
- [x] **Fixtures referenced in the relevant profile API responses (link, sanitized)** — per-service `fixture` reference on the agent-catalog services detail, linking the full sanitized body.
- [ ] **Frontend "sample request/response" block** — follow-on metagraphed-ui PR (issue allows a linked FE PR).
- [x] **Public-safe; `scan-public-safety` clean; no secrets/PII** — the reference carries no body; the linked fixture is already sanitized + scanned. `scan:public-safety` ✓.
- [x] **Schema touched → build + commit contract; `validate` + tests pass** — new `SurfaceFixtureReference` component; contract regenerated (openapi/types/client/api-components); `validate:contract-drift` ✓.
- [x] **Conventional Commit title** ✓.

## Implementation
- `scripts/lib.mjs` — new `surfaceFixtureReference(surfaceId, fixture)` helper (bounded projection, returns null when absent).
- `scripts/build-artifacts.mjs` — `buildSubnetServices` attaches it from the existing `capturedFixtures` map (conditional; omitted when no fixture).
- `schemas/components/04-surfaces.schema.json` — `SurfaceFixtureReference` + the optional `fixture` property on services.
- `tests/lib-helpers.test.mjs` — 4 unit tests (projection, never-inlines-body, defaults/missing fields, null cases).

## Verified
`validate:contract-drift` · `validate:schemas` · `validate:api` · `validate:openapi` · `validate:types` · `validate:mcp` · `scan:public-safety` · `eslint` · `prettier` — all green on a fresh build. Only the contract subset + source committed (data-artifact churn restored per the build discipline).