### PR TITLE
feat(ci): validate:committed-seed cold-start gate (#1000)

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -138,6 +138,7 @@ jobs:
           npm run validate:schema-enums
           npm run validate:openapi-examples
           npm run validate:generated-client
+          npm run validate:committed-seed
 
       - name: Build artifacts
         if: steps.route.outputs.mode == 'full'

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "scan:public-safety": "node scripts/scan-public-safety.mjs",
     "validate:schemas": "node scripts/validate-schemas.mjs",
     "validate:api": "node scripts/validate-api.mjs",
+    "validate:committed-seed": "node scripts/validate-committed-seed.mjs",
     "validate:mcp": "node scripts/validate-mcp.mjs",
     "validate:ai": "node scripts/validate-ai-routes.mjs",
     "validate:openapi": "node scripts/validate-openapi.mjs",

--- a/scripts/validate-committed-seed.mjs
+++ b/scripts/validate-committed-seed.mjs
@@ -1,0 +1,146 @@
+// #1000 — Cold-start committed-seed gate.
+//
+// On an R2 cold start — and on any clean checkout — the Worker serves the
+// COMMITTED public/ seed (the DUAL-tier artifacts in src/artifact-storage.mjs).
+// That seed is only refreshed by a manual `npm run build` + commit, so a
+// schema/contract change that lands WITHOUT the seed refresh ships a seed that
+// no longer satisfies the contract. #356 did exactly this (added the required
+// `readiness_tier` field) and it stayed invisible in CI: the `checks` job builds
+// fresh BEFORE `validate:api` runs, so validate:api only ever sees rebuilt
+// output, never the committed seed. The drift only surfaced on a contributor's
+// clean checkout (and took three iterations to land the #998 catch-up).
+//
+// This gate runs BEFORE the build and validates the responses the Worker
+// produces from the committed seed alone — so seed drift fails fast here.
+//
+// Scope: only routes backed by a DUAL-tier (committed) artifact are checked.
+// R2-only routes (providers, surfaces, search, per-subnet detail, D1-computed
+// health/analytics) need a build to populate dist/ and would 404 on a clean
+// checkout — they're out of scope here and are covered by validate:api after
+// the build. The set is DERIVED from the contract + storage tiers, so new
+// committed routes are picked up automatically.
+
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import Ajv2020 from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+import { API_ROUTES } from "../src/contracts.mjs";
+import { handleRequest } from "../workers/api.mjs";
+import {
+  ARTIFACT_STORAGE_TIERS,
+  artifactStorageTierForPath,
+} from "../src/artifact-storage.mjs";
+import { createLocalArtifactEnv, readJson, repoRoot } from "./lib.mjs";
+
+export const SEED_FAILURE_HINT =
+  "Fix: run `npm run build`, then commit the regenerated public/ artifacts " +
+  "(the committed seed must track schema/contract changes — see the " +
+  "schema-change-regenerate-contract rule).";
+
+// Paramless GET routes whose backing artifact is committed to git (DUAL tier) —
+// the only routes guaranteed to resolve from the committed seed on a clean
+// checkout, with no build and no R2/D1.
+export function committedSeedRoutes(routes = API_ROUTES) {
+  return routes.filter(
+    (route) =>
+      route.method === "GET" &&
+      !route.path.includes("{") &&
+      route.artifact_path &&
+      artifactStorageTierForPath(route.artifact_path) ===
+        ARTIFACT_STORAGE_TIERS.dual,
+  );
+}
+
+// Exercise each committed-seed-backed route through the Worker and validate the
+// response against the generated OpenAPI 200 schema. Returns the routes checked
+// and a list of human-readable failures (empty = the committed seed is valid).
+export async function runCommittedSeedGate({ env, openapi }) {
+  const ajv = new Ajv2020({
+    allErrors: true,
+    allowUnionTypes: true,
+    strict: false,
+    validateFormats: true,
+  });
+  addFormats(ajv);
+
+  const routes = committedSeedRoutes();
+  const errors = [];
+
+  for (const route of routes) {
+    let response;
+    try {
+      response = await handleRequest(
+        new Request(`https://metagraph.sh${route.path}`),
+        env,
+        {},
+      );
+    } catch (error) {
+      errors.push(`${route.path}: handler threw — ${error?.message ?? error}`);
+      continue;
+    }
+    if (response.status !== 200) {
+      errors.push(
+        `${route.path}: committed seed should serve 200 (got ${response.status})`,
+      );
+      continue;
+    }
+    const body = await response.json();
+    if (body.ok !== true) {
+      errors.push(`${route.path}: committed seed should serve an ok envelope`);
+      continue;
+    }
+    const operation = openapi.paths?.[route.path]?.[route.method.toLowerCase()];
+    const responseSchema =
+      operation?.responses?.["200"]?.content?.["application/json"]?.schema;
+    if (!responseSchema) {
+      errors.push(
+        `${route.path}: missing OpenAPI 200 schema in the committed contract`,
+      );
+      continue;
+    }
+    const validator = ajv.compile({
+      components: openapi.components,
+      ...responseSchema,
+    });
+    if (!validator(body)) {
+      errors.push(
+        `${route.path}: committed seed response no longer matches the schema — ${ajv.errorsText(
+          validator.errors,
+        )}`,
+      );
+    }
+  }
+
+  return { checked: routes.length, errors };
+}
+
+async function main() {
+  const openapi = await readJson(
+    path.join(repoRoot, "public/metagraph/openapi.json"),
+  );
+  const env = createLocalArtifactEnv();
+  const { checked, errors } = await runCommittedSeedGate({ env, openapi });
+
+  if (errors.length > 0) {
+    console.error(
+      `✖ Committed cold-start seed is stale or schema-invalid (${errors.length} issue(s)):`,
+    );
+    for (const message of errors) {
+      console.error(`  - ${message}`);
+    }
+    console.error(`\n${SEED_FAILURE_HINT}`);
+    process.exit(1);
+  }
+
+  console.log(
+    `✓ Committed cold-start seed valid — ${checked} DUAL-tier route(s) checked (pre-build, no R2/D1).`,
+  );
+}
+
+// Run as a CLI only when invoked directly (not when imported by a test).
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await main();
+}

--- a/tests/committed-seed-gate.test.mjs
+++ b/tests/committed-seed-gate.test.mjs
@@ -1,0 +1,85 @@
+// #1000 — the cold-start committed-seed gate. Proves it (a) passes on the
+// current committed seed and (b) catches the exact #356/#998 drift class
+// (a required field added to the schema but missing from the committed seed),
+// using a synthetic env so the real public/ files are never touched.
+
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  committedSeedRoutes,
+  runCommittedSeedGate,
+} from "../scripts/validate-committed-seed.mjs";
+import { createLocalArtifactEnv, readJson, repoRoot } from "../scripts/lib.mjs";
+
+const openapi = await readJson(
+  path.join(repoRoot, "public/metagraph/openapi.json"),
+);
+
+describe("committed cold-start seed gate", () => {
+  it("derives the DUAL-tier committed routes (incl. agent-catalog)", () => {
+    const paths = committedSeedRoutes().map((route) => route.path);
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths).toContain("/api/v1/agent-catalog");
+    // Per-subnet detail is R2-only and must NOT be in scope (it 404s pre-build).
+    expect(paths.every((p) => !p.includes("{"))).toBe(true);
+  });
+
+  it("passes on the current committed seed", async () => {
+    const env = createLocalArtifactEnv();
+    const { checked, errors } = await runCommittedSeedGate({ env, openapi });
+    expect(checked).toBeGreaterThan(0);
+    expect(errors).toEqual([]);
+  });
+
+  it("flags a stale agent-catalog seed missing readiness_tier", async () => {
+    // Build a deliberately-stale agent-catalog (readiness_tier stripped) and
+    // serve it from BOTH tiers the Worker may read (ASSETS + R2 archive), so the
+    // injection is robust to the R2-preferred-dual serving order. Every other
+    // path passes through to the real committed seed.
+    const fresh = await readJson(
+      path.join(repoRoot, "public/metagraph/agent-catalog.json"),
+    );
+    const stale = structuredClone(fresh);
+    for (const subnet of stale.subnets ?? []) {
+      if (subnet.readiness) delete subnet.readiness.readiness_tier;
+    }
+    const isAgentCatalog = (value) =>
+      String(value).endsWith("agent-catalog.json");
+
+    const base = createLocalArtifactEnv();
+    const env = {
+      ...base,
+      ASSETS: {
+        async fetch(request) {
+          if (isAgentCatalog(new URL(request.url).pathname)) {
+            return new Response(JSON.stringify(stale), {
+              status: 200,
+              headers: { "content-type": "application/json" },
+            });
+          }
+          return base.ASSETS.fetch(request);
+        },
+      },
+      METAGRAPH_ARCHIVE: {
+        async get(key) {
+          if (isAgentCatalog(key)) {
+            return {
+              async json() {
+                return stale;
+              },
+              async text() {
+                return JSON.stringify(stale);
+              },
+            };
+          }
+          return base.METAGRAPH_ARCHIVE.get(key);
+        },
+      },
+    };
+
+    const { errors } = await runCommittedSeedGate({ env, openapi });
+    const joined = errors.join("\n");
+    expect(joined).toMatch(/agent-catalog/);
+    expect(joined).toMatch(/readiness_tier/);
+  });
+});


### PR DESCRIPTION
Closes #1000 · Part of #999 (Phase 1 — stop silent drift).

## Problem
The committed `public/` seed is what the Worker serves on an R2 cold start (and on any clean checkout), but it's only refreshed by a manual `npm run build` + commit. A schema/contract change that lands **without** the seed refresh ships a seed that no longer satisfies the contract — and it's **invisible in CI**: the `checks` job builds fresh before `validate:api` runs, so validate:api only ever sees rebuilt output, never the committed seed. #356 (added required `readiness_tier`) hit exactly this; it only surfaced on a clean checkout and took three iterations to land the #998 catch-up.

## Fix
A new `validate:committed-seed` gate that runs **before the build** and validates the responses the Worker produces from the committed seed alone, against the generated OpenAPI schema.

- **Scope is derived, not hardcoded:** the 11 DUAL-tier (committed) paramless GET routes — including `/api/v1/agent-catalog`, where `readiness_tier` lives. R2-only routes (providers/surfaces/search/per-subnet/D1-analytics) need a build and 404 on a clean checkout, so they're out of scope here and stay covered by `validate:api` post-build. New committed routes are picked up automatically.
- Wired into the `checks` job's pre-build **"Validate committed contract (drift)"** step (full-mode only).

## Verification
- `npm run validate:committed-seed` → ✓ 11 routes valid on the current seed.
- Reproduced the **real** pre-#998 seed → the gate fails with `data/subnets/N/readiness must have required property 'readiness_tier'` + a `run npm run build` hint.
- Hermetic vitest (`tests/committed-seed-gate.test.mjs`): passes on the current seed, catches a `readiness_tier`-stripped agent-catalog, asserts the derived route set excludes templated routes. **3/3 green**; eslint + prettier clean.