### PR TITLE
feat(registry): enrich SN64 Chutes — add utilization data artifact

### DIFF
--- a/registry/candidates/community/community-sn-64-data-artifact-api-chutes-ai.json
+++ b/registry/candidates/community/community-sn-64-data-artifact-api-chutes-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.chutes.ai/openapi.json",
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.chutes.ai/users/growth"
+      "url": "https://api.chutes.ai/chutes/utilization"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public endpoint at `https://api.chutes.ai/chutes/utilization`, verified with curl (HTTP 200 + JSON).

Closes #959.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` + `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed
- [x] URL not a duplicate subnet-api surface in surfaces.csv

Made with [Cursor](https://cursor.com)