### PR TITLE
feat(registry): enrich SN49 Nepher Robotics — add active tournament id data artifact

### DIFF
--- a/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
+++ b/registry/candidates/community/community-sn-49-data-artifact-tournament-api-nepher-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://tournament-api.nepher.ai/openapi.json",
       "source_urls": ["https://tournament-api.nepher.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://tournament-api.nepher.ai/api/v1/scores/leaderboard/active"
+      "url": "https://tournament-api.nepher.ai/api/v1/tournaments/active/id"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Pick The Right Template

- [x] Direct subnet/interface candidate: one `registry/candidates/community/*.json` file only.

## Summary

Submit the live public endpoint at `https://tournament-api.nepher.ai/api/v1/tournaments/active/id`, verified with curl (HTTP 200 + JSON).

Closes #962.

## Candidate

- Netuid: 49
- Kind: data-artifact
- Public URL: https://tournament-api.nepher.ai/api/v1/tournaments/active/id
- Source URL: https://tournament-api.nepher.ai/openapi.json
- Provider/operator: nepher-robotics

## Validation

- [x] Exactly one `registry/candidates/community/*.json` file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (`errors: []`, `manual_reasons: []`, `public_state: submit_pr`)
- [x] URL returns HTTP 200 + JSON (curl verified)
- [x] Does not duplicate a curated subnet surface for this kind+URL