### PR TITLE
feat(registry): enrich SN7 Allways — confirm OpenAPI schema candidate

### DIFF
--- a/registry/candidates/community/community-sn-7-openapi-api-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-openapi-api-all-ways-io.json
@@ -1,0 +1,28 @@
+{
+  "candidates": [
+    {
+      "auth_required": false,
+      "confidence": "medium",
+      "id": "community-sn-7-openapi-api-all-ways-io",
+      "kind": "openapi",
+      "name": "Allways community openapi",
+      "netuid": 7,
+      "provider": "allways",
+      "public_safe": true,
+      "rate_limit_notes": "",
+      "review_notes": "Community-submitted public interface candidate.",
+      "schema_version": 1,
+      "source_tier": "community-docs",
+      "source_type": "community-pr-intake",
+      "source_url": "https://www.all-ways.io/",
+      "source_urls": ["https://www.all-ways.io/"],
+      "state": "schema-valid",
+      "url": "https://api.all-ways.io/swagger-json"
+    }
+  ],
+  "schema_version": 1,
+  "submission": {
+    "submitted_by": "kiannidev",
+    "submitted_by_url": "https://github.com/kiannidev"
+  }
+}


### PR DESCRIPTION
## Summary
Submit verified public endpoint at `https://api.all-ways.io/swagger-json`.

Closes #903.

## Validation
- [x] Exactly one community candidate file changed
- [x] candidate:new + submission:pr passed locally

Made with [Cursor](https://cursor.com)