### PR TITLE
feat(registry): enrich SN74 Gittensor — add miners subnet API

### DIFF
--- a/registry/candidates/community/community-sn-74-subnet-api-api-gittensor-io.json
+++ b/registry/candidates/community/community-sn-74-subnet-api-api-gittensor-io.json
@@ -14,15 +14,15 @@
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://api.gittensor.io/swagger",
-      "source_urls": ["https://api.gittensor.io/swagger"],
+      "source_url": "https://api.gittensor.io/swagger-json",
+      "source_urls": ["https://api.gittensor.io/swagger-json"],
       "state": "schema-valid",
-      "url": "https://api.gittensor.io/dash/repos"
+      "url": "https://api.gittensor.io/miners"
     }
   ],
   "schema_version": 1,
   "submission": {
-    "submitted_by": "jaso0n0818",
-    "submitted_by_url": "https://github.com/jaso0n0818"
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
   }
 }


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.gittensor.io/miners`.

Closes #723.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally