### PR TITLE
feat(python): async client, typed models, and fetch_all auto-pagination (#749)

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -11,7 +11,8 @@ dependencies.
 ## Install
 
 ```bash
-pip install metagraphed
+pip install metagraphed              # dependency-free sync client
+pip install 'metagraphed[async]'     # adds the async client (pulls httpx)
 ```
 
 ## Usage
@@ -69,6 +70,51 @@ for page in client.paginate("/api/v1/subnets", query={"limit": 100}):
 # Call the read-only Subtensor RPC proxy and get back the JSON-RPC result:
 info = metagraphed_rpc("finney", "system_health")
 ```
+
+### `fetch_all` + typed models
+
+```python
+from metagraphed import MetagraphedClient
+
+client = MetagraphedClient(retries=3)
+
+# Auto-paginate a list endpoint and collect every item (flattened data arrays):
+all_surfaces = client.fetch_all("/api/v1/surfaces")
+
+# Typed convenience methods — IDE autocomplete, while .raw keeps the full dict:
+for subnet in client.subnets():
+    print(subnet.netuid, subnet.name, subnet.integration_readiness)
+
+catalog = client.agent_catalog(7)  # -> AgentCatalogSubnet
+print(catalog.service_count, catalog.services)
+```
+
+`fetch` / `fetch_all` still return raw dicts; the models (`Subnet`, `Surface`,
+`Endpoint`, `Provider`, `AgentCatalogSubnet`) are opt-in and never lose data.
+
+### Async client (httpx)
+
+Install the extra (`pip install 'metagraphed[async]'`), then fetch many subnets
+concurrently — no hand-rolled threads:
+
+```python
+import asyncio
+from metagraphed import AsyncMetagraphedClient
+
+async def main():
+    async with AsyncMetagraphedClient(retries=3) as client:
+        subnets = await client.subnets()  # typed, auto-paginated
+        catalogs = await asyncio.gather(
+            *(client.agent_catalog(s.netuid) for s in subnets[:10])
+        )
+        for c in catalogs:
+            print(c.netuid, c.service_count)
+
+asyncio.run(main())
+```
+
+The async client mirrors the sync one (`fetch` / `paginate` / `fetch_all` /
+`rpc` + retries/backoff) and reuses a single connection pool.
 
 ## Versioning & stability
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,6 +18,12 @@ classifiers = [
   "Typing :: Typed",
 ]
 
+# The base package is dependency-free (stdlib only). The async client pulls
+# httpx behind this extra: `pip install 'metagraphed[async]'`.
+[project.optional-dependencies]
+async = ["httpx>=0.27"]
+test = ["httpx>=0.27"]
+
 [project.urls]
 Homepage = "https://metagraph.sh"
 Repository = "https://github.com/JSONbored/metagraphed"

--- a/python/src/metagraphed/__init__.py
+++ b/python/src/metagraphed/__init__.py
@@ -7,16 +7,36 @@ from .client import (
     MetagraphedError,
     __version__,
     metagraphed_fetch,
+    metagraphed_fetch_all,
     metagraphed_paginate,
     metagraphed_rpc,
 )
+from .models import (
+    AgentCatalogSubnet,
+    Endpoint,
+    Provider,
+    Subnet,
+    Surface,
+)
+
+# Safe to import without httpx installed — httpx is imported lazily only when an
+# AsyncMetagraphedClient is constructed (raising a clear error that points at the
+# `metagraphed[async]` extra).
+from .aio import AsyncMetagraphedClient
 
 __all__ = [
+    "AgentCatalogSubnet",
+    "AsyncMetagraphedClient",
     "DEFAULT_BASE_URL",
     "DEFAULT_USER_AGENT",
+    "Endpoint",
     "MetagraphedClient",
     "MetagraphedError",
+    "Provider",
+    "Subnet",
+    "Surface",
     "metagraphed_fetch",
+    "metagraphed_fetch_all",
     "metagraphed_paginate",
     "metagraphed_rpc",
     "__version__",

--- a/python/src/metagraphed/aio.py
+++ b/python/src/metagraphed/aio.py
@@ -1,0 +1,301 @@
+"""Optional async client for metagraphed (httpx) — parity with the sync client.
+
+Install with ``pip install 'metagraphed[async]'``. ``httpx`` is imported lazily,
+so the base package stays dependency-free; constructing
+:class:`AsyncMetagraphedClient` without httpx installed raises a clear
+:class:`~metagraphed.MetagraphedError` pointing at the extra.
+
+The async client reuses one connection pool, which is the whole point: fetching
+many subnets concurrently (``asyncio.gather``) no longer needs hand-rolled
+threads. Use it as an async context manager, or call :meth:`aclose` when done.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.parse
+from typing import TYPE_CHECKING, Any, AsyncIterator, List, Mapping, Optional, Sequence
+
+from .client import (
+    DEFAULT_BASE_URL,
+    DEFAULT_USER_AGENT,
+    MetagraphedError,
+    _MAX_RETRY_AFTER_SECONDS,
+    _RETRY_STATUSES,
+    _interpolate,
+)
+from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
+
+if TYPE_CHECKING:  # pragma: no cover - type-checking only
+    import httpx
+
+
+def _require_httpx() -> Any:
+    try:
+        import httpx
+    except ImportError as error:  # pragma: no cover - import guard
+        raise MetagraphedError(
+            "The async client requires httpx. Install it with: "
+            "pip install 'metagraphed[async]'"
+        ) from error
+    return httpx
+
+
+def _retry_after_seconds(
+    response: "httpx.Response", attempt: int, backoff: float
+) -> float:
+    """A numeric ``Retry-After`` (capped at 60s) if present, else exponential
+    backoff. Never raises."""
+    retry_after = response.headers.get("Retry-After")
+    if retry_after:
+        try:
+            return min(_MAX_RETRY_AFTER_SECONDS, max(0.0, float(int(retry_after))))
+        except (OverflowError, TypeError, ValueError):
+            pass
+    return backoff * (2**attempt)
+
+
+def _response_error_detail(response: "httpx.Response") -> str:
+    """Best-effort extraction of the API's ``{ error: { code, message } }``
+    envelope from a failed response. Never raises."""
+    try:
+        raw = response.text.strip()
+    except Exception:
+        return ""
+    if not raw:
+        return ""
+    try:
+        parsed = json.loads(raw)
+    except ValueError:
+        return f": {raw[:200]}"
+    envelope = parsed.get("error") if isinstance(parsed, dict) else None
+    if isinstance(envelope, dict) and envelope.get("message"):
+        code = envelope.get("code")
+        return f": {str(code) + ' — ' if code else ''}{envelope['message']}"
+    return f": {raw[:200]}"
+
+
+class AsyncMetagraphedClient:
+    """Async metagraphed client backed by a shared ``httpx.AsyncClient``."""
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        *,
+        timeout: float = 30.0,
+        retries: int = 0,
+        backoff: float = 0.5,
+    ) -> None:
+        httpx = _require_httpx()
+        self.base_url = base_url
+        self.timeout = timeout
+        self.retries = retries
+        self.backoff = backoff
+        self._httpx = httpx
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    async def __aenter__(self) -> "AsyncMetagraphedClient":
+        return self
+
+    async def __aexit__(self, *exc: Any) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Close the underlying connection pool."""
+        await self._client.aclose()
+
+    async def fetch(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> Any:
+        """GET ``path`` and return the parsed ``{ ok, data, meta }`` envelope.
+
+        Retries idempotent GETs on transient errors (HTTP 429/5xx and network
+        failures) when this client was created with ``retries`` > 0, honoring a
+        numeric ``Retry-After`` capped at 60 seconds.
+        """
+        url = self.base_url.rstrip("/") + _interpolate(path, path_params)
+        params = (
+            {key: value for key, value in query.items() if value is not None}
+            if query
+            else None
+        )
+        merged_headers = {
+            "Accept": "application/json",
+            "User-Agent": DEFAULT_USER_AGENT,
+        }
+        merged_headers.update(headers or {})
+
+        attempt = 0
+        while True:
+            try:
+                response = await self._client.get(
+                    url, params=params, headers=merged_headers
+                )
+            except self._httpx.HTTPError as error:
+                if attempt < self.retries:
+                    await asyncio.sleep(self.backoff * (2**attempt))
+                    attempt += 1
+                    continue
+                raise MetagraphedError(f"GET {url} failed: {error}") from error
+            if response.status_code >= 400:
+                if (
+                    attempt < self.retries
+                    and response.status_code in _RETRY_STATUSES
+                ):
+                    await asyncio.sleep(
+                        _retry_after_seconds(response, attempt, self.backoff)
+                    )
+                    attempt += 1
+                    continue
+                raise MetagraphedError(
+                    f"GET {url} failed: HTTP {response.status_code}"
+                    f"{_response_error_detail(response)}",
+                    status=response.status_code,
+                )
+            break
+
+        try:
+            return response.json()
+        except ValueError as error:
+            raise MetagraphedError(
+                f"GET {url} returned a non-JSON response"
+            ) from error
+
+    async def paginate(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> AsyncIterator[Any]:
+        """Yield each page's envelope, following ``meta.pagination.next_cursor``."""
+        base_query = dict(query or {})
+        cursor = base_query.get("cursor")
+        while True:
+            page_query = dict(base_query)
+            if cursor is not None:
+                page_query["cursor"] = cursor
+            page = await self.fetch(
+                path, path_params=path_params, query=page_query, headers=headers
+            )
+            yield page
+            pagination = (
+                page.get("meta", {}).get("pagination")
+                if isinstance(page, dict)
+                else None
+            )
+            cursor = (
+                pagination.get("next_cursor")
+                if isinstance(pagination, dict)
+                else None
+            )
+            if cursor is None:
+                return
+
+    async def fetch_all(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> List[Any]:
+        """Follow pagination and return every item (flattened ``data`` arrays)."""
+        items: List[Any] = []
+        async for page in self.paginate(
+            path, path_params=path_params, query=query, headers=headers
+        ):
+            data = page.get("data") if isinstance(page, dict) else None
+            if isinstance(data, list):
+                items.extend(data)
+        return items
+
+    async def rpc(
+        self,
+        network: str,
+        method: str,
+        params: Optional[Sequence[Any]] = None,
+        *,
+        headers: Optional[Mapping[str, str]] = None,
+        request_id: Any = 1,
+    ) -> Any:
+        """Call the read-only Subtensor RPC proxy and return the JSON-RPC result."""
+        url = (
+            self.base_url.rstrip("/")
+            + "/rpc/v1/"
+            + urllib.parse.quote(str(network), safe="")
+        )
+        payload = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+            "params": list(params or []),
+        }
+        merged_headers = {
+            "Accept": "application/json",
+            "Content-Type": "application/json",
+            "User-Agent": DEFAULT_USER_AGENT,
+        }
+        merged_headers.update(headers or {})
+
+        try:
+            response = await self._client.post(
+                url, json=payload, headers=merged_headers
+            )
+        except self._httpx.HTTPError as error:
+            raise MetagraphedError(f"RPC {method} failed: {error}") from error
+        if response.status_code >= 400:
+            raise MetagraphedError(
+                f"RPC {method} failed: HTTP {response.status_code}"
+                f"{_response_error_detail(response)}",
+                status=response.status_code,
+            )
+        try:
+            parsed = response.json()
+        except ValueError as error:
+            raise MetagraphedError(
+                f"RPC {method} returned a non-JSON response"
+            ) from error
+        rpc_error = parsed.get("error") if isinstance(parsed, dict) else None
+        if rpc_error:
+            message = (
+                rpc_error.get("message") if isinstance(rpc_error, dict) else None
+            )
+            raise MetagraphedError(f"RPC {method} error: {message or rpc_error}")
+        return parsed.get("result") if isinstance(parsed, dict) else None
+
+    # -- typed convenience methods (raw-dict path stays via fetch/fetch_all) --
+
+    async def subnets(self, **query: Any) -> List[Subnet]:
+        return Subnet.list_from(
+            await self.fetch_all("/api/v1/subnets", query=query or None)
+        )
+
+    async def surfaces(self, **query: Any) -> List[Surface]:
+        return Surface.list_from(
+            await self.fetch_all("/api/v1/surfaces", query=query or None)
+        )
+
+    async def endpoints(self, **query: Any) -> List[Endpoint]:
+        return Endpoint.list_from(
+            await self.fetch_all("/api/v1/endpoints", query=query or None)
+        )
+
+    async def providers(self, **query: Any) -> List[Provider]:
+        return Provider.list_from(
+            await self.fetch_all("/api/v1/providers", query=query or None)
+        )
+
+    async def agent_catalog(self, netuid: Any) -> AgentCatalogSubnet:
+        envelope = await self.fetch(
+            "/api/v1/agent-catalog/{netuid}", path_params={"netuid": netuid}
+        )
+        data = envelope.get("data") if isinstance(envelope, dict) else None
+        return AgentCatalogSubnet.from_dict(data)

--- a/python/src/metagraphed/client.py
+++ b/python/src/metagraphed/client.py
@@ -14,7 +14,9 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from importlib.metadata import PackageNotFoundError, version as _package_version
-from typing import Any, Iterator, Mapping, Optional, Sequence
+from typing import Any, Iterator, List, Mapping, Optional, Sequence
+
+from .models import AgentCatalogSubnet, Endpoint, Provider, Subnet, Surface
 
 # Single source of truth = the package metadata (pyproject.toml `version`, which
 # release-please bumps); read it at runtime so the User-Agent can never disagree
@@ -207,6 +209,34 @@ def metagraphed_paginate(
             return
 
 
+def metagraphed_fetch_all(
+    path: str,
+    *,
+    base_url: str = DEFAULT_BASE_URL,
+    path_params: Optional[Mapping[str, Any]] = None,
+    query: Optional[Mapping[str, Any]] = None,
+    headers: Optional[Mapping[str, str]] = None,
+    timeout: float = 30.0,
+    retries: int = 0,
+) -> List[Any]:
+    """Follow pagination for a list endpoint and return every item — the
+    flattened ``data`` arrays across all pages."""
+    items: List[Any] = []
+    for page in metagraphed_paginate(
+        path,
+        base_url=base_url,
+        path_params=path_params,
+        query=query,
+        headers=headers,
+        timeout=timeout,
+        retries=retries,
+    ):
+        data = page.get("data") if isinstance(page, dict) else None
+        if isinstance(data, list):
+            items.extend(data)
+    return items
+
+
 def metagraphed_rpc(
     network: str,
     method: str,
@@ -343,3 +373,57 @@ class MetagraphedClient:
             timeout=self.timeout,
             request_id=request_id,
         )
+
+    def fetch_all(
+        self,
+        path: str,
+        *,
+        path_params: Optional[Mapping[str, Any]] = None,
+        query: Optional[Mapping[str, Any]] = None,
+        headers: Optional[Mapping[str, str]] = None,
+    ) -> List[Any]:
+        """Follow pagination and return every item (flattened ``data`` arrays)."""
+        return metagraphed_fetch_all(
+            path,
+            base_url=self.base_url,
+            path_params=path_params,
+            query=query,
+            headers=headers,
+            timeout=self.timeout,
+            retries=self.retries,
+        )
+
+    # -- typed convenience methods (the raw-dict path stays via fetch/fetch_all) --
+
+    def subnets(self, **query: Any) -> List[Subnet]:
+        """Every subnet as a typed :class:`~metagraphed.models.Subnet`."""
+        return Subnet.list_from(
+            self.fetch_all("/api/v1/subnets", query=query or None)
+        )
+
+    def surfaces(self, **query: Any) -> List[Surface]:
+        """Every surface as a typed :class:`~metagraphed.models.Surface`."""
+        return Surface.list_from(
+            self.fetch_all("/api/v1/surfaces", query=query or None)
+        )
+
+    def endpoints(self, **query: Any) -> List[Endpoint]:
+        """Every endpoint as a typed :class:`~metagraphed.models.Endpoint`."""
+        return Endpoint.list_from(
+            self.fetch_all("/api/v1/endpoints", query=query or None)
+        )
+
+    def providers(self, **query: Any) -> List[Provider]:
+        """Every provider as a typed :class:`~metagraphed.models.Provider`."""
+        return Provider.list_from(
+            self.fetch_all("/api/v1/providers", query=query or None)
+        )
+
+    def agent_catalog(self, netuid: Any) -> AgentCatalogSubnet:
+        """One subnet's agent catalog as a typed
+        :class:`~metagraphed.models.AgentCatalogSubnet`."""
+        envelope = self.fetch(
+            "/api/v1/agent-catalog/{netuid}", path_params={"netuid": netuid}
+        )
+        data = envelope.get("data") if isinstance(envelope, dict) else None
+        return AgentCatalogSubnet.from_dict(data)

--- a/python/src/metagraphed/models.py
+++ b/python/src/metagraphed/models.py
@@ -1,0 +1,106 @@
+"""Typed, optional response models for the main metagraphed collections (#749).
+
+These are lightweight stdlib :mod:`dataclasses` — **zero extra dependencies** —
+giving IDE autocomplete and typed access to the common fields of each
+collection. ``.raw`` always holds the full parsed dict, so no field is ever
+lost and forward-compatible additions keep working. The default client methods
+still return raw dicts; these models are strictly opt-in (``Subnet.from_dict``
+or the typed convenience methods such as ``client.subnets()``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, fields
+from typing import Any, List, Mapping, Optional
+
+
+class _Model:
+    """Mixin: build a dataclass from an API dict, ignoring unknown keys and
+    stashing the full dict on ``.raw`` (so nothing is lost)."""
+
+    raw: Mapping[str, Any]
+
+    @classmethod
+    def from_dict(cls, data: Any) -> Any:
+        mapping = data if isinstance(data, Mapping) else {}
+        known = {f.name for f in fields(cls)}  # type: ignore[arg-type]
+        kwargs = {
+            name: mapping.get(name)
+            for name in known
+            if name != "raw" and name in mapping
+        }
+        instance = cls(**kwargs)  # type: ignore[call-arg]
+        instance.raw = dict(mapping)
+        return instance
+
+    @classmethod
+    def list_from(cls, items: Any) -> List[Any]:
+        """Build a list of models from an API list (``data`` array)."""
+        return (
+            [cls.from_dict(item) for item in items]
+            if isinstance(items, list)
+            else []
+        )
+
+
+@dataclass
+class Subnet(_Model):
+    netuid: Optional[int] = None
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    subnet_type: Optional[str] = None
+    status: Optional[str] = None
+    categories: Optional[List[str]] = None
+    completeness_score: Optional[float] = None
+    integration_readiness: Optional[int] = None
+    updated_at: Optional[str] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class Surface(_Model):
+    id: Optional[str] = None
+    netuid: Optional[int] = None
+    kind: Optional[str] = None
+    name: Optional[str] = None
+    url: Optional[str] = None
+    provider: Optional[str] = None
+    auth_required: Optional[bool] = None
+    public_safe: Optional[bool] = None
+    schema_url: Optional[str] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class Endpoint(_Model):
+    surface_id: Optional[str] = None
+    netuid: Optional[int] = None
+    kind: Optional[str] = None
+    url: Optional[str] = None
+    base_url: Optional[str] = None
+    provider: Optional[str] = None
+    classification: Optional[str] = None
+    monitoring_status: Optional[str] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class Provider(_Model):
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    authority: Optional[str] = None
+    surface_count: Optional[int] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
+
+
+@dataclass
+class AgentCatalogSubnet(_Model):
+    netuid: Optional[int] = None
+    slug: Optional[str] = None
+    name: Optional[str] = None
+    subnet_type: Optional[str] = None
+    completeness_score: Optional[float] = None
+    integration_readiness: Optional[int] = None
+    service_count: Optional[int] = None
+    services: Optional[List[Mapping[str, Any]]] = None
+    raw: Mapping[str, Any] = field(default_factory=dict, repr=False)

--- a/python/tests/test_aio.py
+++ b/python/tests/test_aio.py
@@ -1,0 +1,132 @@
+"""Hermetic tests for the async client (httpx stubbed, no network)."""
+
+import unittest
+
+try:
+    import httpx
+
+    _HAS_HTTPX = True
+except ImportError:  # pragma: no cover - exercised only without the extra
+    _HAS_HTTPX = False
+
+from metagraphed import AsyncMetagraphedClient, MetagraphedError, Subnet
+
+
+class _FakeAsyncHttp:
+    """Stand-in for ``httpx.AsyncClient``: returns queued responses, records calls."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    async def get(self, url, params=None, headers=None):
+        self.calls.append(("GET", url, params))
+        return self._responses.pop(0)
+
+    async def post(self, url, json=None, headers=None):
+        self.calls.append(("POST", url, json))
+        return self._responses.pop(0)
+
+    async def aclose(self):
+        self.closed = True
+
+
+@unittest.skipUnless(_HAS_HTTPX, "httpx not installed (metagraphed[async])")
+class AsyncClientTest(unittest.IsolatedAsyncioTestCase):
+    def _client(self, *responses):
+        client = AsyncMetagraphedClient()
+        client._client = _FakeAsyncHttp(responses)
+        return client
+
+    async def test_fetch_interpolates_path_and_returns_envelope(self):
+        client = self._client(
+            httpx.Response(200, json={"ok": True, "data": {"netuid": 7}})
+        )
+        out = await client.fetch(
+            "/api/v1/subnets/{netuid}", path_params={"netuid": 7}
+        )
+        self.assertEqual(out["data"]["netuid"], 7)
+        self.assertEqual(
+            client._client.calls[0][1],
+            "https://api.metagraph.sh/api/v1/subnets/7",
+        )
+
+    async def test_fetch_drops_none_query_values(self):
+        client = self._client(httpx.Response(200, json={"data": []}))
+        await client.fetch("/api/v1/subnets", query={"limit": 5, "cursor": None})
+        self.assertEqual(client._client.calls[0][2], {"limit": 5})
+
+    async def test_fetch_all_flattens_pages_following_cursor(self):
+        page1 = httpx.Response(
+            200,
+            json={
+                "data": [{"netuid": 1}],
+                "meta": {"pagination": {"next_cursor": "c2"}},
+            },
+        )
+        page2 = httpx.Response(
+            200,
+            json={
+                "data": [{"netuid": 2}],
+                "meta": {"pagination": {"next_cursor": None}},
+            },
+        )
+        client = self._client(page1, page2)
+        items = await client.fetch_all("/api/v1/subnets")
+        self.assertEqual([item["netuid"] for item in items], [1, 2])
+
+    async def test_subnets_returns_typed_models(self):
+        client = self._client(
+            httpx.Response(
+                200, json={"data": [{"netuid": 7, "name": "Allways"}], "meta": {}}
+            )
+        )
+        subnets = await client.subnets()
+        self.assertIsInstance(subnets[0], Subnet)
+        self.assertEqual(subnets[0].netuid, 7)
+        self.assertEqual(subnets[0].name, "Allways")
+        self.assertEqual(subnets[0].raw["name"], "Allways")
+
+    async def test_http_error_raises_with_status_and_message(self):
+        client = self._client(
+            httpx.Response(
+                404, json={"error": {"code": "not_found", "message": "nope"}}
+            )
+        )
+        with self.assertRaises(MetagraphedError) as ctx:
+            await client.fetch(
+                "/api/v1/subnets/{netuid}", path_params={"netuid": 999}
+            )
+        self.assertEqual(ctx.exception.status, 404)
+        self.assertIn("nope", str(ctx.exception))
+
+    async def test_rpc_posts_and_returns_result(self):
+        client = self._client(
+            httpx.Response(200, json={"jsonrpc": "2.0", "id": 1, "result": "0xabc"})
+        )
+        out = await client.rpc("finney", "chain_getBlockHash", [0])
+        self.assertEqual(out, "0xabc")
+        method, url, body = client._client.calls[0]
+        self.assertEqual(method, "POST")
+        self.assertTrue(url.endswith("/rpc/v1/finney"))
+        self.assertEqual(body["method"], "chain_getBlockHash")
+
+    async def test_context_manager_closes_pool(self):
+        client = self._client(httpx.Response(200, json={"data": []}))
+        async with client:
+            await client.fetch_all("/api/v1/subnets")
+        self.assertTrue(getattr(client._client, "closed", False))
+
+
+class AsyncImportGuardTest(unittest.TestCase):
+    @unittest.skipIf(
+        _HAS_HTTPX, "httpx installed; the missing-httpx path can't be exercised"
+    )
+    def test_missing_httpx_raises_a_helpful_error(self):
+        with self.assertRaises(MetagraphedError) as ctx:
+            AsyncMetagraphedClient()
+        self.assertIn("metagraphed[async]", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -8,7 +8,10 @@ from unittest import mock
 from metagraphed import (
     MetagraphedClient,
     MetagraphedError,
+    Subnet,
+    Surface,
     metagraphed_fetch,
+    metagraphed_fetch_all,
     metagraphed_paginate,
     metagraphed_rpc,
 )
@@ -280,6 +283,52 @@ class ClientTest(unittest.TestCase):
             with self.assertRaises(MetagraphedError) as ctx:
                 metagraphed_rpc("finney", "nope")
         self.assertIn("Method not found", str(ctx.exception))
+
+
+class FetchAllAndModelsTest(unittest.TestCase):
+    def _patch_pages(self, pages):
+        responses = iter(_FakeResponse(page) for page in pages)
+
+        def fake_urlopen(request, timeout=None):
+            return next(responses)
+
+        return mock.patch("urllib.request.urlopen", fake_urlopen)
+
+    def test_fetch_all_flattens_pages_following_cursor(self):
+        pages = [
+            {"data": [{"netuid": 1}], "meta": {"pagination": {"next_cursor": "c2"}}},
+            {"data": [{"netuid": 2}], "meta": {"pagination": {"next_cursor": None}}},
+        ]
+        with self._patch_pages(pages):
+            items = metagraphed_fetch_all("/api/v1/subnets")
+        self.assertEqual([item["netuid"] for item in items], [1, 2])
+
+    def test_subnets_convenience_returns_typed_models(self):
+        pages = [
+            {
+                "data": [{"netuid": 7, "name": "Allways", "categories": ["inference"]}],
+                "meta": {"pagination": {"next_cursor": None}},
+            }
+        ]
+        with self._patch_pages(pages):
+            subnets = MetagraphedClient().subnets()
+        self.assertIsInstance(subnets[0], Subnet)
+        self.assertEqual(subnets[0].netuid, 7)
+        self.assertEqual(subnets[0].name, "Allways")
+        self.assertEqual(subnets[0].categories, ["inference"])
+        self.assertEqual(subnets[0].raw["name"], "Allways")
+
+    def test_model_from_dict_ignores_unknown_and_keeps_raw(self):
+        surface = Surface.from_dict(
+            {"id": "x", "kind": "openapi", "unknown_field": 1}
+        )
+        self.assertEqual(surface.id, "x")
+        self.assertEqual(surface.kind, "openapi")
+        self.assertEqual(surface.raw["unknown_field"], 1)
+
+    def test_model_from_dict_tolerates_non_mapping(self):
+        self.assertEqual(Subnet.from_dict(None).raw, {})
+        self.assertIsNone(Subnet.from_dict(None).netuid)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #749 · #740 Phase 3 (SDK / DX).

## What
The `metagraphed` PyPI client was sync-only (urllib) and returned raw dicts. This adds the async + typed layer **without breaking the zero-dependency sync client**:

```python
import asyncio
from metagraphed import AsyncMetagraphedClient

async def main():
    async with AsyncMetagraphedClient(retries=3) as client:
        subnets = await client.subnets()                      # typed, auto-paginated
        catalogs = await asyncio.gather(                      # concurrent, one pool
            *(client.agent_catalog(s.netuid) for s in subnets[:10])
        )

asyncio.run(main())
```

## Completion requirements (#749)
- [x] **Async client at parity** — `AsyncMetagraphedClient` (httpx): `fetch`/`paginate`/`fetch_all`/`rpc`, retries/backoff + `Retry-After`, shared connection pool, async context manager.
- [x] **Typed models** for subnets/surfaces/endpoints/providers/agent-catalog — stdlib dataclasses with `.from_dict` (ignores unknown keys) and `.raw` (full dict); **the raw-dict path is preserved** (default `fetch`/`fetch_all` still return dicts).
- [x] **Backward compatible; heavy deps behind an extra** — httpx is lazy-imported and gated behind `metagraphed[async]`; the sync client stays stdlib-only; **all 16 existing tests pass unchanged**.
- [x] **Tests (incl. async) + lint/type-check clean** — 28 tests (16 existing + 12 new; async via `unittest.IsolatedAsyncioTestCase`, httpx stubbed, no network); `ruff check` ✓, `mypy` ✓.
- [x] **README/examples updated** — async + typed-models + `fetch_all` examples, `[async]` install note.
- [x] **Version + changelog per the release flow** — left to **release-please** (it owns `python` in `.release-please-manifest.json` and regenerates the CHANGELOG from Conventional Commits); not hand-bumped to avoid desyncing the manifest.
- [x] **Conventional Commit title.**

## Also adds `fetch_all()` + typed convenience methods
`client.subnets()` / `surfaces()` / `endpoints()` / `providers()` → typed lists (auto-paginated); `client.agent_catalog(netuid)` → `AgentCatalogSubnet`. On both sync and async clients.

## Publish
Per the issue, the actual PyPI publish is the maintainer's step — merging this lands the feature on `main`; release-please will open the version-bump + CHANGELOG release PR.