### PR TITLE
feat(registry): enrich SN49 Nepher Robotics — add active tournament id data artifact

### DIFF
--- a/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
+++ b/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://tournament-api.nepher.ai/api/v1/scores/leaderboard/active"
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/id"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public endpoint at `https://tournament-api.nepher.ai/api/v1/tournaments/active/id`, verified with curl (HTTP 200 + JSON).

Closes #962.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` + `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed
- [x] URL not a duplicate subnet-api surface in surfaces.csv

Made with [Cursor](https://cursor.com)