### PR TITLE
feat(registry): enrich SN14 Cacheon — add evaluations data artifact

### DIFF
--- a/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
+++ b/registry/candidates/community/community-sn-14-data-artifact-api-cacheon-ai.json
@@ -17,7 +17,7 @@
       "source_url": "https://cacheon.ai/docs/miners/api-contract",
       "source_urls": ["https://cacheon.ai/docs/miners/api-contract"],
       "state": "schema-valid",
-      "url": "https://api.cacheon.ai/api/leader/history"
+      "url": "https://api.cacheon.ai/api/evaluations"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Pick The Right Template

- [x] Direct subnet/interface candidate: one `registry/candidates/community/*.json` file only.

## Summary

Submit the live public endpoint at `https://api.cacheon.ai/api/evaluations`, verified with curl (HTTP 200 + JSON).

Closes #913.

## Candidate

- Netuid: 14
- Kind: data-artifact
- Public URL: https://api.cacheon.ai/api/evaluations
- Source URL: https://cacheon.ai/docs/miners/api-contract
- Provider/operator: cacheon

## Validation

- [x] Exactly one `registry/candidates/community/*.json` file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (`errors: []`, `manual_reasons: []`, `public_state: submit_pr`)
- [x] URL returns HTTP 200 + JSON (curl verified)
- [x] Does not duplicate a curated subnet surface for this kind+URL