### PR TITLE
feat(registry): enrich SN7 Allways — add protocol constants data artifact

### DIFF
--- a/registry/candidates/community/community-sn-7-data-artifact-api-all-ways-io.json
+++ b/registry/candidates/community/community-sn-7-data-artifact-api-all-ways-io.json
@@ -17,7 +17,7 @@
       "source_url": "https://api.all-ways.io/swagger-json",
       "source_urls": ["https://api.all-ways.io/swagger-json"],
       "state": "schema-valid",
-      "url": "https://api.all-ways.io/miners/leaderboard"
+      "url": "https://api.all-ways.io/protocol/constants"
     }
   ],
   "schema_version": 1,


### PR DESCRIPTION
## Summary
Submit the live public endpoint at `https://api.all-ways.io/protocol/constants`, verified with curl (HTTP 200 + JSON).

Closes #903.

## Validation
- [x] Exactly one community candidate file changed
- [x] `npm run candidate:new` + `npm run validate:candidate` passed
- [x] `npm run submission:pr` passed (`public_state: submit_pr`, `manual_reasons: []`)

Made with [Cursor](https://cursor.com)