### PR TITLE
feat(registry): enrich SN33 ReadyAI — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-33-openapi-api-readyai-ai.json
+++ b/registry/candidates/community/community-sn-33-openapi-api-readyai-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-33-openapi-api-readyai-ai",
+      "kind": "openapi",
+      "name": "ReadyAI community openapi",
+      "netuid": 33,
+      "provider": "readyai",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://readyai.ai/docs",
+      "source_urls": ["https://readyai.ai/docs"],
+      "state": "schema-valid",
+      "url": "https://api.readyai.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.readyai.ai/openapi.json`.

Closes #707.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally