### PR TITLE
feat(registry): enrich SN58 Handshake58 — add marketplace subnet API

### DIFF
--- a/registry/candidates/community/community-sn-58-subnet-api-api-handshake58-com.json
+++ b/registry/candidates/community/community-sn-58-subnet-api-api-handshake58-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-58-subnet-api-api-handshake58-com",
+      "kind": "subnet-api",
+      "name": "Pending community subnet-api",
+      "netuid": 58,
+      "provider": "handshake58",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://handshake58.com/openapi.json",
+      "source_urls": ["https://handshake58.com/openapi.json"],
+      "state": "schema-valid",
+      "url": "https://api.handshake58.com/v1/marketplace"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.handshake58.com/v1/marketplace`.

Closes #958.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally