### PR TITLE
feat(registry): enrich SN64 Chutes — add daily revenue summary data artifact

### DIFF
--- a/registry/candidates/community/community-sn-64-data-artifact-api-chutes-ai.json
+++ b/registry/candidates/community/community-sn-64-data-artifact-api-chutes-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.chutes.ai/openapi.json",
       "source_urls": ["https://api.chutes.ai/openapi.json"],
       "state": "schema-valid",
-      "url": "https://api.chutes.ai/users/growth"
+      "url": "https://api.chutes.ai/daily_revenue_summary"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Pick The Right Template

- [x] Direct subnet/interface candidate: one `registry/candidates/community/*.json` file only.

## Summary

Submit the live public endpoint at `https://api.chutes.ai/daily_revenue_summary`, verified with curl (HTTP 200 + JSON).

Closes #959.

## Candidate

- Netuid: 64
- Kind: data-artifact
- Public URL: https://api.chutes.ai/daily_revenue_summary
- Source URL: https://api.chutes.ai/openapi.json
- Provider/operator: chutes

## Validation

- [x] Exactly one `registry/candidates/community/*.json` file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (`errors: []`, `manual_reasons: []`, `public_state: submit_pr`)
- [x] URL returns HTTP 200 + JSON (curl verified)
- [x] Does not duplicate a curated subnet surface for this kind+URL