### PR TITLE
feat(registry): enrich SN14 Cacheon — add evaluations data artifact

### DIFF
--- a/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://cacheon.ai/docs/miners/api-contract",
       "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
       "state": "schema-valid",
-      "url": "https://api.cacheon.ai/api/leader/history"
+      "url": "https://api.cacheon.ai/api/evaluations"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public endpoint at `https://api.cacheon.ai/api/evaluations`, verified with curl (HTTP 200 + JSON).

Closes #913.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` + `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed
- [x] URL not a duplicate subnet-api surface in surfaces.csv

Made with [Cursor](https://cursor.com)