### PR TITLE
feat(registry): enrich SN27 Nodexo — confirm Byzantium source repository candidate

### DIFF
--- a/registry/candidates/community/community-sn-27-source-repo-github-com.json
+++ b/registry/candidates/community/community-sn-27-source-repo-github-com.json
@@ -7,19 +7,17 @@
       "kind": "source-repo",
       "name": "Team TBC community source-repo",
       "netuid": 27,
-      "provider": "nodexo",
+      "provider": "byzantium",
       "public_safe": true,
       "rate_limit_notes": "",
       "review_notes": "Community-submitted public interface candidate.",
       "schema_version": 1,
       "source_tier": "community-docs",
       "source_type": "community-pr-intake",
-      "source_url": "https://github.com/neuralinternet/SN27-opencompute/blob/main/server.py",
-      "source_urls": [
-        "https://github.com/neuralinternet/SN27-opencompute/blob/main/server.py"
-      ],
+      "source_url": "https://github.com/safe-scan-ai/cancer-ai",
+      "source_urls": ["https://github.com/safe-scan-ai/cancer-ai"],
       "state": "schema-valid",
-      "url": "https://github.com/neuralinternet/SN27-opencompute"
+      "url": "https://github.com/safe-scan-ai/cancer-ai"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://github.com/safe-scan-ai/cancer-ai`.

Closes #956.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally