### PR TITLE
feat(registry): enrich SN12 Compute Horde — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-12-openapi-api-computehorde-io.json
+++ b/registry/candidates/community/community-sn-12-openapi-api-computehorde-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-12-openapi-api-computehorde-io",
+      "kind": "openapi",
+      "name": "Compute Horde community openapi",
+      "netuid": 12,
+      "provider": "compute-horde",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://computehorde.io/docs",
+      "source_urls": ["https://computehorde.io/docs"],
+      "state": "schema-valid",
+      "url": "https://api.computehorde.io/openapi.json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.computehorde.io/openapi.json`.

Closes #726.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally