### PR TITLE
feat(registry): enrich SN58 Handshake58 — add skills index data artifact

### DIFF
--- a/registry/candidates/community/community-sn-58-data-artifact-handshake58-com.json
+++ b/registry/candidates/community/community-sn-58-data-artifact-handshake58-com.json
@@ -17,7 +17,7 @@
       "source_url": "https://handshake58.com/openapi.json",
       "source_urls": ["https://handshake58.com/openapi.json"],
       "state": "schema-valid",
-      "url": "https://handshake58.com/api/mcp/providers"
+      "url": "https://handshake58.com/api/skills"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Pick The Right Template

- [x] Direct subnet/interface candidate: one `registry/candidates/community/*.json` file only.

## Summary

Submit the live public endpoint at `https://handshake58.com/api/skills`, verified with curl (HTTP 200 + JSON).

Closes #958.

## Candidate

- Netuid: 58
- Kind: data-artifact
- Public URL: https://handshake58.com/api/skills
- Source URL: https://handshake58.com/openapi.json
- Provider/operator: handshake58

## Validation

- [x] Exactly one `registry/candidates/community/*.json` file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr -- --changed-files ... --submitter kiannidev` passed (`errors: []`, `manual_reasons: []`, `public_state: submit_pr`)
- [x] URL returns HTTP 200 + JSON (curl verified)
- [x] Does not duplicate a curated subnet surface for this kind+URL