### PR TITLE
feat(registry): enrich SN98 ForeverMoney — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-98-openapi-api-forevermoney-ai.json
+++ b/registry/candidates/community/community-sn-98-openapi-api-forevermoney-ai.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-98-openapi-api-forevermoney-ai",
+      "kind": "openapi",
+      "name": "ForeverMoney community openapi",
+      "netuid": 98,
+      "provider": "forevermoney",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://forevermoney.ai/docs",
+      "source_urls": ["https://forevermoney.ai/docs"],
+      "state": "schema-valid",
+      "url": "https://api.forevermoney.ai/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.forevermoney.ai/openapi.json`.

Closes #700.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally