### PR TITLE
feat(registry): enrich SN56 Gradients — add weight projection static data artifact

### DIFF
--- a/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
+++ b/registry/candidates/community/community-sn-56-data-artifact-api-gradients-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.gradients.io/docs",
       "source_urls": ["https://api.gradients.io/docs"],
       "state": "schema-valid",
-      "url": "https://api.gradients.io/tournament/latest/details"
+      "url": "https://api.gradients.io/v1/performance/weight-projection-static"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Pick The Right Template

- [x] Direct subnet/interface candidate: one `registry/candidates/community/*.json` file only.

## Summary

Submit the live public endpoint at `https://api.gradients.io/v1/performance/weight-projection-static`, verified with curl (HTTP 200 + JSON).

Closes #957.

## Candidate

- Netuid: 56
- Kind: data-artifact
- Public URL: https://api.gradients.io/v1/performance/weight-projection-static
- Source URL: https://api.gradients.io/docs
- Provider/operator: gradients

## Validation

- [x] Exactly one `registry/candidates/community/*.json` file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (`errors: []`, `manual_reasons: []`, `public_state: submit_pr`)
- [x] URL returns HTTP 200 + JSON (curl verified)
- [x] Does not duplicate a curated subnet surface for this kind+URL