### PR TITLE
feat(registry): enrich SN96 Verathos — add models data artifact

### DIFF
--- a/registry/candidates/community/community-sn-96-data-artifact-api-verathos-ai.json
+++ b/registry/candidates/community/community-sn-96-data-artifact-api-verathos-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-96-data-artifact-api-verathos-ai",
+      "kind": "data-artifact",
+      "name": "Verathos community data-artifact",
+      "netuid": 96,
+      "provider": "verathos",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://verathos.ai/openapi.json",
+      "source_urls": ["https://verathos.ai/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.verathos.ai/v1/models"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.verathos.ai/v1/models`.

Closes #736.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally