### PR TITLE
feat(registry): enrich SN56 Gradients — add weight projection static data artifact

### DIFF
--- a/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
+++ b/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.gradients.io/docs",
       "source_urls": ["https://api.gradients.io/docs"],
       "state": "schema-valid",
-      "url": "https://api.gradients.io/tournament/latest/details"
+      "url": "https://api.gradients.io/v1/performance/weight-projection-static"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.gradients.io/v1/performance/weight-projection-static`.

Closes #957.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally