### PR TITLE
feat(python): async client + typed models (#749)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -11,7 +11,8 @@ dependencies.
 ## Install
 
 ```bash
-pip install metagraphed
+pip install metagraphed            # sync client + typed models (stdlib only)
+pip install "metagraphed[async]"   # adds the async client (httpx)
 ```
 
 ## Usage
@@ -68,6 +69,59 @@ for page in client.paginate("/api/v1/subnets", query={"limit": 100}):
 
 # Call the read-only Subtensor RPC proxy and get back the JSON-RPC result:
 info = metagraphed_rpc("finney", "system_health")
+```
+
+### Collect every row (`fetch_all`)
+
+List endpoints nest rows under `data.<collection>` (named by
+`meta.pagination.collection`) and paginate via `meta.pagination.next_cursor`.
+`fetch_all` follows the cursor and concatenates the rows for you:
+
+```python
+subnets = client.fetch_all("/api/v1/subnets")  # every subnet, across all pages
+print(len(subnets), subnets[0]["name"])
+```
+
+There are also thin convenience wrappers over the canonical routes —
+`client.subnets(...)`, `client.get_subnet(7)`, `client.providers(...)`,
+`client.get_provider("synth")`, `client.surfaces(...)`, `client.endpoints(...)`,
+`client.health()`, `client.agent_catalog()` — each returning the raw envelope.
+
+### Typed models (optional)
+
+`fetch`/`fetch_all` return plain dicts. For typed attribute access, parse rows
+into the dependency-free dataclasses — the **full** payload always stays on
+`.raw`, so nothing is lost:
+
+```python
+from metagraphed import MetagraphedClient, Subnet
+
+client = MetagraphedClient()
+subnets = [Subnet.from_dict(row) for row in client.fetch_all("/api/v1/subnets")]
+subnets[0].name           # typed attribute
+subnets[0].raw["tempo"]   # anything else, from the raw payload
+```
+
+Models: `Subnet`, `Surface`, `Provider`, `Endpoint`, `AgentCatalogEntry` — each
+with `.from_dict()` / `.from_list()` and a `.raw` escape hatch.
+
+### Async client (`metagraphed[async]`)
+
+`AsyncMetagraphedClient` mirrors the sync client (`fetch` / `paginate` /
+`fetch_all` / `rpc` + the same convenience methods), powered by `httpx`. The sync
+path stays dependency-free; importing the async client is what pulls in httpx.
+
+```python
+import asyncio
+from metagraphed import AsyncMetagraphedClient
+
+async def main():
+    async with AsyncMetagraphedClient(retries=2) as client:
+        health = await client.health()
+        subnets = await client.fetch_all("/api/v1/subnets")
+        info = await client.rpc("finney", "system_health")
+
+asyncio.run(main())
 ```
 
 ## Versioning & stability

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,6 +18,10 @@ classifiers = [
   "Typing :: Typed",
 ]
 
+[project.optional-dependencies]
+# The sync client + typed models are stdlib-only; the async client needs httpx.
+async = ["httpx>=0.27"]
+
 [project.urls]
 Homepage = "https://metagraph.sh"
 Repository = "https://github.com/JSONbored/metagraphed"

--- a/python/src/metagraphed/__init__.py
+++ b/python/src/metagraphed/__init__.py
@@ -1,4 +1,11 @@
-"""metagraphed — thin Python client for the Bittensor subnet registry API."""
+"""metagraphed — thin Python client for the Bittensor subnet registry API.
+
+The sync client (``MetagraphedClient`` + ``metagraphed_*`` functions) and the
+typed models are dependency-free. ``AsyncMetagraphedClient`` is imported lazily
+and needs the optional ``httpx`` dependency: ``pip install metagraphed[async]``.
+"""
+
+from typing import Any
 
 from .client import (
     DEFAULT_BASE_URL,
@@ -7,8 +14,16 @@ from .client import (
     MetagraphedError,
     __version__,
     metagraphed_fetch,
+    metagraphed_fetch_all,
     metagraphed_paginate,
     metagraphed_rpc,
+)
+from .models import (
+    AgentCatalogEntry,
+    Endpoint,
+    Provider,
+    Subnet,
+    Surface,
 )
 
 __all__ = [
@@ -17,7 +32,27 @@ __all__ = [
     "MetagraphedClient",
     "MetagraphedError",
     "metagraphed_fetch",
+    "metagraphed_fetch_all",
     "metagraphed_paginate",
     "metagraphed_rpc",
+    "Subnet",
+    "Surface",
+    "Provider",
+    "Endpoint",
+    "AgentCatalogEntry",
+    # "AsyncMetagraphedClient" is intentionally NOT in __all__ so `import *`
+    # stays zero-dep; import it explicitly (it pulls in httpx via [async]).
     "__version__",
 ]
+
+_LAZY = {"AsyncMetagraphedClient"}
+
+
+def __getattr__(name: str) -> Any:
+    # PEP 562: keep httpx off the import path until the async client is actually
+    # requested, so the sync surface never requires the [async] extra.
+    if name in _LAZY:
+        from . import async_client
+
+        return getattr(async_client, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/python/src/metagraphed/async_client.py
+++ b/python/src/metagraphed/async_client.py
@@ -1,0 +1,288 @@
+"""Async metagraphed client (httpx) — at parity with the sync client.
+
+Requires the optional ``httpx`` dependency (``pip install metagraphed[async]``).
+The sync client stays dependency-free; importing this module is what pulls in
+httpx, so ``import metagraphed`` and the sync path never need it.
+
+    import asyncio
+    from metagraphed import AsyncMetagraphedClient
+
+    async def main():
+        async with AsyncMetagraphedClient(retries=2) as client:
+            health = await client.health()
+            subnets = await client.fetch_all("/api/v1/subnets")
+
+    asyncio.run(main())
+"""
+
+from __future__ import annotations
+
+import asyncio
+import urllib.parse
+from typing import Any, AsyncIterator, List, Mapping, Optional, Sequence
+
+import httpx
+
+from .client import (
+    DEFAULT_BASE_URL,
+    DEFAULT_USER_AGENT,
+    _MAX_RETRY_AFTER_SECONDS,
+    _RETRY_STATUSES,
+    MetagraphedError,
+    _interpolate,
+    collection_rows,
+)
+
+
+def _async_retry_delay(response: "httpx.Response", attempt: int, backoff: float) -> float:
+    """Seconds to wait before a retry: a numeric Retry-After if present (capped),
+    else exponential backoff. Never raises."""
+    retry_after = response.headers.get("retry-after")
+    if retry_after:
+        try:
+            return min(_MAX_RETRY_AFTER_SECONDS, max(0.0, float(int(retry_after))))
+        except (OverflowError, TypeError, ValueError):
+            pass
+    return backoff * (2**attempt)
+
+
+def _response_error_detail(response: "httpx.Response") -> str:
+    """Best-effort extraction of the API's ``{ error: { code, message } }``
+    envelope from a failed response. Never raises."""
+    try:
+        raw = response.text.strip()
+    except Exception:
+        return ""
+    if not raw:
+        return ""
+    try:
+        parsed = response.json()
+    except ValueError:
+        return f": {raw[:200]}"
+    envelope = parsed.get("error") if isinstance(parsed, dict) else None
+    if isinstance(envelope, dict) and envelope.get("message"):
+        code = envelope.get("code")
+        return f": {str(code) + ' — ' if code else ''}{envelope['message']}"
+    return f": {raw[:200]}"
+
+
+class AsyncMetagraphedClient:
+    """Async wrapper over the metagraphed API (httpx). Mirrors
+    :class:`metagraphed.MetagraphedClient`: ``fetch`` / ``paginate`` /
+    ``fetch_all`` / ``rpc`` plus the same convenience methods, all awaitable.
+
+    Use as an async context manager (recommended) so the underlying
+    ``httpx.AsyncClient`` is closed, or pass your own via ``client=`` (which the
+    instance will not close)."""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        *,
+        timeout: float = 30.0,
+        retries: int = 0,
+        backoff: float = 0.5,
+        client: Optional["httpx.AsyncClient"] = None,
+    ) -> None:
+        self.base_url = base_url
+        self.timeout = timeout
+        self.retries = retries
+        self.backoff = backoff
+        self._client = client
+        self._owns_client = client is None
+
+    async def __aenter__(self) -> "AsyncMetagraphedClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+    def _get_client(self) -> "httpx.AsyncClient":
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self.timeout)
+        return self._client
+
+    async def aclose(self) -> None:
+        """Close the owned ``httpx.AsyncClient`` (no-op for an injected one)."""
+        if self._client is not None and self._owns_client:
+            await self._client.aclose()
+            self._client = None
+
+    async def fetch(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        """GET ``path`` and return the parsed ``{ ok, data, meta }`` envelope.
+        Honors this client's ``retries`` (transient HTTP + transport errors,
+        numeric Retry-After capped at 60s)."""
+        url = self.base_url.rstrip("/") + _interpolate(path, path_params)
+        params = (
+            {key: value for key, value in query.items() if value is not None}
+            if query
+            else None
+        )
+        merged_headers = {"Accept": "application/json", "User-Agent": DEFAULT_USER_AGENT}
+        merged_headers.update(headers or {})
+        client = self._get_client()
+
+        attempt = 0
+        while True:
+            try:
+                response = await client.get(url, params=params, headers=merged_headers)
+            except httpx.HTTPError as error:
+                if attempt < self.retries:
+                    await asyncio.sleep(self.backoff * (2**attempt))
+                    attempt += 1
+                    continue
+                raise MetagraphedError(f"GET {url} failed: {error}") from error
+
+            if response.status_code >= 400:
+                if attempt < self.retries and response.status_code in _RETRY_STATUSES:
+                    await asyncio.sleep(
+                        _async_retry_delay(response, attempt, self.backoff)
+                    )
+                    attempt += 1
+                    continue
+                raise MetagraphedError(
+                    f"GET {url} failed: HTTP {response.status_code}"
+                    f"{_response_error_detail(response)}",
+                    status=response.status_code,
+                )
+            try:
+                return response.json()
+            except ValueError as error:
+                raise MetagraphedError(
+                    f"GET {url} returned a non-JSON response"
+                ) from error
+
+    async def paginate(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> AsyncIterator[Any]:
+        """Async-yield each page's envelope, following
+        ``meta.pagination.next_cursor`` until exhausted."""
+        base_query = dict(query or {})
+        cursor = base_query.get("cursor")
+        while True:
+            page_query = dict(base_query)
+            if cursor is not None:
+                page_query["cursor"] = cursor
+            page = await self.fetch(
+                path, path_params=path_params, query=page_query, headers=headers
+            )
+            yield page
+            pagination = (
+                page.get("meta", {}).get("pagination")
+                if isinstance(page, dict)
+                else None
+            )
+            cursor = (
+                pagination.get("next_cursor") if isinstance(pagination, dict) else None
+            )
+            if cursor is None:
+                return
+
+    async def fetch_all(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> List[Any]:
+        """Collect every ``data`` row of a list endpoint across all pages."""
+        rows: List[Any] = []
+        async for page in self.paginate(
+            path, path_params=path_params, query=query, headers=headers
+        ):
+            rows.extend(collection_rows(page))
+        return rows
+
+    async def rpc(
+        self,
+        network: str,
+        method: str,
+        params: Optional[Sequence[Any]] = None,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        request_id: Any = 1,
+    ) -> Any:
+        """Call the read-only Subtensor RPC proxy and return the JSON-RPC
+        ``result``. Raises on a transport, HTTP, or JSON-RPC-level error."""
+        url = (
+            self.base_url.rstrip("/")
+            + "/rpc/v1/"
+            + urllib.parse.quote(str(network), safe="")
+        )
+        merged_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": DEFAULT_USER_AGENT,
+        }
+        merged_headers.update(headers or {})
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": list(params or []),
+        }
+        client = self._get_client()
+        try:
+            response = await client.post(url, json=payload, headers=merged_headers)
+        except httpx.HTTPError as error:
+            raise MetagraphedError(f"RPC {method} failed: {error}") from error
+        if response.status_code >= 400:
+            raise MetagraphedError(
+                f"RPC {method} failed: HTTP {response.status_code}"
+                f"{_response_error_detail(response)}",
+                status=response.status_code,
+            )
+        try:
+            parsed = response.json()
+        except ValueError as error:
+            raise MetagraphedError(
+                f"RPC {method} returned a non-JSON response"
+            ) from error
+        rpc_error = parsed.get("error") if isinstance(parsed, dict) else None
+        if rpc_error:
+            message = rpc_error.get("message") if isinstance(rpc_error, dict) else None
+            raise MetagraphedError(f"RPC {method} error: {message or rpc_error}")
+        return parsed.get("result") if isinstance(parsed, dict) else None
+
+    # Convenience wrappers (awaitable), mirroring the sync client.
+    async def subnets(self, **query: Any) -> Any:
+        return await self.fetch("/api/v1/subnets", query=query)
+
+    async def get_subnet(self, netuid: int) -> Any:
+        return await self.fetch(
+            "/api/v1/subnets/{netuid}", path_params={"netuid": netuid}
+        )
+
+    async def providers(self, **query: Any) -> Any:
+        return await self.fetch("/api/v1/providers", query=query)
+
+    async def get_provider(self, slug: str) -> Any:
+        return await self.fetch("/api/v1/providers/{slug}", path_params={"slug": slug})
+
+    async def surfaces(self, **query: Any) -> Any:
+        return await self.fetch("/api/v1/surfaces", query=query)
+
+    async def endpoints(self, **query: Any) -> Any:
+        return await self.fetch("/api/v1/endpoints", query=query)
+
+    async def health(self) -> Any:
+        return await self.fetch("/api/v1/health")
+
+    async def agent_catalog(self, **query: Any) -> Any:
+        return await self.fetch("/api/v1/agent-catalog", query=query)
+
+
+__all__ = ["AsyncMetagraphedClient"]

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -14,7 +14,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from importlib.metadata import PackageNotFoundError, version as _package_version
-from typing import Any, Iterator, Mapping, Optional, Sequence
+from typing import Any, Iterator, List, Mapping, Optional, Sequence
 
 # Single source of truth = the package metadata (pyproject.toml `version`, which
 # release-please bumps); read it at runtime so the User-Agent can never disagree
@@ -207,6 +207,54 @@ def metagraphed_paginate(
             return
 
 
+def collection_rows(page: Any) -> List[Any]:
+    """Extract a list-endpoint page's rows. The API nests rows under
+    ``data[<collection>]`` where ``meta.pagination.collection`` names the key
+    (e.g. ``data.subnets`` for ``/api/v1/subnets``); falls back to ``data``
+    itself when it's already a list. Returns ``[]`` for anything else."""
+    if not isinstance(page, dict):
+        return []
+    data = page.get("data")
+    if isinstance(data, list):
+        return data
+    meta = page.get("meta")
+    pagination = meta.get("pagination") if isinstance(meta, dict) else None
+    collection = pagination.get("collection") if isinstance(pagination, dict) else None
+    if collection and isinstance(data, dict):
+        rows = data.get(collection)
+        if isinstance(rows, list):
+            return rows
+    return []
+
+
+def metagraphed_fetch_all(
+    path: str,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    path_params: Optional[Mapping[str, Any]] = None,
+    query: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    timeout: float = 30.0,
+    retries: int = 0,
+) -> List[Any]:
+    """Eagerly collect every row of a list endpoint across all pages.
+
+    Convenience over :func:`metagraphed_paginate` for the common "give me all of
+    them" case: concatenates each page's rows (see :func:`collection_rows`)."""
+    rows: List[Any] = []
+    for page in metagraphed_paginate(
+        path,
+        base_url=base_url,
+        path_params=path_params,
+        query=query,
+        headers=headers,
+        timeout=timeout,
+        retries=retries,
+    ):
+        rows.extend(collection_rows(page))
+    return rows
+
+
 def metagraphed_rpc(
     network: str,
     method: str,
@@ -343,3 +391,58 @@ class MetagraphedClient:
             timeout=self.timeout,
             request_id=request_id,
         )
+
+    def fetch_all(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> List[Any]:
+        """Collect every ``data`` row of a list endpoint across all pages."""
+        return metagraphed_fetch_all(
+            path,
+            base_url=self.base_url,
+            path_params=path_params,
+            query=query,
+            headers=headers,
+            timeout=self.timeout,
+            retries=self.retries,
+        )
+
+    # Convenience wrappers over the canonical list/detail routes. Each returns
+    # the raw ``{ ok, data, meta }`` envelope; pair with the typed models in
+    # ``metagraphed.models`` (e.g. ``Subnet.from_list(client.fetch_all(...))``).
+    def subnets(self, **query: Any) -> Any:
+        """GET /api/v1/subnets (one page — pass ``limit``/``cursor``, or use
+        :meth:`fetch_all`)."""
+        return self.fetch("/api/v1/subnets", query=query)
+
+    def get_subnet(self, netuid: int) -> Any:
+        """GET /api/v1/subnets/{netuid}."""
+        return self.fetch("/api/v1/subnets/{netuid}", path_params={"netuid": netuid})
+
+    def providers(self, **query: Any) -> Any:
+        """GET /api/v1/providers."""
+        return self.fetch("/api/v1/providers", query=query)
+
+    def get_provider(self, slug: str) -> Any:
+        """GET /api/v1/providers/{slug}."""
+        return self.fetch("/api/v1/providers/{slug}", path_params={"slug": slug})
+
+    def surfaces(self, **query: Any) -> Any:
+        """GET /api/v1/surfaces."""
+        return self.fetch("/api/v1/surfaces", query=query)
+
+    def endpoints(self, **query: Any) -> Any:
+        """GET /api/v1/endpoints."""
+        return self.fetch("/api/v1/endpoints", query=query)
+
+    def health(self) -> Any:
+        """GET /api/v1/health."""
+        return self.fetch("/api/v1/health")
+
+    def agent_catalog(self, **query: Any) -> Any:
+        """GET /api/v1/agent-catalog."""
+        return self.fetch("/api/v1/agent-catalog", query=query)

--- a/python/src/metagraphed/models.py
+++ b/python/src/metagraphed/models.py
@@ -1,0 +1,166 @@
+"""Optional typed models for the main metagraphed collections.
+
+Dependency-free (stdlib ``dataclasses``). Each model exposes the common, stable
+fields as typed attributes and keeps the **full** server payload on ``.raw`` —
+so nothing the API returns is ever lost, and the plain ``dict`` path
+(``client.fetch(...)``) stays available for callers who don't want models.
+
+    from metagraphed import MetagraphedClient, Subnet
+
+    client = MetagraphedClient()
+    rows = client.fetch_all("/api/v1/subnets")
+    subnets = [Subnet.from_dict(row) for row in rows]
+    subnets[0].name          # typed attribute
+    subnets[0].raw["tempo"]  # anything else, from the raw payload
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Type, TypeVar
+
+_T = TypeVar("_T", bound="_Model")
+
+
+class _Model:
+    """Mixin: build an instance from a server ``dict``, mapping declared fields
+    and stashing the complete payload on ``raw`` (unknown keys are preserved
+    there, never dropped)."""
+
+    raw: Dict[str, Any]
+
+    @classmethod
+    def from_dict(cls: Type[_T], data: Mapping[str, Any]) -> _T:
+        names = {f.name for f in dataclasses.fields(cls) if f.name != "raw"}  # type: ignore[arg-type]
+        kwargs = {key: value for key, value in data.items() if key in names}
+        instance = cls(**kwargs)  # type: ignore[call-arg]
+        instance.raw = dict(data)
+        return instance
+
+    @classmethod
+    def from_list(cls: Type[_T], rows: Any) -> List[_T]:
+        """Parse a list of payloads (e.g. a list endpoint's ``data``)."""
+        return [cls.from_dict(row) for row in rows or []]
+
+
+@dataclass
+class Subnet(_Model):
+    """A subnet row (``/api/v1/subnets`` index or ``/{netuid}`` detail)."""
+
+    netuid: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    status: Optional[str] = None
+    lifecycle: Optional[str] = None
+    description: Optional[str] = None
+    website_url: Optional[str] = None
+    docs_url: Optional[str] = None
+    source_repo: Optional[str] = None
+    dashboard_url: Optional[str] = None
+    logo_url: Optional[str] = None
+    categories: Optional[List[str]] = None
+    coverage_level: Optional[str] = None
+    curation_level: Optional[str] = None
+    subnet_type: Optional[str] = None
+    integration_readiness: Optional[int] = None
+    surface_count: Optional[int] = None
+    gap_count: Optional[int] = None
+    participant_count: Optional[int] = None
+    symbol: Optional[str] = None
+    social: Optional[Dict[str, Any]] = None
+    raw: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class Surface(_Model):
+    """A subnet surface (``/api/v1/surfaces`` or a subnet's ``surfaces[]``)."""
+
+    id: Optional[str] = None
+    netuid: Optional[int] = None
+    name: Optional[str] = None
+    kind: Optional[str] = None
+    url: Optional[str] = None
+    provider: Optional[str] = None
+    authority: Optional[str] = None
+    classification: Optional[str] = None
+    status: Optional[str] = None
+    auth_required: Optional[bool] = None
+    public_safe: Optional[bool] = None
+    subnet_name: Optional[str] = None
+    subnet_slug: Optional[str] = None
+    schema_url: Optional[str] = None
+    source_urls: Optional[List[str]] = None
+    raw: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class Provider(_Model):
+    """An operator / team profile (``/api/v1/providers``)."""
+
+    id: Optional[str] = None
+    name: Optional[str] = None
+    kind: Optional[str] = None
+    authority: Optional[str] = None
+    website_url: Optional[str] = None
+    docs_url: Optional[str] = None
+    github_url: Optional[str] = None
+    contact_url: Optional[str] = None
+    team_url: Optional[str] = None
+    logo_url: Optional[str] = None
+    social: Optional[Dict[str, Any]] = None
+    netuids: Optional[List[int]] = None
+    subnet_count: Optional[int] = None
+    surface_count: Optional[int] = None
+    endpoint_count: Optional[int] = None
+    public_notes: Optional[str] = None
+    cluster_id: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class Endpoint(_Model):
+    """A callable endpoint resource (``/api/v1/endpoints``)."""
+
+    id: Optional[str] = None
+    netuid: Optional[int] = None
+    kind: Optional[str] = None
+    url: Optional[str] = None
+    provider: Optional[str] = None
+    operator: Optional[str] = None
+    network: Optional[str] = None
+    layer: Optional[str] = None
+    status: Optional[str] = None
+    classification: Optional[str] = None
+    auth_required: Optional[bool] = None
+    public_safe: Optional[bool] = None
+    pool_eligible: Optional[bool] = None
+    score: Optional[int] = None
+    latency_ms: Optional[int] = None
+    latest_block: Optional[int] = None
+    last_checked: Optional[str] = None
+    last_ok: Optional[str] = None
+    subnet_name: Optional[str] = None
+    subnet_slug: Optional[str] = None
+    surface_id: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class AgentCatalogEntry(_Model):
+    """An agent-catalog entry (``/api/v1/agent-catalog``). Thin by design — the
+    catalog shape evolves, so use ``.raw`` for fields beyond the basics."""
+
+    netuid: Optional[int] = None
+    name: Optional[str] = None
+    slug: Optional[str] = None
+    raw: Dict[str, Any] = field(default_factory=dict, repr=False)
+
+
+__all__ = [
+    "Subnet",
+    "Surface",
+    "Provider",
+    "Endpoint",
+    "AgentCatalogEntry",
+]

--- a/python/tests/test_async.py
+++ b/python/tests/test_async.py
@@ -1,0 +1,157 @@
+"""Hermetic tests for the async client (httpx MockTransport, no network).
+
+Skipped when the optional ``[async]`` extra (httpx) isn't installed."""
+
+import contextlib
+import json
+import unittest
+
+try:
+    import httpx
+except ImportError:  # pragma: no cover
+    httpx = None  # type: ignore[assignment]
+
+
+@contextlib.asynccontextmanager
+async def _client(handler, **kwargs):
+    from metagraphed import AsyncMetagraphedClient
+
+    http = httpx.AsyncClient(transport=httpx.MockTransport(handler))
+    try:
+        yield AsyncMetagraphedClient(client=http, backoff=0, **kwargs)
+    finally:
+        await http.aclose()
+
+
+@unittest.skipIf(httpx is None, "httpx not installed (the [async] extra)")
+class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
+    async def test_fetch_builds_url_sets_accept_returns_envelope(self):
+        seen = {}
+
+        def handler(request):
+            seen["url"] = str(request.url)
+            seen["accept"] = request.headers.get("accept")
+            return httpx.Response(200, json={"ok": True, "data": {"netuid": 7}})
+
+        async with _client(handler) as client:
+            out = await client.fetch(
+                "/api/v1/subnets/{netuid}", path_params={"netuid": 7}
+            )
+        self.assertEqual(out["data"]["netuid"], 7)
+        self.assertEqual(seen["url"], "https://api.metagraph.sh/api/v1/subnets/7")
+        self.assertEqual(seen["accept"], "application/json")
+
+    async def test_drops_none_query_values(self):
+        seen = {}
+
+        def handler(request):
+            seen["url"] = str(request.url)
+            return httpx.Response(200, json={"ok": True, "data": []})
+
+        async with _client(handler) as client:
+            await client.fetch(
+                "/api/v1/subnets", query={"limit": 2, "cursor": None, "q": None}
+            )
+        self.assertIn("limit=2", seen["url"])
+        self.assertNotIn("cursor", seen["url"])
+
+    async def test_retries_on_429_honoring_retry_after(self):
+        calls = {"n": 0}
+
+        def handler(request):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return httpx.Response(
+                    429,
+                    headers={"retry-after": "0"},
+                    json={"ok": False, "error": {"code": "rate_limited", "message": "x"}},
+                )
+            return httpx.Response(200, json={"ok": True, "data": {"up": True}})
+
+        async with _client(handler, retries=2) as client:
+            out = await client.fetch("/api/v1/health")
+        self.assertEqual(calls["n"], 2)
+        self.assertTrue(out["data"]["up"])
+
+    async def test_raises_metagrapherror_surfacing_envelope(self):
+        from metagraphed import MetagraphedError
+
+        def handler(request):
+            return httpx.Response(
+                404,
+                json={
+                    "ok": False,
+                    "error": {"code": "artifact_not_found", "message": "no subnet"},
+                },
+            )
+
+        async with _client(handler) as client:
+            with self.assertRaises(MetagraphedError) as ctx:
+                await client.fetch(
+                    "/api/v1/subnets/{netuid}", path_params={"netuid": 99999}
+                )
+        self.assertEqual(ctx.exception.status, 404)
+        self.assertIn("no subnet", str(ctx.exception))
+
+    async def test_fetch_all_paginates(self):
+        pages = [
+            {
+                "ok": True,
+                "data": {"subnets": [1, 2]},
+                "meta": {"pagination": {"collection": "subnets", "next_cursor": "c2"}},
+            },
+            {
+                "ok": True,
+                "data": {"subnets": [3]},
+                "meta": {"pagination": {"collection": "subnets", "next_cursor": None}},
+            },
+        ]
+        urls = []
+
+        def handler(request):
+            urls.append(str(request.url))
+            return httpx.Response(200, json=pages[len(urls) - 1])
+
+        async with _client(handler) as client:
+            rows = await client.fetch_all("/api/v1/subnets", query={"limit": 2})
+        self.assertEqual(rows, [1, 2, 3])
+        self.assertIn("cursor=c2", urls[1])
+
+    async def test_rpc_posts_and_returns_result(self):
+        seen = {}
+
+        def handler(request):
+            seen["method"] = request.method
+            seen["url"] = str(request.url)
+            seen["body"] = json.loads(request.content)
+            return httpx.Response(
+                200, json={"jsonrpc": "2.0", "id": 1, "result": {"peers": 40}}
+            )
+
+        async with _client(handler) as client:
+            result = await client.rpc("finney", "system_health")
+        self.assertEqual(result, {"peers": 40})
+        self.assertEqual(seen["method"], "POST")
+        self.assertEqual(seen["url"], "https://api.metagraph.sh/rpc/v1/finney")
+        self.assertEqual(seen["body"]["method"], "system_health")
+
+    async def test_rpc_raises_on_jsonrpc_error(self):
+        from metagraphed import MetagraphedError
+
+        def handler(request):
+            return httpx.Response(
+                200,
+                json={
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "error": {"code": -32601, "message": "Method not found"},
+                },
+            )
+
+        async with _client(handler) as client:
+            with self.assertRaises(MetagraphedError):
+                await client.rpc("finney", "nope")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_extras.py
+++ b/python/tests/test_extras.py
@@ -1,0 +1,94 @@
+"""Tests for fetch_all + convenience methods on the sync client (urllib mocked)."""
+
+import json
+import unittest
+from unittest import mock
+
+from metagraphed import MetagraphedClient, metagraphed_fetch_all
+from metagraphed.client import collection_rows
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._body = json.dumps(payload).encode("utf-8")
+
+    def read(self):
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class FetchAllTest(unittest.TestCase):
+    def test_fetch_all_collects_data_across_pages(self):
+        # Real API shape: rows nest under data[<collection>], named by
+        # meta.pagination.collection (here "subnets").
+        pages = [
+            {
+                "ok": True,
+                "data": {"subnets": [{"netuid": 1}, {"netuid": 2}]},
+                "meta": {"pagination": {"collection": "subnets", "next_cursor": "c2"}},
+            },
+            {
+                "ok": True,
+                "data": {"subnets": [{"netuid": 3}]},
+                "meta": {"pagination": {"collection": "subnets", "next_cursor": None}},
+            },
+        ]
+        calls = []
+
+        def fake_urlopen(request, timeout=None):
+            calls.append(request.full_url)
+            return _FakeResponse(pages[len(calls) - 1])
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            rows = metagraphed_fetch_all("/api/v1/subnets", query={"limit": 2})
+
+        self.assertEqual([row["netuid"] for row in rows], [1, 2, 3])
+        self.assertIn("cursor=c2", calls[1])
+
+    def test_collection_rows_handles_both_shapes(self):
+        # Named collection (the real API shape):
+        self.assertEqual(
+            collection_rows(
+                {
+                    "data": {"providers": [{"id": "a"}]},
+                    "meta": {"pagination": {"collection": "providers"}},
+                }
+            ),
+            [{"id": "a"}],
+        )
+        # Flat-list data (fallback):
+        self.assertEqual(collection_rows({"data": [1, 2]}), [1, 2])
+        # Nothing usable:
+        self.assertEqual(collection_rows({"data": {"x": 1}, "meta": {}}), [])
+        self.assertEqual(collection_rows("nope"), [])
+
+    def test_convenience_methods_build_the_right_paths(self):
+        captured = {}
+
+        def fake_urlopen(request, timeout=None):
+            captured["url"] = request.full_url
+            return _FakeResponse({"ok": True, "data": {}})
+
+        client = MetagraphedClient()
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            client.get_subnet(7)
+        self.assertEqual(captured["url"], "https://api.metagraph.sh/api/v1/subnets/7")
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            client.subnets(limit=5)
+        self.assertIn("/api/v1/subnets?limit=5", captured["url"])
+
+        with mock.patch("urllib.request.urlopen", fake_urlopen):
+            client.get_provider("synth")
+        self.assertEqual(
+            captured["url"], "https://api.metagraph.sh/api/v1/providers/synth"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_models.py
+++ b/python/tests/test_models.py
@@ -1,0 +1,53 @@
+"""Tests for the optional typed models (dataclasses, no network)."""
+
+import unittest
+
+from metagraphed import AgentCatalogEntry, Endpoint, Provider, Subnet, Surface
+
+
+class ModelsTest(unittest.TestCase):
+    def test_subnet_maps_known_fields_and_preserves_raw(self):
+        subnet = Subnet.from_dict(
+            {"netuid": 50, "name": "Synth", "tempo": 360, "unknown_field": 1}
+        )
+        self.assertEqual(subnet.netuid, 50)
+        self.assertEqual(subnet.name, "Synth")
+        self.assertIsNone(subnet.slug)  # absent -> default None
+        # everything (incl. undeclared keys) stays on .raw
+        self.assertEqual(subnet.raw["tempo"], 360)
+        self.assertEqual(subnet.raw["unknown_field"], 1)
+        self.assertEqual(subnet.raw["netuid"], 50)
+
+    def test_from_list_and_none(self):
+        surfaces = Surface.from_list(
+            [{"id": "a", "kind": "website"}, {"id": "b", "kind": "openapi"}]
+        )
+        self.assertEqual([s.id for s in surfaces], ["a", "b"])
+        self.assertEqual(surfaces[1].kind, "openapi")
+        self.assertEqual(Provider.from_list(None), [])
+
+    def test_provider_endpoint_catalog(self):
+        provider = Provider.from_dict(
+            {
+                "id": "synth",
+                "name": "Synth",
+                "netuids": [50],
+                "social": {"x": "https://x.com/synthdataco"},
+            }
+        )
+        self.assertEqual(provider.netuids, [50])
+        self.assertEqual(provider.social["x"], "https://x.com/synthdataco")
+
+        endpoint = Endpoint.from_dict(
+            {"id": "e1", "netuid": 7, "pool_eligible": True, "latency_ms": 42}
+        )
+        self.assertTrue(endpoint.pool_eligible)
+        self.assertEqual(endpoint.latency_ms, 42)
+
+        entry = AgentCatalogEntry.from_dict({"netuid": 1, "name": "Apex", "tools": ["x"]})
+        self.assertEqual(entry.name, "Apex")
+        self.assertEqual(entry.raw["tools"], ["x"])  # thin model, raw has the rest
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
Implements the Python SDK feature — async client + typed models — mirroring the merged TS SDK (#790). All additive and backward-compatible: the sync client is unchanged and stays dependency-free.

Closes #749.

## What's added
- **`AsyncMetagraphedClient`** (httpx) at parity with the sync client — `fetch` / `paginate` / `fetch_all` / `rpc` + the same convenience methods, with opt-in retries/backoff honoring a numeric `Retry-After`. Behind the new **`[async]` extra**, and imported lazily (PEP 562) so `import metagraphed` and the entire sync path never require httpx.
- **Typed models** (`Subnet`, `Surface`, `Provider`, `Endpoint`, `AgentCatalogEntry`) — dependency-free dataclasses with `.from_dict()` / `.from_list()` and a `.raw` escape hatch that preserves the **full** payload, so nothing is dropped. The raw-dict path stays available.
- **`fetch_all`** auto-pagination (sync + async) + thin convenience wrappers (`subnets`, `get_subnet`, `providers`, `get_provider`, `surfaces`, `endpoints`, `health`, `agent_catalog`). `fetch_all` extracts rows from `data[<collection>]` (the key named by `meta.pagination.collection`, e.g. `data.subnets`), with a flat-list fallback.

## Compatibility
- Sync client + public API unchanged; **stays zero-dep** — httpx is pulled in only via `pip install metagraphed[async]`.
- Typed models and the async client are opt-in; `import *` stays light (the async client is intentionally not in `__all__`).

## Validation (local)
- `python -m unittest` — **29 tests pass** (existing 16 + new sync `fetch_all`/convenience, typed models, and async tests via httpx `MockTransport`).
- `ruff check` clean · `mypy src/metagraphed` clean.
- `python -m build` produces a wheel including the new modules.
- Version bump + changelog are handled by release-please from this `feat(python)` commit (component `python`).
