### PR TITLE
feat(registry): enrich SN61 RedTeam — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-61-openapi-api-redteamsubnet-com.json
+++ b/registry/candidates/community/community-sn-61-openapi-api-redteamsubnet-com.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-61-openapi-api-redteamsubnet-com",
+      "kind": "openapi",
+      "name": "RedTeam community openapi",
+      "netuid": 61,
+      "provider": "redteam",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://redteamsubnet.com/docs",
+      "source_urls": ["https://redteamsubnet.com/docs"],
+      "state": "schema-valid",
+      "url": "https://api.redteamsubnet.com/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.redteamsubnet.com/openapi.json`.

Closes #716.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally