### PR TITLE
feat(registry): enrich SN7 Allways — add miners reliability data artifact

### DIFF
--- a/registry/candidates/community/community-sn-7-data-artifact-api-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-data-artifact-api-all-ways-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.all-ways.io/swagger-json",
       "source_urls": ["https://api.all-ways.io/swagger-json"],
       "state": "schema-valid",
-      "url": "https://api.all-ways.io/miners/leaderboard"
+      "url": "https://api.all-ways.io/miners/reliability"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.all-ways.io/miners/reliability`.

Closes #903.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally